### PR TITLE
Fix issue that main thread doesn't wait for completion of assertion

### DIFF
--- a/atomic/src/test/java/io/atomix/atomic/DistributedAtomicLongTest.java
+++ b/atomic/src/test/java/io/atomix/atomic/DistributedAtomicLongTest.java
@@ -102,6 +102,7 @@ public class DistributedAtomicLongTest extends AbstractAtomicTest {
     RaftClient client = createClient();
     DistributedAtomicLong atomic = new DistributedAtomicLong(client);
     consumer.accept(atomic);
+    await();
   }
 
 }


### PR DESCRIPTION
I found the main thread doesn't wait for completion of the assertion in DistributedAtomicLongTest. It causes all tests always pass without verifying assertions.