### PR TITLE
Fix InMemoryLog.removeAfter.

### DIFF
--- a/copycat-core/src/main/java/net/kuujo/copycat/log/Compactable.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/log/Compactable.java
@@ -27,7 +27,7 @@ public interface Compactable {
   /**
    * Compacts the log.
    *
-   * @param index The index at which to compact the log.
+   * @param index The index at which to compact the log, inclusive.
    * @param entry A snapshot entry to place at the start of the compacted log.
    * @throws IOException If the snapshot persistence failed.
    */

--- a/copycat-core/src/main/java/net/kuujo/copycat/log/InMemoryLog.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/log/InMemoryLog.java
@@ -153,8 +153,8 @@ public class InMemoryLog extends BaseLog implements Compactable {
   @Override
   public synchronized void removeAfter(long index) {
     if (!log.isEmpty()) {
-      for (long i = index; i <= log.lastKey(); i++) {
-        removeEntry(index);
+      for (long i = index + 1; i <= log.lastKey(); i++) {
+        removeEntry(i);
       }
     }
   }
@@ -164,6 +164,7 @@ public class InMemoryLog extends BaseLog implements Compactable {
     kryo.writeClassAndObject(output, entry);
     byte[] bytes = output.toBytes();
     output.clear();
+    // TODO - calculate newSize by doing the lesser of subtracting out removed entries or adding remaining entries.
     log.headMap(index).clear();
     log.put(index, bytes);
     long newSize = 0;

--- a/copycat-core/src/main/java/net/kuujo/copycat/log/Log.java
+++ b/copycat-core/src/main/java/net/kuujo/copycat/log/Log.java
@@ -131,7 +131,7 @@ public interface Log {
   void removeEntry(long index);
 
   /**
-   * Removes all entries after the given index.
+   * Removes all entries after the given index, exclusive.
    *
    * @param index The index after which to remove entries.
    */

--- a/copycat-core/src/test/java/net/kuujo/copycat/LogTest.java
+++ b/copycat-core/src/test/java/net/kuujo/copycat/LogTest.java
@@ -251,7 +251,6 @@ public class LogTest {
     Assert.assertTrue(index == 5);
     if (log instanceof Compactable) {
       ((Compactable) log).compact(3, new SnapshotEntry(1, new ClusterConfig().withLocalMember(new Member("foo")).withRemoteMembers(new Member("bar"), new Member("baz")), "Hello world!".getBytes()));
-      Assert.assertTrue(log.size() == 3);
       Assert.assertTrue(log.firstIndex() == 3);
       Assert.assertTrue(log.lastIndex() == 5);
       SnapshotEntry entry = log.getEntry(3);
@@ -284,7 +283,6 @@ public class LogTest {
     Assert.assertTrue(index == 5);
     if (log instanceof Compactable) {
       ((Compactable) log).compact(5, new SnapshotEntry(1, new ClusterConfig().withLocalMember(new Member("foo")).withRemoteMembers(new Member("bar"), new Member("baz")), "Hello world!".getBytes()));
-      Assert.assertTrue(log.size() == 1);
       Assert.assertTrue(log.firstIndex() == 5);
       Assert.assertTrue(log.lastIndex() == 5);
       SnapshotEntry entry = log.getEntry(5);


### PR DESCRIPTION
Remove log size assertions from LogTest since size is measured in bytes.
