### PR TITLE
Update Atomix usage of Copycat APIs

### DIFF
--- a/collections/src/main/java/io/atomix/collections/DistributedMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMap.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.MapCommands;
 import io.atomix.collections.state.MapState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -51,7 +51,7 @@ import java.util.concurrent.CompletableFuture;
 public class DistributedMap<K, V> extends Resource {
   public static final ResourceType<DistributedMap> TYPE = new ResourceType<>(DistributedMap.class);
 
-  public DistributedMap(RaftClient client) {
+  public DistributedMap(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.MultiMapCommands;
 import io.atomix.collections.state.MultiMapState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletableFuture;
 public class DistributedMultiMap<K, V> extends Resource {
   public static final ResourceType<DistributedMultiMap> TYPE = new ResourceType<>(DistributedMultiMap.class);
 
-  public DistributedMultiMap(RaftClient client) {
+  public DistributedMultiMap(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/main/java/io/atomix/collections/DistributedQueue.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedQueue.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.QueueCommands;
 import io.atomix.collections.state.QueueState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
 public class DistributedQueue<T> extends Resource {
   public static final ResourceType<DistributedQueue> TYPE = new ResourceType<>(DistributedQueue.class);
 
-  public DistributedQueue(RaftClient client) {
+  public DistributedQueue(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/main/java/io/atomix/collections/DistributedSet.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedSet.java
@@ -17,7 +17,7 @@ package io.atomix.collections;
 
 import io.atomix.collections.state.SetCommands;
 import io.atomix.collections.state.SetState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -36,7 +36,7 @@ import java.util.concurrent.CompletableFuture;
 public class DistributedSet<T> extends Resource {
   public static final ResourceType<DistributedSet> TYPE = new ResourceType<>(DistributedSet.class);
 
-  public DistributedSet(RaftClient client) {
+  public DistributedSet(CopycatClient client) {
     super(client);
   }
 

--- a/collections/src/test/java/io/atomix/collections/AbstractCollectionsTest.java
+++ b/collections/src/test/java/io/atomix/collections/AbstractCollectionsTest.java
@@ -19,9 +19,9 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.server.CopycatServer;
-import io.atomix.copycat.server.RaftServer;
+import io.atomix.copycat.server.CopycatServer;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import io.atomix.resource.ResourceStateMachine;
@@ -45,8 +45,8 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   protected LocalServerRegistry registry;
   protected int port;
   protected List<Address> members;
-  protected List<RaftClient> clients = new ArrayList<>();
-  protected List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatClient> clients = new ArrayList<>();
+  protected List<CopycatServer> servers = new ArrayList<>();
 
   /**
    * Creates a new resource state machine.
@@ -69,8 +69,8 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int nodes) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int nodes) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
     List<Address> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
@@ -78,7 +78,7 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
     }
 
     for (int i = 0; i < nodes; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -91,8 +91,8 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int live, int total) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int live, int total) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
     List<Address> members = new ArrayList<>();
     for (int i = 0; i < total; i++) {
@@ -100,7 +100,7 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
     }
 
     for (int i = 0; i < live; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -113,8 +113,8 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   /**
    * Creates a Raft server.
    */
-  protected RaftServer createServer(Address address) {
-    RaftServer server = CopycatServer.builder(address, members)
+  protected CopycatServer createServer(Address address) {
+    CopycatServer server = CopycatServer.builder(address, members)
       .withTransport(new LocalTransport(registry))
       .withStorage(new Storage(StorageLevel.MEMORY))
       .withStateMachine(createStateMachine())
@@ -126,8 +126,8 @@ public abstract class AbstractCollectionsTest extends ConcurrentTestCase {
   /**
    * Creates a Copycat client.
    */
-  protected RaftClient createClient() throws Throwable {
-    RaftClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
+  protected CopycatClient createClient() throws Throwable {
+    CopycatClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
     await();
     clients.add(client);

--- a/coordination/src/main/java/io/atomix/coordination/DistributedLeaderElection.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedLeaderElection.java
@@ -18,7 +18,7 @@ package io.atomix.coordination;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.coordination.state.LeaderElectionCommands;
 import io.atomix.coordination.state.LeaderElectionState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -69,7 +69,7 @@ public class DistributedLeaderElection extends Resource {
 
   private final Set<Consumer<Long>> listeners = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-  public DistributedLeaderElection(RaftClient client) {
+  public DistributedLeaderElection(CopycatClient client) {
     super(client);
     client.session().<Long>onEvent("elect", epoch -> {
       for (Consumer<Long> listener : listeners) {

--- a/coordination/src/main/java/io/atomix/coordination/DistributedLock.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedLock.java
@@ -17,7 +17,7 @@ package io.atomix.coordination;
 
 import io.atomix.coordination.state.LockCommands;
 import io.atomix.coordination.state.LockState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -61,7 +61,7 @@ public class DistributedLock extends Resource {
 
   private final Queue<Consumer<Boolean>> queue = new ConcurrentLinkedQueue<>();
 
-  public DistributedLock(RaftClient client) {
+  public DistributedLock(CopycatClient client) {
     super(client);
     client.session().onEvent("lock", this::handleEvent);
   }

--- a/coordination/src/main/java/io/atomix/coordination/DistributedMembershipGroup.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedMembershipGroup.java
@@ -20,7 +20,7 @@ import io.atomix.catalyst.util.Listeners;
 import io.atomix.coordination.state.MembershipGroupCommands;
 import io.atomix.coordination.state.MembershipGroupState;
 import io.atomix.copycat.client.Command;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -101,7 +101,7 @@ public class DistributedMembershipGroup extends Resource {
   private GroupMember member;
   private final Map<Long, GroupMember> members = new ConcurrentHashMap<>();
 
-  public DistributedMembershipGroup(RaftClient client) {
+  public DistributedMembershipGroup(CopycatClient client) {
     super(client);
 
     client.session().<Long>onEvent("join", memberId -> {

--- a/coordination/src/main/java/io/atomix/coordination/DistributedMessageBus.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedMessageBus.java
@@ -22,7 +22,7 @@ import io.atomix.catalyst.transport.Server;
 import io.atomix.catalyst.util.concurrent.Futures;
 import io.atomix.coordination.state.MessageBusCommands;
 import io.atomix.coordination.state.MessageBusState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -83,7 +83,7 @@ public class DistributedMessageBus extends Resource {
   private final Map<String, InternalMessageConsumer> consumers = new ConcurrentHashMap<>();
   private volatile boolean open;
 
-  public DistributedMessageBus(RaftClient client) {
+  public DistributedMessageBus(CopycatClient client) {
     super(client);
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/DistributedTopic.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedTopic.java
@@ -18,7 +18,7 @@ package io.atomix.coordination;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.coordination.state.TopicCommands;
 import io.atomix.coordination.state.TopicState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
@@ -65,7 +65,7 @@ public class DistributedTopic<T> extends Resource {
   private final Set<Consumer<T>> listeners = new HashSet<>();
 
   @SuppressWarnings("unchecked")
-  public DistributedTopic(RaftClient client) {
+  public DistributedTopic(CopycatClient client) {
     super(client);
     client.session().onEvent("message", event -> {
       for (Consumer<T> listener : listeners) {

--- a/coordination/src/test/java/io/atomix/coordination/AbstractCoordinationTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/AbstractCoordinationTest.java
@@ -19,9 +19,9 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.server.CopycatServer;
-import io.atomix.copycat.server.RaftServer;
+import io.atomix.copycat.server.CopycatServer;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import io.atomix.resource.ResourceStateMachine;
@@ -45,8 +45,8 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   protected LocalServerRegistry registry;
   protected int port;
   protected List<Address> members;
-  protected List<RaftClient> clients = new ArrayList<>();
-  protected List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatClient> clients = new ArrayList<>();
+  protected List<CopycatServer> servers = new ArrayList<>();
 
   /**
    * Creates a new resource state machine.
@@ -69,8 +69,8 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int nodes) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int nodes) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
     List<Address> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
@@ -78,7 +78,7 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
     }
 
     for (int i = 0; i < nodes; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -91,8 +91,8 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int live, int total) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int live, int total) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
     List<Address> members = new ArrayList<>();
     for (int i = 0; i < total; i++) {
@@ -100,7 +100,7 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
     }
 
     for (int i = 0; i < live; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -113,8 +113,8 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   /**
    * Creates a Raft server.
    */
-  protected RaftServer createServer(Address address) {
-    RaftServer server = CopycatServer.builder(address, members)
+  protected CopycatServer createServer(Address address) {
+    CopycatServer server = CopycatServer.builder(address, members)
       .withTransport(new LocalTransport(registry))
       .withStorage(new Storage(StorageLevel.MEMORY))
       .withStateMachine(createStateMachine())
@@ -126,8 +126,8 @@ public abstract class AbstractCoordinationTest extends ConcurrentTestCase {
   /**
    * Creates a Copycat client.
    */
-  protected RaftClient createClient() throws Throwable {
-    RaftClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
+  protected CopycatClient createClient() throws Throwable {
+    CopycatClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
     await();
     clients.add(client);

--- a/coordination/src/test/java/io/atomix/coordination/DistributedLeaderElectionTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedLeaderElectionTest.java
@@ -16,7 +16,7 @@
 package io.atomix.coordination;
 
 import io.atomix.coordination.state.LeaderElectionState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
 
@@ -53,8 +53,8 @@ public class DistributedLeaderElectionTest extends AbstractCoordinationTest {
   public void testNextElection() throws Throwable {
     createServers(3);
 
-    RaftClient client1 = createClient();
-    RaftClient client2 = createClient();
+    CopycatClient client1 = createClient();
+    CopycatClient client2 = createClient();
 
     DistributedLeaderElection election1 = new DistributedLeaderElection(client1);
     DistributedLeaderElection election2 = new DistributedLeaderElection(client2);

--- a/coordination/src/test/java/io/atomix/coordination/DistributedLockTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedLockTest.java
@@ -16,7 +16,7 @@
 package io.atomix.coordination;
 
 import io.atomix.coordination.state.LockState;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
 
@@ -54,8 +54,8 @@ public class DistributedLockTest extends AbstractCoordinationTest {
   public void testReleaseOnClose() throws Throwable {
     createServers(3);
 
-    RaftClient client1 = createClient();
-    RaftClient client2 = createClient();
+    CopycatClient client1 = createClient();
+    CopycatClient client2 = createClient();
 
     DistributedLock lock1 = new DistributedLock(client1);
     DistributedLock lock2 = new DistributedLock(client2);

--- a/manager/src/main/java/io/atomix/AtomixReplica.java
+++ b/manager/src/main/java/io/atomix/AtomixReplica.java
@@ -19,7 +19,7 @@ import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.*;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.ConfigurationException;
-import io.atomix.copycat.client.ConnectionStrategy;
+import io.atomix.copycat.client.SubmissionStrategy;
 import io.atomix.copycat.server.CopycatServer;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.manager.ResourceManager;
@@ -153,12 +153,12 @@ public final class AtomixReplica extends Atomix {
   }
 
   /**
-   * Combined connection strategy.
+   * Combined submission strategy.
    */
-  private static class CombinedConnectionStrategy implements ConnectionStrategy {
+  private static class CombinedSubmissionStrategy implements SubmissionStrategy {
     private final Address address;
 
-    private CombinedConnectionStrategy(Address address) {
+    private CombinedSubmissionStrategy(Address address) {
       this.address = address;
     }
 
@@ -439,7 +439,7 @@ public final class AtomixReplica extends Atomix {
       // directly through the local server, ensuring we don't incur unnecessary network traffic by
       // sending operations to a remote server when a local server is already available in the same JVM.=
       clientBuilder.withTransport(new LocalTransport(localRegistry))
-        .withConnectionStrategy(new CombinedConnectionStrategy(clientAddress)).build();
+        .withSubmissionStrategy(new CombinedSubmissionStrategy(clientAddress)).build();
 
       // Construct the underlying CopycatServer. The server should have been configured with a CombinedTransport
       // that facilitates the local client connecting directly to the server.

--- a/manager/src/main/java/io/atomix/resource/InstanceClient.java
+++ b/manager/src/main/java/io/atomix/resource/InstanceClient.java
@@ -21,7 +21,7 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.session.Session;
 import io.atomix.manager.DeleteResource;
 
@@ -32,16 +32,16 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class InstanceClient implements RaftClient {
+public class InstanceClient implements CopycatClient {
   private final long resource;
-  private final RaftClient client;
+  private final CopycatClient client;
   private final Transport transport;
   private final InstanceSession session;
 
   /**
    * @throws NullPointerException if {@code client} is null
    */
-  public InstanceClient(long resource, RaftClient client, Transport transport) {
+  public InstanceClient(long resource, CopycatClient client, Transport transport) {
     this.resource = resource;
     this.client = Assert.notNull(client, "client");
     this.transport = transport;
@@ -82,7 +82,7 @@ public class InstanceClient implements RaftClient {
   }
 
   @Override
-  public CompletableFuture<RaftClient> open() {
+  public CompletableFuture<CopycatClient> open() {
     return CompletableFuture.completedFuture(this);
   }
 

--- a/manager/src/test/java/io/atomix/AtomixClientServerTest.java
+++ b/manager/src/test/java/io/atomix/AtomixClientServerTest.java
@@ -18,7 +18,7 @@ package io.atomix;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.server.Commit;
 import io.atomix.resource.*;
 import org.testng.annotations.Test;
@@ -245,7 +245,7 @@ public class AtomixClientServerTest extends AbstractServerTest {
   public static class TestResource extends Resource {
     public static final ResourceType<TestResource> TYPE = new ResourceType<>(TestResource.class);
 
-    public TestResource(RaftClient client) {
+    public TestResource(CopycatClient client) {
       super(client);
     }
 
@@ -319,7 +319,7 @@ public class AtomixClientServerTest extends AbstractServerTest {
   public static class ValueResource extends Resource {
     public static final ResourceType<ValueResource> TYPE = new ResourceType<ValueResource>(ValueResource.class);
 
-    public ValueResource(RaftClient client) {
+    public ValueResource(CopycatClient client) {
       super(client);
     }
 

--- a/manager/src/test/java/io/atomix/AtomixReplicaTest.java
+++ b/manager/src/test/java/io/atomix/AtomixReplicaTest.java
@@ -17,7 +17,7 @@ package io.atomix;
 
 import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.server.Commit;
 import io.atomix.resource.*;
 import org.testng.annotations.Test;
@@ -217,7 +217,7 @@ public class AtomixReplicaTest extends AbstractReplicaTest {
   public static class TestResource extends Resource {
     public static final ResourceType<TestResource> TYPE = new ResourceType<>(TestResource.class);
 
-    public TestResource(RaftClient client) {
+    public TestResource(CopycatClient client) {
       super(client);
     }
 
@@ -291,7 +291,7 @@ public class AtomixReplicaTest extends AbstractReplicaTest {
   public static class ValueResource extends Resource {
     public static final ResourceType<ValueResource> TYPE = new ResourceType<ValueResource>(ValueResource.class);
 
-    public ValueResource(RaftClient client) {
+    public ValueResource(CopycatClient client) {
       super(client);
     }
 

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -18,15 +18,15 @@ package io.atomix.resource;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.Command;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.Query;
-import io.atomix.copycat.client.RaftClient;
 
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Fault-tolerant stateful distributed object.
  * <p>
- * Resources are stateful distributed objects that run across a set of {@link io.atomix.copycat.server.RaftServer}s
+ * Resources are stateful distributed objects that run across a set of {@link io.atomix.copycat.server.CopycatServer}s
  * in a cluster.
  * <p>
  * Resources can be created either as standalone {@link io.atomix.copycat.server.StateMachine}s in
@@ -40,10 +40,10 @@ import java.util.concurrent.CompletableFuture;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public abstract class Resource {
-  protected RaftClient client;
+  protected CopycatClient client;
   private Consistency consistency = Consistency.ATOMIC;
 
-  protected Resource(RaftClient client) {
+  protected Resource(CopycatClient client) {
     this.client = Assert.notNull(client, "client");
   }
 
@@ -52,7 +52,7 @@ public abstract class Resource {
    *
    * @param client The internal Raft client.
    */
-  final void reset(RaftClient client) {
+  final void reset(CopycatClient client) {
     this.client = Assert.notNull(client, "client");
   }
 

--- a/variables/src/main/java/io/atomix/variables/DistributedLong.java
+++ b/variables/src/main/java/io/atomix/variables/DistributedLong.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.variables;
 
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.variables.state.ValueState;
 import io.atomix.resource.Consistency;
 import io.atomix.resource.ResourceType;
@@ -34,7 +34,7 @@ public class DistributedLong extends DistributedValue<Long> {
   public static final ResourceType<DistributedLong> TYPE = new ResourceType<>(DistributedLong.class);
   private Long value;
 
-  public DistributedLong(RaftClient client) {
+  public DistributedLong(CopycatClient client) {
     super(client);
   }
 

--- a/variables/src/main/java/io/atomix/variables/DistributedValue.java
+++ b/variables/src/main/java/io/atomix/variables/DistributedValue.java
@@ -16,7 +16,7 @@
 package io.atomix.variables;
 
 import io.atomix.catalyst.util.Listener;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.variables.state.ValueCommands;
 import io.atomix.variables.state.ValueState;
 import io.atomix.resource.Consistency;
@@ -40,7 +40,7 @@ public class DistributedValue<T> extends Resource {
   public static final ResourceType<DistributedValue> TYPE = new ResourceType<>(DistributedValue.class);
   private final java.util.Set<Consumer<T>> changeListeners = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-  public DistributedValue(RaftClient client) {
+  public DistributedValue(CopycatClient client) {
     super(client);
     client.session().<T>onEvent("change", event -> {
       for (Consumer<T> listener : changeListeners) {

--- a/variables/src/test/java/io/atomix/variables/AbstractVariableTest.java
+++ b/variables/src/test/java/io/atomix/variables/AbstractVariableTest.java
@@ -19,9 +19,8 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.LocalServerRegistry;
 import io.atomix.catalyst.transport.LocalTransport;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.server.CopycatServer;
-import io.atomix.copycat.server.RaftServer;
 import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import io.atomix.resource.ResourceStateMachine;
@@ -45,8 +44,8 @@ public abstract class AbstractVariableTest extends ConcurrentTestCase {
   protected LocalServerRegistry registry;
   protected int port;
   protected List<Address> members;
-  protected List<RaftClient> clients = new ArrayList<>();
-  protected List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatClient> clients = new ArrayList<>();
+  protected List<CopycatServer> servers = new ArrayList<>();
 
   /**
    * Creates a new resource state machine.
@@ -69,8 +68,8 @@ public abstract class AbstractVariableTest extends ConcurrentTestCase {
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int nodes) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int nodes) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
     List<Address> members = new ArrayList<>();
     for (int i = 0; i < nodes; i++) {
@@ -78,7 +77,7 @@ public abstract class AbstractVariableTest extends ConcurrentTestCase {
     }
 
     for (int i = 0; i < nodes; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -91,8 +90,8 @@ public abstract class AbstractVariableTest extends ConcurrentTestCase {
   /**
    * Creates a set of Raft servers.
    */
-  protected List<RaftServer> createServers(int live, int total) throws Throwable {
-    List<RaftServer> servers = new ArrayList<>();
+  protected List<CopycatServer> createServers(int live, int total) throws Throwable {
+    List<CopycatServer> servers = new ArrayList<>();
 
     List<Address> members = new ArrayList<>();
     for (int i = 0; i < total; i++) {
@@ -100,7 +99,7 @@ public abstract class AbstractVariableTest extends ConcurrentTestCase {
     }
 
     for (int i = 0; i < live; i++) {
-      RaftServer server = createServer(members.get(i));
+      CopycatServer server = createServer(members.get(i));
       server.open().thenRun(this::resume);
       servers.add(server);
     }
@@ -113,8 +112,8 @@ public abstract class AbstractVariableTest extends ConcurrentTestCase {
   /**
    * Creates a Raft server.
    */
-  protected RaftServer createServer(Address address) {
-    RaftServer server = CopycatServer.builder(address, members)
+  protected CopycatServer createServer(Address address) {
+    CopycatServer server = CopycatServer.builder(address, members)
       .withTransport(new LocalTransport(registry))
       .withStorage(new Storage(StorageLevel.MEMORY))
       .withStateMachine(createStateMachine())
@@ -126,8 +125,8 @@ public abstract class AbstractVariableTest extends ConcurrentTestCase {
   /**
    * Creates a Copycat client.
    */
-  protected RaftClient createClient() throws Throwable {
-    RaftClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
+  protected CopycatClient createClient() throws Throwable {
+    CopycatClient client = CopycatClient.builder(members).withTransport(new LocalTransport(registry)).build();
     client.open().thenRun(this::resume);
     await();
     clients.add(client);

--- a/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
+++ b/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.variables;
 
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.variables.state.ValueState;
 import io.atomix.resource.ResourceStateMachine;
 import org.testng.annotations.Test;
@@ -98,7 +98,7 @@ public class DistributedLongTest extends AbstractVariableTest {
    */
   private void testAtomic(int servers, Consumer<DistributedLong> consumer) throws Throwable {
     createServers(servers);
-    RaftClient client = createClient();
+    CopycatClient client = createClient();
     DistributedLong atomic = new DistributedLong(client);
     consumer.accept(atomic);
     await();

--- a/variables/src/test/java/io/atomix/variables/DistributedValueTest.java
+++ b/variables/src/test/java/io/atomix/variables/DistributedValueTest.java
@@ -17,7 +17,7 @@ package io.atomix.variables;
 
 import org.testng.annotations.Test;
 
-import io.atomix.copycat.client.RaftClient;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.variables.state.ValueState;
 import io.atomix.resource.ResourceStateMachine;
 
@@ -39,7 +39,7 @@ public class DistributedValueTest extends AbstractVariableTest {
    */
   public void testAtomicSetGet() throws Throwable {
     createServers(3);
-    RaftClient client = createClient();
+    CopycatClient client = createClient();
     DistributedValue<String> atomic = new DistributedValue<>(client);
     atomic.set("Hello world!").thenRun(() -> {
       atomic.get().thenAccept(value -> {


### PR DESCRIPTION
This PR updates usage of Copycat APIs including most importantly `CopycatServer` and `CopycatClient`. Recent API changes have removed `RaftClient` and `RaftServer` before the release.