### PR TITLE
Update CopycatClient usage for client rewrite

### DIFF
--- a/coordination/src/main/java/io/atomix/coordination/state/MembershipGroupState.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/MembershipGroupState.java
@@ -63,7 +63,8 @@ public class MembershipGroupState extends ResourceStateMachine implements Sessio
     }
 
     for (Commit<MembershipGroupCommands.Join> member : members.values()) {
-      member.session().publish("leave", session.id());
+      if (member.session().state() == Session.State.OPEN)
+        member.session().publish("leave", session.id());
     }
   }
 

--- a/manager/src/main/java/io/atomix/Atomix.java
+++ b/manager/src/main/java/io/atomix/Atomix.java
@@ -430,9 +430,10 @@ public abstract class Atomix implements Managed<Atomix> {
 
     protected Builder(Collection<Address> members) {
       clientBuilder = CopycatClient.builder(members)
-        .withConnectionStrategy(ConnectionStrategies.BACKOFF)
+        .withServerSelectionStrategy(ServerSelectionStrategies.ANY)
+        .withConnectionStrategy(ConnectionStrategies.FIBONACCI_BACKOFF)
         .withRecoveryStrategy(RecoveryStrategies.RECOVER)
-        .withSubmissionStrategy(SubmissionStrategies.ANY);
+        .withRetryStrategy(RetryStrategies.FIBONACCI_BACKOFF);
     }
 
     /**

--- a/manager/src/main/java/io/atomix/manager/CloseResource.java
+++ b/manager/src/main/java/io/atomix/manager/CloseResource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.manager;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.SerializeWith;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.copycat.client.Command;
+
+/**
+ * Close resource command.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+@SerializeWith(id=38)
+public class CloseResource implements Command<Void>, CatalystSerializable {
+  private long resource;
+
+  public CloseResource() {
+  }
+
+  public CloseResource(long resource) {
+    this.resource = resource;
+  }
+
+  @Override
+  public CompactionMode compaction() {
+    return CompactionMode.SEQUENTIAL;
+  }
+
+  /**
+   * Returns the resource ID.
+   *
+   * @return The resource ID.
+   */
+  public long resource() {
+    return resource;
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    buffer.writeLong(resource);
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    resource = buffer.readLong();
+  }
+
+}

--- a/manager/src/main/java/io/atomix/manager/CloseResource.java
+++ b/manager/src/main/java/io/atomix/manager/CloseResource.java
@@ -27,7 +27,7 @@ import io.atomix.copycat.client.Command;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-@SerializeWith(id=38)
+@SerializeWith(id=42)
 public class CloseResource implements Command<Void>, CatalystSerializable {
   private long resource;
 

--- a/manager/src/main/java/io/atomix/resource/InstanceClient.java
+++ b/manager/src/main/java/io/atomix/resource/InstanceClient.java
@@ -39,21 +39,25 @@ import java.util.function.Consumer;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class InstanceClient implements CopycatClient {
-  private final long resource;
+  private long resource;
   private final CopycatClient client;
   private final Transport transport;
-  private final InstanceSession session;
+  private InstanceSession session;
   private final Map<String, Set<EventListener>> eventListeners = new ConcurrentHashMap<>();
   private final Map<String, Listener<InstanceEvent<?>>> listeners = new ConcurrentHashMap<>();
 
-  /**
-   * @throws NullPointerException if {@code client} is null
-   */
-  public InstanceClient(long resource, CopycatClient client, Transport transport) {
-    this.resource = resource;
+  public InstanceClient(CopycatClient client, Transport transport) {
     this.client = Assert.notNull(client, "client");
-    this.transport = transport;
-    this.session = new InstanceSession(resource, client.session(), client.context());
+    this.transport = Assert.notNull(transport, "transport");
+  }
+
+  /**
+   * Resets the instance resource ID.
+   */
+  InstanceClient reset(long resourceId) {
+    this.resource = resourceId;
+    this.session = new InstanceSession(resourceId, client.session(), client.context());;
+    return this;
   }
 
   @Override
@@ -83,7 +87,7 @@ public class InstanceClient implements CopycatClient {
 
   @Override
   public Serializer serializer() {
-    return null;
+    return client.serializer();
   }
 
   @Override

--- a/manager/src/main/java/io/atomix/resource/InstanceFactory.java
+++ b/manager/src/main/java/io/atomix/resource/InstanceFactory.java
@@ -365,7 +365,12 @@ public class InstanceFactory implements Managed<InstanceFactory> {
    */
   @Override
   public CompletableFuture<Void> close() {
-    return client.close();
+    CompletableFuture<?>[] futures = new CompletableFuture[instances.size()];
+    int i = 0;
+    for (Instance instance : instances.values()) {
+      futures[i++] = instance.instance.close();
+    }
+    return CompletableFuture.allOf(futures).thenCompose(v -> client.close());
   }
 
   /**
@@ -381,7 +386,7 @@ public class InstanceFactory implements Managed<InstanceFactory> {
   /**
    * Resource instance.
    */
-  private static class Instance<T extends Resource> {
+  final static class Instance<T extends Resource> {
 
     /**
      * The method with which the resource was opened.

--- a/manager/src/main/java/io/atomix/resource/InstanceFactory.java
+++ b/manager/src/main/java/io/atomix/resource/InstanceFactory.java
@@ -44,7 +44,7 @@ public class InstanceFactory implements Managed<InstanceFactory> {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceFactory.class);
   private final CopycatClient client;
   private final Transport transport;
-  private final Map<Long, Instance> instances = new ConcurrentHashMap<>();
+  final Map<Long, Instance> instances = new ConcurrentHashMap<>();
 
   public InstanceFactory(CopycatClient client, Transport transport) {
     this.client = Assert.notNull(client, "client");
@@ -173,7 +173,7 @@ public class InstanceFactory implements Managed<InstanceFactory> {
     return client.submit(new GetResource(Assert.notNull(key, "key"), Assert.notNull(type, "type").id()))
       .thenApply(id -> instances.computeIfAbsent(id, i -> {
         try {
-          InstanceClient instanceClient = new InstanceClient(client, transport);
+          InstanceClient instanceClient = new InstanceClient(client, transport, this);
           T instance = type.resource().getConstructor(CopycatClient.class).newInstance(instanceClient.reset(id));
           return new Instance<>(key, type, Instance.Method.GET, instanceClient, instance);
         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
@@ -238,7 +238,7 @@ public class InstanceFactory implements Managed<InstanceFactory> {
     return client.submit(new CreateResource(Assert.notNull(key, "key"), Assert.notNull(type, "type").id()))
       .thenApply(id -> instances.computeIfAbsent(id, i -> {
         try {
-          InstanceClient instanceClient = new InstanceClient(client, transport);
+          InstanceClient instanceClient = new InstanceClient(client, transport, this);
           T instance = type.resource().getConstructor(CopycatClient.class).newInstance(instanceClient.reset(id));
           return new Instance<>(key, type, Instance.Method.CREATE, instanceClient, instance);
         } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {

--- a/manager/src/main/java/io/atomix/resource/InstanceSession.java
+++ b/manager/src/main/java/io/atomix/resource/InstanceSession.java
@@ -53,13 +53,13 @@ public final class InstanceSession implements Session {
   }
 
   @Override
-  public boolean isOpen() {
-    return parent.isOpen();
+  public State state() {
+    return parent.state();
   }
 
   @Override
-  public Listener<Session> onOpen(Consumer<Session> listener) {
-    return parent.onOpen(Assert.notNull(listener, "listener"));
+  public Listener<State> onStateChange(Consumer<State> callback) {
+    return parent.onStateChange(callback);
   }
 
   @Override
@@ -117,21 +117,6 @@ public final class InstanceSession implements Session {
         }
       }
     }
-  }
-
-  @Override
-  public Listener<Session> onClose(Consumer<Session> listener) {
-    return parent.onClose(Assert.notNull(listener, "listener"));
-  }
-
-  @Override
-  public boolean isClosed() {
-    return parent.isClosed();
-  }
-
-  @Override
-  public boolean isExpired() {
-    return parent.isExpired();
   }
 
   @Override

--- a/manager/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
+++ b/manager/src/main/resources/META-INF/services/io.atomix.catalyst.serializer.CatalystSerializable
@@ -21,6 +21,7 @@ io.atomix.manager.GetResource
 io.atomix.manager.GetResourceIfExists
 io.atomix.manager.CreateResource
 io.atomix.manager.CreateResourceIfExists
+io.atomix.manager.CloseResource
 io.atomix.manager.DeleteResource
 io.atomix.manager.ResourceExists
 io.atomix.manager.GetResourceKeys

--- a/messaging/src/main/java/io/atomix/messaging/DistributedMessageBus.java
+++ b/messaging/src/main/java/io/atomix/messaging/DistributedMessageBus.java
@@ -314,12 +314,7 @@ public class DistributedMessageBus extends Resource<DistributedMessageBus> {
     });
   }
 
-  /**
-   * Closes the message bus.
-   *
-   * @return A completable future to be completed once the message bus is closed.
-   * @throws IllegalStateException if the message bus is not open
-   */
+  @Override
   public synchronized CompletableFuture<Void> close() {
     if (closeFuture != null)
       return closeFuture;

--- a/messaging/src/main/java/io/atomix/messaging/state/MessageBusState.java
+++ b/messaging/src/main/java/io/atomix/messaging/state/MessageBusState.java
@@ -51,7 +51,8 @@ public class MessageBusState extends ResourceStateMachine implements SessionList
   public void close(Session session) {
     members.remove(session.id());
     for (Commit<MessageBusCommands.Join> member : members.values()) {
-      member.session().publish("leave", session.id());
+      if (member.session().state() == Session.State.OPEN)
+        member.session().publish("leave", session.id());
     }
   }
 

--- a/messaging/src/main/java/io/atomix/messaging/state/TopicState.java
+++ b/messaging/src/main/java/io/atomix/messaging/state/TopicState.java
@@ -85,7 +85,7 @@ public class TopicState extends ResourceStateMachine implements SessionListener 
       Iterator<Map.Entry<Long, Commit<TopicCommands.Listen>>> iterator = listeners.entrySet().iterator();
       while (iterator.hasNext()) {
         Commit<TopicCommands.Listen> listener = iterator.next().getValue();
-        if (listener.session().isOpen()) {
+        if (listener.session().state() == Session.State.OPEN) {
           listener.session().publish("message", commit.operation().message());
         } else {
           iterator.remove();

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -192,6 +192,15 @@ public abstract class Resource<T extends Resource<T>> {
   }
 
   /**
+   * Closes the resource.
+   *
+   * @return A completable future to be completed once the resource is closed.
+   */
+  public CompletableFuture<Void> close() {
+    return client.close();
+  }
+
+  /**
    * Deletes the resource state.
    *
    * @return A completable future to be completed once the resource has been deleted.

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -48,15 +48,6 @@ public abstract class Resource<T extends Resource<T>> {
   }
 
   /**
-   * Resets the internal Raft client.
-   *
-   * @param client The internal Raft client.
-   */
-  final void reset(CopycatClient client) {
-    this.client = Assert.notNull(client, "client");
-  }
-
-  /**
    * Returns the resource type.
    *
    * @return The resource type.

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -16,12 +16,16 @@
 package io.atomix.resource;
 
 import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.util.Listener;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.Query;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
 
 /**
  * Fault-tolerant stateful distributed object.
@@ -40,11 +44,45 @@ import java.util.concurrent.CompletableFuture;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public abstract class Resource<T extends Resource<T>> {
+
+  /**
+   * Resource state.
+   */
+  public enum State {
+
+    /**
+     * Indicates that the client is connected to the cluster and operating normally.
+     */
+    CONNECTED,
+
+    /**
+     * Indicates that the client is suspended and unable to communicate with the cluster.
+     */
+    SUSPENDED,
+
+    /**
+     * Indicates that the client is closed.
+     */
+    CLOSED
+
+  }
+
   protected CopycatClient client;
+  private State state;
+  private final Set<StateChangeListener> changeListeners = new CopyOnWriteArraySet<>();
   private Consistency consistency = Consistency.ATOMIC;
 
   protected Resource(CopycatClient client) {
     this.client = Assert.notNull(client, "client");
+    client.onStateChange(this::onStateChange);
+  }
+
+  /**
+   * Called when a client state change occurs.
+   */
+  private void onStateChange(CopycatClient.State state) {
+    this.state = State.valueOf(state.name());
+    changeListeners.forEach(l -> l.accept(this.state));
   }
 
   /**
@@ -53,6 +91,25 @@ public abstract class Resource<T extends Resource<T>> {
    * @return The resource type.
    */
   public abstract ResourceType<T> type();
+
+  /**
+   * Returns the current resource state.
+   *
+   * @return The current resource state.
+   */
+  public State state() {
+    return state;
+  }
+
+  /**
+   * Registers a resource state change listener.
+   *
+   * @param callback The callback to call when the resource state changes.
+   * @return The state change listener.
+   */
+  public Listener<State> onStateChange(Consumer<State> callback) {
+    return new StateChangeListener(Assert.notNull(callback, "callback"));
+  }
 
   /**
    * Returns the resource thread context.
@@ -156,6 +213,28 @@ public abstract class Resource<T extends Resource<T>> {
   @Override
   public String toString() {
     return String.format("%s[id=%s]", getClass().getSimpleName(), client.session().id());
+  }
+
+  /**
+   * Resource state change listener.
+   */
+  private class StateChangeListener implements Listener<State> {
+    private final Consumer<State> callback;
+
+    private StateChangeListener(Consumer<State> callback) {
+      this.callback = callback;
+      changeListeners.add(this);
+    }
+
+    @Override
+    public void accept(State state) {
+      callback.accept(state);
+    }
+
+    @Override
+    public void close() {
+      changeListeners.remove(this);
+    }
   }
 
 }


### PR DESCRIPTION
The `CopycatClient` was rewritten to handle a variety of issues. This PR is a first step at taking advantage of the new client features. A not-insignificant additional amount of work will have to go into Atomix to handle the changes in logical session IDs across Copycat client session IDs and ensure operations are resubmitted properly across sessions.