### PR TITLE
Fix improper replace checks in DistributedMap

### DIFF
--- a/collections/src/main/java/io/atomix/collections/state/MapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/MapCommands.java
@@ -394,11 +394,11 @@ public class MapCommands {
     public ReplaceIfPresent() {
     }
 
-    public ReplaceIfPresent(Object key, Object value, Object replace) {
-      this(key, value, replace, 0);
+    public ReplaceIfPresent(Object key, Object replace, Object value) {
+      this(key, replace, value, 0);
     }
 
-    public ReplaceIfPresent(Object key, Object value, Object replace, long ttl) {
+    public ReplaceIfPresent(Object key, Object replace, Object value, long ttl) {
       super(key, value, ttl);
       this.replace = replace;
     }

--- a/collections/src/test/java/io/atomix/collections/DistributedMapTest.java
+++ b/collections/src/test/java/io/atomix/collections/DistributedMapTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.collections;
 
-import io.atomix.resource.ResourceType;
 import io.atomix.testing.AbstractCopycatTest;
 import org.testng.annotations.Test;
 
@@ -103,6 +102,36 @@ public class DistributedMapTest extends AbstractCopycatTest<DistributedMap> {
     map.put("bar", "Hello world again!").join();
     map.containsKey("foo").thenAccept(result -> {
       threadAssertFalse(result);
+      resume();
+    });
+    await(10000);
+  }
+
+  /**
+   * Tests replace.
+   */
+  public void testMapReplace() throws Throwable {
+    createServers(3);
+
+    DistributedMap<String, String> map = createResource();
+
+    map.put("foo", "Hello world!").thenRun(this::resume);
+    await(10000);
+
+    map.replace("foo", "Hello world!", "Hello world again!").thenAccept(result -> {
+      threadAssertTrue(result);
+      resume();
+    });
+    await(10000);
+
+    map.replace("foo", "Hello world!", "Hello world again!").thenAccept(result -> {
+      threadAssertFalse(result);
+      resume();
+    });
+    await(10000);
+
+    map.get("foo").thenAccept(result -> {
+      threadAssertEquals(result, "Hello world again!");
       resume();
     });
     await(10000);


### PR DESCRIPTION
Checks for `DistributedMap` `replace` methods are incorrect. Currently, the `value` is checked against the current value rather than the replacement value. This PR modifies parameters to the `ReplaceIfPresent` command to resolve the comparison issue.