### PR TITLE
Add support for configuring AtomixClient and AtomixReplica with Properties

### DIFF
--- a/coordination/src/test/java/io/atomix/coordination/DistributedMembershipGroupTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedMembershipGroupTest.java
@@ -236,30 +236,4 @@ public class DistributedMembershipGroupTest extends AbstractCopycatTest<Distribu
     await(10000, 2);
   }
 
-  /**
-   * Tests executing an immediate callback.
-   */
-  public void testRemoteExecute() throws Throwable {
-    createServers(3);
-
-    DistributedMembershipGroup group1 = createResource();
-    DistributedMembershipGroup group2 = createResource();
-
-    group2.join().thenRun(() -> {
-      threadAssertEquals(group2.members().size(), 1);
-      resume();
-    });
-
-    await(5000);
-
-    AtomicInteger counter = new AtomicInteger();
-    group1.join().thenRun(() -> {
-      for (GroupMember member : group1.members()) {
-        member.execute((Runnable & Serializable) counter::incrementAndGet).thenRun(this::resume);
-      }
-    });
-
-    await(10000, 2);
-  }
-
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,6 +48,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.atomix.catalyst</groupId>
+      <artifactId>catalyst-netty</artifactId>
+      <version>${catalyst.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/io/atomix/Atomix.java
+++ b/core/src/main/java/io/atomix/Atomix.java
@@ -15,6 +15,7 @@
  */
 package io.atomix;
 
+import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.collections.DistributedMap;
@@ -55,6 +56,15 @@ public abstract class Atomix implements ResourceManager<Atomix> {
 
   protected Atomix(ResourceClient client) {
     this.client = Assert.notNull(client, "client");
+  }
+
+  /**
+   * Returns the Atomix serializer.
+   *
+   * @return The Atomix serializer.
+   */
+  public Serializer serializer() {
+    return client.client().serializer();
   }
 
   /**

--- a/core/src/main/java/io/atomix/AtomixProperties.java
+++ b/core/src/main/java/io/atomix/AtomixProperties.java
@@ -16,12 +16,9 @@
 package io.atomix;
 
 import io.atomix.catalyst.transport.Address;
-import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.PropertiesReader;
-import io.atomix.catalyst.util.QualifiedProperties;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Properties;
 
@@ -31,10 +28,7 @@ import java.util.Properties;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public abstract class AtomixProperties {
-  public static final String TRANSPORT = "transport";
-  public static final String REPLICA = "replica";
-
-  private static final String DEFAULT_TRANSPORT = "io.atomix.catalyst.transport.NettyTransport";
+  public static final String SEED = "cluster.seed";
 
   protected final PropertiesReader reader;
 
@@ -43,28 +37,12 @@ public abstract class AtomixProperties {
   }
 
   /**
-   * Returns the replica transport.
-   *
-   * @return The replica transport.
-   */
-  public Transport transport() {
-    String transportClass = reader.getString(TRANSPORT, DEFAULT_TRANSPORT);
-    try {
-      return (Transport) Class.forName(transportClass).getConstructor(Properties.class).newInstance(new QualifiedProperties(reader.properties(), TRANSPORT));
-    } catch (ClassNotFoundException e) {
-      throw new ConfigurationException("unknown transport class: " + transportClass, e);
-    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-      throw new ConfigurationException("failed to instantiate transport", e);
-    }
-  }
-
-  /**
    * Returns the collection of replicas.
    *
    * @return The collection of replicas.
    */
   public Collection<Address> replicas() {
-    return reader.getCollection(REPLICA, p -> parseAddress(reader.getString(p)));
+    return reader.getCollection(SEED, p -> parseAddress(reader.getString(p)));
   }
 
   /**

--- a/core/src/main/java/io/atomix/AtomixProperties.java
+++ b/core/src/main/java/io/atomix/AtomixProperties.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix;
+
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.transport.Transport;
+import io.atomix.catalyst.util.ConfigurationException;
+import io.atomix.catalyst.util.PropertiesReader;
+import io.atomix.catalyst.util.QualifiedProperties;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Properties;
+
+/**
+ * Base class for Atomix properties.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public abstract class AtomixProperties {
+  public static final String TRANSPORT = "transport";
+  public static final String REPLICA = "replica";
+
+  private static final String DEFAULT_TRANSPORT = "io.atomix.catalyst.transport.NettyTransport";
+
+  protected final PropertiesReader reader;
+
+  protected AtomixProperties(Properties properties) {
+    this.reader = new PropertiesReader(properties);
+  }
+
+  /**
+   * Returns the replica transport.
+   *
+   * @return The replica transport.
+   */
+  public Transport transport() {
+    String transportClass = reader.getString(TRANSPORT, DEFAULT_TRANSPORT);
+    try {
+      return (Transport) Class.forName(transportClass).getConstructor(Properties.class).newInstance(new QualifiedProperties(reader.properties(), TRANSPORT));
+    } catch (ClassNotFoundException e) {
+      throw new ConfigurationException("unknown transport class: " + transportClass, e);
+    } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+      throw new ConfigurationException("failed to instantiate transport", e);
+    }
+  }
+
+  /**
+   * Returns the collection of replicas.
+   *
+   * @return The collection of replicas.
+   */
+  public Collection<Address> replicas() {
+    return reader.getCollection(REPLICA, p -> parseAddress(reader.getString(p)));
+  }
+
+  /**
+   * Parses an address string.
+   *
+   * @param address The address string.
+   * @return The address.
+   */
+  protected Address parseAddress(String address) {
+    String[] split = address.split(":");
+    if (split.length != 2) {
+      throw new ConfigurationException("malformed address: " + address);
+    }
+
+    try {
+      return new Address(split[0], Integer.valueOf(split[1]));
+    } catch (NumberFormatException e) {
+      throw new ConfigurationException("invalid port number: " + split[1]);
+    }
+  }
+
+}

--- a/core/src/main/java/io/atomix/ClientProperties.java
+++ b/core/src/main/java/io/atomix/ClientProperties.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix;
+
+import java.util.Properties;
+
+/**
+ * Atomix client properties.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public final class ClientProperties extends AtomixProperties {
+
+  public ClientProperties(Properties properties) {
+    super(properties);
+  }
+
+}

--- a/core/src/main/java/io/atomix/ReplicaProperties.java
+++ b/core/src/main/java/io/atomix/ReplicaProperties.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix;
+
+import io.atomix.catalyst.transport.Address;
+import io.atomix.copycat.server.storage.StorageLevel;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Properties;
+
+/**
+ * Replica properties.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public final class ReplicaProperties extends AtomixProperties {
+  public static final String ADDRESS = "address";
+  public static final String CLIENT_ADDRESS = "clientAddress";
+  public static final String SERVER_ADDRESS = "serverAddress";
+  public static final String QUORUM_HINT = "quorumHint";
+  public static final String BACKUP_COUNT = "backupCount";
+  public static final String ELECTION_TIMEOUT = "electionTimeout";
+  public static final String HEARTBEAT_INTERVAL = "heartbeatInterval";
+  public static final String SESSION_TIMEOUT = "sessionTimeout";
+  public static final String STORAGE_DIRECTORY = "storage.directory";
+  public static final String STORAGE_LEVEL = "storage.level";
+  public static final String MAX_SEGMENT_SIZE = "storage.maxSegmentSize";
+  public static final String MAX_ENTRIES_PER_SEGMENT = "storage.maxEntriesPerSegment";
+  public static final String MAX_SNAPSHOT_SIZE = "storage.maxSnapshotSize";
+  public static final String RETAIN_STALE_SNAPSHOTS = "storage.retainStaleSnapshots";
+  public static final String COMPACTION_THREADS = "storage.compactionThreads";
+  public static final String MINOR_COMPACTION_INTERVAL = "storage.minorCompactionInterval";
+  public static final String MAJOR_COMPACTION_INTERVAL = "storage.majorCompactionInterval";
+  public static final String COMPACTION_THRESHOLD = "storage.compactionThreshold";
+
+  private static final int DEFAULT_QUORUM_HINT = -1;
+  private static final int DEFAULT_BACKUP_COUNT = 0;
+  private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(500);
+  private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
+  private static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofSeconds(5);
+  private static final File DEFAULT_STORAGE_DIRECTORY = new File(System.getProperty("user.dir"));
+  private static final StorageLevel DEFAULT_STORAGE_LEVEL = StorageLevel.DISK;
+  private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
+  private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
+  private static final int DEFAULT_MAX_SNAPSHOT_SIZE = 1024 * 1024 * 32;
+  private static final boolean DEFAULT_RETAIN_STALE_SNAPSHOTS = false;
+  private static final int DEFAULT_COMPACTION_THREADS = Runtime.getRuntime().availableProcessors() / 2;
+  private static final Duration DEFAULT_MINOR_COMPACTION_INTERVAL = Duration.ofMinutes(1);
+  private static final Duration DEFAULT_MAJOR_COMPACTION_INTERVAL = Duration.ofHours(1);
+  private static final double DEFAULT_COMPACTION_THRESHOLD = 0.5;
+
+  public ReplicaProperties(Properties properties) {
+    super(properties);
+  }
+
+  /**
+   * Returns the replica client address.
+   *
+   * @return The replica client address.
+   */
+  public Address clientAddress() {
+    return parseAddress(reader.getString(CLIENT_ADDRESS, reader.getString(SERVER_ADDRESS, reader.getString(ADDRESS))));
+  }
+
+  /**
+   * Returns the replica server address.
+   *
+   * @return The replica server address.
+   */
+  public Address serverAddress() {
+    return parseAddress(reader.getString(SERVER_ADDRESS, reader.getString(ADDRESS)));
+  }
+
+  /**
+   * Returns the quorum hint.
+   *
+   * @return The quorum hint.
+   */
+  public int quorumHint() {
+    return reader.getInteger(QUORUM_HINT, DEFAULT_QUORUM_HINT);
+  }
+
+  /**
+   * Returns the backup count.
+   *
+   * @return The backup count.
+   */
+  public int backupCount() {
+    return reader.getInteger(BACKUP_COUNT, DEFAULT_BACKUP_COUNT);
+  }
+
+  /**
+   * Returns the election timeout.
+   *
+   * @return The election timeout.
+   */
+  public Duration electionTimeout() {
+    return reader.getDuration(ELECTION_TIMEOUT, DEFAULT_ELECTION_TIMEOUT);
+  }
+
+  /**
+   * Returns the heartbeat interval.
+   *
+   * @return The heartbeat interval.
+   */
+  public Duration heartbeatInterval() {
+    return reader.getDuration(HEARTBEAT_INTERVAL, DEFAULT_HEARTBEAT_INTERVAL);
+  }
+
+  /**
+   * Returns the session timeout.
+   *
+   * @return The session timeout.
+   */
+  public Duration sessionTimeout() {
+    return reader.getDuration(SESSION_TIMEOUT, DEFAULT_SESSION_TIMEOUT);
+  }
+
+  /**
+   * Returns the storage directory.
+   *
+   * @return The storage directory.
+   */
+  public File storageDirectory() {
+    return reader.getFile(STORAGE_DIRECTORY, DEFAULT_STORAGE_DIRECTORY);
+  }
+
+  /**
+   * Returns the storage level.
+   *
+   * @return The storage level.
+   */
+  public StorageLevel storageLevel() {
+    return reader.getEnum(STORAGE_LEVEL, StorageLevel.class, DEFAULT_STORAGE_LEVEL);
+  }
+
+  /**
+   * Returns the maximum segment size in bytes.
+   *
+   * @return The maximum segment size in bytes.
+   */
+  public int maxSegmentSize() {
+    return reader.getInteger(MAX_SEGMENT_SIZE, DEFAULT_MAX_SEGMENT_SIZE);
+  }
+
+  /**
+   * Returns the maximum number of entries per segment.
+   *
+   * @return The maximum number of entries per segment.
+   */
+  public int maxEntriesPerSegment() {
+    return reader.getInteger(MAX_ENTRIES_PER_SEGMENT, DEFAULT_MAX_ENTRIES_PER_SEGMENT);
+  }
+
+  /**
+   * Returns the maximum snapshot size in bytes.
+   *
+   * @return The maximum snapshot size in bytes.
+   */
+  public int maxSnapshotSize() {
+    return reader.getInteger(MAX_SNAPSHOT_SIZE, DEFAULT_MAX_SNAPSHOT_SIZE);
+  }
+
+  /**
+   * Returns a boolean indicating whether to retain stale snapshots.
+   *
+   * @return A boolean indicating whether to retain stale snapshots.
+   */
+  public boolean retainStaleSnapshots() {
+    return reader.getBoolean(RETAIN_STALE_SNAPSHOTS, DEFAULT_RETAIN_STALE_SNAPSHOTS);
+  }
+
+  /**
+   * Returns the number of storage compaction threads.
+   *
+   * @return The number of storage compaction threads.
+   */
+  public int compactionThreads() {
+    return reader.getInteger(COMPACTION_THREADS, DEFAULT_COMPACTION_THREADS);
+  }
+
+  /**
+   * Returns the minor compaction interval.
+   *
+   * @return The minor compaction interval.
+   */
+  public Duration minorCompactionInterval() {
+    return reader.getDuration(MINOR_COMPACTION_INTERVAL, DEFAULT_MINOR_COMPACTION_INTERVAL);
+  }
+
+  /**
+   * Returns the major compaction interval.
+   *
+   * @return The major compaction interval.
+   */
+  public Duration majorCompactionInterval() {
+    return reader.getDuration(MAJOR_COMPACTION_INTERVAL, DEFAULT_MAJOR_COMPACTION_INTERVAL);
+  }
+
+  /**
+   * Returns the number of compaction threads.
+   *
+   * @return The number of compaction threads.
+   */
+  public double compactionThreshold() {
+    return reader.getDouble(COMPACTION_THRESHOLD, DEFAULT_COMPACTION_THRESHOLD);
+  }
+
+}

--- a/core/src/main/java/io/atomix/util/AtomixCopycatClient.java
+++ b/core/src/main/java/io/atomix/util/AtomixCopycatClient.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix;
+package io.atomix.util;
 
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.Transport;
@@ -29,11 +29,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 /**
- * Special CopycatClient implementation that provides a user-defined transport.
+ * A simple {@link CopycatClient} wrapper that exposes a custom {@link Transport}.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-final class AtomixCopycatClient implements CopycatClient {
+public class AtomixCopycatClient implements CopycatClient {
   private final CopycatClient client;
   private final Transport transport;
 

--- a/core/src/main/java/io/atomix/util/ClusterBalancer.java
+++ b/core/src/main/java/io/atomix/util/ClusterBalancer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.util;
+
+import io.atomix.copycat.server.cluster.Cluster;
+import io.atomix.copycat.server.cluster.Member;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Handles balancing of Atomix clusters.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class ClusterBalancer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterBalancer.class);
+  private final int quorumHint;
+  private final int backupCount;
+
+  public ClusterBalancer(int quorumHint, int backupCount) {
+    this.quorumHint = quorumHint;
+    this.backupCount = backupCount;
+  }
+
+  /**
+   * Balances the given cluster.
+   *
+   * @param cluster The cluster to rebalance.
+   * @return A completable future to be completed once the cluster has been balanced.
+   */
+  public CompletableFuture<Void> balance(Cluster cluster) {
+    LOGGER.info("Balancing cluster...");
+    return balance(cluster, new CompletableFuture<>());
+  }
+
+  /**
+   * Balances the cluster, recursively promoting/demoting members as necessary.
+   */
+  private CompletableFuture<Void> balance(Cluster cluster, CompletableFuture<Void> future) {
+    Collection<Member> members = cluster.members();
+    Member member = cluster.member();
+
+    Collection<Member> active = members.stream().filter(m -> m.type() == Member.Type.ACTIVE).collect(Collectors.toList());
+    Collection<Member> passive = members.stream().filter(m -> m.type() == Member.Type.PASSIVE).collect(Collectors.toList());
+    Collection<Member> reserve = members.stream().filter(m -> m.type() == Member.Type.RESERVE).collect(Collectors.toList());
+
+    int totalActiveCount = active.size();
+    int totalPassiveCount = passive.size();
+
+    long availableActiveCount = active.stream().filter(m -> m.status() == Member.Status.AVAILABLE).count();
+    long availablePassiveCount = passive.stream().filter(m -> m.status() == Member.Status.AVAILABLE).count();
+    long availableReserveCount = reserve.stream().filter(m -> m.status() == Member.Status.AVAILABLE).count();
+
+    // If the number of available active members is less than the quorum hint, promote a passive or reserve member.
+    if (availableActiveCount < quorumHint) {
+      // If a passive member is available, promote it.
+      if (availablePassiveCount > 0) {
+        passive.stream().filter(m -> m.status() == Member.Status.AVAILABLE).findFirst().get()
+          .promote(Member.Type.ACTIVE)
+          .thenRun(() -> balance(cluster, future));
+        return future;
+      }
+      // If a reserve member is available, promote it.
+      else if (availableReserveCount > 0) {
+        reserve.stream().filter(m -> m.status() == Member.Status.AVAILABLE).findFirst().get()
+          .promote(Member.Type.ACTIVE)
+          .thenRun(() -> balance(cluster, future));
+        return future;
+      }
+    }
+
+    // If the total number of active members is greater than the quorum hint, demote an active member.
+    // Preferably, we want to demote a member that is unavailable.
+    if (totalActiveCount > quorumHint) {
+      // If the number of available passive members is less than the required number, demote an active
+      // member to passive.
+      if (availablePassiveCount < quorumHint * backupCount) {
+        active.stream().filter(m -> m.status() == Member.Status.UNAVAILABLE).findFirst()
+          .orElseGet(() -> active.stream().filter(m -> !m.equals(member)).findAny().get())
+          .demote(Member.Type.PASSIVE)
+          .thenRun(() -> balance(cluster, future));
+        return future;
+      }
+      // Otherwise, demote an active member to reserve.
+      else {
+        active.stream().filter(m -> m.status() == Member.Status.UNAVAILABLE).findAny()
+          .orElseGet(() -> active.stream().filter(m -> !m.equals(member)).findAny().get())
+          .demote(Member.Type.RESERVE)
+          .thenRun(() -> balance(cluster, future));
+        return future;
+      }
+    }
+
+    // If the number of available passive members is less than the required number of passive members,
+    // promote a reserve member.
+    if (availablePassiveCount < quorumHint * backupCount) {
+      // If any reserve members are available, promote to passive.
+      if (availableReserveCount > 0) {
+        reserve.stream().filter(m -> m.status() == Member.Status.AVAILABLE).findFirst().get()
+          .promote(Member.Type.PASSIVE)
+          .thenRun(() -> balance(cluster, future));
+        return future;
+      }
+    }
+
+    // If the total number of passive members is greater than the required number of passive members,
+    // demote a passive member. Preferably we demote an unavailable member.
+    if (totalPassiveCount > quorumHint * backupCount) {
+      passive.stream().filter(m -> m.status() == Member.Status.UNAVAILABLE).findAny()
+        .orElseGet(() -> passive.stream().findAny().get())
+        .demote(Member.Type.RESERVE)
+        .thenRun(() -> balance(cluster, future));
+      return future;
+    }
+
+    // If we've made it this far then the cluster is balanced.
+    future.complete(null);
+    return future;
+  }
+
+}

--- a/core/src/test/java/io/atomix/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/AbstractAtomixTest.java
@@ -106,7 +106,10 @@ public abstract class AbstractAtomixTest extends ConcurrentTestCase {
    * Creates a client.
    */
   protected Atomix createClient() throws Throwable {
-    AtomixClient client = AtomixClient.builder(members).withTransport(new LocalTransport(registry)).build();
+    AtomixClient client = AtomixClient.builder(members)
+      .withTransport(new LocalTransport(registry))
+      .build();
+    client.serializer().disableWhitelist();
     client.open().thenRun(this::resume);
     clients.add(client);
     await(10000);
@@ -123,6 +126,7 @@ public abstract class AbstractAtomixTest extends ConcurrentTestCase {
       .withQuorumHint(quorumHint)
       .withBackupCount(backupCount)
       .build();
+    replica.serializer().disableWhitelist();
     replicas.add(replica);
     return replica;
   }

--- a/core/src/test/java/io/atomix/ClientPropertiesTest.java
+++ b/core/src/test/java/io/atomix/ClientPropertiesTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix;
+
+import io.atomix.catalyst.transport.NettyTransport;
+import io.atomix.catalyst.transport.Transport;
+import io.atomix.catalyst.util.PropertiesReader;
+import org.testng.annotations.Test;
+
+import java.util.Properties;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Client properties test.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@Test
+public class ClientPropertiesTest {
+
+  /**
+   * Tests default client properties.
+   */
+  public void testPropertyDefaults() {
+    ClientProperties properties = new ClientProperties(new Properties());
+    assertTrue(properties.transport() instanceof NettyTransport);
+  }
+
+  /**
+   * Tests reading properties.
+   */
+  public void testProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(ClientProperties.TRANSPORT, "io.atomix.catalyst.transport.NettyTransport");
+    properties.setProperty("transport.threads", "1");
+
+    ClientProperties clientProperties = new ClientProperties(properties);
+    Transport transport = clientProperties.transport();
+    assertTrue(transport instanceof NettyTransport);
+    assertEquals(((NettyTransport) transport).properties().threads(), 1);
+  }
+
+  /**
+   * Tests reading properties from a file.
+   */
+  public void testPropertiesFile() {
+    ClientProperties clientProperties = new ClientProperties(PropertiesReader.load("client-test.properties").properties());
+    assertTrue(clientProperties.transport() instanceof NettyTransport);
+    assertEquals(((NettyTransport) clientProperties.transport()).properties().threads(), 1);
+  }
+
+}

--- a/core/src/test/java/io/atomix/ClientPropertiesTest.java
+++ b/core/src/test/java/io/atomix/ClientPropertiesTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix;
 
+import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.NettyTransport;
 import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.PropertiesReader;
@@ -46,8 +47,11 @@ public class ClientPropertiesTest {
    */
   public void testProperties() {
     Properties properties = new Properties();
-    properties.setProperty(ClientProperties.TRANSPORT, "io.atomix.catalyst.transport.NettyTransport");
-    properties.setProperty("transport.threads", "1");
+    properties.setProperty("client.transport", "io.atomix.catalyst.transport.NettyTransport");
+    properties.setProperty("client.transport.threads", "1");
+    properties.setProperty("cluster.seed.1", "localhost:5000");
+    properties.setProperty("cluster.seed.2", "localhost:5001");
+    properties.setProperty("cluster.seed.3", "localhost:5002");
 
     ClientProperties clientProperties = new ClientProperties(properties);
     Transport transport = clientProperties.transport();
@@ -62,6 +66,11 @@ public class ClientPropertiesTest {
     ClientProperties clientProperties = new ClientProperties(PropertiesReader.load("client-test.properties").properties());
     assertTrue(clientProperties.transport() instanceof NettyTransport);
     assertEquals(((NettyTransport) clientProperties.transport()).properties().threads(), 1);
+
+    assertEquals(clientProperties.replicas().size(), 3);
+    assertTrue(clientProperties.replicas().contains(new Address("localhost", 5000)));
+    assertTrue(clientProperties.replicas().contains(new Address("localhost", 5001)));
+    assertTrue(clientProperties.replicas().contains(new Address("localhost", 5002)));
   }
 
 }

--- a/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
+++ b/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
@@ -66,27 +66,27 @@ public class ReplicaPropertiesTest {
    */
   public void testProperties() {
     Properties properties = new Properties();
-    properties.setProperty(ReplicaProperties.ADDRESS, "localhost:5000");
-    properties.setProperty("replica.1", "localhost:5000");
-    properties.setProperty("replica.2", "localhost:5001");
-    properties.setProperty("replica.3", "localhost:5002");
-    properties.setProperty(ReplicaProperties.TRANSPORT, "io.atomix.catalyst.transport.NettyTransport");
-    properties.setProperty("transport.threads", "1");
-    properties.setProperty(ReplicaProperties.QUORUM_HINT, "3");
-    properties.setProperty(ReplicaProperties.BACKUP_COUNT, "1");
-    properties.setProperty(ReplicaProperties.ELECTION_TIMEOUT, "200");
-    properties.setProperty(ReplicaProperties.HEARTBEAT_INTERVAL, "100");
-    properties.setProperty(ReplicaProperties.SESSION_TIMEOUT, "1000");
-    properties.setProperty(ReplicaProperties.STORAGE_DIRECTORY, "test");
-    properties.setProperty(ReplicaProperties.STORAGE_LEVEL, "MEMORY");
-    properties.setProperty(ReplicaProperties.MAX_SEGMENT_SIZE, "1024");
-    properties.setProperty(ReplicaProperties.MAX_ENTRIES_PER_SEGMENT, "1024");
-    properties.setProperty(ReplicaProperties.MAX_SNAPSHOT_SIZE, "1024");
-    properties.setProperty(ReplicaProperties.RETAIN_STALE_SNAPSHOTS, "true");
-    properties.setProperty(ReplicaProperties.COMPACTION_THREADS, "1");
-    properties.setProperty(ReplicaProperties.MINOR_COMPACTION_INTERVAL, "1000");
-    properties.setProperty(ReplicaProperties.MAJOR_COMPACTION_INTERVAL, "10000");
-    properties.setProperty(ReplicaProperties.COMPACTION_THRESHOLD, "0.2");
+    properties.setProperty("node.address", "localhost:5000");
+    properties.setProperty("cluster.seed.1", "localhost:5000");
+    properties.setProperty("cluster.seed.2", "localhost:5001");
+    properties.setProperty("cluster.seed.3", "localhost:5002");
+    properties.setProperty("node.transport", "io.atomix.catalyst.transport.NettyTransport");
+    properties.setProperty("node.transport.threads", "1");
+    properties.setProperty("cluster.quorumHint", "3");
+    properties.setProperty("cluster.backupCount", "1");
+    properties.setProperty("cluster.electionTimeout", "200");
+    properties.setProperty("cluster.heartbeatInterval", "100");
+    properties.setProperty("cluster.sessionTimeout", "1000");
+    properties.setProperty("storage.directory", "test");
+    properties.setProperty("storage.level", "MEMORY");
+    properties.setProperty("storage.maxSegmentSize", "1024");
+    properties.setProperty("storage.maxEntriesPerSegment", "1024");
+    properties.setProperty("storage.compaction.maxSnapshotSize", "1024");
+    properties.setProperty("storage.compaction.retainSnapshots", "true");
+    properties.setProperty("storage.compaction.threads", "1");
+    properties.setProperty("storage.compaction.minor", "1000");
+    properties.setProperty("storage.compaction.major", "10000");
+    properties.setProperty("storage.compaction.threshold", "0.2");
 
     ReplicaProperties replicaProperties = new ReplicaProperties(properties);
     Transport transport = replicaProperties.transport();

--- a/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
+++ b/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix;
+
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.transport.NettyTransport;
+import io.atomix.catalyst.transport.Transport;
+import io.atomix.catalyst.util.PropertiesReader;
+import io.atomix.copycat.server.storage.StorageLevel;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Server properties test.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+@Test
+public class ReplicaPropertiesTest {
+
+  /**
+   * Tests default server properties.
+   */
+  public void testPropertyDefaults() {
+    ReplicaProperties properties = new ReplicaProperties(new Properties());
+    assertTrue(properties.transport() instanceof NettyTransport);
+    assertEquals(properties.quorumHint(), -1);
+    assertEquals(properties.backupCount(), 0);
+    assertEquals(properties.electionTimeout(), Duration.ofMillis(500));
+    assertEquals(properties.heartbeatInterval(), Duration.ofMillis(250));
+    assertEquals(properties.sessionTimeout(), Duration.ofSeconds(5));
+    assertEquals(properties.storageDirectory(), new File(System.getProperty("user.dir")));
+    assertEquals(properties.storageLevel(), StorageLevel.DISK);
+    assertEquals(properties.maxSegmentSize(), 1024 * 1024 * 32);
+    assertEquals(properties.maxEntriesPerSegment(), 1024 * 1024);
+    assertEquals(properties.maxSnapshotSize(), 1024 * 1024 * 32);
+    assertFalse(properties.retainStaleSnapshots());
+    assertEquals(properties.compactionThreads(), Runtime.getRuntime().availableProcessors() / 2);
+    assertEquals(properties.minorCompactionInterval(), Duration.ofMinutes(1));
+    assertEquals(properties.majorCompactionInterval(), Duration.ofHours(1));
+    assertEquals(properties.compactionThreshold(), 0.5);
+  }
+
+  /**
+   * Tests reading properties.
+   */
+  public void testProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(ReplicaProperties.ADDRESS, "localhost:5000");
+    properties.setProperty("replica.1", "localhost:5000");
+    properties.setProperty("replica.2", "localhost:5001");
+    properties.setProperty("replica.3", "localhost:5002");
+    properties.setProperty(ReplicaProperties.TRANSPORT, "io.atomix.catalyst.transport.NettyTransport");
+    properties.setProperty("transport.threads", "1");
+    properties.setProperty(ReplicaProperties.QUORUM_HINT, "3");
+    properties.setProperty(ReplicaProperties.BACKUP_COUNT, "1");
+    properties.setProperty(ReplicaProperties.ELECTION_TIMEOUT, "200");
+    properties.setProperty(ReplicaProperties.HEARTBEAT_INTERVAL, "100");
+    properties.setProperty(ReplicaProperties.SESSION_TIMEOUT, "1000");
+    properties.setProperty(ReplicaProperties.STORAGE_DIRECTORY, "test");
+    properties.setProperty(ReplicaProperties.STORAGE_LEVEL, "MEMORY");
+    properties.setProperty(ReplicaProperties.MAX_SEGMENT_SIZE, "1024");
+    properties.setProperty(ReplicaProperties.MAX_ENTRIES_PER_SEGMENT, "1024");
+    properties.setProperty(ReplicaProperties.MAX_SNAPSHOT_SIZE, "1024");
+    properties.setProperty(ReplicaProperties.RETAIN_STALE_SNAPSHOTS, "true");
+    properties.setProperty(ReplicaProperties.COMPACTION_THREADS, "1");
+    properties.setProperty(ReplicaProperties.MINOR_COMPACTION_INTERVAL, "1000");
+    properties.setProperty(ReplicaProperties.MAJOR_COMPACTION_INTERVAL, "10000");
+    properties.setProperty(ReplicaProperties.COMPACTION_THRESHOLD, "0.2");
+
+    ReplicaProperties replicaProperties = new ReplicaProperties(properties);
+    Transport transport = replicaProperties.transport();
+    assertTrue(transport instanceof NettyTransport);
+    assertEquals(((NettyTransport) transport).properties().threads(), 1);
+
+    assertEquals(replicaProperties.serverAddress(), new Address("localhost", 5000));
+    assertEquals(replicaProperties.replicas().size(), 3);
+    assertTrue(replicaProperties.replicas().contains(new Address("localhost", 5000)));
+    assertTrue(replicaProperties.replicas().contains(new Address("localhost", 5001)));
+    assertTrue(replicaProperties.replicas().contains(new Address("localhost", 5002)));
+
+    assertEquals(replicaProperties.quorumHint(), 3);
+    assertEquals(replicaProperties.backupCount(), 1);
+    assertEquals(replicaProperties.electionTimeout(), Duration.ofMillis(200));
+    assertEquals(replicaProperties.heartbeatInterval(), Duration.ofMillis(100));
+    assertEquals(replicaProperties.sessionTimeout(), Duration.ofMillis(1000));
+    assertEquals(replicaProperties.storageDirectory(), new File("test"));
+    assertEquals(replicaProperties.storageLevel(), StorageLevel.MEMORY);
+    assertEquals(replicaProperties.maxSegmentSize(), 1024);
+    assertEquals(replicaProperties.maxEntriesPerSegment(), 1024);
+    assertEquals(replicaProperties.maxSnapshotSize(), 1024);
+    assertTrue(replicaProperties.retainStaleSnapshots());
+    assertEquals(replicaProperties.compactionThreads(), 1);
+    assertEquals(replicaProperties.minorCompactionInterval(), Duration.ofSeconds(1));
+    assertEquals(replicaProperties.majorCompactionInterval(), Duration.ofSeconds(10));
+    assertEquals(replicaProperties.compactionThreshold(), 0.2);
+  }
+
+  /**
+   * Tests reading properties from a file.
+   */
+  public void testPropertiesFile() {
+    ReplicaProperties replicaProperties = new ReplicaProperties(PropertiesReader.load("replica-test.properties").properties());
+    assertTrue(replicaProperties.transport() instanceof NettyTransport);
+    assertEquals(((NettyTransport) replicaProperties.transport()).properties().threads(), 1);
+
+    assertEquals(replicaProperties.serverAddress(), new Address("localhost", 5000));
+    assertEquals(replicaProperties.replicas().size(), 3);
+    assertTrue(replicaProperties.replicas().contains(new Address("localhost", 5000)));
+    assertTrue(replicaProperties.replicas().contains(new Address("localhost", 5001)));
+    assertTrue(replicaProperties.replicas().contains(new Address("localhost", 5002)));
+
+    assertEquals(replicaProperties.quorumHint(), 3);
+    assertEquals(replicaProperties.backupCount(), 1);
+    assertEquals(replicaProperties.electionTimeout(), Duration.ofMillis(200));
+    assertEquals(replicaProperties.heartbeatInterval(), Duration.ofMillis(100));
+    assertEquals(replicaProperties.sessionTimeout(), Duration.ofMillis(1000));
+    assertEquals(replicaProperties.storageDirectory(), new File("test"));
+    assertEquals(replicaProperties.storageLevel(), StorageLevel.MEMORY);
+    assertEquals(replicaProperties.maxSegmentSize(), 1024);
+    assertEquals(replicaProperties.maxEntriesPerSegment(), 1024);
+    assertEquals(replicaProperties.maxSnapshotSize(), 1024);
+    assertTrue(replicaProperties.retainStaleSnapshots());
+    assertEquals(replicaProperties.compactionThreads(), 1);
+    assertEquals(replicaProperties.minorCompactionInterval(), Duration.ofSeconds(1));
+    assertEquals(replicaProperties.majorCompactionInterval(), Duration.ofSeconds(10));
+    assertEquals(replicaProperties.compactionThreshold(), 0.2);
+  }
+
+}

--- a/core/src/test/resources/client-test.properties
+++ b/core/src/test/resources/client-test.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+transport=io.atomix.catalyst.transport.NettyTransport
+transport.threads=1

--- a/core/src/test/resources/client-test.properties
+++ b/core/src/test/resources/client-test.properties
@@ -13,5 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 #
-transport=io.atomix.catalyst.transport.NettyTransport
-transport.threads=1
+client.transport=io.atomix.catalyst.transport.NettyTransport
+client.transport.threads=1
+
+cluster.seed.1=localhost:5000
+cluster.seed.2=localhost:5001
+cluster.seed.3=localhost:5002

--- a/core/src/test/resources/replica-test.properties
+++ b/core/src/test/resources/replica-test.properties
@@ -1,0 +1,41 @@
+
+#
+# Copyright 2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+address=localhost:5000
+
+replica.1=localhost:5000
+replica.2=localhost:5001
+replica.3=localhost:5002
+
+transport=io.atomix.catalyst.transport.NettyTransport
+transport.threads=1
+
+quorumHint=3
+backupCount=1
+electionTimeout=200
+heartbeatInterval=100
+sessionTimeout=1000
+
+storage.directory=test
+storage.level=MEMORY
+storage.maxSegmentSize=1024
+storage.maxEntriesPerSegment=1024
+storage.maxSnapshotSize=1024
+storage.retainStaleSnapshots=true
+storage.compactionThreads=1
+storage.minorCompactionInterval=1000
+storage.majorCompactionInterval=10000
+storage.compactionThreshold=0.2

--- a/core/src/test/resources/replica-test.properties
+++ b/core/src/test/resources/replica-test.properties
@@ -14,28 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 #
-address=localhost:5000
+node.address=localhost:5000
 
-replica.1=localhost:5000
-replica.2=localhost:5001
-replica.3=localhost:5002
+node.transport=io.atomix.catalyst.transport.NettyTransport
+node.transport.threads=1
 
-transport=io.atomix.catalyst.transport.NettyTransport
-transport.threads=1
+cluster.seed.1=localhost:5000
+cluster.seed.2=localhost:5001
+cluster.seed.3=localhost:5002
 
-quorumHint=3
-backupCount=1
-electionTimeout=200
-heartbeatInterval=100
-sessionTimeout=1000
+cluster.quorumHint=3
+cluster.backupCount=1
+cluster.electionTimeout=200
+cluster.heartbeatInterval=100
+cluster.sessionTimeout=1000
 
 storage.directory=test
 storage.level=MEMORY
 storage.maxSegmentSize=1024
 storage.maxEntriesPerSegment=1024
-storage.maxSnapshotSize=1024
-storage.retainStaleSnapshots=true
-storage.compactionThreads=1
-storage.minorCompactionInterval=1000
-storage.majorCompactionInterval=10000
-storage.compactionThreshold=0.2
+
+storage.compaction.maxSnapshotSize=1024
+storage.compaction.retainSnapshots=true
+storage.compaction.threads=1
+storage.compaction.minor=1000
+storage.compaction.major=10000
+storage.compaction.threshold=0.2

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.0.0-rc6</catalyst.version>
+    <catalyst.version>1.0.0-SNAPSHOT</catalyst.version>
     <copycat.version>1.0.0-SNAPSHOT</copycat.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>


### PR DESCRIPTION
This PR adds support for configuring clients and replicas with a properties file or object. No properties file is provided by default, but a `Properties` constructor for each type is provided.