### PR TITLE
Add methods for getting map keys, values, and entries

### DIFF
--- a/collections/src/main/java/io/atomix/collections/DistributedMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMap.java
@@ -23,6 +23,9 @@ import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceTypeInfo;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -965,6 +968,99 @@ public class DistributedMap<K, V> extends Resource<DistributedMap<K, V>> {
   @SuppressWarnings("unchecked")
   public CompletableFuture<Boolean> replace(K key, V oldValue, V newValue, Duration ttl) {
     return submit(new MapCommands.ReplaceIfPresent(key, oldValue, newValue, ttl.toMillis()));
+  }
+
+  /**
+   * Reads the set of all keys in the map.
+   * <p>
+   * This method returns a {@link CompletableFuture} which can be used to block until the operation completes
+   * or to be notified in a separate thread once the operation completes. To block until the operation completes,
+   * use the {@link CompletableFuture#get()} or {@link CompletableFuture#join()} method to block the calling thread:
+   * <pre>
+   *   {@code
+   *   Set<String> keys = map.keySet().get();
+   *   }
+   * </pre>
+   * Alternatively, to execute the operation asynchronous and be notified once the operation is complete in a different
+   * thread, use one of the many completable future callbacks:
+   * <pre>
+   *   {@code
+   *   map.keySet().thenAccept(keys -> {
+   *     keys.forEach(key -> ...);
+   *   });
+   *   map.replace("key", "Hello world!", "Hello world again!", Duration.ofSeconds(10)).thenAccept(oldValue -> {
+   *     ...
+   *   });
+   *   }
+   * </pre>
+   *
+   * @return A completable future to be completed with the result once complete.
+   */
+  @SuppressWarnings("unchecked")
+  public CompletableFuture<Set<K>> keySet() {
+    return submit(new MapCommands.KeySet()).thenApply(keys -> (Set<K>) keys);
+  }
+
+  /**
+   * Reads the collection of all values in the map.
+   * <p>
+   * This method returns a {@link CompletableFuture} which can be used to block until the operation completes
+   * or to be notified in a separate thread once the operation completes. To block until the operation completes,
+   * use the {@link CompletableFuture#get()} or {@link CompletableFuture#join()} method to block the calling thread:
+   * <pre>
+   *   {@code
+   *   Set<String> keys = map.keySet().get();
+   *   }
+   * </pre>
+   * Alternatively, to execute the operation asynchronous and be notified once the operation is complete in a different
+   * thread, use one of the many completable future callbacks:
+   * <pre>
+   *   {@code
+   *   map.keySet().thenAccept(keys -> {
+   *     keys.forEach(key -> ...);
+   *   });
+   *   map.replace("key", "Hello world!", "Hello world again!", Duration.ofSeconds(10)).thenAccept(oldValue -> {
+   *     ...
+   *   });
+   *   }
+   * </pre>
+   *
+   * @return A completable future to be completed with the result once complete.
+   */
+  @SuppressWarnings("unchecked")
+  public CompletableFuture<Collection<V>> values() {
+    return submit(new MapCommands.Values()).thenApply(values -> (Collection<V>) values);
+  }
+
+  /**
+   * Reads the set of all entries in the map.
+   * <p>
+   * This method returns a {@link CompletableFuture} which can be used to block until the operation completes
+   * or to be notified in a separate thread once the operation completes. To block until the operation completes,
+   * use the {@link CompletableFuture#get()} or {@link CompletableFuture#join()} method to block the calling thread:
+   * <pre>
+   *   {@code
+   *   Set<String> keys = map.keySet().get();
+   *   }
+   * </pre>
+   * Alternatively, to execute the operation asynchronous and be notified once the operation is complete in a different
+   * thread, use one of the many completable future callbacks:
+   * <pre>
+   *   {@code
+   *   map.keySet().thenAccept(keys -> {
+   *     keys.forEach(key -> ...);
+   *   });
+   *   map.replace("key", "Hello world!", "Hello world again!", Duration.ofSeconds(10)).thenAccept(oldValue -> {
+   *     ...
+   *   });
+   *   }
+   * </pre>
+   *
+   * @return A completable future to be completed with the result once complete.
+   */
+  @SuppressWarnings("unchecked")
+  public CompletableFuture<Set<Map.Entry<K, V>>> entrySet() {
+    return submit(new MapCommands.EntrySet()).thenApply(entries -> (Set<Map.Entry<K, V>>) entries);
   }
 
   /**

--- a/collections/src/main/java/io/atomix/collections/state/MapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/MapCommands.java
@@ -25,6 +25,9 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.client.Command;
 import io.atomix.copycat.client.Query;
 
+import java.util.Collection;
+import java.util.Set;
+
 /**
  * Map commands.
  * <p>
@@ -438,6 +441,24 @@ public class MapCommands {
   }
 
   /**
+   * Values query.
+   */
+  public static class Values extends MapQuery<Collection> {
+  }
+
+  /**
+   * Key set query.
+   */
+  public static class KeySet extends MapQuery<Set> {
+  }
+
+  /**
+   * Entry set query.
+   */
+  public static class EntrySet extends MapQuery<Set> {
+  }
+
+  /**
    * Clear command.
    */
   public static class Clear extends MapCommand<Void> {
@@ -464,6 +485,9 @@ public class MapCommands {
       registry.register(RemoveIfPresent.class, -72);
       registry.register(Replace.class, -73);
       registry.register(ReplaceIfPresent.class, -74);
+      registry.register(Values.class, -154);
+      registry.register(KeySet.class, -155);
+      registry.register(EntrySet.class, -156);
       registry.register(IsEmpty.class, -75);
       registry.register(Size.class, -76);
       registry.register(Clear.class, -77);

--- a/collections/src/test/java/io/atomix/collections/DistributedMapTest.java
+++ b/collections/src/test/java/io/atomix/collections/DistributedMapTest.java
@@ -19,6 +19,9 @@ import io.atomix.testing.AbstractCopycatTest;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Distributed map test.
@@ -205,6 +208,70 @@ public class DistributedMapTest extends AbstractCopycatTest<DistributedMap> {
         threadAssertTrue(result);
         resume();
       });
+    });
+    await(10000);
+  }
+
+  /**
+   * Tests getting map values.
+   */
+  public void testMapValues() throws Throwable {
+    createServers(3);
+
+    DistributedMap<String, String> map = createResource();
+
+    map.put("foo", "Hello world!").thenRun(this::resume);
+    map.put("bar", "Hello world again!").thenRun(this::resume);
+    await(10000, 2);
+
+    map.values().thenAccept(values -> {
+      threadAssertTrue(values.contains("Hello world!"));
+      threadAssertTrue(values.contains("Hello world again!"));
+      resume();
+    });
+    await(10000);
+  }
+
+  /**
+   * Tests getting map keys.
+   */
+  public void testMapKeySet() throws Throwable {
+    createServers(3);
+
+    DistributedMap<String, String> map = createResource();
+
+    map.put("foo", "Hello world!").thenRun(this::resume);
+    map.put("bar", "Hello world again!").thenRun(this::resume);
+    await(10000, 2);
+
+    map.keySet().thenAccept(keys -> {
+      threadAssertTrue(keys.contains("foo"));
+      threadAssertTrue(keys.contains("bar"));
+      resume();
+    });
+    await(10000);
+  }
+
+  /**
+   * Tests getting map entries.
+   */
+  public void testMapEntrySet() throws Throwable {
+    createServers(3);
+
+    DistributedMap<String, String> map = createResource();
+
+    map.put("foo", "Hello world!").thenRun(this::resume);
+    map.put("bar", "Hello world again!").thenRun(this::resume);
+    await(10000, 2);
+
+    map.entrySet().thenAccept(entries -> {
+      Set<String> keys = entries.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
+      Set<String> values = entries.stream().map(Map.Entry::getValue).collect(Collectors.toSet());
+      threadAssertTrue(keys.contains("foo"));
+      threadAssertTrue(keys.contains("bar"));
+      threadAssertTrue(values.contains("Hello world!"));
+      threadAssertTrue(values.contains("Hello world again!"));
+      resume();
     });
     await(10000);
   }


### PR DESCRIPTION
This PR makes moderate improvements to `DistributedMap` to allow reading the set of keys, values, and entries from a map. This is a naive implementation. It's likely that an improvement will have to be made to take a snapshot of the set of entries in the map and return a reference to that snapshot to the client. The client can then iterate the map keys through multiple requests during iteration.