### PR TITLE
Simplified LongState + Added unit test for a scenario previously broken

### DIFF
--- a/variables/src/main/java/io/atomix/variables/DistributedLong.java
+++ b/variables/src/main/java/io/atomix/variables/DistributedLong.java
@@ -20,6 +20,7 @@ import io.atomix.resource.ResourceType;
 import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.variables.state.LongCommands;
 import io.atomix.variables.state.LongState;
+import io.atomix.variables.state.ValueCommands;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -43,7 +44,7 @@ public class DistributedLong extends AbstractDistributedValue<DistributedLong, L
 
   @Override
   public CompletableFuture<Long> get() {
-    return super.get().thenApply(l -> l != null ? l : 0);
+    return submit(new ValueCommands.Get<>());
   }
 
   /**

--- a/variables/src/main/java/io/atomix/variables/state/LongState.java
+++ b/variables/src/main/java/io/atomix/variables/state/LongState.java
@@ -46,7 +46,7 @@ public class LongState extends ValueState<Long> implements Snapshottable {
   @Override
   public void set(Commit<ValueCommands.Set<Long>> commit) {
     try {
-      value.set((Long) commit.operation().value());
+      value.set(commit.operation().value());
     } finally {
       commit.close();
     }
@@ -82,8 +82,8 @@ public class LongState extends ValueState<Long> implements Snapshottable {
   @Override
   public boolean compareAndSet(Commit<ValueCommands.CompareAndSet<Long>> commit) {
     try {
-      Long expect = (Long) commit.operation().expect();
-      Long update = (Long) commit.operation().update();
+      Long expect = commit.operation().expect();
+      Long update = commit.operation().update();
       return value.compareAndSet(expect, update);
     } finally {
       commit.close();

--- a/variables/src/main/java/io/atomix/variables/state/LongState.java
+++ b/variables/src/main/java/io/atomix/variables/state/LongState.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.variables.state;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import io.atomix.copycat.server.Commit;
 import io.atomix.copycat.server.Snapshottable;
 import io.atomix.copycat.server.storage.snapshot.SnapshotReader;
@@ -25,17 +27,67 @@ import io.atomix.copycat.server.storage.snapshot.SnapshotWriter;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class LongState extends ValueState implements Snapshottable {
-  private long diff;
+public class LongState extends ValueState<Long> implements Snapshottable {
+  private AtomicLong value = new AtomicLong(0);
 
   @Override
   public void snapshot(SnapshotWriter writer) {
-    writer.writeLong(diff);
+    writer.writeLong(value.get());
   }
 
   @Override
   public void install(SnapshotReader reader) {
-    diff = reader.readLong();
+    value = new AtomicLong(reader.readLong());
+  }
+
+  /**
+   * Handles a set commit.
+   */
+  @Override
+  public void set(Commit<ValueCommands.Set<Long>> commit) {
+    try {
+      value.set((Long) commit.operation().value());
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles a get commit.
+   */
+  @Override
+  public Long get(Commit<ValueCommands.Get<Long>> commit) {
+    try {
+      return value.get();
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles a get and set commit.
+   */
+  @Override
+  public Long getAndSet(Commit<ValueCommands.GetAndSet<Long>> commit) {
+    try {
+      return value.getAndSet(commit.operation().value());
+    } finally {
+      commit.close();
+    }
+  }
+
+  /**
+   * Handles a compare and set commit.
+   */
+  @Override
+  public boolean compareAndSet(Commit<ValueCommands.CompareAndSet<Long>> commit) {
+    try {
+      Long expect = (Long) commit.operation().expect();
+      Long update = (Long) commit.operation().update();
+      return value.compareAndSet(expect, update);
+    } finally {
+      commit.close();
+    }
   }
 
   /**
@@ -43,9 +95,7 @@ public class LongState extends ValueState implements Snapshottable {
    */
   public long incrementAndGet(Commit<LongCommands.IncrementAndGet> commit) {
     try {
-      diff++;
-      Long value = (Long) this.value;
-      return value != null ? value + diff : diff;
+      return value.incrementAndGet();
     } finally {
       commit.close();
     }
@@ -56,8 +106,7 @@ public class LongState extends ValueState implements Snapshottable {
    */
   public long decrementAndGet(Commit<LongCommands.DecrementAndGet> commit) {
     try {
-      diff--;
-      return value();
+      return value.decrementAndGet();
     } finally {
       commit.close();
     }
@@ -68,9 +117,7 @@ public class LongState extends ValueState implements Snapshottable {
    */
   public long getAndIncrement(Commit<LongCommands.GetAndIncrement> commit) {
     try {
-      long value = value();
-      diff++;
-      return value;
+      return value.getAndIncrement();
     } finally {
       commit.close();
     }
@@ -81,9 +128,7 @@ public class LongState extends ValueState implements Snapshottable {
    */
   public long getAndDecrement(Commit<LongCommands.GetAndDecrement> commit) {
     try {
-      long value = value();
-      diff--;
-      return value;
+      return value.getAndDecrement();
     } finally {
       commit.close();
     }
@@ -94,8 +139,7 @@ public class LongState extends ValueState implements Snapshottable {
    */
   public long addAndGet(Commit<LongCommands.AddAndGet> commit) {
     try {
-      diff += commit.operation().delta();
-      return value();
+      return value.addAndGet(commit.operation().delta());
     } finally {
       commit.close();
     }
@@ -106,22 +150,9 @@ public class LongState extends ValueState implements Snapshottable {
    */
   public long getAndAdd(Commit<LongCommands.GetAndAdd> commit) {
     try {
-      long value = value();
-      diff += commit.operation().delta();
-      return value;
+      return value.getAndAdd(commit.operation().delta());
     } finally {
       commit.close();
     }
   }
-
-  /**
-   * Returns the current value.
-   *
-   * @return The current value.
-   */
-  private long value() {
-    Long value = (Long) this.value;
-    return value != null ? value + diff : diff;
-  }
-
 }

--- a/variables/src/main/java/io/atomix/variables/state/ValueCommands.java
+++ b/variables/src/main/java/io/atomix/variables/state/ValueCommands.java
@@ -98,17 +98,17 @@ public class ValueCommands {
    * Set command.
    */
   @SerializeWith(id=51)
-  public static class Set extends ValueCommand<Void> {
-    private Object value;
+  public static class Set<T> extends ValueCommand<T> {
+    private T value;
 
     public Set() {
     }
 
-    public Set(Object value) {
+    public Set(T value) {
       this.value = value;
     }
 
-    public Set(Object value, long ttl) {
+    public Set(T value, long ttl) {
       super(ttl);
       this.value = value;
     }
@@ -118,7 +118,7 @@ public class ValueCommands {
      *
      * @return The command value.
      */
-    public Object value() {
+    public T value() {
       return value;
     }
 
@@ -142,19 +142,19 @@ public class ValueCommands {
    * Compare and set command.
    */
   @SerializeWith(id=52)
-  public static class CompareAndSet extends ValueCommand<Boolean> {
-    private Object expect;
-    private Object update;
+  public static class CompareAndSet<T> extends ValueCommand<Boolean> {
+    private T expect;
+    private T update;
 
     public CompareAndSet() {
     }
 
-    public CompareAndSet(Object expect, Object update) {
+    public CompareAndSet(T expect, T update) {
       this.expect = expect;
       this.update = update;
     }
 
-    public CompareAndSet(Object expect, Object update, long ttl) {
+    public CompareAndSet(T expect, T update, long ttl) {
       super(ttl);
       this.expect = expect;
       this.update = update;
@@ -165,7 +165,7 @@ public class ValueCommands {
      *
      * @return The expected value.
      */
-    public Object expect() {
+    public T expect() {
       return expect;
     }
 
@@ -174,7 +174,7 @@ public class ValueCommands {
      *
      * @return The updated value.
      */
-    public Object update() {
+    public T update() {
       return update;
     }
 
@@ -201,16 +201,16 @@ public class ValueCommands {
    */
   @SerializeWith(id=53)
   public static class GetAndSet<T> extends ValueCommand<T> {
-    private Object value;
+    private T value;
 
     public GetAndSet() {
     }
 
-    public GetAndSet(Object value) {
+    public GetAndSet(T value) {
       this.value = value;
     }
 
-    public GetAndSet(Object value, long ttl) {
+    public GetAndSet(T value, long ttl) {
       super(ttl);
       this.value = value;
     }
@@ -220,7 +220,7 @@ public class ValueCommands {
      *
      * @return The command value.
      */
-    public Object value() {
+    public T value() {
       return value;
     }
 

--- a/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
+++ b/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
@@ -81,6 +81,16 @@ public class DistributedLongTest extends AbstractCopycatTest {
   }
 
   /**
+   * Tests incrementing a value followed by setting it and then incrementing it again.
+   */
+  public void testSequenceOfUpdates() throws Throwable {
+    Function<DistributedLong, CompletableFuture<Long>> sequence = l -> l.incrementAndGet()
+                                                                 .thenCompose(v -> l.set(10L))
+                                                                 .thenCompose(v -> l.incrementAndGet());
+    testAtomic(3, atomic(sequence, l -> 11L));
+  }
+
+  /**
    * Returns an atomic set/get test callback.
    */
   private Consumer<DistributedLong> atomic(Function<DistributedLong, CompletableFuture<Long>> commandFunction, Function<Long, Long> resultFunction) {


### PR DESCRIPTION
Previously the following scenario was broken:

`long.incrementAndGet()
long.set(10)
long.incrementAndGet()`

The above sequence of commands would return `12` instead of the expected value of `11`. This is because the `diff` variable in `LongState` is not reset when the value is set (in `ValueState`).

This commit is an attempt to simplify `LongState` by just keeping track of the current value of the counter.
The new snapshot capability makes this so much simpler.

Also in this commit are changes to make `ValueCommands` more type safe.

