### PR TITLE
Use 'atomix' name in Atomix server/replica logs on disk

### DIFF
--- a/manager/src/main/java/io/atomix/AtomixReplica.java
+++ b/manager/src/main/java/io/atomix/AtomixReplica.java
@@ -242,6 +242,7 @@ public final class AtomixReplica extends Atomix {
    * memory or memory-mapped files.
    */
   public static class Builder extends Atomix.Builder {
+    private static final String SERVER_NAME = "atomix";
     private final Address clientAddress;
     private final CopycatServer.Builder serverBuilder;
     private Transport clientTransport;
@@ -251,7 +252,7 @@ public final class AtomixReplica extends Atomix {
     private Builder(Address clientAddress, Address serverAddress, Collection<Address> members) {
       super(Collections.singleton(Assert.notNull(clientAddress, "clientAddress")));
       this.clientAddress = clientAddress;
-      this.serverBuilder = CopycatServer.builder(clientAddress, serverAddress, members);
+      this.serverBuilder = CopycatServer.builder(clientAddress, serverAddress, members).withName(SERVER_NAME);
     }
 
     /**

--- a/manager/src/main/java/io/atomix/AtomixServer.java
+++ b/manager/src/main/java/io/atomix/AtomixServer.java
@@ -185,11 +185,12 @@ public final class AtomixServer implements Managed<AtomixServer> {
    * memory or memory-mapped files.
    */
   public static class Builder extends io.atomix.catalyst.util.Builder<AtomixServer> {
+    private static final String SERVER_NAME = "atomix";
     private final CopycatServer.Builder builder;
     private ResourceTypeResolver resourceResolver = new ServiceLoaderResourceResolver();
 
     private Builder(Address clientAddress, Address serverAddress, Collection<Address> members) {
-      this.builder = CopycatServer.builder(clientAddress, serverAddress, members);
+      this.builder = CopycatServer.builder(clientAddress, serverAddress, members).withName(SERVER_NAME);
     }
 
     /**


### PR DESCRIPTION
This PR uses Copycat's new [server name support](https://github.com/atomix/copycat/pull/94) to store Atomix log files on disk with the `atomix` prefix. To do so, all we have to do is set the server name when constructing a new `AtomixServer` or `AtomixReplica`.