### PR TITLE
Add support for serializer properties in AtomixClient and AtomixReplica

### DIFF
--- a/core/src/main/java/io/atomix/AtomixClient.java
+++ b/core/src/main/java/io/atomix/AtomixClient.java
@@ -95,7 +95,8 @@ public class AtomixClient extends Atomix {
   public static Builder builder(Properties properties) {
     ClientProperties clientProperties = new ClientProperties(properties);
     return builder(clientProperties.replicas())
-      .withTransport(clientProperties.transport());
+      .withTransport(clientProperties.transport())
+      .withSerializer(clientProperties.serializer());
   }
 
   /**

--- a/core/src/main/java/io/atomix/AtomixProperties.java
+++ b/core/src/main/java/io/atomix/AtomixProperties.java
@@ -15,9 +15,11 @@
  */
 package io.atomix;
 
+import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.PropertiesReader;
+import io.atomix.catalyst.util.QualifiedProperties;
 
 import java.util.Collection;
 import java.util.Properties;
@@ -29,6 +31,7 @@ import java.util.Properties;
  */
 abstract class AtomixProperties {
   public static final String SEED = "cluster.seed";
+  public static final String SERIALIZER = "serializer";
 
   protected final PropertiesReader reader;
 
@@ -62,6 +65,15 @@ abstract class AtomixProperties {
     } catch (NumberFormatException e) {
       throw new ConfigurationException("invalid port number: " + split[1]);
     }
+  }
+
+  /**
+   * Returns the Atomix serializer.
+   *
+   * @return The Atomix serializer.
+   */
+  public Serializer serializer() {
+    return new Serializer(new QualifiedProperties(reader.properties(), SERIALIZER));
   }
 
 }

--- a/core/src/main/java/io/atomix/AtomixReplica.java
+++ b/core/src/main/java/io/atomix/AtomixReplica.java
@@ -124,6 +124,7 @@ public final class AtomixReplica extends Atomix {
         .withMajorCompactionInterval(replicaProperties.majorCompactionInterval())
         .withCompactionThreshold(replicaProperties.compactionThreshold())
         .build())
+      .withSerializer(replicaProperties.serializer())
       .withQuorumHint(replicaProperties.quorumHint() != -1 ? replicaProperties.quorumHint() : replicas.size())
       .withBackupCount(replicaProperties.backupCount())
       .withElectionTimeout(replicaProperties.electionTimeout())

--- a/core/src/test/java/io/atomix/ClientPropertiesTest.java
+++ b/core/src/test/java/io/atomix/ClientPropertiesTest.java
@@ -23,8 +23,7 @@ import org.testng.annotations.Test;
 
 import java.util.Properties;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * Client properties test.
@@ -40,6 +39,7 @@ public class ClientPropertiesTest {
   public void testPropertyDefaults() {
     ClientProperties properties = new ClientProperties(new Properties());
     assertTrue(properties.transport() instanceof NettyTransport);
+    assertTrue(properties.serializer().isWhitelistRequired());
   }
 
   /**
@@ -52,11 +52,13 @@ public class ClientPropertiesTest {
     properties.setProperty("cluster.seed.1", "localhost:5000");
     properties.setProperty("cluster.seed.2", "localhost:5001");
     properties.setProperty("cluster.seed.3", "localhost:5002");
+    properties.setProperty("serializer.whitelist", "false");
 
     ClientProperties clientProperties = new ClientProperties(properties);
     Transport transport = clientProperties.transport();
     assertTrue(transport instanceof NettyTransport);
     assertEquals(((NettyTransport) transport).properties().threads(), 1);
+    assertFalse(clientProperties.serializer().isWhitelistRequired());
   }
 
   /**
@@ -71,6 +73,7 @@ public class ClientPropertiesTest {
     assertTrue(clientProperties.replicas().contains(new Address("localhost", 5000)));
     assertTrue(clientProperties.replicas().contains(new Address("localhost", 5001)));
     assertTrue(clientProperties.replicas().contains(new Address("localhost", 5002)));
+    assertFalse(clientProperties.serializer().isWhitelistRequired());
   }
 
 }

--- a/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
+++ b/core/src/test/java/io/atomix/ReplicaPropertiesTest.java
@@ -59,6 +59,7 @@ public class ReplicaPropertiesTest {
     assertEquals(properties.minorCompactionInterval(), Duration.ofMinutes(1));
     assertEquals(properties.majorCompactionInterval(), Duration.ofHours(1));
     assertEquals(properties.compactionThreshold(), 0.5);
+    assertTrue(properties.serializer().isWhitelistRequired());
   }
 
   /**
@@ -87,6 +88,7 @@ public class ReplicaPropertiesTest {
     properties.setProperty("storage.compaction.minor", "1000");
     properties.setProperty("storage.compaction.major", "10000");
     properties.setProperty("storage.compaction.threshold", "0.2");
+    properties.setProperty("serializer.whitelist", "false");
 
     ReplicaProperties replicaProperties = new ReplicaProperties(properties);
     Transport transport = replicaProperties.transport();
@@ -114,6 +116,8 @@ public class ReplicaPropertiesTest {
     assertEquals(replicaProperties.minorCompactionInterval(), Duration.ofSeconds(1));
     assertEquals(replicaProperties.majorCompactionInterval(), Duration.ofSeconds(10));
     assertEquals(replicaProperties.compactionThreshold(), 0.2);
+
+    assertFalse(replicaProperties.serializer().isWhitelistRequired());
   }
 
   /**
@@ -145,6 +149,8 @@ public class ReplicaPropertiesTest {
     assertEquals(replicaProperties.minorCompactionInterval(), Duration.ofSeconds(1));
     assertEquals(replicaProperties.majorCompactionInterval(), Duration.ofSeconds(10));
     assertEquals(replicaProperties.compactionThreshold(), 0.2);
+
+    assertFalse(replicaProperties.serializer().isWhitelistRequired());
   }
 
 }

--- a/core/src/test/resources/client-test.properties
+++ b/core/src/test/resources/client-test.properties
@@ -19,3 +19,5 @@ client.transport.threads=1
 cluster.seed.1=localhost:5000
 cluster.seed.2=localhost:5001
 cluster.seed.3=localhost:5002
+
+serializer.whitelist=false

--- a/core/src/test/resources/replica-test.properties
+++ b/core/src/test/resources/replica-test.properties
@@ -40,3 +40,5 @@ storage.compaction.threads=1
 storage.compaction.minor=1000
 storage.compaction.major=10000
 storage.compaction.threshold=0.2
+
+serializer.whitelist=false


### PR DESCRIPTION
This PR adds support for configuring `Serializer` for both types of `Atomix` instances via a `Properties` configuration. Serializer configurations are prefixed with the `serializer` prefix.