### PR TITLE
Ensure commit is not accessed after close in MultiMapState

### DIFF
--- a/collections/src/main/java/io/atomix/collections/state/MultiMapState.java
+++ b/collections/src/main/java/io/atomix/collections/state/MultiMapState.java
@@ -111,13 +111,13 @@ public class MultiMapState extends ResourceStateMachine {
         Commit<? extends MultiMapCommands.TtlCommand> previous = values.remove(commit.operation().value());
         if (previous == null) {
           return false;
-        } else {
-          previous.close();
         }
 
         Scheduled timer = timers.remove(previous.index());
         if (timer != null)
           timer.cancel();
+
+        previous.close();
 
         if (values.isEmpty())
           map.remove(commit.operation().key());
@@ -131,6 +131,7 @@ public class MultiMapState extends ResourceStateMachine {
             if (timer != null)
               timer.cancel();
             results.add(value.operation().value());
+            value.close();
           }
           return results;
         }


### PR DESCRIPTION
This PR fixes a bug in `MultiMapState` wherein a `Commit` is closed prior to attempting to access its `index()`. Once a commit has been closed, the `index` is typically reset. Later attempts to access the commit will throw an `IllegalStateException`. Thus, we must ensure no access takes place after `close()`ing a commit.