### PR TITLE
Support for listing created resources

### DIFF
--- a/manager/src/main/java/io/atomix/Atomix.java
+++ b/manager/src/main/java/io/atomix/Atomix.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -198,6 +199,64 @@ public abstract class Atomix implements Managed<Atomix> {
    */
   public <T extends Resource> CompletableFuture<T> get(String key, Class<? super T> type, Function<RaftClient, T> factory) {
     return this.factory.get(key, type, factory);
+  }
+
+  /**
+   * Returns keys of all existing resources.
+   *
+   * <p>
+   * This method returns a {@link CompletableFuture} which can be used to block until the operation completes
+   * or to be notified in a separate thread once the operation completes. To block until the operation completes,
+   * use the {@link CompletableFuture#get()} method:
+   * <pre>
+   *   {@code
+   *   Collection<String> resourceKeys = atomix.keys().get();
+   *   }
+   * </pre>
+   * Alternatively, to execute the operation asynchronous and be notified once the result is received in a different
+   * thread, use one of the many completable future callbacks:
+   * <pre>
+   *   {@code
+   *   atomix.<Collection<String>>keys().thenAccept(resourceKeys -> {
+   *     ...
+   *   });
+   *   }
+   * </pre>
+   *
+   * @return A completable future to be completed with the keys of all existing resources.
+   */
+  public CompletableFuture<Set<String>> keys() {
+    return this.factory.keys();
+  }
+
+  /**
+   * Returns the keys of existing resources belonging to a resource type.
+   *
+   * <p>
+   * This method returns a {@link CompletableFuture} which can be used to block until the operation completes
+   * or to be notified in a separate thread once the operation completes. To block until the operation completes,
+   * use the {@link CompletableFuture#get()} method:
+   * <pre>
+   *   {@code
+   *   Set<String> resourceKeys = atomix.keys(DistributedLock.class).get();
+   *   }
+   * </pre>
+   * Alternatively, to execute the operation asynchronous and be notified once the result is received in a different
+   * thread, use one of the many completable future callbacks:
+   * <pre>
+   *   {@code
+   *   atomix.<Set<String>>keys().thenAccept(resourceKeys -> {
+   *     ...
+   *   });
+   *   }
+   * </pre>
+   *
+   * @param type The resource type by which to filter resources.
+   * @param <T> The resource type.
+   * @return A completable future to be completed with the set of resource keys.
+   */
+  public <T extends Resource> CompletableFuture<Set<String>> keys(Class<? super T> type) {
+    return this.factory.keys(type);
   }
 
   /**

--- a/manager/src/main/java/io/atomix/manager/GetResourceKeys.java
+++ b/manager/src/main/java/io/atomix/manager/GetResourceKeys.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.manager;
+
+import java.util.Set;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.SerializationException;
+import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.copycat.client.Query;
+import io.atomix.resource.ResourceStateMachine;
+
+/**
+ * Get resource keys query.
+ */
+@SerializeWith(id=41)
+public class GetResourceKeys implements Query<Set<String>>, CatalystSerializable {
+
+  Class<? extends ResourceStateMachine> type;
+
+  public GetResourceKeys() {
+    type = null;
+  }
+
+  public GetResourceKeys(Class<? extends ResourceStateMachine> type) {
+    this.type = type;
+  }
+
+  /**
+   * Returns the resource state machine class.
+   *
+   * @return The resource state machine class
+   */
+  public Class<? extends ResourceStateMachine> type() {
+    return type;
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    if (type == null) {
+      buffer.writeInt(0);
+    } else {
+      buffer.writeInt(type.getName().getBytes().length).write(type.getName().getBytes());
+    }
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    int classNameSize = buffer.readInt();
+    if (classNameSize == 0) {
+      type = null;
+      return;
+    }
+    byte[] bytes = new byte[classNameSize];
+    buffer.read(bytes);
+    String typeName = new String(bytes);
+    try {
+      type = (Class<? extends ResourceStateMachine>) Class.forName(typeName);
+    } catch (ClassNotFoundException e) {
+      throw new SerializationException(e);
+    }
+  }
+}

--- a/manager/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/manager/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -23,3 +23,4 @@ io.atomix.manager.CreateResource
 io.atomix.manager.CreateResourceIfExists
 io.atomix.manager.DeleteResource
 io.atomix.manager.ResourceExists
+io.atomix.manager.GetResourceKeys

--- a/manager/src/test/java/io/atomix/AtomixClientServerTest.java
+++ b/manager/src/test/java/io/atomix/AtomixClientServerTest.java
@@ -192,6 +192,46 @@ public class AtomixClientServerTest extends AbstractServerTest {
   }
 
   /**
+   * Tests getting resource keys.
+   */
+  public void testGetResourceKeys() throws Throwable {
+    createServers(5);
+    Atomix client = createClient();
+
+    client.keys().thenAccept(result -> {
+      threadAssertTrue(result.isEmpty());
+      resume();
+    });
+    await();
+
+    client.create("test", TestResource.class).get();
+    client.keys().thenAccept(result -> {
+      threadAssertTrue(result.size() == 1 && result.contains("test"));
+      resume();
+    });
+    await();
+
+    client.create("value", ValueResource.class).get();
+    client.keys().thenAccept(result -> {
+      threadAssertTrue(result.size() == 2 && result.contains("test") && result.contains("value"));
+      resume();
+    });
+    await();
+
+    client.keys(TestResource.class).thenAccept(result -> {
+      threadAssertTrue(result.size() == 1 && result.contains("test"));
+      resume();
+    });
+    await();
+
+    client.keys(ValueResource.class).thenAccept(result -> {
+      threadAssertTrue(result.size() == 1 && result.contains("value"));
+      resume();
+    });
+    await();
+  }
+
+  /**
    * Creates a client.
    */
   private Atomix createClient() throws Throwable {


### PR DESCRIPTION
(#59) Adds `Atomix#keys()` method to get a listing of resource keys. A variant of this method takes the resource type as input parameter and returns relevant resource keys.
