### PR TITLE
Fix bugs in lock resource and state machine

### DIFF
--- a/coordination/src/main/java/io/atomix/coordination/state/LockCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/LockCommands.java
@@ -63,13 +63,24 @@ public final class LockCommands {
    * Lock command.
    */
   public static class Lock extends LockCommand<Void> {
+    private int id;
     private long timeout;
 
     public Lock() {
     }
 
-    public Lock(long timeout) {
+    public Lock(int id, long timeout) {
+      this.id = id;
       this.timeout = timeout;
+    }
+
+    /**
+     * Returns the lock ID.
+     *
+     * @return The lock ID.
+     */
+    public int id() {
+      return id;
     }
 
     /**
@@ -88,11 +99,12 @@ public final class LockCommands {
 
     @Override
     public void writeObject(BufferOutput buffer, Serializer serializer) {
-      buffer.writeLong(timeout);
+      buffer.writeInt(id).writeLong(timeout);
     }
 
     @Override
     public void readObject(BufferInput buffer, Serializer serializer) {
+      id = buffer.readInt();
       timeout = buffer.readLong();
     }
   }
@@ -101,9 +113,87 @@ public final class LockCommands {
    * Unlock command.
    */
   public static class Unlock extends LockCommand<Void> {
+    private int id;
+
+    public Unlock() {
+    }
+
+    public Unlock(int id) {
+      this.id = id;
+    }
+
+    /**
+     * Returns the lock ID.
+     *
+     * @return The lock ID.
+     */
+    public int id() {
+      return id;
+    }
+
     @Override
     public CompactionMode compaction() {
       return CompactionMode.SEQUENTIAL;
+    }
+
+    @Override
+    public void writeObject(BufferOutput buffer, Serializer serializer) {
+      buffer.writeInt(id);
+    }
+
+    @Override
+    public void readObject(BufferInput buffer, Serializer serializer) {
+      id = buffer.readInt();
+    }
+  }
+
+  /**
+   * Lock event.
+   */
+  public static class LockEvent implements CatalystSerializable {
+    private int id;
+    private long version;
+
+    public LockEvent() {
+    }
+
+    public LockEvent(int id, long version) {
+      this.id = id;
+      this.version = version;
+    }
+
+    /**
+     * Returns the lock ID.
+     *
+     * @return The lock ID.
+     */
+    public int id() {
+      return id;
+    }
+
+    /**
+     * Returns the lock version.
+     *
+     * @return The lock version.
+     */
+    public long version() {
+      return version;
+    }
+
+    @Override
+    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+      buffer.writeInt(id).writeLong(version);
+    }
+
+    @Override
+    public void readObject(BufferInput<?> buffer, Serializer serializer) {
+      id = buffer.readInt();
+      version = buffer.readLong();
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%s[id=%d, version=%d]", getClass().getSimpleName(), id, version);
     }
   }
 
@@ -115,6 +205,7 @@ public final class LockCommands {
     public void resolve(SerializerRegistry registry) {
       registry.register(Lock.class, -141);
       registry.register(Unlock.class, -142);
+      registry.register(LockEvent.class, -143);
     }
   }
 

--- a/coordination/src/test/java/io/atomix/coordination/DistributedLockTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedLockTest.java
@@ -15,9 +15,10 @@
  */
 package io.atomix.coordination;
 
+import io.atomix.testing.AbstractCopycatTest;
 import org.testng.annotations.Test;
 
-import io.atomix.testing.AbstractCopycatTest;
+import java.time.Duration;
 
 /**
  * Async lock test.
@@ -61,6 +62,25 @@ public class DistributedLockTest extends AbstractCopycatTest<DistributedLock> {
 
     lock2.lock().thenRun(this::resume);
     lock1.close();
+    await(10000);
+  }
+
+  /**
+   * Tests attempting to acquire a lock with a timeout.
+   */
+  public void testTryLockFail() throws Throwable {
+    createServers(3);
+
+    DistributedLock lock1 = createResource();
+    DistributedLock lock2 = createResource();
+
+    lock1.lock().thenRun(this::resume);
+    await(10000);
+
+    lock2.tryLock(Duration.ofSeconds(1)).thenAccept(result -> {
+      threadAssertNull(result);
+      resume();
+    });
     await(10000);
   }
 

--- a/coordination/src/test/resources/logback.xml
+++ b/coordination/src/test/resources/logback.xml
@@ -21,7 +21,7 @@
     </encoder>
   </appender>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/coordination/src/test/resources/logback.xml
+++ b/coordination/src/test/resources/logback.xml
@@ -21,7 +21,7 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
This PR fixes various bugs in the lock resource and state machine. Most significantly, it adds a monotonically increasing, per-client lock `id` which allows concurrent lock requests to be associated with the correct `CompletableFuture` when receiving session events. Additionally, a session event was added for `fail`ing `tryLock` attempts.