### PR TITLE
Ensure locks are released when sessions are closed

### DIFF
--- a/coordination/src/test/java/io/atomix/coordination/DistributedLockTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedLockTest.java
@@ -16,6 +16,7 @@
 package io.atomix.coordination;
 
 import io.atomix.coordination.state.LockState;
+import io.atomix.copycat.client.RaftClient;
 import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
 
@@ -44,6 +45,26 @@ public class DistributedLockTest extends AbstractCoordinationTest {
     await();
 
     lock.unlock().thenRun(this::resume);
+    await();
+  }
+
+  /**
+   * Tests releasing a lock when the client's session is closed.
+   */
+  public void testReleaseOnClose() throws Throwable {
+    createServers(3);
+
+    RaftClient client1 = createClient();
+    RaftClient client2 = createClient();
+
+    DistributedLock lock1 = new DistributedLock(client1);
+    DistributedLock lock2 = new DistributedLock(client2);
+
+    lock1.lock().thenRun(this::resume);
+    await();
+
+    lock2.lock().thenRun(this::resume);
+    client1.close();
     await();
   }
 


### PR DESCRIPTION
This PR addresses a *critical bug* in `LockState` wherein locks were never released in the event that a client's session was closed while it held a lock. The fix is to add a `close` method to `LockState` to release the lock of a closed session and grant the lock to the next commit in the queue.