### PR TITLE
Refactor distributed long to use snapshotting for increment/decrement

### DIFF
--- a/all/src/test/java/io/atomix/AtomixLongTest.java
+++ b/all/src/test/java/io/atomix/AtomixLongTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix;
+
+import io.atomix.variables.DistributedLong;
+import org.testng.annotations.Test;
+
+import java.util.function.Function;
+
+/**
+ * Atomix long test.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@Test
+public class AtomixLongTest extends AbstractAtomixTest {
+
+  public void testClientLongGet() throws Throwable {
+    Atomix client1 = createClient();
+    Atomix client2 = createClient();
+    testLong(client1, client2, get("test-client-long-get", DistributedLong.TYPE));
+  }
+
+  public void testClientLongCreate() throws Throwable {
+    Atomix client1 = createClient();
+    Atomix client2 = createClient();
+    testLong(client1, client2, create("test-client-long-create", DistributedLong.TYPE));
+  }
+
+  public void testReplicaLongGet() throws Throwable {
+    testLong(replicas.get(0), replicas.get(1), get("test-replica-long-get", DistributedLong.TYPE));
+  }
+
+  public void testReplicaLongCreate() throws Throwable {
+    testLong(replicas.get(0), replicas.get(1), create("test-replica-long-create", DistributedLong.TYPE));
+  }
+
+  public void testMixLong() throws Throwable {
+    Atomix client = createClient();
+    testLong(replicas.get(0), client, create("test-long-mix", DistributedLong.TYPE));
+  }
+
+  /**
+   * Tests creating a distributed long.
+   */
+  private void testLong(Atomix client1, Atomix client2, Function<Atomix, DistributedLong> factory) throws Throwable {
+    DistributedLong value1 = factory.apply(client1);
+    value1.set(10L).join();
+    value1.getAndIncrement().thenAccept(result -> {
+      threadAssertEquals(result, 10L);
+      resume();
+    });
+    await(1000);
+
+    DistributedLong value2 = factory.apply(client2);
+    value2.incrementAndGet().thenAccept(result -> {
+      threadAssertEquals(result, 12L);
+      resume();
+    });
+    await(1000);
+  }
+
+}

--- a/variables/src/main/java/io/atomix/variables/state/LongCommands.java
+++ b/variables/src/main/java/io/atomix/variables/state/LongCommands.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.variables.state;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.copycat.client.Command;
+
+/**
+ * Long commands.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public final class LongCommands {
+
+  private LongCommands() {
+  }
+
+  /**
+   * Abstract long command.
+   */
+  public static abstract class LongCommand<V> implements Command<V>, CatalystSerializable {
+
+    protected LongCommand() {
+    }
+
+    @Override
+    public CompactionMode compaction() {
+      return CompactionMode.SNAPSHOT;
+    }
+
+    @Override
+    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    }
+
+    @Override
+    public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    }
+  }
+
+  /**
+   * Increment and get command.
+   */
+  @SerializeWith(id=54)
+  public static class IncrementAndGet extends LongCommand<Long> {
+  }
+
+  /**
+   * Decrement and get command.
+   */
+  @SerializeWith(id=55)
+  public static class DecrementAndGet extends LongCommand<Long> {
+  }
+
+  /**
+   * Get and increment command.
+   */
+  @SerializeWith(id=56)
+  public static class GetAndIncrement extends LongCommand<Long> {
+  }
+
+  /**
+   * Get and decrement command.
+   */
+  @SerializeWith(id=57)
+  public static class GetAndDecrement extends LongCommand<Long> {
+  }
+
+  /**
+   * Delta command.
+   */
+  public static abstract class DeltaCommand extends LongCommand<Long> {
+    private long delta;
+
+    public DeltaCommand() {
+    }
+
+    public DeltaCommand(long delta) {
+      this.delta = delta;
+    }
+
+    /**
+     * Returns the delta.
+     *
+     * @return The delta.
+     */
+    public long delta() {
+      return delta;
+    }
+
+    @Override
+    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+      buffer.writeLong(delta);
+    }
+
+    @Override
+    public void readObject(BufferInput<?> buffer, Serializer serializer) {
+      delta = buffer.readLong();
+    }
+  }
+
+  /**
+   * Get and add command.
+   */
+  @SerializeWith(id=58)
+  public static class GetAndAdd extends DeltaCommand {
+    public GetAndAdd() {
+    }
+
+    public GetAndAdd(long delta) {
+      super(delta);
+    }
+  }
+
+  /**
+   * Add and get command.
+   */
+  @SerializeWith(id=59)
+  public static class AddAndGet extends DeltaCommand {
+    public AddAndGet() {
+    }
+
+    public AddAndGet(long delta) {
+      super(delta);
+    }
+  }
+
+}

--- a/variables/src/main/java/io/atomix/variables/state/LongState.java
+++ b/variables/src/main/java/io/atomix/variables/state/LongState.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.variables.state;
+
+import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.Snapshottable;
+import io.atomix.copycat.server.storage.snapshot.SnapshotReader;
+import io.atomix.copycat.server.storage.snapshot.SnapshotWriter;
+
+/**
+ * Long state machine.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class LongState extends ValueState implements Snapshottable {
+  private long diff;
+
+  @Override
+  public void snapshot(SnapshotWriter writer) {
+    writer.writeLong(diff);
+  }
+
+  @Override
+  public void install(SnapshotReader reader) {
+    diff = reader.readLong();
+  }
+
+  /**
+   * Handles an increment and get commit.
+   */
+  public long incrementAndGet(Commit<LongCommands.IncrementAndGet> commit) {
+    try {
+      diff++;
+      Long value = (Long) this.value;
+      return value != null ? value + diff : diff;
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles a decrement and get commit.
+   */
+  public long decrementAndGet(Commit<LongCommands.DecrementAndGet> commit) {
+    try {
+      diff--;
+      return value();
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles a get and increment commit.
+   */
+  public long getAndIncrement(Commit<LongCommands.GetAndIncrement> commit) {
+    try {
+      long value = value();
+      diff++;
+      return value;
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles a get and decrement commit.
+   */
+  public long getAndDecrement(Commit<LongCommands.GetAndDecrement> commit) {
+    try {
+      long value = value();
+      diff--;
+      return value;
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles an add and get commit.
+   */
+  public long addAndGet(Commit<LongCommands.AddAndGet> commit) {
+    try {
+      diff += commit.operation().delta();
+      return value();
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles a get and add commit.
+   */
+  public long getAndAdd(Commit<LongCommands.GetAndAdd> commit) {
+    try {
+      long value = value();
+      diff += commit.operation().delta();
+      return value;
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Returns the current value.
+   *
+   * @return The current value.
+   */
+  private long value() {
+    Long value = (Long) this.value;
+    return value != null ? value + diff : diff;
+  }
+
+}

--- a/variables/src/main/java/io/atomix/variables/state/ValueCommands.java
+++ b/variables/src/main/java/io/atomix/variables/state/ValueCommands.java
@@ -240,42 +240,4 @@ public class ValueCommands {
     }
   }
 
-  /**
-   * Change listen.
-   */
-  @SerializeWith(id=54)
-  public static class Listen implements Command<Void>, CatalystSerializable {
-    @Override
-    public CompactionMode compaction() {
-      return CompactionMode.QUORUM;
-    }
-
-    @Override
-    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
-    }
-
-    @Override
-    public void readObject(BufferInput<?> buffer, Serializer serializer) {
-    }
-  }
-
-  /**
-   * Change unlisten.
-   */
-  @SerializeWith(id=55)
-  public static class Unlisten implements Command<Void>, CatalystSerializable {
-    @Override
-    public CompactionMode compaction() {
-      return CompactionMode.SEQUENTIAL;
-    }
-
-    @Override
-    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
-    }
-
-    @Override
-    public void readObject(BufferInput<?> buffer, Serializer serializer) {
-    }
-  }
-
 }

--- a/variables/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/variables/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -17,5 +17,9 @@ io.atomix.variables.state.ValueCommands$CompareAndSet
 io.atomix.variables.state.ValueCommands$Get
 io.atomix.variables.state.ValueCommands$GetAndSet
 io.atomix.variables.state.ValueCommands$Set
-io.atomix.variables.state.ValueCommands$Listen
-io.atomix.variables.state.ValueCommands$Unlisten
+io.atomix.variables.state.LongCommands$IncrementAndGet
+io.atomix.variables.state.LongCommands$DecrementAndGet
+io.atomix.variables.state.LongCommands$GetAndIncrement
+io.atomix.variables.state.LongCommands$GetAndDecrement
+io.atomix.variables.state.LongCommands$AddAndGet
+io.atomix.variables.state.LongCommands$GetAndAdd

--- a/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
+++ b/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
@@ -15,16 +15,15 @@
  */
 package io.atomix.variables;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
-import org.testng.annotations.Test;
-
 import io.atomix.atomix.testing.AbstractAtomixTest;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceStateMachine;
-import io.atomix.variables.state.ValueState;
+import io.atomix.variables.state.LongState;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Distributed atomic long test.
@@ -36,7 +35,7 @@ public class DistributedLongTest extends AbstractAtomixTest {
 
   @Override
   protected ResourceStateMachine createStateMachine() {
-    return new ValueState();
+    return new LongState();
   }
 
   /**


### PR DESCRIPTION
This PR refactors the `DistributedLong` resource to take advantage of the new snapshotting support in Copycat. Copycat's legacy log compaction algorithm does not allow state machines to handle things like counting very easily because a counter is a data type that relies all essentially *all* increments to represent its final value. Thus, to get around this limitation the previous `DistributedLong` implementation used optimistic locking for increments and decrements, doing a `compareAndSet` to update the `Long` value. This implementation uses snapshotting to store the final value of all increments and decrements of the number in the snapshot. This allows all increment/decrement commands to be removed from the Raft log once a snapshot has been taken. Because `LongState` still extends `ValueState`, it still takes advantage of log cleaning for direct `set` or `compareAndSet` calls, so this is a particularly interesting use case.