### PR TITLE
Push DistributedTaskQueue tasks to consumers in batches

### DIFF
--- a/messaging/src/main/java/io/atomix/messaging/state/TaskQueueState.java
+++ b/messaging/src/main/java/io/atomix/messaging/state/TaskQueueState.java
@@ -20,10 +20,7 @@ import io.atomix.copycat.server.Commit;
 import io.atomix.copycat.server.session.SessionListener;
 import io.atomix.resource.ResourceStateMachine;
 
-import java.util.ArrayDeque;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.LinkedBlockingDeque;
 
 /**
@@ -32,10 +29,10 @@ import java.util.concurrent.LinkedBlockingDeque;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public class TaskQueueState extends ResourceStateMachine implements SessionListener {
+  private static final int BATCH_SIZE = 8;
   private final Map<Long, Commit<TaskQueueCommands.Subscribe>> workers = new HashMap<>();
-  private final Queue<Session> workerQueue = new ArrayDeque<>();
   private final LinkedBlockingDeque<Commit<TaskQueueCommands.Submit>> taskQueue = new LinkedBlockingDeque<>();
-  private final Map<Long, Commit<TaskQueueCommands.Submit>> processing = new HashMap<>();
+  private final Map<Long, List<Commit<TaskQueueCommands.Submit>>> processing = new HashMap<>();
 
   @Override
   public void register(Session session) {
@@ -57,17 +54,36 @@ public class TaskQueueState extends ResourceStateMachine implements SessionListe
       commit.close();
 
     // Remove the session from the worker queue.
-    workerQueue.remove(session);
+    workers.remove(session.id());
 
-    Commit<TaskQueueCommands.Submit> task = processing.remove(session.id());
-    if (task != null) {
-      Session next = workerQueue.poll();
-      if (next != null) {
-        next.publish("process", task.operation().task());
-      } else {
-        taskQueue.addFirst(task);
+    List<Commit<TaskQueueCommands.Submit>> tasks = processing.remove(session.id());
+    if (tasks != null) {
+      Collections.reverse(tasks);
+      for (Commit<TaskQueueCommands.Submit> task : tasks) {
+        Session worker = selectWorker();
+        if (worker != null) {
+          worker.publish("process", task.operation().task());
+        } else {
+          taskQueue.addFirst(task);
+        }
       }
     }
+  }
+
+  /**
+   * Selects a worker to which to publish a task.
+   */
+  private Session selectWorker() {
+    int count = -1;
+    long worker = -1;
+    for (Map.Entry<Long, List<Commit<TaskQueueCommands.Submit>>> entry : processing.entrySet()) {
+      List<Commit<TaskQueueCommands.Submit>> tasks = entry.getValue();
+      if (tasks.size() < BATCH_SIZE && count == -1 || tasks.size() < count) {
+        count = entry.getValue().size();
+        worker = entry.getKey();
+      }
+    }
+    return worker != -1 ? workers.get(worker).session() : null;
   }
 
   /**
@@ -75,13 +91,14 @@ public class TaskQueueState extends ResourceStateMachine implements SessionListe
    */
   public void subscribe(Commit<TaskQueueCommands.Subscribe> commit) {
     workers.put(commit.session().id(), commit);
+    List<Commit<TaskQueueCommands.Submit>> tasks = new ArrayList<>(BATCH_SIZE);
+    processing.put(commit.session().id(), tasks);
 
     Commit<TaskQueueCommands.Submit> task = taskQueue.poll();
-    if (task != null) {
-      processing.put(commit.session().id(), task);
+    while (task != null && tasks.size() < BATCH_SIZE) {
+      tasks.add(task);
       commit.session().publish("process", task.operation().task());
-    } else {
-      workerQueue.add(commit.session());
+      task = taskQueue.poll();
     }
   }
 
@@ -97,10 +114,11 @@ public class TaskQueueState extends ResourceStateMachine implements SessionListe
    */
   public void submit(Commit<TaskQueueCommands.Submit> commit) {
     try {
-      Session session = workerQueue.poll();
-      if (session != null) {
-        session.publish("process", commit.operation().task());
-        processing.put(session.id(), commit);
+      Session worker = selectWorker();
+      if (worker != null) {
+        List<Commit<TaskQueueCommands.Submit>> tasks = processing.get(worker.id());
+        tasks.add(commit);
+        worker.publish("process", commit.operation().task());
       } else {
         taskQueue.add(commit);
       }
@@ -116,30 +134,30 @@ public class TaskQueueState extends ResourceStateMachine implements SessionListe
   public Object ack(Commit<TaskQueueCommands.Ack> commit) {
     try {
       // Remove the task being processed by the given commit.
-      Commit<TaskQueueCommands.Submit> acked = processing.remove(commit.session().id());
+      List<Commit<TaskQueueCommands.Submit>> tasks = processing.get(commit.session().id());
 
       // If no known task was being processed, throw an exception.
-      if (acked == null) {
+      if (tasks == null || tasks.isEmpty()) {
         throw new IllegalStateException("unknown task");
       }
 
+      Commit<TaskQueueCommands.Submit> task = tasks.remove(0);
+
       // Send an ack message to the session that submitted the task.
-      if (acked.operation().ack() && acked.session().state() == Session.State.OPEN) {
-        acked.session().publish("ack", acked.operation().id());
+      if (task.operation().ack() && task.session().state() == Session.State.OPEN) {
+        task.session().publish("ack", task.operation().id());
       }
 
       // Close the task commit to allow it to be garbage collected.
-      acked.close();
+      task.close();
 
       // Get and send the next task in the queue.
       Commit<TaskQueueCommands.Submit> next = taskQueue.poll();
       if (next != null) {
-        processing.put(commit.session().id(), next);
+        tasks.add(next);
         return next.operation().task();
-      } else {
-        workerQueue.add(commit.session());
-        return null;
       }
+      return null;
     } finally {
       commit.close();
     }

--- a/messaging/src/test/java/io/atomix/messaging/DistributedTaskQueueTest.java
+++ b/messaging/src/test/java/io/atomix/messaging/DistributedTaskQueueTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.messaging;
 
-import io.atomix.resource.ResourceType;
 import io.atomix.testing.AbstractCopycatTest;
 import org.testng.annotations.Test;
 

--- a/messaging/src/test/resources/logback.xml
+++ b/messaging/src/test/resources/logback.xml
@@ -21,7 +21,7 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
This PR modifies the `DistributedTaskQueue` to pipeline tasks to consumers to improve performance. Currently, consumers acknowledge and retrieve a task in a single commit. This allows multiple tasks to be pushed to each consumer.