### PR TITLE
Do not close resource creation commit when session is closed

### DIFF
--- a/examples/distributed-value/src/main/java/io/atomix/examples/variables/DistributedValueExample.java
+++ b/examples/distributed-value/src/main/java/io/atomix/examples/variables/DistributedValueExample.java
@@ -63,7 +63,7 @@ public class DistributedValueExample {
         .withMinorCompactionInterval(Duration.ofSeconds(30))
         .withMajorCompactionInterval(Duration.ofMinutes(1))
         .withMaxSegmentSize(1024 * 1024 * 8)
-        .withMaxEntriesPerSegment(1024 * 1024)
+        .withMaxEntriesPerSegment(1024 * 8)
         .build())
       .build();
 

--- a/examples/distributed-value/src/main/resources/logback.xml
+++ b/examples/distributed-value/src/main/resources/logback.xml
@@ -23,7 +23,7 @@
 
   <logger name="io.atomix.catalyst" level="WARN" />
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
This PR attempts to resolve #129. The problem is, when the first client opens a resource, the client's `GetResource` commit becomes the commit that created that resource. However, `GetResource` is also used as the commit that created a logical session/connection from the client to the replicated resource. When a session is closed or the client closes the resource, the commit that created the session is closed:
https://github.com/atomix/atomix/blob/master/manager/src/main/java/io/atomix/manager/state/ResourceManagerState.java#L322

But the commit that created the *first* session for a resource was also the commit that created the resource. Thus, we resolve this by preventing the `ResourceHolder`'s `commit` from being `close`d by a session being closed.

@madjam can you give this a test and see if it resolves your issue?