### PR TITLE
Ensure scheduled state machine callbacks are executed in the proper context

### DIFF
--- a/manager/src/main/java/io/atomix/manager/state/ResourceManagerStateMachineExecutor.java
+++ b/manager/src/main/java/io/atomix/manager/state/ResourceManagerStateMachineExecutor.java
@@ -103,14 +103,14 @@ class ResourceManagerStateMachineExecutor implements StateMachineExecutor {
 
   @Override
   public Scheduled schedule(Duration delay, Runnable callback) {
-    Scheduled task = parent.schedule(delay, () -> parent.executor().execute(callback));
+    Scheduled task = parent.schedule(delay, callback);
     tasks.add(task);
     return task;
   }
 
   @Override
   public Scheduled schedule(Duration initialDelay, Duration interval, Runnable callback) {
-    Scheduled task = parent.schedule(initialDelay, interval, () -> parent.executor().execute(callback));
+    Scheduled task = parent.schedule(initialDelay, interval, callback);
     tasks.add(task);
     return task;
   }


### PR DESCRIPTION
This PR resolves a bug in scheduling time-based callbacks within state machines. The current implementation executes callbacks asynchronously once they expire. However, this prevents some determinism in the state machine. This PR simply changes scheduled callback execution in the `StateMachineExecutor` wrapper to be done synchronously and thus deterministically.