### PR TITLE
Fix NPE in DistributedGroup

### DIFF
--- a/coordination/src/main/java/io/atomix/coordination/DistributedGroup.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedGroup.java
@@ -159,7 +159,7 @@ public class DistributedGroup extends Resource<DistributedGroup> {
       });
 
       client.<String>onEvent("resign", leader -> {
-        if (this.leader.equals(leader)) {
+        if (this.leader != null && this.leader.equals(leader)) {
           this.leader = null;
         }
       });


### PR DESCRIPTION
Fixes an NPE in `DistributedGroup` when the `leader` is unset prior to receiving a `resign` event.