### PR TITLE
Add multimap configuration for configuring map value order

### DIFF
--- a/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
@@ -52,6 +52,54 @@ public class DistributedMultiMap<K, V> extends Resource<DistributedMultiMap<K, V
     return new Config();
   }
 
+  /**
+   * Multimap configuration.
+   */
+  public static class Config extends Resource.Config {
+
+    /**
+     * Sets the map value order.
+     *
+     * @param order The map value order.
+     * @return The map configuration.
+     */
+    public Config withValueOrder(Order order) {
+      setProperty("order", order.name().toLowerCase());
+      return this;
+    }
+
+    /**
+     * Returns the map value order.
+     *
+     * @return The map value order.
+     */
+    public Order getValueOrder() {
+      return Order.valueOf(getProperty("order", Order.INSERT.name().toLowerCase()).toUpperCase());
+    }
+  }
+
+  /**
+   * Map value order.
+   */
+  public enum Order {
+
+    /**
+     * Indicates that values should be stored in natural order.
+     */
+    NATURAL,
+
+    /**
+     * Indicates that values should be stored in insertion order.
+     */
+    INSERT,
+
+    /**
+     * Indicates that no order is required for values.
+     */
+    NONE
+
+  }
+
   public DistributedMultiMap(CopycatClient client, Resource.Options options) {
     super(client, options);
   }

--- a/resource/src/main/java/io/atomix/resource/ResourceStateMachine.java
+++ b/resource/src/main/java/io/atomix/resource/ResourceStateMachine.java
@@ -27,15 +27,16 @@ import io.atomix.copycat.server.StateMachine;
 import io.atomix.copycat.server.StateMachineExecutor;
 import io.atomix.copycat.server.session.SessionListener;
 
+import java.util.Properties;
+
 /**
  * Base resource state machine.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public abstract class ResourceStateMachine<T extends Resource.Config> extends StateMachine implements SessionListener {
+public abstract class ResourceStateMachine extends StateMachine implements SessionListener {
   private final ResourceType type;
   private Commit<ConfigureCommand> configureCommit;
-  protected T config;
 
   protected ResourceStateMachine(ResourceType type) {
     this.type = Assert.notNull(type, "type");
@@ -67,7 +68,7 @@ public abstract class ResourceStateMachine<T extends Resource.Config> extends St
     if (configureCommit != null)
       configureCommit.close();
     configureCommit = commit;
-    configure((T) configureCommit.operation().config());
+    configure(configureCommit.operation().config());
   }
 
   /**
@@ -75,8 +76,7 @@ public abstract class ResourceStateMachine<T extends Resource.Config> extends St
    *
    * @param config The resource configuration.
    */
-  public void configure(T config) {
-    this.config = config;
+  public void configure(Properties config) {
   }
 
   @Override
@@ -116,9 +116,12 @@ public abstract class ResourceStateMachine<T extends Resource.Config> extends St
    * Resource configure command.
    */
   public static class ConfigureCommand implements Command<Void>, CatalystSerializable {
-    private Resource.Config config;
+    private Properties config;
 
-    public ConfigureCommand(Resource.Config config) {
+    public ConfigureCommand() {
+    }
+
+    public ConfigureCommand(Properties config) {
       this.config = Assert.notNull(config, "config");
     }
 
@@ -127,7 +130,7 @@ public abstract class ResourceStateMachine<T extends Resource.Config> extends St
      *
      * @return The resource configuration.
      */
-    public Resource.Config config() {
+    public Properties config() {
       return config;
     }
 

--- a/testing/src/main/java/io/atomix/testing/AbstractCopycatTest.java
+++ b/testing/src/main/java/io/atomix/testing/AbstractCopycatTest.java
@@ -99,8 +99,22 @@ public abstract class AbstractCopycatTest<T extends Resource> extends Concurrent
   /**
    * Creates a new resource instance.
    */
+  protected T createResource(Resource.Config config) throws Throwable {
+    return createResource(config, new Resource.Options());
+  }
+
+  /**
+   * Creates a new resource instance.
+   */
+  protected T createResource(Resource.Options options) throws Throwable  {
+    return createResource(new Resource.Config(), options);
+  }
+
+  /**
+   * Creates a new resource instance.
+   */
   @SuppressWarnings("unchecked")
-  protected T createResource(Resource.Options options) throws Throwable {
+  protected T createResource(Resource.Config config, Resource.Options options) throws Throwable {
     CopycatClient client = CopycatClient.builder(members)
       .withTransport(new LocalTransport(registry))
       .withServerSelectionStrategy(ServerSelectionStrategies.ANY)
@@ -112,6 +126,8 @@ public abstract class AbstractCopycatTest<T extends Resource> extends Concurrent
     T resource = (T) type.factory().create(client, options);
     resource.open().thenRun(this::resume);
     resources.add(resource);
+    await(10000);
+    resource.configure(config).thenRun(this::resume);
     await(10000);
     return resource;
   }


### PR DESCRIPTION
This PR adds support for configuring `DistributedMultiMap` to set the map value order. The supported value orders are `NONE`, `INSERT`, and `NATURAL`. Order is configured via the `DistributedMultiMap.Config`.

```java
DistributedMultiMap.Config config = DistributedMultiMap.config()
  .withValueOrder(DistributedMultiMap.Order.INSERT);
DistributedMultiMap<String, String> map = atomix.getMultiMap("foo", config).get();
```