### PR TITLE
Use slf4j for logging

### DIFF
--- a/copycat-core/src/main/java/net/kuujo/copycat/state/impl/Candidate.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/state/impl/Candidate.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Logger;
 
 import net.kuujo.copycat.cluster.Member;
 import net.kuujo.copycat.log.Entry;
@@ -28,6 +27,9 @@ import net.kuujo.copycat.protocol.RequestVoteRequest;
 import net.kuujo.copycat.protocol.RequestVoteResponse;
 import net.kuujo.copycat.state.State;
 import net.kuujo.copycat.util.Quorum;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Candidate state.<p>
@@ -41,7 +43,7 @@ import net.kuujo.copycat.util.Quorum;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class Candidate extends RaftState {
-  private static final Logger logger = Logger.getLogger(Candidate.class.getCanonicalName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(Candidate.class);
   private Quorum quorum;
   private ScheduledFuture<Void> currentTimer;
 
@@ -53,7 +55,7 @@ public class Candidate extends RaftState {
   @Override
   public void init(RaftStateContext context) {
     super.init(context);
-    logger.info(String.format("%s starting election", context.cluster().config().getLocalMember()));
+    LOGGER.info("{} starting election", context.cluster().config().getLocalMember());
     resetTimer();
   }
 
@@ -73,13 +75,13 @@ public class Candidate extends RaftState {
     currentTimer = context.config().getTimerStrategy().schedule(() -> {
       // When the election times out, clear the previous majority vote
       // check and restart the election.
-      logger.info(String.format("%s election timed out", context.cluster().config().getLocalMember()));
+      LOGGER.info("{} election timed out", context.cluster().config().getLocalMember());
       if (quorum != null) {
         quorum.cancel();
         quorum = null;
       }
       resetTimer();
-      logger.info(String.format("%s restarted election", context.cluster().config().getLocalMember()));
+      LOGGER.info("{} restarted election", context.cluster().config().getLocalMember());
     }, delay, TimeUnit.MILLISECONDS);
 
     final AtomicBoolean complete = new AtomicBoolean();

--- a/copycat-core/src/main/java/net/kuujo/copycat/state/impl/Follower.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/state/impl/Follower.java
@@ -18,13 +18,15 @@ package net.kuujo.copycat.state.impl;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 import net.kuujo.copycat.protocol.AppendEntriesRequest;
 import net.kuujo.copycat.protocol.AppendEntriesResponse;
 import net.kuujo.copycat.protocol.RequestVoteRequest;
 import net.kuujo.copycat.protocol.RequestVoteResponse;
 import net.kuujo.copycat.state.State;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Follower state.<p>
@@ -38,7 +40,7 @@ import net.kuujo.copycat.state.State;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class Follower extends RaftState {
-  private static final Logger logger = Logger.getLogger(Follower.class.getCanonicalName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(Follower.class);
   private ScheduledFuture<Void> currentTimer;
   private boolean shutdown = true;
 
@@ -77,7 +79,7 @@ public class Follower extends RaftState {
         // candidate and start a new election.
         currentTimer = null;
         if (context.getLastVotedFor() == null) {
-          logger.info("Election timed out. Transitioning to candidate.");
+          LOGGER.info("Election timed out. Transitioning to candidate.");
           context.transition(Candidate.class);
         } else {
           // If the node voted for a candidate then reset the election timer.

--- a/copycat-core/src/main/java/net/kuujo/copycat/state/impl/RaftStateContext.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/state/impl/RaftStateContext.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.logging.Logger;
 
 import net.kuujo.copycat.CopyCatConfig;
 import net.kuujo.copycat.CopyCatException;
@@ -45,13 +44,16 @@ import net.kuujo.copycat.registry.Registry;
 import net.kuujo.copycat.state.State;
 import net.kuujo.copycat.state.StateContext;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Raft state context.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class RaftStateContext implements StateContext {
-  private static final Logger logger = Logger.getLogger(StateContext.class.getCanonicalName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(StateContext.class);
   private final Executor executor = Executors.newCachedThreadPool();
   private final StateMachine stateMachine;
   private final Cluster cluster;
@@ -71,7 +73,8 @@ public class RaftStateContext implements StateContext {
   private volatile long commitIndex = 0;
   private volatile long lastApplied = 0;
 
-  public RaftStateContext(StateMachine stateMachine, LogFactory logFactory, ClusterConfig cluster, CopyCatConfig config, Registry registry) {
+  public RaftStateContext(StateMachine stateMachine, LogFactory logFactory, ClusterConfig cluster,
+      CopyCatConfig config, Registry registry) {
     this.stateMachine = stateMachine;
     this.logFactory = logFactory;
     this.config = config;
@@ -168,7 +171,7 @@ public class RaftStateContext implements StateContext {
       return;
     }
 
-    logger.info(cluster.localMember() + " transitioning to " + type.toString());
+    LOGGER.info("{} transitioning to {}", cluster.localMember(), type);
     final RaftState oldState = currentState;
     try {
       currentState = type.newInstance();
@@ -197,7 +200,7 @@ public class RaftStateContext implements StateContext {
    */
   public RaftStateContext setCurrentLeader(String leader) {
     if (currentLeader == null || !currentLeader.equals(leader)) {
-      logger.finer(String.format("Current cluster leader changed: %s", leader));
+      LOGGER.trace("Current cluster leader changed: {}", leader);
     }
 
     if (currentLeader == null && leader != null) {
@@ -254,7 +257,7 @@ public class RaftStateContext implements StateContext {
   public RaftStateContext setCurrentTerm(long term) {
     if (term > currentTerm) {
       currentTerm = term;
-      logger.finer(String.format("Updated current term %d", term));
+      LOGGER.trace("Updated current term {}", term);
       lastVotedFor = null;
     }
     return this;
@@ -272,7 +275,7 @@ public class RaftStateContext implements StateContext {
    */
   public RaftStateContext setLastVotedFor(String candidate) {
     if (lastVotedFor == null || !lastVotedFor.equals(candidate)) {
-      logger.finer(String.format("Voted for %s", candidate));
+      LOGGER.trace("Voted for {}", candidate);
     }
     lastVotedFor = candidate;
     return this;

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -18,6 +19,8 @@
 
   <properties>
     <junit.version>4.8.2</junit.version>
+    <slf4j.version>1.7.7</slf4j.version>
+    <logback.version>1.1.2</logback.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>
@@ -75,10 +78,22 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
-      <scope>compile</scope>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -126,7 +141,8 @@
 
     <pluginManagement>
       <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence 
+          on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>


### PR DESCRIPTION
This PR introduces the slf4j for logging.

While JUL doesn't require external dependencies, it doesn't necessarily play nice with existing logging that people may be using. slf4j allows copycat to play nice with whatever existing logging the user already has in place, whether it's JUL or logback or whatever.

The only added dependency is the slf4j-api. The logging implementation is still specified by the user.
