### PR TITLE
Log compaction updates

### DIFF
--- a/collections/src/main/java/io/atomix/collections/state/MapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/MapCommands.java
@@ -40,6 +40,10 @@ public class MapCommands {
    * Abstract map command.
    */
   public static abstract class MapCommand<V> implements Command<V>, CatalystSerializable {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
 
     @Override
     public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
@@ -224,8 +228,8 @@ public class MapCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return ttl > 0 ? PersistenceLevel.PERSISTENT : PersistenceLevel.EPHEMERAL;
+    public CompactionMode compaction() {
+      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.FULL_CLEAN;
     }
 
     /**
@@ -348,8 +352,8 @@ public class MapCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 
@@ -367,8 +371,8 @@ public class MapCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 
@@ -451,8 +455,8 @@ public class MapCommands {
   public static class Clear extends MapCommand<Void> {
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 

--- a/collections/src/main/java/io/atomix/collections/state/MapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/MapCommands.java
@@ -229,7 +229,7 @@ public class MapCommands {
 
     @Override
     public CompactionMode compaction() {
-      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.FULL_CLEAN;
+      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.QUORUM_CLEAN;
     }
 
     /**

--- a/collections/src/main/java/io/atomix/collections/state/MultiMapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/MultiMapCommands.java
@@ -42,6 +42,10 @@ public class MultiMapCommands {
    * Abstract map command.
    */
   public static abstract class MultiMapCommand<V> implements Command<V>, CatalystSerializable {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
 
     @Override
     public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
@@ -291,8 +295,8 @@ public class MultiMapCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return ttl > 0 ? PersistenceLevel.PERSISTENT : PersistenceLevel.EPHEMERAL;
+    public CompactionMode compaction() {
+      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.FULL_CLEAN;
     }
 
     /**
@@ -364,8 +368,8 @@ public class MultiMapCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 
@@ -391,8 +395,8 @@ public class MultiMapCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
 
     @Override
@@ -433,8 +437,8 @@ public class MultiMapCommands {
   public static class Clear extends MultiMapCommand<Void> {
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 

--- a/collections/src/main/java/io/atomix/collections/state/MultiMapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/MultiMapCommands.java
@@ -296,7 +296,7 @@ public class MultiMapCommands {
 
     @Override
     public CompactionMode compaction() {
-      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.FULL_CLEAN;
+      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.QUORUM_CLEAN;
     }
 
     /**

--- a/collections/src/main/java/io/atomix/collections/state/QueueCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/QueueCommands.java
@@ -39,6 +39,10 @@ public class QueueCommands {
    * Abstract queue command.
    */
   private static abstract class QueueCommand<V> implements Command<V>, CatalystSerializable {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
 
     @Override
     public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
@@ -180,8 +184,8 @@ public class QueueCommands {
   public static class Poll extends QueueCommand<Object> {
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 
@@ -192,8 +196,8 @@ public class QueueCommands {
   public static class Element extends QueueCommand<Object> {
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 
@@ -210,8 +214,8 @@ public class QueueCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 
@@ -236,8 +240,8 @@ public class QueueCommands {
   public static class Clear extends QueueCommand<Void> {
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 

--- a/collections/src/main/java/io/atomix/collections/state/SetCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/SetCommands.java
@@ -160,7 +160,7 @@ public class SetCommands {
 
     @Override
     public CompactionMode compaction() {
-      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.FULL_CLEAN;
+      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.QUORUM_CLEAN;
     }
 
     /**

--- a/collections/src/main/java/io/atomix/collections/state/SetCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/SetCommands.java
@@ -39,6 +39,10 @@ public class SetCommands {
    * Abstract set command.
    */
   private static abstract class SetCommand<V> implements Command<V>, CatalystSerializable {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
 
     @Override
     public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
@@ -155,8 +159,8 @@ public class SetCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return ttl > 0 ? PersistenceLevel.PERSISTENT : PersistenceLevel.EPHEMERAL;
+    public CompactionMode compaction() {
+      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.FULL_CLEAN;
     }
 
     /**
@@ -212,8 +216,8 @@ public class SetCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 
@@ -238,8 +242,8 @@ public class SetCommands {
   public static class Clear extends SetCommand<Void> {
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/state/LeaderElectionCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/LeaderElectionCommands.java
@@ -31,7 +31,7 @@ import io.atomix.copycat.client.Query;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class LeaderElectionCommands {
+public final class LeaderElectionCommands {
 
   private LeaderElectionCommands() {
   }
@@ -59,6 +59,10 @@ public class LeaderElectionCommands {
    * Abstract election command.
    */
   public static abstract class ElectionCommand<V> implements Command<V>, CatalystSerializable {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
 
     @Override
     public ConsistencyLevel consistency() {
@@ -79,6 +83,10 @@ public class LeaderElectionCommands {
    */
   @SerializeWith(id=110)
   public static class Listen extends ElectionCommand<Void> {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
   }
 
   /**
@@ -86,10 +94,9 @@ public class LeaderElectionCommands {
    */
   @SerializeWith(id=111)
   public static class Unlisten extends ElectionCommand<Void> {
-
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
     }
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/state/LeaderElectionState.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/LeaderElectionState.java
@@ -17,6 +17,7 @@ package io.atomix.coordination.state;
 
 import io.atomix.copycat.client.session.Session;
 import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.session.SessionListener;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.util.Iterator;
@@ -28,9 +29,24 @@ import java.util.Map;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class LeaderElectionState extends ResourceStateMachine {
+public class LeaderElectionState extends ResourceStateMachine implements SessionListener {
   private Commit<LeaderElectionCommands.Listen> leader;
   private final Map<Long, Commit<LeaderElectionCommands.Listen>> listeners = new LinkedHashMap<>();
+
+  @Override
+  public void register(Session session) {
+
+  }
+
+  @Override
+  public void unregister(Session session) {
+
+  }
+
+  @Override
+  public void expire(Session session) {
+
+  }
 
   @Override
   public void close(Session session) {

--- a/coordination/src/main/java/io/atomix/coordination/state/LockCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/LockCommands.java
@@ -29,7 +29,7 @@ import io.atomix.copycat.client.Command;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class LockCommands {
+public final class LockCommands {
 
   private LockCommands() {
   }
@@ -42,6 +42,11 @@ public class LockCommands {
     @Override
     public ConsistencyLevel consistency() {
       return ConsistencyLevel.LINEARIZABLE;
+    }
+
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
     }
 
     @Override
@@ -77,6 +82,11 @@ public class LockCommands {
     }
 
     @Override
+    public CompactionMode compaction() {
+      return timeout > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.QUORUM_CLEAN;
+    }
+
+    @Override
     public void writeObject(BufferOutput buffer, Serializer serializer) {
       buffer.writeLong(timeout);
     }
@@ -92,12 +102,10 @@ public class LockCommands {
    */
   @SerializeWith(id=116)
   public static class Unlock extends LockCommand<Void> {
-
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_CLEAN;
     }
-
   }
 
 }

--- a/coordination/src/main/java/io/atomix/coordination/state/LockState.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/LockState.java
@@ -18,6 +18,7 @@ package io.atomix.coordination.state;
 import io.atomix.catalyst.util.concurrent.Scheduled;
 import io.atomix.copycat.client.session.Session;
 import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.session.SessionListener;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.time.Duration;
@@ -31,10 +32,25 @@ import java.util.Queue;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class LockState extends ResourceStateMachine {
+public class LockState extends ResourceStateMachine implements SessionListener {
   private Commit<LockCommands.Lock> lock;
   private final Queue<Commit<LockCommands.Lock>> queue = new ArrayDeque<>();
   private final Map<Long, Scheduled> timers = new HashMap<>();
+
+  @Override
+  public void register(Session session) {
+
+  }
+
+  @Override
+  public void unregister(Session session) {
+
+  }
+
+  @Override
+  public void expire(Session session) {
+
+  }
 
   @Override
   public void close(Session session) {

--- a/coordination/src/main/java/io/atomix/coordination/state/MembershipGroupCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/MembershipGroupCommands.java
@@ -32,7 +32,7 @@ import java.util.Set;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class MembershipGroupCommands {
+public final class MembershipGroupCommands {
 
   private MembershipGroupCommands() {
   }
@@ -45,6 +45,11 @@ public class MembershipGroupCommands {
     @Override
     public ConsistencyLevel consistency() {
       return ConsistencyLevel.LINEARIZABLE;
+    }
+
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
     }
 
     @Override
@@ -68,10 +73,9 @@ public class MembershipGroupCommands {
    */
   @SerializeWith(id=121)
   public static class Leave extends GroupCommand<Void> {
-
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_CLEAN;
     }
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/state/MembershipGroupState.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/MembershipGroupState.java
@@ -17,6 +17,7 @@ package io.atomix.coordination.state;
 
 import io.atomix.copycat.client.session.Session;
 import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.session.SessionListener;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.time.Duration;
@@ -30,8 +31,23 @@ import java.util.Set;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class MembershipGroupState extends ResourceStateMachine {
+public class MembershipGroupState extends ResourceStateMachine implements SessionListener {
   private final Map<Long, Commit<MembershipGroupCommands.Join>> members = new HashMap<>();
+
+  @Override
+  public void register(Session session) {
+
+  }
+
+  @Override
+  public void unregister(Session session) {
+
+  }
+
+  @Override
+  public void expire(Session session) {
+
+  }
 
   @Override
   public void close(Session session) {

--- a/coordination/src/main/java/io/atomix/coordination/state/MessageBusCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/MessageBusCommands.java
@@ -34,7 +34,7 @@ import java.util.Set;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class MessageBusCommands {
+public final class MessageBusCommands {
 
   private MessageBusCommands() {
   }
@@ -47,6 +47,11 @@ public class MessageBusCommands {
     @Override
     public ConsistencyLevel consistency() {
       return ConsistencyLevel.LINEARIZABLE;
+    }
+
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
     }
 
     @Override
@@ -97,10 +102,9 @@ public class MessageBusCommands {
    */
   @SerializeWith(id=86)
   public static class Leave extends MessageBusCommand<Void> {
-
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_CLEAN;
     }
   }
 
@@ -162,8 +166,8 @@ public class MessageBusCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_CLEAN;
     }
 
     @Override

--- a/coordination/src/main/java/io/atomix/coordination/state/MessageBusState.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/MessageBusState.java
@@ -18,6 +18,7 @@ package io.atomix.coordination.state;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.copycat.client.session.Session;
 import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.session.SessionListener;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.util.*;
@@ -27,9 +28,24 @@ import java.util.*;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class MessageBusState extends ResourceStateMachine {
+public class MessageBusState extends ResourceStateMachine implements SessionListener {
   private final Map<Long, Commit<MessageBusCommands.Join>> members = new HashMap<>();
   private final Map<String, Map<Long, Commit<MessageBusCommands.Register>>> topics = new HashMap<>();
+
+  @Override
+  public void register(Session session) {
+
+  }
+
+  @Override
+  public void unregister(Session session) {
+
+  }
+
+  @Override
+  public void expire(Session session) {
+
+  }
 
   @Override
   public void close(Session session) {

--- a/coordination/src/main/java/io/atomix/coordination/state/TopicCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/TopicCommands.java
@@ -29,7 +29,7 @@ import io.atomix.copycat.client.Command;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class TopicCommands {
+public final class TopicCommands {
 
   private TopicCommands() {
   }
@@ -38,6 +38,11 @@ public class TopicCommands {
    * Abstract topic command.
    */
   public static abstract class TopicCommand<V> implements Command<V>, CatalystSerializable {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
+
     @Override
     public void writeObject(BufferOutput buffer, Serializer serializer) {
     }
@@ -52,6 +57,11 @@ public class TopicCommands {
    */
   @SerializeWith(id=125)
   public static class Listen extends TopicCommand<Void> {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
+
     @Override
     public ConsistencyLevel consistency() {
       return ConsistencyLevel.LINEARIZABLE;
@@ -69,8 +79,8 @@ public class TopicCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return PersistenceLevel.PERSISTENT;
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_CLEAN;
     }
   }
 
@@ -95,6 +105,11 @@ public class TopicCommands {
      */
     public T message() {
       return message;
+    }
+
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_COMMIT;
     }
 
     @Override

--- a/coordination/src/main/java/io/atomix/coordination/state/TopicState.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/TopicState.java
@@ -17,6 +17,7 @@ package io.atomix.coordination.state;
 
 import io.atomix.copycat.client.session.Session;
 import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.session.SessionListener;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.util.HashMap;
@@ -28,8 +29,23 @@ import java.util.Map;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class TopicState extends ResourceStateMachine {
+public class TopicState extends ResourceStateMachine implements SessionListener {
   private final Map<Long, Commit<TopicCommands.Listen>> listeners = new HashMap<>();
+
+  @Override
+  public void register(Session session) {
+
+  }
+
+  @Override
+  public void unregister(Session session) {
+
+  }
+
+  @Override
+  public void expire(Session session) {
+
+  }
 
   @Override
   public void close(Session session) {

--- a/variables/src/main/java/io/atomix/variables/state/ValueCommands.java
+++ b/variables/src/main/java/io/atomix/variables/state/ValueCommands.java
@@ -49,8 +49,8 @@ public class ValueCommands {
     }
 
     @Override
-    public PersistenceLevel persistence() {
-      return ttl > 0 ? PersistenceLevel.PERSISTENT : PersistenceLevel.EPHEMERAL;
+    public CompactionMode compaction() {
+      return ttl > 0 ? CompactionMode.FULL_SEQUENTIAL_CLEAN : CompactionMode.QUORUM_CLEAN;
     }
 
     /**
@@ -246,6 +246,11 @@ public class ValueCommands {
   @SerializeWith(id=54)
   public static class Listen implements Command<Void>, CatalystSerializable {
     @Override
+    public CompactionMode compaction() {
+      return CompactionMode.QUORUM_CLEAN;
+    }
+
+    @Override
     public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     }
 
@@ -259,6 +264,11 @@ public class ValueCommands {
    */
   @SerializeWith(id=55)
   public static class Unlisten implements Command<Void>, CatalystSerializable {
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.FULL_SEQUENTIAL_COMMIT;
+    }
+
     @Override
     public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     }


### PR DESCRIPTION
This PR updates all Atomix code to comply with the changes made in Copycat to log compaction processes. These changes include adding `CompactionMode`s to relevant commands, supporting `Snapshottable` state machines, and implementing `SessionListener` for state machines that need to listen for sessions being registered/unregistered/expired/closed.