### PR TITLE
Add resource options to DistributedMessageBus

### DIFF
--- a/core/src/main/java/io/atomix/Atomix.java
+++ b/core/src/main/java/io/atomix/Atomix.java
@@ -15,6 +15,7 @@
  */
 package io.atomix;
 
+import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.collections.DistributedMap;
@@ -170,10 +171,11 @@ public abstract class Atomix implements ResourceManager<Atomix> {
    * Gets or creates a distributed message bus.
    *
    * @param key The resource key.
+   * @param address The local message bus address.
    * @return A completable future to be completed once the message bus has been created.
    */
-  public CompletableFuture<DistributedMessageBus> getMessageBus(String key) {
-    return get(key, DistributedMessageBus.class);
+  public CompletableFuture<DistributedMessageBus> getMessageBus(String key, Address address) {
+    return get(key, DistributedMessageBus.class, DistributedMessageBus.options().withAddress(address).build());
   }
 
   @Override

--- a/core/src/test/java/io/atomix/AtomixMessageBusTest.java
+++ b/core/src/test/java/io/atomix/AtomixMessageBusTest.java
@@ -20,8 +20,6 @@ import io.atomix.messaging.DistributedMessageBus;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.function.Function;
-
 /**
  * Atomix message bus test.
  *
@@ -37,22 +35,19 @@ public class AtomixMessageBusTest extends AbstractAtomixTest {
   public void testClientMessageBusGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testMessageBus(client1, client2, get("test-client-bus-get", DistributedMessageBus.class));
+    testMessageBus(client1, client2, "test-client-bus-get");
   }
 
   public void testReplicaMessageBusGet() throws Throwable {
-    testMessageBus(replicas.get(0), replicas.get(1), get("test-replica-bus-get", DistributedMessageBus.class));
+    testMessageBus(replicas.get(0), replicas.get(1), "test-replica-bus-get");
   }
 
   /**
    * Tests sending and receiving messages on a message bus.
    */
-  private void testMessageBus(Atomix client1, Atomix client2, Function<Atomix, DistributedMessageBus> factory) throws Throwable {
-    DistributedMessageBus bus1 = factory.apply(client1);
-    DistributedMessageBus bus2 = factory.apply(client2);
-
-    bus1.open(new Address("localhost", 6000)).join();
-    bus2.open(new Address("localhost", 6001)).join();
+  private void testMessageBus(Atomix client1, Atomix client2, String key) throws Throwable {
+    DistributedMessageBus bus1 = client1.getMessageBus(key, new Address("localhost", 6000)).get();
+    DistributedMessageBus bus2 = client2.getMessageBus(key, new Address("localhost", 6001)).get();
 
     bus1.<String>consumer("test", message -> {
       threadAssertEquals(message, "Hello world!");

--- a/messaging/src/test/java/io/atomix/messaging/DistributedMessageBusTest.java
+++ b/messaging/src/test/java/io/atomix/messaging/DistributedMessageBusTest.java
@@ -16,7 +16,6 @@
 package io.atomix.messaging;
 
 import io.atomix.catalyst.transport.Address;
-import io.atomix.resource.ResourceType;
 import io.atomix.testing.AbstractCopycatTest;
 import org.testng.annotations.Test;
 
@@ -39,11 +38,8 @@ public class DistributedMessageBusTest extends AbstractCopycatTest<DistributedMe
   public void testSend() throws Throwable {
     createServers(3);
 
-    DistributedMessageBus bus1 = createResource();
-    DistributedMessageBus bus2 = createResource();
-
-    bus1.open(new Address("localhost", 6000)).join();
-    bus2.open(new Address("localhost", 6001)).join();
+    DistributedMessageBus bus1 = createResource(DistributedMessageBus.options().withAddress(new Address("localhost", 6000)).build());
+    DistributedMessageBus bus2 = createResource(DistributedMessageBus.options().withAddress(new Address("localhost", 6001)).build());
 
     bus1.<String>consumer("test", message -> {
       threadAssertEquals(message, "Hello world!");

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -64,6 +64,13 @@ public abstract class Resource<T extends Resource<T, U>, U extends Resource.Opti
    * Resource options.
    */
   public interface Options {
+
+    /**
+     * Indicates
+     */
+    class None implements Resource.Options {
+    }
+
   }
 
   /**

--- a/resource/src/main/java/io/atomix/resource/ResourceType.java
+++ b/resource/src/main/java/io/atomix/resource/ResourceType.java
@@ -27,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class ResourceType {
   private final Class<? extends Resource> type;
+  private final Class<? extends Resource.Options> options;
   private final int id;
   private final Class<? extends ResourceStateMachine> stateMachine;
 
@@ -40,6 +41,7 @@ public class ResourceType {
 
     this.id = info.id();
     this.stateMachine = info.stateMachine();
+    this.options = info.options();
   }
 
   /**
@@ -61,6 +63,15 @@ public class ResourceType {
   }
 
   /**
+   * Returns the resource options class.
+   *
+   * @return The resource options class.
+   */
+  public Class<? extends Resource.Options> options() {
+    return options;
+  }
+
+  /**
    * Returns the resource instance factory.
    *
    * @return The resource instance factory.
@@ -68,7 +79,7 @@ public class ResourceType {
   public ResourceFactory factory() {
     return (client, options) -> {
       try {
-        return resource().getConstructor(CopycatClient.class, Resource.Options.class).newInstance(client, options);
+        return resource().getConstructor(CopycatClient.class, options()).newInstance(client, options);
       } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
         throw new ResourceException("failed to instantiate resource class", e);
       }

--- a/resource/src/main/java/io/atomix/resource/ResourceTypeInfo.java
+++ b/resource/src/main/java/io/atomix/resource/ResourceTypeInfo.java
@@ -39,4 +39,9 @@ public @interface ResourceTypeInfo {
    */
   Class<? extends ResourceStateMachine> stateMachine();
 
+  /**
+   * The resource options class.
+   */
+  Class<? extends Resource.Options> options() default Resource.Options.None.class;
+
 }

--- a/testing/src/main/java/io/atomix/testing/AbstractCopycatTest.java
+++ b/testing/src/main/java/io/atomix/testing/AbstractCopycatTest.java
@@ -91,8 +91,15 @@ public abstract class AbstractCopycatTest<T extends Resource> extends Concurrent
   /**
    * Creates a new resource instance.
    */
-  @SuppressWarnings("unchecked")
   protected T createResource() throws Throwable {
+    return createResource(null);
+  }
+
+  /**
+   * Creates a new resource instance.
+   */
+  @SuppressWarnings("unchecked")
+  protected T createResource(Resource.Options options) throws Throwable {
     CopycatClient client = CopycatClient.builder(members)
       .withTransport(new LocalTransport(registry))
       .withServerSelectionStrategy(ServerSelectionStrategies.ANY)
@@ -101,7 +108,7 @@ public abstract class AbstractCopycatTest<T extends Resource> extends Concurrent
       .withRetryStrategy(RetryStrategies.FIBONACCI_BACKOFF)
       .build();
     ResourceType type = new ResourceType((Class<? extends Resource>) type());
-    T resource = (T) type.factory().create(client, null);
+    T resource = (T) type.factory().create(client, options);
     resource.open().thenRun(this::resume);
     resources.add(resource);
     await(10000);


### PR DESCRIPTION
This PR modifies the `DistributedMessageBus` resource to use an `Options` class to specify the message bus server `Address`, presenting a more consistent API.