### PR TITLE
Rename node to replica configuration

### DIFF
--- a/core/src/main/java/io/atomix/ReplicaProperties.java
+++ b/core/src/main/java/io/atomix/ReplicaProperties.java
@@ -32,10 +32,10 @@ import java.util.Properties;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 final class ReplicaProperties extends AtomixProperties {
-  public static final String TRANSPORT = "node.transport";
-  public static final String ADDRESS = "node.address";
-  public static final String CLIENT_ADDRESS = "node.clientAddress";
-  public static final String SERVER_ADDRESS = "node.serverAddress";
+  public static final String TRANSPORT = "replica.transport";
+  public static final String ADDRESS = "replica.address";
+  public static final String CLIENT_ADDRESS = "replica.clientAddress";
+  public static final String SERVER_ADDRESS = "replica.serverAddress";
   public static final String QUORUM_HINT = "cluster.quorumHint";
   public static final String BACKUP_COUNT = "cluster.backupCount";
   public static final String ELECTION_TIMEOUT = "cluster.electionTimeout";

--- a/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
+++ b/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
@@ -66,12 +66,12 @@ public class ReplicaPropertiesTest {
    */
   public void testProperties() {
     Properties properties = new Properties();
-    properties.setProperty("node.address", "localhost:5000");
+    properties.setProperty("replica.address", "localhost:5000");
     properties.setProperty("cluster.seed.1", "localhost:5000");
     properties.setProperty("cluster.seed.2", "localhost:5001");
     properties.setProperty("cluster.seed.3", "localhost:5002");
-    properties.setProperty("node.transport", "io.atomix.catalyst.transport.NettyTransport");
-    properties.setProperty("node.transport.threads", "1");
+    properties.setProperty("replica.transport", "io.atomix.catalyst.transport.NettyTransport");
+    properties.setProperty("replica.transport.threads", "1");
     properties.setProperty("cluster.quorumHint", "3");
     properties.setProperty("cluster.backupCount", "1");
     properties.setProperty("cluster.electionTimeout", "200");

--- a/core/src/test/resources/replica-test.properties
+++ b/core/src/test/resources/replica-test.properties
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 #
-node.address=localhost:5000
+replica.address=localhost:5000
 
-node.transport=io.atomix.catalyst.transport.NettyTransport
-node.transport.threads=1
+replica.transport=io.atomix.catalyst.transport.NettyTransport
+replica.transport.threads=1
 
 cluster.seed.1=localhost:5000
 cluster.seed.2=localhost:5001


### PR DESCRIPTION
This PR does a simple rename of the `node` property to `replica` for consistency in naming