### PR TITLE
Add distributed task queue resource

### DIFF
--- a/coordination/src/main/java/io/atomix/coordination/DistributedCoordination.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedCoordination.java
@@ -47,4 +47,9 @@ public final class DistributedCoordination {
    */
   public static final ResourceType<DistributedMessageBus> MESSAGE_BUS = DistributedMessageBus.TYPE;
 
+  /**
+   * Distributed task queue resource.
+   */
+  public static final ResourceType<DistributedTaskQueue> TASK_QUEUE = DistributedTaskQueue.TYPE;
+
 }

--- a/coordination/src/main/java/io/atomix/coordination/DistributedTaskQueue.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedTaskQueue.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Listener;
+import io.atomix.coordination.state.TaskQueueCommands;
+import io.atomix.coordination.state.TaskQueueState;
+import io.atomix.copycat.client.CopycatClient;
+import io.atomix.resource.Resource;
+import io.atomix.resource.ResourceType;
+import io.atomix.resource.ResourceTypeInfo;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Distributed task queue.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@ResourceTypeInfo(id=-25, stateMachine=TaskQueueState.class)
+public class DistributedTaskQueue<T> extends Resource<DistributedTaskQueue<T>> {
+  public static final ResourceType<DistributedTaskQueue> TYPE = new ResourceType<>(DistributedTaskQueue.class);
+  private long taskId;
+  private final Map<Long, CompletableFuture<Void>> taskFutures = new ConcurrentHashMap<>();
+  private Consumer<T> subscriber;
+
+  @SuppressWarnings("unchecked")
+  public DistributedTaskQueue(CopycatClient client) {
+    super(client);
+    client.session().onEvent("process", this::process);
+    client.session().onEvent("ack", this::ack);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public ResourceType<DistributedTaskQueue<T>> type() {
+    return (ResourceType) TYPE;
+  }
+
+  /**
+   * Begins processing tasks.
+   */
+  @SuppressWarnings("unchecked")
+  private void process(T task) {
+    if (subscriber != null) {
+      subscriber.accept((T) task);
+      submit(new TaskQueueCommands.Ack()).whenComplete((result, error) -> {
+        if (error == null && result != null) {
+          process((T) result);
+        }
+      });
+    }
+  }
+
+  /**
+   * Handles a task acknowledgement.
+   */
+  private void ack(long taskId) {
+    CompletableFuture<Void> future = taskFutures.remove(taskId);
+    if (future != null) {
+      future.complete(null);
+    }
+  }
+
+  /**
+   * Submits a task to the task queue.
+   *
+   * @param task The task to submit.
+   * @return A completable future to be completed once the task has been completed.
+   */
+  public CompletableFuture<Void> submit(T task) {
+    return submit(new TaskQueueCommands.Submit(++taskId, task, false));
+  }
+
+  /**
+   * Submits a task to the task queue and awaits processing.
+   *
+   * @param task The task to submit.
+   * @return A completable future to be completed once the task has been completed.
+   */
+  public CompletableFuture<Void> submitNow(T task) {
+    long taskId = ++this.taskId;
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    taskFutures.put(taskId, future);
+    submit(new TaskQueueCommands.Submit(taskId, task, true)).whenComplete((result, error) -> {
+      if (error != null) {
+        taskFutures.remove(taskId);
+        future.completeExceptionally(error);
+      }
+    });
+    return future;
+  }
+
+  /**
+   * Subscribes to messages from the topic.
+   * <p>
+   * Once the returned {@link CompletableFuture} is completed, the subscriber is guaranteed to receive all
+   * messages from any client thereafter. Messages are guaranteed to be received in the order specified by
+   * the instance from which they were sent. The provided {@link Consumer} will always be executed on the
+   * same thread.
+   * <p>
+   * This method returns a {@link CompletableFuture} which can be used to block until the listener has been registered
+   * or to be notified in a separate thread once the operation completes. To block until the operation completes,
+   * use the {@link CompletableFuture#join()} method to block the calling thread:
+   * <pre>
+   *   {@code
+   *   topic.subscribe(message -> {
+   *     ...
+   *   }).join();
+   *   }
+   * </pre>
+   * Alternatively, to execute the operation asynchronous and be notified once the lock is acquired in a different
+   * thread, use one of the many completable future callbacks:
+   * <pre>
+   *   {@code
+   *   queue.subscribe(message -> {
+   *     ...
+   *   }).thenRun(() -> System.out.println("Subscribed to queue"));
+   *   }
+   * </pre>
+   *
+   * @param consumer The message consumer.
+   * @return A completable future to be completed once the consumer has been subscribed.
+   */
+  public synchronized CompletableFuture<Listener<T>> subscribe(Consumer<T> consumer) {
+    if (subscriber != null) {
+      subscriber = consumer;
+      return CompletableFuture.completedFuture(new TaskQueueListener(consumer));
+    }
+    subscriber = consumer;
+    return submit(new TaskQueueCommands.Subscribe())
+      .thenApply(v -> new TaskQueueListener(consumer));
+  }
+
+  /**
+   * Task queue listener.
+   */
+  private class TaskQueueListener implements Listener<T> {
+    private final Consumer<T> listener;
+
+    private TaskQueueListener(Consumer<T> listener) {
+      this.listener = listener;
+    }
+
+    @Override
+    public void accept(T message) {
+      listener.accept(message);
+    }
+
+    @Override
+    public void close() {
+      synchronized (DistributedTaskQueue.this) {
+        subscriber = null;
+        submit(new TaskQueueCommands.Unsubscribe());
+      }
+    }
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/state/TaskQueueCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/TaskQueueCommands.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination.state;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.copycat.client.Command;
+
+/**
+ * Distributed task queue commands.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public final class TaskQueueCommands {
+
+  private TaskQueueCommands() {
+  }
+
+  /**
+   * Base task queue command.
+   */
+  public static abstract class TaskQueueCommand<T> implements Command<T>, CatalystSerializable {
+    @Override
+    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+
+    }
+
+    @Override
+    public void readObject(BufferInput<?> buffer, Serializer serializer) {
+
+    }
+  }
+
+  /**
+   * Submit command.
+   */
+  @SerializeWith(id=256)
+  public static class Submit extends TaskQueueCommand<Void> {
+    private long id;
+    private Object task;
+    private boolean ack;
+
+    public Submit() {
+    }
+
+    public Submit(long id, Object task, boolean ack) {
+      this.id = id;
+      this.task = task;
+      this.ack = ack;
+    }
+
+    /**
+     * Returns the task ID.
+     *
+     * @return The task ID.
+     */
+    public long id() {
+      return id;
+    }
+
+    /**
+     * Returns the task.
+     *
+     * @return The task.
+     */
+    public Object task() {
+      return task;
+    }
+
+    /**
+     * Returns whether to acknowledge completion of the task.
+     *
+     * @return Whether to acknowledge completion of the task.
+     */
+    public boolean ack() {
+      return ack;
+    }
+
+    @Override
+    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+      buffer.writeLong(id).writeBoolean(ack);
+      serializer.writeObject(task, buffer);
+    }
+
+    @Override
+    public void readObject(BufferInput<?> buffer, Serializer serializer) {
+      id = buffer.readLong();
+      ack = buffer.readBoolean();
+      task = serializer.readObject(buffer);
+    }
+  }
+
+  /**
+   * Ack command.
+   */
+  @SerializeWith(id=257)
+  public static class Ack extends TaskQueueCommand<Object> {
+  }
+
+  /**
+   * Subscribe command.
+   */
+  @SerializeWith(id=258)
+  public static class Subscribe extends TaskQueueCommand<Void> {
+    @Override
+    public Command.CompactionMode compaction() {
+      return Command.CompactionMode.QUORUM;
+    }
+
+    @Override
+    public Command.ConsistencyLevel consistency() {
+      return Command.ConsistencyLevel.LINEARIZABLE;
+    }
+  }
+
+  /**
+   * Unsubscribe command.
+   */
+  @SerializeWith(id=259)
+  public static class Unsubscribe extends TaskQueueCommand<Void> {
+    @Override
+    public Command.ConsistencyLevel consistency() {
+      return Command.ConsistencyLevel.LINEARIZABLE;
+    }
+
+    @Override
+    public Command.CompactionMode compaction() {
+      return Command.CompactionMode.SEQUENTIAL;
+    }
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/state/TaskQueueState.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/TaskQueueState.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination.state;
+
+import io.atomix.copycat.client.session.Session;
+import io.atomix.copycat.server.Commit;
+import io.atomix.copycat.server.session.SessionListener;
+import io.atomix.resource.ResourceStateMachine;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * Task queue state machine.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class TaskQueueState extends ResourceStateMachine implements SessionListener {
+  private final Map<Long, Commit<TaskQueueCommands.Subscribe>> workers = new HashMap<>();
+  private final Queue<Session> workerQueue = new ArrayDeque<>();
+  private final LinkedBlockingDeque<Commit<TaskQueueCommands.Submit>> taskQueue = new LinkedBlockingDeque<>();
+  private final Map<Long, Commit<TaskQueueCommands.Submit>> processing = new HashMap<>();
+
+  @Override
+  public void register(Session session) {
+  }
+
+  @Override
+  public void unregister(Session session) {
+  }
+
+  @Override
+  public void expire(Session session) {
+  }
+
+  @Override
+  public void close(Session session) {
+    // Remove and close the subscription.
+    Commit<TaskQueueCommands.Subscribe> commit = workers.remove(session.id());
+    if (commit != null)
+      commit.close();
+
+    // Remove the session from the worker queue.
+    workerQueue.remove(session);
+
+    Commit<TaskQueueCommands.Submit> task = processing.remove(session.id());
+    if (task != null) {
+      Session next = workerQueue.poll();
+      if (next != null) {
+        next.publish("process", task.operation().task());
+      } else {
+        taskQueue.addFirst(task);
+      }
+    }
+  }
+
+  /**
+   * Handles a subscribe commit.
+   */
+  public void subscribe(Commit<TaskQueueCommands.Subscribe> commit) {
+    workers.put(commit.session().id(), commit);
+
+    Commit<TaskQueueCommands.Submit> task = taskQueue.poll();
+    if (task != null) {
+      processing.put(commit.session().id(), task);
+      commit.session().publish("process", task.operation().task());
+    } else {
+      workerQueue.add(commit.session());
+    }
+  }
+
+  /**
+   * Handles an unsubscribe commit.
+   */
+  public void unsubscribe(Commit<TaskQueueCommands.Unsubscribe> commit) {
+    close(commit.session());
+  }
+
+  /**
+   * Handles a task submission.
+   */
+  public void submit(Commit<TaskQueueCommands.Submit> commit) {
+    try {
+      Session session = workerQueue.poll();
+      if (session != null) {
+        session.publish("process", commit.operation().task());
+        processing.put(session.id(), commit);
+      } else {
+        taskQueue.add(commit);
+      }
+    } catch (Exception e) {
+      commit.close();
+      throw e;
+    }
+  }
+
+  /**
+   * Handles a task acknowledgement.
+   */
+  public Object ack(Commit<TaskQueueCommands.Ack> commit) {
+    try {
+      // Remove the task being processed by the given commit.
+      Commit<TaskQueueCommands.Submit> acked = processing.remove(commit.session().id());
+
+      // If no known task was being processed, throw an exception.
+      if (acked == null) {
+        throw new IllegalStateException("unknown task");
+      }
+
+      // Send an ack message to the session that submitted the task.
+      if (acked.operation().ack()) {
+        acked.session().publish("ack", acked.operation().id());
+      }
+
+      // Close the task commit to allow it to be garbage collected.
+      acked.close();
+
+      // Get and send the next task in the queue.
+      Commit<TaskQueueCommands.Submit> next = taskQueue.poll();
+      if (next != null) {
+        processing.put(commit.session().id(), next);
+        return next.operation().task();
+      } else {
+        workerQueue.add(commit.session());
+        return null;
+      }
+    } finally {
+      commit.close();
+    }
+  }
+
+}

--- a/coordination/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/coordination/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -30,6 +30,10 @@ io.atomix.coordination.state.MembershipGroupCommands$GetProperty
 io.atomix.coordination.state.MembershipGroupCommands$RemoveProperty
 io.atomix.coordination.state.MembershipGroupCommands$Send
 
+io.atomix.coordination.state.TaskQueueCommands$Subscribe
+io.atomix.coordination.state.TaskQueueCommands$Unsubscribe
+io.atomix.coordination.state.TaskQueueCommands$Submit
+
 io.atomix.coordination.state.MessageBusCommands$Join
 io.atomix.coordination.state.MessageBusCommands$Leave
 io.atomix.coordination.state.MessageBusCommands$Register

--- a/coordination/src/test/java/io/atomix/coordination/DistributedTaskQueueTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedTaskQueueTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.atomix.testing.AbstractCopycatTest;
+import io.atomix.coordination.state.TaskQueueState;
+import io.atomix.resource.ResourceStateMachine;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/**
+ * Distributed task queue test.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@Test
+public class DistributedTaskQueueTest extends AbstractCopycatTest {
+
+  @Override
+  protected ResourceStateMachine createStateMachine() {
+    return new TaskQueueState();
+  }
+
+  /**
+   * Tests submitting and processing tasks.
+   */
+  public void testSubmit() throws Throwable {
+    createServers(3);
+
+    DistributedTaskQueue<String> worker1 = new DistributedTaskQueue<>(createClient());
+    DistributedTaskQueue<String> worker2 = new DistributedTaskQueue<>(createClient());
+    DistributedTaskQueue<String> queue = new DistributedTaskQueue<>(createClient());
+
+    Set<String> tasks = new HashSet<>(Arrays.asList("foo", "bar", "baz"));
+    Set<String> completed = new ConcurrentSkipListSet<>();
+    worker1.subscribe(task -> {
+      threadAssertTrue(tasks.contains(task));
+      threadAssertFalse(completed.contains(task));
+      completed.add(task);
+      resume();
+    }).thenRun(this::resume);
+    worker2.subscribe(task -> {
+      threadAssertTrue(tasks.contains(task));
+      threadAssertFalse(completed.contains(task));
+      completed.add(task);
+      resume();
+    }).thenRun(this::resume);
+
+    await(5000, 2);
+
+    queue.submit("foo");
+    queue.submit("bar");
+    queue.submit("baz");
+    await(5000, 3);
+  }
+
+  /**
+   * Tests submitting and processing tasks and awaiting the acknowledgement.
+   */
+  public void testSubmitNow() throws Throwable {
+    createServers(3);
+
+    DistributedTaskQueue<String> worker1 = new DistributedTaskQueue<>(createClient());
+    DistributedTaskQueue<String> worker2 = new DistributedTaskQueue<>(createClient());
+    DistributedTaskQueue<String> queue = new DistributedTaskQueue<>(createClient());
+
+    Set<String> tasks = new HashSet<>(Arrays.asList("foo", "bar", "baz"));
+    Set<String> completed = new ConcurrentSkipListSet<>();
+    worker1.subscribe(task -> {
+      threadAssertTrue(tasks.contains(task));
+      threadAssertFalse(completed.contains(task));
+      completed.add(task);
+      resume();
+    }).thenRun(this::resume);
+    worker2.subscribe(task -> {
+      threadAssertTrue(tasks.contains(task));
+      threadAssertFalse(completed.contains(task));
+      completed.add(task);
+      resume();
+    }).thenRun(this::resume);
+
+    await(5000, 2);
+
+    queue.submitNow("foo").thenRun(this::resume);
+    queue.submitNow("bar").thenRun(this::resume);
+    queue.submitNow("baz").thenRun(this::resume);
+    await(5000, 6);
+  }
+
+}

--- a/coordination/src/test/java/io/atomix/coordination/DistributedTaskQueueTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedTaskQueueTest.java
@@ -41,22 +41,22 @@ public class DistributedTaskQueueTest extends AbstractCopycatTest {
   /**
    * Tests submitting and processing tasks.
    */
-  public void testSubmit() throws Throwable {
+  public void testSubmitAsync() throws Throwable {
     createServers(3);
 
-    DistributedTaskQueue<String> worker1 = new DistributedTaskQueue<>(createClient());
-    DistributedTaskQueue<String> worker2 = new DistributedTaskQueue<>(createClient());
-    DistributedTaskQueue<String> queue = new DistributedTaskQueue<>(createClient());
+    DistributedTaskQueue<String> worker1 = new DistributedTaskQueue<String>(createClient()).async();
+    DistributedTaskQueue<String> worker2 = new DistributedTaskQueue<String>(createClient()).async();
+    DistributedTaskQueue<String> queue = new DistributedTaskQueue<String>(createClient()).async();
 
     Set<String> tasks = new HashSet<>(Arrays.asList("foo", "bar", "baz"));
     Set<String> completed = new ConcurrentSkipListSet<>();
-    worker1.subscribe(task -> {
+    worker1.consumer(task -> {
       threadAssertTrue(tasks.contains(task));
       threadAssertFalse(completed.contains(task));
       completed.add(task);
       resume();
     }).thenRun(this::resume);
-    worker2.subscribe(task -> {
+    worker2.consumer(task -> {
       threadAssertTrue(tasks.contains(task));
       threadAssertFalse(completed.contains(task));
       completed.add(task);
@@ -74,22 +74,22 @@ public class DistributedTaskQueueTest extends AbstractCopycatTest {
   /**
    * Tests submitting and processing tasks and awaiting the acknowledgement.
    */
-  public void testSubmitNow() throws Throwable {
+  public void testSubmitSync() throws Throwable {
     createServers(3);
 
-    DistributedTaskQueue<String> worker1 = new DistributedTaskQueue<>(createClient());
-    DistributedTaskQueue<String> worker2 = new DistributedTaskQueue<>(createClient());
-    DistributedTaskQueue<String> queue = new DistributedTaskQueue<>(createClient());
+    DistributedTaskQueue<String> worker1 = new DistributedTaskQueue<String>(createClient()).sync();
+    DistributedTaskQueue<String> worker2 = new DistributedTaskQueue<String>(createClient()).sync();
+    DistributedTaskQueue<String> queue = new DistributedTaskQueue<String>(createClient()).sync();
 
     Set<String> tasks = new HashSet<>(Arrays.asList("foo", "bar", "baz"));
     Set<String> completed = new ConcurrentSkipListSet<>();
-    worker1.subscribe(task -> {
+    worker1.consumer(task -> {
       threadAssertTrue(tasks.contains(task));
       threadAssertFalse(completed.contains(task));
       completed.add(task);
       resume();
     }).thenRun(this::resume);
-    worker2.subscribe(task -> {
+    worker2.consumer(task -> {
       threadAssertTrue(tasks.contains(task));
       threadAssertFalse(completed.contains(task));
       completed.add(task);
@@ -98,9 +98,9 @@ public class DistributedTaskQueueTest extends AbstractCopycatTest {
 
     await(5000, 2);
 
-    queue.submitNow("foo").thenRun(this::resume);
-    queue.submitNow("bar").thenRun(this::resume);
-    queue.submitNow("baz").thenRun(this::resume);
+    queue.submit("foo").thenRun(this::resume);
+    queue.submit("bar").thenRun(this::resume);
+    queue.submit("baz").thenRun(this::resume);
     await(5000, 6);
   }
 

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -73,6 +73,20 @@ public abstract class Resource<T extends Resource<T>> {
   }
 
   /**
+   * Returns the configured resource consistency level.
+   * <p>
+   * Resource consistency levels are configured via the {@link #with(Consistency)} setter. By default,
+   * all resources submit commands under the {@link Consistency#ATOMIC} consistency level. See the
+   * {@link Consistency} documentation for information about guarantees provided by specific consistency
+   * levels.
+   *
+   * @return The configured resource consistency level.
+   */
+  public Consistency consistency() {
+    return consistency;
+  }
+
+  /**
    * Sets the resource consistency level.
    * <p>
    * The configured consistency level specifies how operations on the resource should be handled by the


### PR DESCRIPTION
This PR adds a `DistributedTaskQueue` resource as per the request of a user. The task queue works by enqueueing commands and pushing them to subscribed clients. When a task is received by the state machine, if a client is awaiting work the task will be pushed to that client, otherwise the work will be queued. Clients acknowledge a task and receive the next task in a single request.