### PR TITLE
Ensure members are properly removed from group when expired

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.0.2</catalyst.version>
+    <catalyst.version>1.0.3-SNAPSHOT</catalyst.version>
     <copycat.version>1.0.0-SNAPSHOT</copycat.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>


### PR DESCRIPTION
This PR fixes a bug in `DistributedGroup` wherein group members are not properly removed when expired.