### PR TITLE
Register leader election listeners when election is opened

### DIFF
--- a/all/src/test/java/io/atomix/AtomixLeaderElectionTest.java
+++ b/all/src/test/java/io/atomix/AtomixLeaderElectionTest.java
@@ -15,14 +15,13 @@
  */
 package io.atomix;
 
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-
+import io.atomix.coordination.DistributedLeaderElection;
+import io.atomix.testing.AbstractAtomixTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import io.atomix.testing.AbstractAtomixTest;
-import io.atomix.coordination.DistributedLeaderElection;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 
 /**
  * Atomix leader election test.
@@ -68,7 +67,7 @@ public class AtomixLeaderElectionTest extends AbstractAtomixTest {
       threadAssertTrue(epoch > lastEpoch.get());
       lastEpoch.set(epoch);
       resume();
-    }).join();
+    });
 
     await(10000);
 
@@ -76,7 +75,7 @@ public class AtomixLeaderElectionTest extends AbstractAtomixTest {
       threadAssertTrue(epoch > lastEpoch.get());
       lastEpoch.set(epoch);
       resume();
-    }).join();
+    });
 
     client1.close();
 

--- a/coordination/src/test/java/io/atomix/coordination/DistributedLeaderElectionTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedLeaderElectionTest.java
@@ -42,8 +42,8 @@ public class DistributedLeaderElectionTest extends AbstractCopycatTest<Distribut
 
     DistributedLeaderElection election = createResource();
 
-    election.onElection(v -> resume()).thenRun(this::resume);
-    await(0, 2);
+    election.onElection(v -> resume());
+    await(10000);
   }
 
   /**
@@ -60,7 +60,7 @@ public class DistributedLeaderElectionTest extends AbstractCopycatTest<Distribut
       threadAssertTrue(epoch > lastEpoch.get());
       lastEpoch.set(epoch);
       resume();
-    }).join();
+    });
 
     await(10000);
 
@@ -68,7 +68,7 @@ public class DistributedLeaderElectionTest extends AbstractCopycatTest<Distribut
       threadAssertTrue(epoch > lastEpoch.get());
       lastEpoch.set(epoch);
       resume();
-    }).join();
+    });
 
     election1.close();
 
@@ -89,7 +89,7 @@ public class DistributedLeaderElectionTest extends AbstractCopycatTest<Distribut
       threadAssertTrue(epoch > lastEpoch.get());
       lastEpoch.set(epoch);
       resume();
-    }).join();
+    });
 
     await(10000);
 
@@ -97,7 +97,7 @@ public class DistributedLeaderElectionTest extends AbstractCopycatTest<Distribut
       threadAssertTrue(epoch > lastEpoch.get());
       lastEpoch.set(epoch);
       resume();
-    }).join();
+    });
 
     election1.resign(lastEpoch.get());
 

--- a/examples/leader-election/src/main/java/io/atomix/examples/election/LeaderElectionExample.java
+++ b/examples/leader-election/src/main/java/io/atomix/examples/election/LeaderElectionExample.java
@@ -66,7 +66,7 @@ public class LeaderElectionExample {
     // Register a callback to be called when this election instance is elected the leader
     election.onElection(epoch -> {
       System.out.println("Elected leader!");
-    }).join();
+    });
 
     // Block while the replica is open.
     while (atomix.isOpen()) {

--- a/testing/src/main/java/io/atomix/testing/AbstractAtomixTest.java
+++ b/testing/src/main/java/io/atomix/testing/AbstractAtomixTest.java
@@ -30,7 +30,6 @@ import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -159,13 +158,7 @@ public abstract class AbstractAtomixTest extends ConcurrentTestCase {
   protected AtomixServer createServer(Address address, List<Address> members) {
     AtomixServer server = AtomixServer.builder(address, members)
         .withTransport(new LocalTransport(registry))
-        .withStorage(Storage.builder()
-            .withStorageLevel(StorageLevel.MEMORY)
-            .withMaxSegmentSize(1024 * 1024)
-            .withMaxEntriesPerSegment(8)
-            .withMinorCompactionInterval(Duration.ofSeconds(3))
-            .withMajorCompactionInterval(Duration.ofSeconds(7))
-            .build())
+        .withStorage(new Storage(StorageLevel.MEMORY))
         .build();
     servers.add(server);
     return server;


### PR DESCRIPTION
This PR modifies the `DistributedLeaderElection` resource to perform setup of the election resource during the `open()` call which is called when the resource is created. This allows election listeners to be added synchronously and without a separate call to the cluster.