### PR TITLE
Ensure resources can only be configured upon creation

### DIFF
--- a/collections/src/main/java/io/atomix/collections/DistributedMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMap.java
@@ -25,6 +25,7 @@ import io.atomix.resource.ResourceTypeInfo;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -61,30 +62,12 @@ import java.util.concurrent.CompletableFuture;
 @ResourceTypeInfo(id=-11, stateMachine=MapState.class, typeResolver=MapCommands.TypeResolver.class)
 public class DistributedMap<K, V> extends Resource<DistributedMap<K, V>> {
 
-  /**
-   * Returns new map options.
-   *
-   * @return New map options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new map configuration.
-   *
-   * @return A new map configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
   public DistributedMap(CopycatClient client) {
-    this(client, new Options());
+    this(client, new Config(), new Options());
   }
 
-  public DistributedMap(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedMap(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   /**

--- a/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
@@ -24,6 +24,7 @@ import io.atomix.resource.ResourceTypeInfo;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -53,11 +54,6 @@ import java.util.concurrent.CompletableFuture;
  *   DistributedMultiMap<String, String> multiMap = atomix.getMultiMap("foo", config).get();
  *   }
  * </pre>
- * The multimap can also be configured after the instance is created via the {@link #configure(Resource.Config)}
- * method. Note that configurations effect <em>all</em> instances of the resource throughout the cluster.
- * If one node sets the value order to {@link Order#INSERT} and then another to {@link Order#NATURAL}, the
- * last configuration applied will be used.
- * <p>
  * Multi-maps support relaxed consistency levels for some read operations line {@link #size(ReadConsistency)}
  * and {@link #containsKey(Object, ReadConsistency)}. By default, read operations on a queue are linearizable
  * but require some level of communication between nodes.
@@ -68,27 +64,16 @@ import java.util.concurrent.CompletableFuture;
 public class DistributedMultiMap<K, V> extends Resource<DistributedMultiMap<K, V>> {
 
   /**
-   * Returns new multimap options.
-   *
-   * @return New multimap options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new multimap configuration.
-   *
-   * @return A new multimap configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
-  /**
    * Multimap configuration.
    */
   public static class Config extends Resource.Config {
+
+    public Config() {
+    }
+
+    public Config(Properties defaults) {
+      super(defaults);
+    }
 
     /**
      * Sets the map value order.
@@ -133,8 +118,13 @@ public class DistributedMultiMap<K, V> extends Resource<DistributedMultiMap<K, V
 
   }
 
-  public DistributedMultiMap(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedMultiMap(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
+  }
+
+  @Override
+  public Resource.Config config() {
+    return new Config(super.config());
   }
 
   /**

--- a/collections/src/main/java/io/atomix/collections/DistributedQueue.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedQueue.java
@@ -22,6 +22,7 @@ import io.atomix.resource.ReadConsistency;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceTypeInfo;
 
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -57,26 +58,8 @@ import java.util.concurrent.CompletableFuture;
 @ResourceTypeInfo(id=-14, stateMachine=QueueState.class, typeResolver=QueueCommands.TypeResolver.class)
 public class DistributedQueue<T> extends Resource<DistributedQueue<T>> {
 
-  /**
-   * Returns new queue options.
-   *
-   * @return New queue options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new queue configuration.
-   *
-   * @return A new queue configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
-  public DistributedQueue(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedQueue(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   /**

--- a/collections/src/main/java/io/atomix/collections/DistributedSet.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedSet.java
@@ -23,6 +23,7 @@ import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceTypeInfo;
 
 import java.time.Duration;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -53,27 +54,8 @@ import java.util.concurrent.CompletableFuture;
  */
 @ResourceTypeInfo(id=-13, stateMachine=SetState.class, typeResolver=SetCommands.TypeResolver.class)
 public class DistributedSet<T> extends Resource<DistributedSet<T>> {
-
-  /**
-   * Returns new set options.
-   *
-   * @return New set options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new set configuration.
-   *
-   * @return A new set configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
-  public DistributedSet(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedSet(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   /**

--- a/collections/src/test/java/io/atomix/collections/DistributedMultiMapTest.java
+++ b/collections/src/test/java/io/atomix/collections/DistributedMultiMapTest.java
@@ -75,7 +75,7 @@ public class DistributedMultiMapTest extends AbstractCopycatTest<DistributedMult
   public void testMultiMapClear() throws Throwable {
     createServers(3);
 
-    DistributedMultiMap<String, String> map = createResource(DistributedMultiMap.config().withValueOrder(DistributedMultiMap.Order.NATURAL));
+    DistributedMultiMap<String, String> map = createResource(new DistributedMultiMap.Config().withValueOrder(DistributedMultiMap.Order.NATURAL));
 
     map.put("foo", "Hello world!").thenRun(this::resume);
     map.put("foo", "Hello world again!").thenRun(this::resume);
@@ -108,7 +108,7 @@ public class DistributedMultiMapTest extends AbstractCopycatTest<DistributedMult
   public void testNaturalOrder() throws Throwable {
     createServers(3);
 
-    DistributedMultiMap.Config config = DistributedMultiMap.config()
+    DistributedMultiMap.Config config = new DistributedMultiMap.Config()
       .withValueOrder(DistributedMultiMap.Order.NATURAL);
     DistributedMultiMap<String, String> map = createResource(config);
 

--- a/coordination/src/main/java/io/atomix/coordination/DistributedGroup.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedGroup.java
@@ -26,10 +26,7 @@ import io.atomix.resource.ResourceTypeInfo;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -181,25 +178,6 @@ import java.util.function.Consumer;
  */
 @ResourceTypeInfo(id=-20, stateMachine=GroupState.class, typeResolver=GroupCommands.TypeResolver.class)
 public class DistributedGroup extends Resource<DistributedGroup> {
-
-  /**
-   * Returns new group options.
-   *
-   * @return New group options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new group configuration.
-   *
-   * @return A new group configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
   private final Listeners<GroupMember> joinListeners = new Listeners<>();
   private final Listeners<GroupMember> leaveListeners = new Listeners<>();
   private final Listeners<Long> termListeners = new Listeners<>();
@@ -209,8 +187,8 @@ public class DistributedGroup extends Resource<DistributedGroup> {
   private volatile String leader;
   private volatile long term;
 
-  public DistributedGroup(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedGroup(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   @Override

--- a/coordination/src/main/java/io/atomix/coordination/DistributedLock.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedLock.java
@@ -23,6 +23,7 @@ import io.atomix.resource.ResourceTypeInfo;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -134,31 +135,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @ResourceTypeInfo(id=-22, stateMachine=LockState.class, typeResolver=LockCommands.TypeResolver.class)
 public class DistributedLock extends Resource<DistributedLock> {
-
-  /**
-   * Returns new lock options.
-   *
-   * @return New lock options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new lock configuration.
-   *
-   * @return A new lock configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
   private final Map<Integer, CompletableFuture<Long>> futures = new ConcurrentHashMap<>();
   private final AtomicInteger id = new AtomicInteger();
   private int lock;
 
-  public DistributedLock(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedLock(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/Atomix.java
+++ b/core/src/main/java/io/atomix/Atomix.java
@@ -1410,19 +1410,19 @@ public abstract class Atomix implements ResourceManager<Atomix> {
   @Override
   public <T extends Resource> CompletableFuture<T> get(String key, Class<? super T> type) {
     Assert.argNot(key.trim().length() == 0, "invalid resource key: key must be of non-zero length");
-    return client.get(key, type, null, null);
+    return client.get(key, type, new Resource.Config(), new Resource.Options());
   }
 
   @Override
   public <T extends Resource> CompletableFuture<T> get(String key, Class<? super T> type, Resource.Config config) {
     Assert.argNot(key.trim().length() == 0, "invalid resource key: key must be of non-zero length");
-    return client.get(key, type, config, null);
+    return client.get(key, type, config, new Resource.Options());
   }
 
   @Override
   public <T extends Resource> CompletableFuture<T> get(String key, Class<? super T> type, Resource.Options options) {
     Assert.argNot(key.trim().length() == 0, "invalid resource key: key must be of non-zero length");
-    return client.get(key, type, null, options);
+    return client.get(key, type, new Resource.Config(), options);
   }
 
   @Override
@@ -1434,19 +1434,19 @@ public abstract class Atomix implements ResourceManager<Atomix> {
   @Override
   public <T extends Resource> CompletableFuture<T> get(String key, ResourceType type) {
     Assert.argNot(key.trim().length() == 0, "invalid resource key: key must be of non-zero length");
-    return client.get(key, type, null, null);
+    return client.get(key, type, new Resource.Config(), new Resource.Options());
   }
 
   @Override
   public <T extends Resource> CompletableFuture<T> get(String key, ResourceType type, Resource.Config config) {
     Assert.argNot(key.trim().length() == 0, "invalid resource key: key must be of non-zero length");
-    return client.get(key, type, config, null);
+    return client.get(key, type, config, new Resource.Options());
   }
 
   @Override
   public <T extends Resource> CompletableFuture<T> get(String key, ResourceType type, Resource.Options options) {
     Assert.argNot(key.trim().length() == 0, "invalid resource key: key must be of non-zero length");
-    return client.get(key, type, null, options);
+    return client.get(key, type, new Resource.Config(), options);
   }
 
   @Override

--- a/core/src/test/java/io/atomix/AtomixClientTest.java
+++ b/core/src/test/java/io/atomix/AtomixClientTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -227,8 +228,8 @@ public class AtomixClientTest extends AbstractAtomixTest {
   @ResourceTypeInfo(id=1, stateMachine=TestStateMachine.class, typeResolver=TestResource.TypeResolver.class)
   public static class TestResource extends Resource<TestResource> {
 
-    public TestResource(CopycatClient client, Resource.Options options) {
-      super(client, options);
+    public TestResource(CopycatClient client, Properties config, Properties options) {
+      super(client, config, options);
     }
 
     public CompletableFuture<String> command(String value) {
@@ -300,8 +301,8 @@ public class AtomixClientTest extends AbstractAtomixTest {
   @ResourceTypeInfo(id=2, stateMachine=ValueStateMachine.class, typeResolver=ValueResource.TypeResolver.class)
   public static class ValueResource extends Resource<ValueResource> {
 
-    public ValueResource(CopycatClient client, Resource.Options options) {
-      super(client, options);
+    public ValueResource(CopycatClient client, Properties config, Properties options) {
+      super(client, config, options);
     }
 
     public CompletableFuture<Void> set(String value) {

--- a/core/src/test/java/io/atomix/AtomixMessageBusTest.java
+++ b/core/src/test/java/io/atomix/AtomixMessageBusTest.java
@@ -34,15 +34,15 @@ public class AtomixMessageBusTest extends AbstractAtomixTest {
   
   public void testClientMessageBusGet() throws Throwable {
     testMessageBus(
-      createClient().getMessageBus("test-client-bus-get", DistributedMessageBus.options().withAddress(new Address("localhost", 6000))).get(),
-      createClient().getMessageBus("test-client-bus-get", DistributedMessageBus.options().withAddress(new Address("localhost", 6001))).get()
+      createClient().getMessageBus("test-client-bus-get", new DistributedMessageBus.Options().withAddress(new Address("localhost", 6000))).get(),
+      createClient().getMessageBus("test-client-bus-get", new DistributedMessageBus.Options().withAddress(new Address("localhost", 6001))).get()
     );
   }
 
   public void testReplicaMessageBusGet() throws Throwable {
     testMessageBus(
-      replicas.get(0).getMessageBus("test-client-bus-get", DistributedMessageBus.options().withAddress(new Address("localhost", 6002))).get(),
-      replicas.get(1).getMessageBus("test-client-bus-get", DistributedMessageBus.options().withAddress(new Address("localhost", 6003))).get()
+      replicas.get(0).getMessageBus("test-client-bus-get", new DistributedMessageBus.Options().withAddress(new Address("localhost", 6002))).get(),
+      replicas.get(1).getMessageBus("test-client-bus-get", new DistributedMessageBus.Options().withAddress(new Address("localhost", 6003))).get()
     );
   }
 

--- a/core/src/test/java/io/atomix/AtomixReplicaTest.java
+++ b/core/src/test/java/io/atomix/AtomixReplicaTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -187,8 +188,8 @@ public class AtomixReplicaTest extends AbstractAtomixTest {
    */
   @ResourceTypeInfo(id=3, stateMachine=TestStateMachine.class, typeResolver=TestResource.TypeResolver.class)
   public static class TestResource extends Resource<TestResource> {
-    public TestResource(CopycatClient client, Resource.Options options) {
-      super(client, options);
+    public TestResource(CopycatClient client, Properties config, Properties options) {
+      super(client, config, options);
     }
 
     public CompletableFuture<String> command(String value) {
@@ -259,8 +260,8 @@ public class AtomixReplicaTest extends AbstractAtomixTest {
    */
   @ResourceTypeInfo(id=4, stateMachine=ValueStateMachine.class, typeResolver=ValueResource.TypeResolver.class)
   public static class ValueResource extends Resource<ValueResource> {
-    public ValueResource(CopycatClient client, Resource.Options options) {
-      super(client, options);
+    public ValueResource(CopycatClient client, Properties config, Properties options) {
+      super(client, config, options);
     }
 
     public CompletableFuture<Void> set(String value) {

--- a/messaging/src/main/java/io/atomix/messaging/DistributedMessageBus.java
+++ b/messaging/src/main/java/io/atomix/messaging/DistributedMessageBus.java
@@ -66,25 +66,6 @@ import java.util.function.Function;
  */
 @ResourceTypeInfo(id=-30, stateMachine=MessageBusState.class, typeResolver=MessageBusCommands.TypeResolver.class)
 public class DistributedMessageBus extends Resource<DistributedMessageBus> {
-
-  /**
-   * Returns new message bus options.
-   *
-   * @return New message bus options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new message bus configuration.
-   *
-   * @return A new message bus configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
   private Client client;
   private Server server;
   private final Options options;
@@ -95,8 +76,8 @@ public class DistributedMessageBus extends Resource<DistributedMessageBus> {
   private final Map<String, InternalMessageConsumer> consumers = new ConcurrentHashMap<>();
   private volatile boolean open;
 
-  public DistributedMessageBus(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedMessageBus(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
     this.options = new Options(options);
   }
 

--- a/messaging/src/main/java/io/atomix/messaging/DistributedTaskQueue.java
+++ b/messaging/src/main/java/io/atomix/messaging/DistributedTaskQueue.java
@@ -24,6 +24,7 @@ import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.resource.WriteConsistency;
 
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -72,32 +73,13 @@ import java.util.function.Consumer;
  */
 @ResourceTypeInfo(id=-32, stateMachine=TaskQueueState.class, typeResolver=TaskQueueCommands.TypeResolver.class)
 public class DistributedTaskQueue<T> extends Resource<DistributedTaskQueue<T>> {
-
-  /**
-   * Returns new task queue options.
-   *
-   * @return New task queue options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new task queue configuration.
-   *
-   * @return A new task queue configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
   private long taskId;
   private final Map<Long, CompletableFuture<Void>> taskFutures = new ConcurrentHashMap<>();
   private Consumer<T> consumer;
 
   @SuppressWarnings("unchecked")
-  public DistributedTaskQueue(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedTaskQueue(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   @Override

--- a/messaging/src/main/java/io/atomix/messaging/DistributedTopic.java
+++ b/messaging/src/main/java/io/atomix/messaging/DistributedTopic.java
@@ -24,6 +24,7 @@ import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.resource.WriteConsistency;
 
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -59,30 +60,11 @@ import java.util.function.Consumer;
  */
 @ResourceTypeInfo(id=-31, stateMachine=TopicState.class, typeResolver=TopicCommands.TypeResolver.class)
 public class DistributedTopic<T> extends Resource<DistributedTopic<T>> {
-
-  /**
-   * Returns new topic options.
-   *
-   * @return New topic options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new topic configuration.
-   *
-   * @return A new topic configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
   private final Set<Consumer<T>> listeners = new HashSet<>();
 
   @SuppressWarnings("unchecked")
-  public DistributedTopic(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedTopic(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   @Override

--- a/messaging/src/test/java/io/atomix/messaging/DistributedMessageBusTest.java
+++ b/messaging/src/test/java/io/atomix/messaging/DistributedMessageBusTest.java
@@ -38,8 +38,8 @@ public class DistributedMessageBusTest extends AbstractCopycatTest<DistributedMe
   public void testSend() throws Throwable {
     createServers(3);
 
-    DistributedMessageBus bus1 = createResource(DistributedMessageBus.options().withAddress(new Address("localhost", 6000)));
-    DistributedMessageBus bus2 = createResource(DistributedMessageBus.options().withAddress(new Address("localhost", 6001)));
+    DistributedMessageBus bus1 = createResource(new DistributedMessageBus.Options().withAddress(new Address("localhost", 6000)));
+    DistributedMessageBus bus2 = createResource(new DistributedMessageBus.Options().withAddress(new Address("localhost", 6001)));
 
     bus1.<String>consumer("test", message -> {
       threadAssertEquals(message, "Hello world!");

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -69,7 +69,10 @@ public abstract class Resource<T extends Resource<T>> implements Managed<T> {
     }
 
     public Config(Properties defaults) {
-      super(defaults);
+      super();
+      for (String property : defaults.stringPropertyNames()) {
+        setProperty(property, defaults.getProperty(property));
+      }
     }
   }
 

--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -61,11 +61,6 @@ public abstract class Resource<T extends Resource<T>> implements Managed<T> {
   /**
    * Base class for cluster-wide resource configurations.
    * <p>
-   * Configurations can be {@link #configure(Config) submitted} by any client with an open {@link Resource}
-   * instance. Configurations are cluster-wide and affect the resource from the perspective of <em>all</em>
-   * clients. Specifically, resource configurations are committed to the cluster, replicated, and applied
-   * to the server-side replicated state machine for the resource.
-   * <p>
    * Resource configurations control options specific to the resource's replicated {@link ResourceStateMachine}.
    * These options might include a maximum collection size or the order of values in a multi-map.
    */
@@ -168,13 +163,14 @@ public abstract class Resource<T extends Resource<T>> implements Managed<T> {
 
   private final ResourceType type;
   protected final CopycatClient client;
+  protected volatile Config config;
   protected final Options options;
-  private State state;
+  private volatile State state;
   private final Set<StateChangeListener> changeListeners = new CopyOnWriteArraySet<>();
   private WriteConsistency writeConsistency = WriteConsistency.ATOMIC;
   private ReadConsistency readConsistency = ReadConsistency.ATOMIC;
 
-  protected Resource(CopycatClient client, Options options) {
+  protected Resource(CopycatClient client, Properties config, Properties options) {
     this.type = new ResourceType(getClass());
     this.client = Assert.notNull(client, "client");
 
@@ -189,7 +185,8 @@ public abstract class Resource<T extends Resource<T>> implements Managed<T> {
       throw new ResourceException("failed to instantiate resource type resolver");
     }
 
-    this.options = options;
+    this.config = new Config(Assert.notNull(config, "config"));
+    this.options = new Options(Assert.notNull(options, "options"));
     client.onStateChange(this::onStateChange);
   }
 
@@ -208,6 +205,24 @@ public abstract class Resource<T extends Resource<T>> implements Managed<T> {
    */
   public ResourceType type() {
     return type;
+  }
+
+  /**
+   * Returns the resource configuration.
+   *
+   * @return The resource configuration.
+   */
+  public Config config() {
+    return config;
+  }
+
+  /**
+   * Returns the resource options.
+   *
+   * @return The configured resource options.
+   */
+  public Options options() {
+    return options;
   }
 
   /**
@@ -241,22 +256,6 @@ public abstract class Resource<T extends Resource<T>> implements Managed<T> {
    */
   public ThreadContext context() {
     return client.context();
-  }
-
-  /**
-   * Configures the cluster-wide resource.
-   * <p>
-   * The resource configuration will be submitted to the cluster, replicated, and applied on all
-   * state machines in the cluster. Once successful, the configuration is guaranteed to be applied
-   * on all replicas and all resource instances will rely on the updated configuration for linearizable
-   * operations.
-   *
-   * @param config The resource configuration.
-   * @return A completable future to be completed once the resource has been configured.
-   */
-  @SuppressWarnings("unchecked")
-  public CompletableFuture<T> configure(Config config) {
-    return client.submit(new ResourceCommand.Configure(config)).thenApply(v -> (T) this);
   }
 
   /**
@@ -416,7 +415,12 @@ public abstract class Resource<T extends Resource<T>> implements Managed<T> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<T> open() {
-    return client.open().thenApply(v -> (T) this);
+    return client.open()
+      .thenCompose(v -> client.submit(new ResourceCommand.Configure(config)))
+      .thenApply(config -> {
+        this.config = new Config(config);
+        return (T) this;
+      });
   }
 
   @Override

--- a/resource/src/main/java/io/atomix/resource/ResourceStateMachine.java
+++ b/resource/src/main/java/io/atomix/resource/ResourceStateMachine.java
@@ -130,7 +130,7 @@ public abstract class ResourceStateMachine extends StateMachine implements Sessi
     executor.serializer().register(ResourceCommand.Delete.class, -53);
 
     executor.<ResourceCommand.Delete>register(ResourceCommand.Delete.class, this::delete);
-    executor.<ResourceCommand.Configure>register(ResourceCommand.Configure.class, this::configure);
+    executor.register(ResourceCommand.Configure.class, this::configure);
     super.init(new ResourceStateMachineExecutor(executor));
   }
 
@@ -138,11 +138,12 @@ public abstract class ResourceStateMachine extends StateMachine implements Sessi
    * Handles a configure command.
    */
   @SuppressWarnings("unchecked")
-  private void configure(Commit<ResourceCommand.Configure> commit) {
-    if (configureCommit != null)
-      configureCommit.close();
-    configureCommit = commit;
-    configure(configureCommit.operation().config());
+  private Properties configure(Commit<ResourceCommand.Configure> commit) {
+    if (configureCommit == null) {
+      configureCommit = commit;
+      configure(commit.operation().config());
+    }
+    return configureCommit.operation().config();
   }
 
   /**

--- a/resource/src/main/java/io/atomix/resource/ResourceType.java
+++ b/resource/src/main/java/io/atomix/resource/ResourceType.java
@@ -21,6 +21,7 @@ import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.util.ResourceFactory;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
 
 /**
  * Identifier for resource metadata and {@link ResourceStateMachine state machine} information.
@@ -74,9 +75,9 @@ public class ResourceType {
    * @return The resource instance factory.
    */
   public ResourceFactory factory() {
-    return (client, options) -> {
+    return (client, config, options) -> {
       try {
-        return resource().getConstructor(CopycatClient.class, Resource.Options.class).newInstance(client, options);
+        return resource().getConstructor(CopycatClient.class, Properties.class, Properties.class).newInstance(client, config, options);
       } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
         throw new ResourceException("failed to instantiate resource class", e);
       }

--- a/resource/src/main/java/io/atomix/resource/util/ResourceCommand.java
+++ b/resource/src/main/java/io/atomix/resource/util/ResourceCommand.java
@@ -75,7 +75,7 @@ public final class ResourceCommand<T extends Command<U>, U> extends ResourceOper
   /**
    * Resource configure command.
    */
-  public static class Configure implements Command<Void>, CatalystSerializable {
+  public static class Configure implements Command<Properties>, CatalystSerializable {
     private Properties config;
 
     public Configure() {

--- a/resource/src/main/java/io/atomix/resource/util/ResourceFactory.java
+++ b/resource/src/main/java/io/atomix/resource/util/ResourceFactory.java
@@ -18,6 +18,8 @@ package io.atomix.resource.util;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.Resource;
 
+import java.util.Properties;
+
 /**
  * Constructs a resource instance given a client and resource options.
  *
@@ -30,9 +32,10 @@ public interface ResourceFactory<T extends Resource<T>> {
    * Creates a new resource.
    *
    * @param client The Copycat client.
+   * @param config The resource configuration.
    * @param options The resource options.
    * @return The created resource.
    */
-  T create(CopycatClient client, Resource.Options options);
+  T create(CopycatClient client, Properties config, Properties options);
 
 }

--- a/testing/src/main/java/io/atomix/testing/AbstractCopycatTest.java
+++ b/testing/src/main/java/io/atomix/testing/AbstractCopycatTest.java
@@ -123,11 +123,9 @@ public abstract class AbstractCopycatTest<T extends Resource> extends Concurrent
       .withRetryStrategy(RetryStrategies.FIBONACCI_BACKOFF)
       .build();
     ResourceType type = new ResourceType((Class<? extends Resource>) type());
-    T resource = (T) type.factory().create(client, options);
+    T resource = (T) type.factory().create(client, config, options);
     resource.open().thenRun(this::resume);
     resources.add(resource);
-    await(10000);
-    resource.configure(config).thenRun(this::resume);
     await(10000);
     return resource;
   }

--- a/variables/src/main/java/io/atomix/variables/AbstractDistributedValue.java
+++ b/variables/src/main/java/io/atomix/variables/AbstractDistributedValue.java
@@ -21,6 +21,7 @@ import io.atomix.resource.Resource;
 import io.atomix.variables.state.ValueCommands;
 
 import java.time.Duration;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -37,8 +38,8 @@ import java.util.concurrent.CompletableFuture;
 @SuppressWarnings("unchecked")
 public abstract class AbstractDistributedValue<T extends AbstractDistributedValue<T, U>, U> extends Resource<T> {
 
-  protected AbstractDistributedValue(CopycatClient client, Options options) {
-    super(client, options);
+  protected AbstractDistributedValue(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   /**

--- a/variables/src/main/java/io/atomix/variables/DistributedLong.java
+++ b/variables/src/main/java/io/atomix/variables/DistributedLong.java
@@ -17,11 +17,11 @@ package io.atomix.variables;
 
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ReadConsistency;
-import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.variables.state.LongCommands;
 import io.atomix.variables.state.LongState;
 
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -55,26 +55,8 @@ import java.util.concurrent.CompletableFuture;
 @ResourceTypeInfo(id=-2, stateMachine=LongState.class, typeResolver=LongCommands.TypeResolver.class)
 public class DistributedLong extends AbstractDistributedValue<DistributedLong, Long> {
 
-  /**
-   * Returns new long options.
-   *
-   * @return New long options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new long configuration.
-   *
-   * @return A new long configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
-  public DistributedLong(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedLong(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
   /**

--- a/variables/src/main/java/io/atomix/variables/DistributedValue.java
+++ b/variables/src/main/java/io/atomix/variables/DistributedValue.java
@@ -16,10 +16,11 @@
 package io.atomix.variables;
 
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.variables.state.ValueCommands;
 import io.atomix.variables.state.ValueState;
+
+import java.util.Properties;
 
 /**
  * Stores a single replicated value, providing atomic operations for modifying the value.
@@ -52,26 +53,8 @@ import io.atomix.variables.state.ValueState;
 @ResourceTypeInfo(id=-1, stateMachine=ValueState.class, typeResolver=ValueCommands.TypeResolver.class)
 public class DistributedValue<T> extends AbstractDistributedValue<DistributedValue<T>, T> {
 
-  /**
-   * Returns new value options.
-   *
-   * @return New value options.
-   */
-  public static Options options() {
-    return new Options();
-  }
-
-  /**
-   * Returns a new value configuration.
-   *
-   * @return A new value configuration.
-   */
-  public static Config config() {
-    return new Config();
-  }
-
-  public DistributedValue(CopycatClient client, Resource.Options options) {
-    super(client, options);
+  public DistributedValue(CopycatClient client, Properties config, Properties options) {
+    super(client, config, options);
   }
 
 }


### PR DESCRIPTION
This PR modifies the process of configuring resources to ensure that resource configurations cannot change after a resource has already been created and used. Configurations apply to the resource's state machine and/or all instances of the resource in the cluster. Modifying an existing resource's configuration requires significantly more complexity in many cases to transform resource state between two different configurations. So, instead only the first configuration used when creating the first instance of a resource will be used to configure the resource, and that configuration will be published to all remaining instances of the resource. To alter an existing resource's configuration, the resource must be recreated.