### PR TITLE
Bugfix in instantiation logic of UriInjector

### DIFF
--- a/copycat-core/src/main/java/net/kuujo/copycat/uri/UriInjector.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/uri/UriInjector.java
@@ -85,6 +85,7 @@ public class UriInjector {
         }
         try {
           object = (T) constructor.newInstance(args);
+          break;
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
           throw new UriException(e);
         }


### PR DESCRIPTION
Added break in order for UriInjector to correctly break when Object could be instantiated by constructor
