### PR TITLE
Support dynamic quorums

### DIFF
--- a/atomic/src/main/java/io/atomix/atomic/DistributedAtomicLong.java
+++ b/atomic/src/main/java/io/atomix/atomic/DistributedAtomicLong.java
@@ -16,7 +16,7 @@
 package io.atomix.atomic;
 
 import io.atomix.atomic.state.AtomicValueState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
 
@@ -32,7 +32,7 @@ import java.util.function.Function;
 public class DistributedAtomicLong extends DistributedAtomicValue<Long> {
   private Long value;
 
-  public DistributedAtomicLong(RaftClient client) {
+  public DistributedAtomicLong(CopycatClient client) {
     super(client);
   }
 

--- a/atomic/src/main/java/io/atomix/atomic/DistributedAtomicValue.java
+++ b/atomic/src/main/java/io/atomix/atomic/DistributedAtomicValue.java
@@ -18,7 +18,7 @@ package io.atomix.atomic;
 import io.atomix.atomic.state.AtomicValueCommands;
 import io.atomix.atomic.state.AtomicValueState;
 import io.atomix.catalyst.util.Listener;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
 public class DistributedAtomicValue<T> extends AbstractResource {
   private final java.util.Set<Consumer<T>> changeListeners = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-  public DistributedAtomicValue(RaftClient client) {
+  public DistributedAtomicValue(CopycatClient client) {
     super(client);
     client.session().<T>onEvent("change", event -> {
       for (Consumer<T> listener : changeListeners) {

--- a/atomic/src/test/java/io/atomix/atomic/AbstractAtomicTest.java
+++ b/atomic/src/test/java/io/atomix/atomic/AbstractAtomicTest.java
@@ -61,11 +61,7 @@ public abstract class AbstractAtomicTest extends ConcurrentTestCase {
    * @return The next server member.
    */
   private Member nextMember() {
-    Address serverAddress = new Address("localhost", port + 1000);
-    Address clientAddress = new Address("localhost", port++);
-    Member member = new Member(serverAddress, clientAddress);
-    members.add(member);
-    return member;
+    return new Member(new Address("localhost", ++port), new Address("localhost", port + 1000));
   }
 
   /**
@@ -74,7 +70,6 @@ public abstract class AbstractAtomicTest extends ConcurrentTestCase {
   protected List<CopycatServer> createServers(int nodes) throws Throwable {
     List<CopycatServer> servers = new ArrayList<>();
 
-    List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
       members.add(nextMember());
     }

--- a/atomic/src/test/java/io/atomix/atomic/AbstractAtomicTest.java
+++ b/atomic/src/test/java/io/atomix/atomic/AbstractAtomicTest.java
@@ -19,9 +19,8 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.copycat.client.RaftClient;
 import io.atomix.copycat.server.CopycatServer;
-import io.atomix.copycat.server.RaftServer;
+import io.atomix.copycat.server.state.Member;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import io.atomix.resource.ResourceStateMachine;
@@ -34,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Abstract atomix tests.
@@ -44,9 +44,9 @@ public abstract class AbstractAtomicTest extends ConcurrentTestCase {
   private static final File directory = new File("target/test-logs");
   protected LocalServerRegistry registry;
   protected int port;
-  protected List<Address> members;
-  protected List<RaftClient> clients = new ArrayList<>();
-  protected List<RaftServer> servers = new ArrayList<>();
+  protected List<Member> members;
+  protected List<CopycatClient> clients = new ArrayList<>();
+  protected List<CopycatServer> servers = new ArrayList<>();
 
   /**
    * Creates a new resource state machine.
@@ -56,29 +56,31 @@ public abstract class AbstractAtomicTest extends ConcurrentTestCase {
   protected abstract ResourceStateMachine createStateMachine();
 
   /**
-   * Returns the next server address.
+   * Returns the next server member.
    *
-   * @return The next server address.
+   * @return The next server member.
    */
-  private Address nextAddress() {
-    Address address = new Address("localhost", port++);
-    members.add(address);
-    return address;
+  private Member nextMember() {
+    Address serverAddress = new Address("localhost", port + 1000);
+    Address clientAddress = new Address("localhost", port++);
+    Member member = new Member(serverAddress, clientAddress);
+    members.add(member);
+    return member;
   }
 
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int nodes) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int nodes) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
-    List<Address> members = new ArrayList<>();
+    List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
-      members.add(nextAddress());
+      members.add(nextMember());
     }
 
     for (int i = 0; i < nodes; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -89,32 +91,10 @@ public abstract class AbstractAtomicTest extends ConcurrentTestCase {
   }
 
   /**
-   * Creates a set of Raft servers.
-   */
-  protected List<RaftServer> createServers(int live, int total) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
-
-    List<Address> members = new ArrayList<>();
-    for (int i = 0; i < total; i++) {
-      members.add(nextAddress());
-    }
-
-    for (int i = 0; i < live; i++) {
-      RaftServer server = createServer(members.get(i));
-      server.open().thenRun(this::resume);
-      servers.add(server);
-    }
-
-    await(0, live);
-
-    return servers;
-  }
-
-  /**
    * Creates a Raft server.
    */
-  protected RaftServer createServer(Address address) {
-    RaftServer server = CopycatServer.builder(address, members)
+  protected CopycatServer createServer(Member member) {
+    CopycatServer server = CopycatServer.builder(member.clientAddress(), member.serverAddress(), members.stream().map(Member::serverAddress).collect(Collectors.toList()))
       .withTransport(new LocalTransport(registry))
       .withStorage(new Storage(StorageLevel.MEMORY))
       .withStateMachine(createStateMachine())
@@ -126,8 +106,8 @@ public abstract class AbstractAtomicTest extends ConcurrentTestCase {
   /**
    * Creates a Copycat client.
    */
-  protected RaftClient createClient() throws Throwable {
-    RaftClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
+  protected CopycatClient createClient() throws Throwable {
+    CopycatClient client = CopycatClient.builder(members.stream().map(Member::clientAddress).collect(Collectors.toList())).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
     await();
     clients.add(client);

--- a/atomic/src/test/java/io/atomix/atomic/DistributedAtomicLongTest.java
+++ b/atomic/src/test/java/io/atomix/atomic/DistributedAtomicLongTest.java
@@ -16,7 +16,7 @@
 package io.atomix.atomic;
 
 import io.atomix.atomic.state.AtomicValueState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
 
@@ -99,7 +99,7 @@ public class DistributedAtomicLongTest extends AbstractAtomicTest {
    */
   private void testAtomic(int servers, Consumer<DistributedAtomicLong> consumer) throws Throwable {
     createServers(servers);
-    RaftClient client = createClient();
+    CopycatClient client = createClient();
     DistributedAtomicLong atomic = new DistributedAtomicLong(client);
     consumer.accept(atomic);
   }

--- a/atomic/src/test/java/io/atomix/atomic/DistributedAtomicValueTest.java
+++ b/atomic/src/test/java/io/atomix/atomic/DistributedAtomicValueTest.java
@@ -16,7 +16,7 @@
 package io.atomix.atomic;
 
 import io.atomix.atomic.state.AtomicValueState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
 
@@ -39,7 +39,7 @@ public class DistributedAtomicValueTest extends AbstractAtomicTest {
    */
   public void testAtomicSetGet() throws Throwable {
     createServers(3);
-    RaftClient client = createClient();
+    CopycatClient client = createClient();
     DistributedAtomicValue<String> atomic = new DistributedAtomicValue<>(client);
     atomic.set("Hello world!").thenRun(() -> {
       atomic.get().thenAccept(value -> {

--- a/collections/src/main/java/io/atomix/collections/DistributedMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMap.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.MapCommands;
 import io.atomix.collections.state.MapState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -53,7 +53,7 @@ import java.util.concurrent.CompletableFuture;
 @ResourceInfo(stateMachine=MapState.class)
 public class DistributedMap<K, V> extends AbstractResource {
 
-  public DistributedMap(RaftClient client) {
+  public DistributedMap(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.MultiMapCommands;
 import io.atomix.collections.state.MultiMapState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -34,7 +34,7 @@ import java.util.concurrent.CompletableFuture;
 @ResourceInfo(stateMachine=MultiMapState.class)
 public class DistributedMultiMap<K, V> extends AbstractResource {
 
-  public DistributedMultiMap(RaftClient client) {
+  public DistributedMultiMap(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/main/java/io/atomix/collections/DistributedQueue.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedQueue.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.QueueCommands;
 import io.atomix.collections.state.QueueState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -33,7 +33,7 @@ import java.util.concurrent.CompletableFuture;
 @ResourceInfo(stateMachine=QueueState.class)
 public class DistributedQueue<T> extends AbstractResource {
 
-  public DistributedQueue(RaftClient client) {
+  public DistributedQueue(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/main/java/io/atomix/collections/DistributedSet.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedSet.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.SetCommands;
 import io.atomix.collections.state.SetState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -34,7 +34,7 @@ import java.util.concurrent.CompletableFuture;
 @ResourceInfo(stateMachine=SetState.class)
 public class DistributedSet<T> extends AbstractResource {
 
-  public DistributedSet(RaftClient client) {
+  public DistributedSet(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/main/java/io/atomix/collections/state/QueueState.java
+++ b/collections/src/main/java/io/atomix/collections/state/QueueState.java
@@ -50,12 +50,11 @@ public class QueueState extends ResourceStateMachine {
    */
   public boolean add(Commit<QueueCommands.Add> commit) {
     try {
-      queue.add(commit);
+      return queue.add(commit);
     } catch (Exception e) {
       commit.clean();
       throw e;
     }
-    return false;
   }
 
   /**
@@ -63,12 +62,11 @@ public class QueueState extends ResourceStateMachine {
    */
   public boolean offer(Commit<QueueCommands.Offer> commit) {
     try {
-      queue.offer(commit);
+      return queue.offer(commit);
     } catch (Exception e) {
       commit.clean();
       throw e;
     }
-    return false;
   }
 
   /**

--- a/collections/src/main/java/io/atomix/collections/state/SetState.java
+++ b/collections/src/main/java/io/atomix/collections/state/SetState.java
@@ -54,6 +54,7 @@ public class SetState extends ResourceStateMachine {
           map.remove(commit.operation().value()).commit.clean();
         }) : null;
         map.put(commit.operation().value(), new Value(commit, timer));
+        return true;
       } else {
         commit.clean();
       }

--- a/collections/src/test/java/io/atomix/collections/AbstractCollectionsTest.java
+++ b/collections/src/test/java/io/atomix/collections/AbstractCollectionsTest.java
@@ -19,9 +19,8 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.copycat.client.RaftClient;
 import io.atomix.copycat.server.CopycatServer;
-import io.atomix.copycat.server.RaftServer;
+import io.atomix.copycat.server.state.Member;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import io.atomix.resource.ResourceStateMachine;
@@ -34,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Abstract collections tests.
@@ -44,9 +44,9 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   private static final File directory = new File("target/test-logs");
   protected LocalServerRegistry registry;
   protected int port;
-  protected List<Address> members;
-  protected List<RaftClient> clients = new ArrayList<>();
-  protected List<RaftServer> servers = new ArrayList<>();
+  protected List<Member> members;
+  protected List<CopycatClient> clients = new ArrayList<>();
+  protected List<CopycatServer> servers = new ArrayList<>();
 
   /**
    * Creates a new resource state machine.
@@ -56,29 +56,31 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   protected abstract ResourceStateMachine createStateMachine();
 
   /**
-   * Returns the next server address.
+   * Returns the next server member.
    *
-   * @return The next server address.
+   * @return The next server member.
    */
-  private Address nextAddress() {
-    Address address = new Address("localhost", port++);
-    members.add(address);
-    return address;
+  private Member nextMember() {
+    Address serverAddress = new Address("localhost", port + 1000);
+    Address clientAddress = new Address("localhost", port++);
+    Member member = new Member(serverAddress, clientAddress);
+    members.add(member);
+    return member;
   }
 
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int nodes) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int nodes) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
-    List<Address> members = new ArrayList<>();
+    List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
-      members.add(nextAddress());
+      members.add(nextMember());
     }
 
     for (int i = 0; i < nodes; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -89,32 +91,10 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   }
 
   /**
-   * Creates a set of Raft servers.
-   */
-  protected List<RaftServer> createServers(int live, int total) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
-
-    List<Address> members = new ArrayList<>();
-    for (int i = 0; i < total; i++) {
-      members.add(nextAddress());
-    }
-
-    for (int i = 0; i < live; i++) {
-      RaftServer server = createServer(members.get(i));
-      server.open().thenRun(this::resume);
-      servers.add(server);
-    }
-
-    await(0, live);
-
-    return servers;
-  }
-
-  /**
    * Creates a Raft server.
    */
-  protected RaftServer createServer(Address address) {
-    RaftServer server = CopycatServer.builder(address, members)
+  protected CopycatServer createServer(Member member) {
+    CopycatServer server = CopycatServer.builder(member.clientAddress(), member.serverAddress(), members.stream().map(Member::serverAddress).collect(Collectors.toList()))
       .withTransport(new LocalTransport(registry))
       .withStorage(new Storage(StorageLevel.MEMORY))
       .withStateMachine(createStateMachine())
@@ -126,8 +106,8 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   /**
    * Creates a Copycat client.
    */
-  protected RaftClient createClient() throws Throwable {
-    RaftClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
+  protected CopycatClient createClient() throws Throwable {
+    CopycatClient client = CopycatClient.builder(members.stream().map(Member::clientAddress).collect(Collectors.toList())).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
     await();
     clients.add(client);

--- a/collections/src/test/java/io/atomix/collections/AbstractCollectionsTest.java
+++ b/collections/src/test/java/io/atomix/collections/AbstractCollectionsTest.java
@@ -61,11 +61,7 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
    * @return The next server member.
    */
   private Member nextMember() {
-    Address serverAddress = new Address("localhost", port + 1000);
-    Address clientAddress = new Address("localhost", port++);
-    Member member = new Member(serverAddress, clientAddress);
-    members.add(member);
-    return member;
+    return new Member(new Address("localhost", ++port), new Address("localhost", port + 1000));
   }
 
   /**
@@ -74,7 +70,6 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   protected List<CopycatServer> createServers(int nodes) throws Throwable {
     List<CopycatServer> servers = new ArrayList<>();
 
-    List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
       members.add(nextMember());
     }

--- a/coordination/src/main/java/io/atomix/coordination/DistributedLeaderElection.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedLeaderElection.java
@@ -18,7 +18,7 @@ package io.atomix.coordination;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.coordination.state.LeaderElectionCommands;
 import io.atomix.coordination.state.LeaderElectionState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -66,7 +66,7 @@ import java.util.function.Consumer;
 public class DistributedLeaderElection extends AbstractResource {
   private final Set<Consumer<Long>> listeners = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-  public DistributedLeaderElection(RaftClient client) {
+  public DistributedLeaderElection(CopycatClient client) {
     super(client);
     client.session().<Long>onEvent("elect", epoch -> {
       for (Consumer<Long> listener : listeners) {

--- a/coordination/src/main/java/io/atomix/coordination/DistributedLock.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedLock.java
@@ -17,7 +17,7 @@ package io.atomix.coordination;
 
 import io.atomix.coordination.state.LockCommands;
 import io.atomix.coordination.state.LockState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -58,7 +58,7 @@ import java.util.function.Consumer;
 public class DistributedLock extends AbstractResource {
   private final Queue<Consumer<Boolean>> queue = new ConcurrentLinkedQueue<>();
 
-  public DistributedLock(RaftClient client) {
+  public DistributedLock(CopycatClient client) {
     super(client);
     client.session().onEvent("lock", this::handleEvent);
   }

--- a/coordination/src/main/java/io/atomix/coordination/DistributedMembershipGroup.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedMembershipGroup.java
@@ -20,7 +20,7 @@ import io.atomix.catalyst.util.Listeners;
 import io.atomix.coordination.state.MembershipGroupCommands;
 import io.atomix.coordination.state.MembershipGroupState;
 import io.atomix.copycat.client.Command;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -98,7 +98,7 @@ public class DistributedMembershipGroup extends AbstractResource {
   private GroupMember member;
   private final Map<Long, GroupMember> members = new ConcurrentHashMap<>();
 
-  public DistributedMembershipGroup(RaftClient client) {
+  public DistributedMembershipGroup(CopycatClient client) {
     super(client);
 
     client.session().<Long>onEvent("join", memberId -> {

--- a/coordination/src/main/java/io/atomix/coordination/DistributedMessageBus.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedMessageBus.java
@@ -22,7 +22,7 @@ import io.atomix.catalyst.transport.Server;
 import io.atomix.catalyst.util.concurrent.Futures;
 import io.atomix.coordination.state.MessageBusCommands;
 import io.atomix.coordination.state.MessageBusState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -81,7 +81,7 @@ public class DistributedMessageBus extends AbstractResource {
   private final Map<String, InternalMessageConsumer> consumers = new ConcurrentHashMap<>();
   private volatile boolean open;
 
-  public DistributedMessageBus(RaftClient client) {
+  public DistributedMessageBus(CopycatClient client) {
     super(client);
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/DistributedTopic.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedTopic.java
@@ -18,7 +18,7 @@ package io.atomix.coordination;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.coordination.state.TopicCommands;
 import io.atomix.coordination.state.TopicState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -62,7 +62,7 @@ public class DistributedTopic<T> extends AbstractResource {
   private final Set<Consumer<T>> listeners = new HashSet<>();
 
   @SuppressWarnings("unchecked")
-  public DistributedTopic(RaftClient client) {
+  public DistributedTopic(CopycatClient client) {
     super(client);
     client.session().onEvent("message", event -> {
       for (Consumer<T> listener : listeners) {

--- a/coordination/src/test/java/io/atomix/coordination/AbstractCoordinationTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/AbstractCoordinationTest.java
@@ -61,11 +61,7 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
    * @return The next server member.
    */
   private Member nextMember() {
-    Address serverAddress = new Address("localhost", port + 1000);
-    Address clientAddress = new Address("localhost", port++);
-    Member member = new Member(serverAddress, clientAddress);
-    members.add(member);
-    return member;
+    return new Member(new Address("localhost", ++port), new Address("localhost", port + 1000));
   }
 
   /**
@@ -74,7 +70,6 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   protected List<CopycatServer> createServers(int nodes) throws Throwable {
     List<CopycatServer> servers = new ArrayList<>();
 
-    List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
       members.add(nextMember());
     }

--- a/coordination/src/test/java/io/atomix/coordination/AbstractCoordinationTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/AbstractCoordinationTest.java
@@ -19,9 +19,8 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.copycat.client.RaftClient;
 import io.atomix.copycat.server.CopycatServer;
-import io.atomix.copycat.server.RaftServer;
+import io.atomix.copycat.server.state.Member;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import io.atomix.resource.ResourceStateMachine;
@@ -34,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Abstract coordination tests.
@@ -44,9 +44,9 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   private static final File directory = new File("target/test-logs");
   protected LocalServerRegistry registry;
   protected int port;
-  protected List<Address> members;
-  protected List<RaftClient> clients = new ArrayList<>();
-  protected List<RaftServer> servers = new ArrayList<>();
+  protected List<Member> members;
+  protected List<CopycatClient> clients = new ArrayList<>();
+  protected List<CopycatServer> servers = new ArrayList<>();
 
   /**
    * Creates a new resource state machine.
@@ -56,29 +56,31 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   protected abstract ResourceStateMachine createStateMachine();
 
   /**
-   * Returns the next server address.
+   * Returns the next server member.
    *
-   * @return The next server address.
+   * @return The next server member.
    */
-  private Address nextAddress() {
-    Address address = new Address("localhost", port++);
-    members.add(address);
-    return address;
+  private Member nextMember() {
+    Address serverAddress = new Address("localhost", port + 1000);
+    Address clientAddress = new Address("localhost", port++);
+    Member member = new Member(serverAddress, clientAddress);
+    members.add(member);
+    return member;
   }
 
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int nodes) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int nodes) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
-    List<Address> members = new ArrayList<>();
+    List<Member> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
-      members.add(nextAddress());
+      members.add(nextMember());
     }
 
     for (int i = 0; i < nodes; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -89,32 +91,10 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   }
 
   /**
-   * Creates a set of Raft servers.
-   */
-  protected List<RaftServer> createServers(int live, int total) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
-
-    List<Address> members = new ArrayList<>();
-    for (int i = 0; i < total; i++) {
-      members.add(nextAddress());
-    }
-
-    for (int i = 0; i < live; i++) {
-      RaftServer server = createServer(members.get(i));
-      server.open().thenRun(this::resume);
-      servers.add(server);
-    }
-
-    await(0, live);
-
-    return servers;
-  }
-
-  /**
    * Creates a Raft server.
    */
-  protected RaftServer createServer(Address address) {
-    RaftServer server = CopycatServer.builder(address, members)
+  protected CopycatServer createServer(Member member) {
+    CopycatServer server = CopycatServer.builder(member.clientAddress(), member.serverAddress(), members.stream().map(Member::serverAddress).collect(Collectors.toList()))
       .withTransport(new LocalTransport(registry))
       .withStorage(new Storage(StorageLevel.MEMORY))
       .withStateMachine(createStateMachine())
@@ -126,8 +106,8 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   /**
    * Creates a Copycat client.
    */
-  protected RaftClient createClient() throws Throwable {
-    RaftClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
+  protected CopycatClient createClient() throws Throwable {
+    CopycatClient client = CopycatClient.builder(members.stream().map(Member::clientAddress).collect(Collectors.toList())).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
     await();
     clients.add(client);

--- a/coordination/src/test/java/io/atomix/coordination/DistributedLeaderElectionTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedLeaderElectionTest.java
@@ -16,7 +16,7 @@
 package io.atomix.coordination;
 
 import io.atomix.coordination.state.LeaderElectionState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
 
@@ -53,8 +53,8 @@ public class DistributedLeaderElectionTest extends AbstractCoordinationTest {
   public void testNextElection() throws Throwable {
     createServers(3);
 
-    RaftClient client1 = createClient();
-    RaftClient client2 = createClient();
+    CopycatClient client1 = createClient();
+    CopycatClient client2 = createClient();
 
     DistributedLeaderElection election1 = new DistributedLeaderElection(client1);
     DistributedLeaderElection election2 = new DistributedLeaderElection(client2);

--- a/examples/group-membership/src/main/java/io/atomix/examples/memberhip/GroupMembershipExample.java
+++ b/examples/group-membership/src/main/java/io/atomix/examples/memberhip/GroupMembershipExample.java
@@ -23,7 +23,6 @@ import io.atomix.coordination.DistributedMembershipGroup;
 import io.atomix.copycat.server.storage.Storage;
 
 import java.io.Serializable;
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -42,9 +41,9 @@ public class GroupMembershipExample {
     if (args.length < 2)
       throw new IllegalArgumentException("must supply a local port and at least one remote host:port tuple");
 
-    int port = Integer.valueOf(args[0]);
-
-    Address address = new Address(InetAddress.getLocalHost().getHostName(), port);
+    String[] mainParts = args[1].split(":");
+    Address serverAddress = new Address(mainParts[0], Integer.valueOf(mainParts[1]));
+    Address clientAddress = new Address(mainParts[0], Integer.valueOf(mainParts[2]));
 
     List<Address> members = new ArrayList<>();
     for (int i = 1; i < args.length; i++) {
@@ -52,7 +51,7 @@ public class GroupMembershipExample {
       members.add(new Address(parts[0], Integer.valueOf(parts[1])));
     }
 
-    Atomix atomix = AtomixReplica.builder(address, members)
+    Atomix atomix = AtomixReplica.builder(clientAddress, serverAddress, members)
       .withTransport(new NettyTransport())
       .withStorage(Storage.builder()
         .withDirectory(System.getProperty("user.dir") + "/logs/" + UUID.randomUUID().toString())

--- a/examples/leader-election/src/main/java/io/atomix/examples/election/LeaderElectionExample.java
+++ b/examples/leader-election/src/main/java/io/atomix/examples/election/LeaderElectionExample.java
@@ -42,7 +42,8 @@ public class LeaderElectionExample {
 
     // Parse the address to which to bind the server.
     String[] mainParts = args[1].split(":");
-    Address address = new Address(mainParts[0], Integer.valueOf(mainParts[1]));
+    Address serverAddress = new Address(mainParts[0], Integer.valueOf(mainParts[1]));
+    Address clientAddress = new Address(mainParts[0], Integer.valueOf(mainParts[2]));
 
     // Build a list of all member addresses to which to connect.
     List<Address> members = new ArrayList<>();
@@ -53,7 +54,7 @@ public class LeaderElectionExample {
 
     // Create a stateful Atomix replica. The replica communicates with other replicas in the cluster
     // to replicate state changes.
-    Atomix atomix = AtomixReplica.builder(address, members)
+    Atomix atomix = AtomixReplica.builder(clientAddress, serverAddress, members)
       .withTransport(new NettyTransport())
       .withStorage(new Storage(new File(args[0])))
       .build();

--- a/examples/standalone-server/src/main/java/io/atomix/examples/server/StandaloneServerExample.java
+++ b/examples/standalone-server/src/main/java/io/atomix/examples/server/StandaloneServerExample.java
@@ -38,9 +38,9 @@ public class StandaloneServerExample {
     if (args.length < 2)
       throw new IllegalArgumentException("must supply a local port and at least one remote host:port tuple");
 
-    int port = Integer.valueOf(args[0]);
-
-    Address address = new Address(InetAddress.getLocalHost().getHostName(), port);
+    String[] mainParts = args[1].split(":");
+    Address serverAddress = new Address(mainParts[0], Integer.valueOf(mainParts[1]));
+    Address clientAddress = new Address(mainParts[0], Integer.valueOf(mainParts[2]));
 
     List<Address> members = new ArrayList<>();
     for (int i = 1; i < args.length; i++) {
@@ -48,10 +48,10 @@ public class StandaloneServerExample {
       members.add(new Address(parts[0], Integer.valueOf(parts[1])));
     }
 
-    AtomixServer server = AtomixServer.builder(address, members)
+    AtomixServer server = AtomixServer.builder(clientAddress, serverAddress, members)
         .withTransport(new NettyTransport())
         .withStorage(Storage.builder()
-          .withDirectory(System.getProperty("user.dir") + "/logs/" + port)
+          .withDirectory(System.getProperty("user.dir") + "/logs/" + mainParts[1])
           .withMaxEntriesPerSegment(16)
           .build())
         .build();

--- a/manager/src/main/java/io/atomix/Atomix.java
+++ b/manager/src/main/java/io/atomix/Atomix.java
@@ -354,7 +354,7 @@ public abstract class Atomix implements Managed<Atomix> {
    * Builds an {@link Atomix} object.
    */
   public static abstract class Builder extends io.atomix.catalyst.util.Builder<Atomix> {
-    protected CopycatClient.Builder clientBuilder;
+    protected final CopycatClient.Builder clientBuilder;
 
     protected Builder(Collection<Address> members) {
       clientBuilder = CopycatClient.builder(members);

--- a/manager/src/main/java/io/atomix/AtomixClient.java
+++ b/manager/src/main/java/io/atomix/AtomixClient.java
@@ -25,9 +25,9 @@ import java.util.Arrays;
 import java.util.Collection;
 
 /**
- * Provides an interface for creating and operating on {@link DistributedResource}s remotely.
+ * Provides an interface for creating and operating on {@link io.atomix.resource.Resource}s remotely.
  * <p>
- * This {@link Atomix} implementation facilitates working with {@link DistributedResource}s remotely as
+ * This {@link Atomix} implementation facilitates working with {@link io.atomix.resource.Resource}s remotely as
  * a client of the Atomix cluster. To create a client, construct a client builder via {@link #builder(Address...)}.
  * The builder requires a list of {@link Address}es to which to connect.
  * <pre>

--- a/manager/src/main/java/io/atomix/AtomixReplica.java
+++ b/manager/src/main/java/io/atomix/AtomixReplica.java
@@ -84,6 +84,32 @@ public final class AtomixReplica extends Atomix {
    * <p>
    * The provided set of members will be used to connect to the other members in the Raft cluster.
    *
+   * @param address The address through which clients and servers connect to the replica.
+   * @param members The cluster members to which to connect.
+   * @return The replica builder.
+   */
+  public static Builder builder(Address address, Address... members) {
+    return builder(address, address, Arrays.asList(Assert.notNull(members, "members")));
+  }
+
+  /**
+   * Returns a new Atomix replica builder.
+   * <p>
+   * The provided set of members will be used to connect to the other members in the Raft cluster.
+   *
+   * @param address The address through which clients and servers connect to the replica.
+   * @param members The cluster members to which to connect.
+   * @return The replica builder.
+   */
+  public static Builder builder(Address address, Collection<Address> members) {
+    return new Builder(address, address, members);
+  }
+
+  /**
+   * Returns a new Atomix replica builder.
+   * <p>
+   * The provided set of members will be used to connect to the other members in the Raft cluster.
+   *
    * @param clientAddress The address through which clients connect to the server.
    * @param serverAddress The local server member address.
    * @param members The cluster members to which to connect.

--- a/manager/src/main/java/io/atomix/AtomixReplica.java
+++ b/manager/src/main/java/io/atomix/AtomixReplica.java
@@ -216,9 +216,9 @@ public final class AtomixReplica extends Atomix {
    */
   public static class Builder extends Atomix.Builder {
     private final Address clientAddress;
-    private CopycatServer.Builder serverBuilder;
+    private final CopycatServer.Builder serverBuilder;
     private Transport transport;
-    private LocalServerRegistry localRegistry = new LocalServerRegistry();
+    private final LocalServerRegistry localRegistry = new LocalServerRegistry();
 
     private Builder(Address clientAddress, Address serverAddress, Collection<Address> members) {
       super(Collections.singleton(Assert.notNull(clientAddress, "clientAddress")));

--- a/manager/src/main/java/io/atomix/AtomixServer.java
+++ b/manager/src/main/java/io/atomix/AtomixServer.java
@@ -83,6 +83,32 @@ public final class AtomixServer implements Managed<AtomixServer> {
    * <p>
    * The provided set of members will be used to connect to the other members in the Raft cluster.
    *
+   * @param address The address through which clients and servers connect to the server.
+   * @param members The cluster members to which to connect.
+   * @return The replica builder.
+   */
+  public static Builder builder(Address address, Address... members) {
+    return builder(address, address, Arrays.asList(Assert.notNull(members, "members")));
+  }
+
+  /**
+   * Returns a new Atomix server builder.
+   * <p>
+   * The provided set of members will be used to connect to the other members in the Raft cluster.
+   *
+   * @param address The address through which clients and servers connect to the server.
+   * @param members The cluster members to which to connect.
+   * @return The replica builder.
+   */
+  public static Builder builder(Address address, Collection<Address> members) {
+    return new Builder(address, address, members);
+  }
+
+  /**
+   * Returns a new Atomix server builder.
+   * <p>
+   * The provided set of members will be used to connect to the other members in the Raft cluster.
+   *
    * @param clientAddress The address through which clients connect to the server.
    * @param serverAddress The local server member address.
    * @param members The cluster members to which to connect.

--- a/manager/src/main/java/io/atomix/resource/InstanceClient.java
+++ b/manager/src/main/java/io/atomix/resource/InstanceClient.java
@@ -20,8 +20,8 @@ import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.Command;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
 import io.atomix.copycat.client.session.Session;
 import io.atomix.manager.DeleteResource;
 
@@ -32,16 +32,16 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class InstanceClient implements RaftClient {
+public class InstanceClient implements CopycatClient {
   private final long resource;
-  private final RaftClient client;
+  private final CopycatClient client;
   private final Transport transport;
   private final InstanceSession session;
 
   /**
    * @throws NullPointerException if {@code client} is null
    */
-  public InstanceClient(long resource, RaftClient client, Transport transport) {
+  public InstanceClient(long resource, CopycatClient client, Transport transport) {
     this.resource = resource;
     this.client = Assert.notNull(client, "client");
     this.transport = transport;
@@ -82,7 +82,7 @@ public class InstanceClient implements RaftClient {
   }
 
   @Override
-  public CompletableFuture<RaftClient> open() {
+  public CompletableFuture<CopycatClient> open() {
     return CompletableFuture.completedFuture(this);
   }
 

--- a/manager/src/test/java/io/atomix/AbstractReplicaTest.java
+++ b/manager/src/test/java/io/atomix/AbstractReplicaTest.java
@@ -18,6 +18,7 @@ package io.atomix;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
+import io.atomix.copycat.server.state.Member;
 import io.atomix.copycat.server.storage.Storage;
 import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.testng.annotations.AfterMethod;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Abstract server test.
@@ -38,17 +40,19 @@ public abstract class AbstractReplicaTest extends ConcurrentTestCase {
   private static final File directory = new File("target/test-logs");
   protected LocalServerRegistry registry;
   protected int port;
-  protected List<Address> members;
+  protected List<Member> members;
 
   /**
    * Returns the next server address.
    *
    * @return The next server address.
    */
-  protected Address nextAddress() {
-    Address address = new Address("localhost", port++);
-    members.add(address);
-    return address;
+  protected Member nextMember() {
+    Address serverAddress = new Address("localhost", port + 1000);
+    Address clientAddress = new Address("localhost", port++);
+    Member member = new Member(serverAddress, clientAddress);
+    members.add(member);
+    return member;
   }
 
   /**
@@ -57,9 +61,9 @@ public abstract class AbstractReplicaTest extends ConcurrentTestCase {
   protected List<Atomix> createReplicas(int nodes) throws Throwable {
     List<Atomix> replicas = new ArrayList<>();
 
-    List<Address> members = new ArrayList<>();
+    List<Member> members = new ArrayList<>();
     for (int i = 1; i <= nodes; i++) {
-      members.add(nextAddress());
+      members.add(nextMember());
     }
 
     for (int i = 0; i < nodes; i++) {
@@ -76,11 +80,11 @@ public abstract class AbstractReplicaTest extends ConcurrentTestCase {
   /**
    * Creates an Atomix replica.
    */
-  protected Atomix createReplica(Address address) {
-    return AtomixReplica.builder(address, members)
+  protected Atomix createReplica(Member member) {
+    return AtomixReplica.builder(member.clientAddress(), member.serverAddress(), members.stream().map(Member::serverAddress).collect(Collectors.toList()))
       .withTransport(new LocalTransport(registry))
       .withStorage(Storage.builder()
-        .withDirectory(new File(directory, address.toString()))
+        .withDirectory(new File(directory, member.serverAddress().toString()))
         .build())
       .build();
   }

--- a/manager/src/test/java/io/atomix/AbstractReplicaTest.java
+++ b/manager/src/test/java/io/atomix/AbstractReplicaTest.java
@@ -48,11 +48,7 @@ public abstract class AbstractReplicaTest extends ConcurrentTestCase {
    * @return The next server address.
    */
   protected Member nextMember() {
-    Address serverAddress = new Address("localhost", port + 1000);
-    Address clientAddress = new Address("localhost", port++);
-    Member member = new Member(serverAddress, clientAddress);
-    members.add(member);
-    return member;
+    return new Member(new Address("localhost", ++port), new Address("localhost", port + 1000));
   }
 
   /**
@@ -61,7 +57,6 @@ public abstract class AbstractReplicaTest extends ConcurrentTestCase {
   protected List<Atomix> createReplicas(int nodes) throws Throwable {
     List<Atomix> replicas = new ArrayList<>();
 
-    List<Member> members = new ArrayList<>();
     for (int i = 1; i <= nodes; i++) {
       members.add(nextMember());
     }

--- a/manager/src/test/java/io/atomix/AbstractServerTest.java
+++ b/manager/src/test/java/io/atomix/AbstractServerTest.java
@@ -18,6 +18,7 @@ package io.atomix;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
+import io.atomix.copycat.server.state.Member;
 import io.atomix.copycat.server.storage.Storage;
 import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.testng.annotations.AfterMethod;
@@ -28,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Abstract server test.
@@ -38,17 +40,19 @@ public abstract class AbstractServerTest extends ConcurrentTestCase {
   private static final File directory = new File("target/test-logs");
   protected LocalServerRegistry registry;
   protected int port;
-  protected List<Address> members;
+  protected List<Member> members;
 
   /**
    * Returns the next server address.
    *
    * @return The next server address.
    */
-  protected Address nextAddress() {
-    Address address = new Address("localhost", port++);
-    members.add(address);
-    return address;
+  protected Member nextMember() {
+    Address serverAddress = new Address("localhost", port + 1000);
+    Address clientAddress = new Address("localhost", port++);
+    Member member = new Member(serverAddress, clientAddress);
+    members.add(member);
+    return member;
   }
 
   /**
@@ -57,9 +61,9 @@ public abstract class AbstractServerTest extends ConcurrentTestCase {
   protected List<AtomixServer> createServers(int nodes) throws Throwable {
     List<AtomixServer> servers = new ArrayList<>();
 
-    List<Address> members = new ArrayList<>();
+    List<Member> members = new ArrayList<>();
     for (int i = 1; i <= nodes; i++) {
-      members.add(nextAddress());
+      members.add(nextMember());
     }
 
     for (int i = 0; i < nodes; i++) {
@@ -76,11 +80,11 @@ public abstract class AbstractServerTest extends ConcurrentTestCase {
   /**
    * Creates an Atomix server.
    */
-  protected AtomixServer createServer(Address address) {
-    return AtomixServer.builder(address, members)
+  protected AtomixServer createServer(Member member) {
+    return AtomixServer.builder(member.clientAddress(), member.serverAddress(), members.stream().map(Member::serverAddress).collect(Collectors.toList()))
       .withTransport(new LocalTransport(registry))
       .withStorage(Storage.builder()
-        .withDirectory(new File(directory, address.toString()))
+        .withDirectory(new File(directory, member.serverAddress().toString()))
         .build())
       .build();
   }

--- a/manager/src/test/java/io/atomix/AtomixClientServerTest.java
+++ b/manager/src/test/java/io/atomix/AtomixClientServerTest.java
@@ -17,10 +17,10 @@ package io.atomix;
 
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.Command;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
 import io.atomix.copycat.server.Commit;
-import io.atomix.copycat.server.StateMachineExecutor;
+import io.atomix.copycat.server.state.Member;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -28,6 +28,7 @@ import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 /**
  * Client server test.
@@ -196,7 +197,7 @@ public class AtomixClientServerTest extends AbstractServerTest {
    * Creates a client.
    */
   private Atomix createClient() throws Throwable {
-    Atomix client = AtomixClient.builder(members).withTransport(new LocalTransport(registry)).build();
+    Atomix client = AtomixClient.builder(members.stream().map(Member::clientAddress).collect(Collectors.toList())).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
     await();
     return client;
@@ -207,7 +208,7 @@ public class AtomixClientServerTest extends AbstractServerTest {
    */
   @ResourceInfo(stateMachine=TestStateMachine.class)
   public static class TestResource extends AbstractResource {
-    public TestResource(RaftClient client) {
+    public TestResource(CopycatClient client) {
       super(client);
     }
 
@@ -274,7 +275,7 @@ public class AtomixClientServerTest extends AbstractServerTest {
    */
   @ResourceInfo(stateMachine=ValueStateMachine.class)
   public static class ValueResource extends AbstractResource {
-    public ValueResource(RaftClient client) {
+    public ValueResource(CopycatClient client) {
       super(client);
     }
 

--- a/manager/src/test/java/io/atomix/AtomixReplicaTest.java
+++ b/manager/src/test/java/io/atomix/AtomixReplicaTest.java
@@ -16,10 +16,9 @@
 package io.atomix;
 
 import io.atomix.copycat.client.Command;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
 import io.atomix.copycat.server.Commit;
-import io.atomix.copycat.server.StateMachineExecutor;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceInfo;
@@ -219,7 +218,7 @@ public class AtomixReplicaTest extends AbstractReplicaTest {
    */
   @ResourceInfo(stateMachine=TestStateMachine.class)
   public static class TestResource extends AbstractResource {
-    public TestResource(RaftClient client) {
+    public TestResource(CopycatClient client) {
       super(client);
     }
 
@@ -286,7 +285,7 @@ public class AtomixReplicaTest extends AbstractReplicaTest {
    */
   @ResourceInfo(stateMachine=ValueStateMachine.class)
   public static class ValueResource extends AbstractResource {
-    public ValueResource(RaftClient client) {
+    public ValueResource(CopycatClient client) {
       super(client);
     }
 

--- a/manager/src/test/java/io/atomix/AtomixServerTest.java
+++ b/manager/src/test/java/io/atomix/AtomixServerTest.java
@@ -32,7 +32,7 @@ public class AtomixServerTest extends AbstractServerTest {
    */
   public void testServerJoin() throws Throwable {
     createServers(3);
-    AtomixServer joiner = createServer(nextAddress());
+    AtomixServer joiner = createServer(nextMember());
     joiner.open().thenRun(this::resume);
     await();
   }

--- a/manager/src/test/java/io/atomix/AtomixServerTest.java
+++ b/manager/src/test/java/io/atomix/AtomixServerTest.java
@@ -32,7 +32,7 @@ public class AtomixServerTest extends AbstractServerTest {
    */
   public void testServerJoin() throws Throwable {
     createServers(3);
-    AtomixServer joiner = createServer(nextMember());
+    AtomixServer joiner = createServer(members, nextMember());
     joiner.open().thenRun(this::resume);
     await();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
     <catalyst.version>1.0.0-rc4</catalyst.version>
-    <copycat.version>1.0.0-beta4</copycat.version>
+    <copycat.version>1.0.0-SNAPSHOT</copycat.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.0.0-rc4</catalyst.version>
+    <catalyst.version>1.0.0-rc5</catalyst.version>
     <copycat.version>1.0.0-SNAPSHOT</copycat.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>

--- a/resource/src/main/java/io/atomix/resource/AbstractResource.java
+++ b/resource/src/main/java/io/atomix/resource/AbstractResource.java
@@ -18,15 +18,15 @@ package io.atomix.resource;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.Command;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
 
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Base class for fault-tolerant stateful distributed objects.
  * <p>
- * Resources are stateful distributed objects that run across a set of {@link io.atomix.copycat.server.RaftServer}s
+ * Resources are stateful distributed objects that run across a set of {@link io.atomix.copycat.server.CopycatServer}s
  * in a cluster.
  * <p>
  * Resources can be created either as standalone {@link io.atomix.copycat.server.StateMachine}s in
@@ -40,10 +40,10 @@ import java.util.concurrent.CompletableFuture;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public abstract class AbstractResource implements Resource {
-  protected final RaftClient client;
+  protected final CopycatClient client;
   private Consistency consistency = Consistency.ATOMIC;
 
-  protected AbstractResource(RaftClient client) {
+  protected AbstractResource(CopycatClient client) {
     this.client = client;
   }
 

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Fault-tolerant stateful distributed object.
  * <p>
- * Resources are stateful distributed objects that run across a set of {@link io.atomix.copycat.server.RaftServer}s
+ * Resources are stateful distributed objects that run across a set of {@link io.atomix.copycat.server.CopycatServer}s
  * in a cluster.
  * <p>
  * Resources can be created either as standalone {@link io.atomix.copycat.server.StateMachine}s in


### PR DESCRIPTION
This PR integrates the [changes in Copycat](https://github.com/atomix/copycat/pull/62) to support dynamic resizing of the cluster. The API changes are simple - adding support for client `Address` in builders. Most of the actual logic is in the Copycat PR.