### PR TITLE
Rewrite DistributedGroup to provide fundamental abstractions for membership and communication

### DIFF
--- a/coordination/src/main/java/io/atomix/coordination/DistributedGroup.java
+++ b/coordination/src/main/java/io/atomix/coordination/DistributedGroup.java
@@ -291,7 +291,7 @@ public class DistributedGroup extends Resource<DistributedGroup> {
     GroupMember member = members.get(message.member());
     if (member != null) {
       if (member instanceof LocalGroupMember) {
-        ((LocalGroupMember) member).handleMessage(message.setFuture(future));
+        ((LocalGroupMember) member).connection().handleMessage(message.setFuture(future));
       } else {
         future.completeExceptionally(new IllegalStateException("not a local member"));
       }
@@ -355,7 +355,7 @@ public class DistributedGroup extends Resource<DistributedGroup> {
           submit(new GroupCommands.Ack(task.id(), task.member(), false));
         }
       });
-      ((LocalGroupMember) localMember).handleTask(task.setFuture(future));
+      ((LocalGroupMember) localMember).tasks().handleTask(task.setFuture(future));
     }
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/GroupConnection.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupConnection.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.util.concurrent.Futures;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupConnection {
+  private final String memberId;
+  private final Address address;
+  private final GroupConnectionManager connections;
+
+  GroupConnection(String memberId, Address address, GroupConnectionManager connections) {
+    this.memberId = Assert.notNull(memberId, "memberId");
+    this.address = address;
+    this.connections = Assert.notNull(connections, "connections");
+  }
+
+  /**
+   * Sends a direct message to the member.
+   *
+   * @param topic The message topic.
+   * @param message The message to send.
+   * @param <T> The message type.
+   * @param <U> The expected response type.
+   * @return A completable future to be completed with the message response.
+   */
+  public <T, U> CompletableFuture<U> send(String topic, T message) {
+    if (address == null)
+      return Futures.exceptionalFuture(new IllegalStateException("no address for member: " + memberId));
+    return connections.getConnection(address).thenCompose(c -> c.send(new GroupMessage<>(memberId, topic, message)));
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[member=%s, address=%s]", getClass().getSimpleName(), memberId, address);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupConnectionManager.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupConnectionManager.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.transport.Client;
+import io.atomix.catalyst.transport.Connection;
+import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.util.concurrent.ComposableFuture;
+import io.atomix.catalyst.util.concurrent.ThreadContext;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Membership group connection manager.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+final class GroupConnectionManager {
+  private final Client client;
+  private final ThreadContext context;
+  private final Map<Integer, Connection> connections = new ConcurrentHashMap<>();
+
+  GroupConnectionManager(Client client, ThreadContext context) {
+    this.client = Assert.notNull(client, "client");
+    this.context = Assert.notNull(context, "context");
+  }
+
+  /**
+   * Returns the connection for the given member.
+   *
+   * @param address The member for which to get the connection.
+   * @return A completable future to be called once the connection is received.
+   */
+  CompletableFuture<Connection> getConnection(Address address) {
+    ComposableFuture<Connection> future = new ComposableFuture<>();
+    context.executor().execute(() -> {
+      Connection connection = connections.get(address.hashCode());
+      if (connection != null) {
+        future.complete(connection);
+      } else {
+        createConnection(address).whenComplete(future);
+      }
+    });
+    return future;
+  }
+
+  /**
+   * Creates a connection for the given member.
+   *
+   * @param address The member for which to create the connection.
+   * @return A completable future to be called once the connection has been created.
+   */
+  CompletableFuture<Connection> createConnection(Address address) {
+    return client.connect(address).thenApply(connection -> {
+      connections.put(address.hashCode(), connection);
+      connection.closeListener(c -> connections.remove(address.hashCode()));
+      return connection;
+    });
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupElection.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupElection.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.util.Listener;
+import io.atomix.catalyst.util.Listeners;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
+
+/**
+ * Group election.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupElection {
+  private final DistributedGroup group;
+  private final Listeners<Long> termListeners = new Listeners<>();
+  private final Listeners<GroupMember> electionListeners = new Listeners<>();
+  private final Map<String, Set<Consumer<Long>>> memberElectionListeners = new ConcurrentHashMap<>();
+  volatile String leader;
+  private volatile long term;
+
+  protected GroupElection(DistributedGroup group) {
+    this.group = Assert.notNull(group, "group");
+  }
+
+  /**
+   * Returns the current group leader.
+   * <p>
+   * The returned leader is the last known leader for the group. The leader is associated with
+   * the current {@link #term()} which is guaranteed to be unique and monotonically increasing.
+   * All resource instances are guaranteed to see leader changes in the same order. If a leader
+   * leaves the group, it is guaranteed that all open resource instances are notified of the change
+   * in leadership prior to the leave operation being completed. This guarantee is maintained only
+   * as long as the resource's session remains open.
+   * <p>
+   * The leader is <em>not</em> guaranteed to be consistent across the cluster at any given point
+   * in time. For example, a long garbage collection pause can result in the resource's session expiring
+   * and the resource failing to increment the leader at the appropriate time. Users should use
+   * the {@link #term()} for fencing when interacting with external systems.
+   *
+   * @return The current group leader.
+   */
+  public GroupMember leader() {
+    return leader != null ? group.member(leader) : null;
+  }
+
+  /**
+   * Returns the current group term.
+   * <p>
+   * The term is a globally unique, monotonically increasing token that represents an epoch.
+   * All resource instances are guaranteed to see term changes in the same order. If a leader
+   * leaves the group, it is guaranteed that the term will be incremented and all open resource
+   * instances are notified of the term change prior to the leave operation being completed. However,
+   * this guarantee is maintained only as long as the resource's session remains open.
+   * <p>
+   * For any given term, the group guarantees that a single {@link #leader()} will be elected
+   * and any leader elected after the leader for this term will be associated with a higher
+   * term.
+   * <p>
+   * The term is <em>not</em> guaranteed to be unique across the cluster at any given point in time.
+   * For example, a long garbage collection pause can result in the resource's session expiring and the
+   * resource failing to increment the term at the appropriate time. Users should use the term for
+   * fencing when interacting with external systems.
+   *
+   * @return The current group term.
+   */
+  public long term() {
+    return term;
+  }
+
+  /**
+   * Registers a callback to be called when the term changes.
+   * <p>
+   * The provided callback will be called when a term change notification is received by the resource.
+   * The returned {@link Listener} can be used to unregister the term listener via {@link Listener#close()}.
+   *
+   * @param callback The callback to be called when the term changes.
+   * @return The term listener.
+   */
+  public Listener<Long> onTerm(Consumer<Long> callback) {
+    return termListeners.add(callback);
+  }
+
+  /**
+   * Registers a callback to be called when a member of the group is elected leader.
+   * <p>
+   * The provided callback will be called when notification of a leader change is received by the resource.
+   * The returned {@link Listener} can be used to unregister the term listener via {@link Listener#close()}.
+   *
+   * @param callback The callback to call when a member of the group is elected leader.
+   * @return The leader election listener.
+   */
+  public Listener<GroupMember> onElection(Consumer<GroupMember> callback) {
+    return electionListeners.add(callback);
+  }
+
+  /**
+   * Registers an election listener callback for a specific member.
+   */
+  protected synchronized Listener<Long> onElection(String memberId, Consumer<Long> callback) {
+    Set<Consumer<Long>> listeners = memberElectionListeners.computeIfAbsent(memberId, m -> new CopyOnWriteArraySet<>());
+    listeners.add(callback);
+    Listener<Long> listener = new Listener<Long>() {
+      @Override
+      public void accept(Long term) {
+        callback.accept(term);
+      }
+      @Override
+      public void close() {
+        listeners.remove(this);
+        synchronized (GroupElection.this) {
+          if (listeners.isEmpty()) {
+            memberElectionListeners.remove(memberId);
+          }
+        }
+      }
+    };
+
+    if (leader != null && leader.equals(memberId)) {
+      listener.accept(term);
+    }
+    return listener;
+  }
+
+  /**
+   * Handles a term change event received from the cluster.
+   */
+  void onTermEvent(long term) {
+    this.term = term;
+    termListeners.accept(term);
+  }
+
+  /**
+   * Handles an elect event received from the cluster.
+   */
+  void onElectEvent(String leader) {
+    this.leader = leader;
+    GroupMember member = group.member(leader);
+    if (member != null) {
+      electionListeners.accept(member);
+      Set<Consumer<Long>> listeners = memberElectionListeners.get(member.id());
+      if (listeners != null) {
+        listeners.forEach(c -> c.accept(term));
+      }
+    }
+  }
+
+  /**
+   * Handles a resign event received from the cluster.
+   */
+  void onResignEvent(String leader) {
+    if (this.leader != null && this.leader.equals(leader)) {
+      this.leader = null;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupHashRing.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupHashRing.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Assert;
+import io.atomix.catalyst.util.hash.Hasher;
+
+import java.util.*;
+
+/**
+ * Distributed group hash ring.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+final class GroupHashRing {
+  private final Hasher hasher;
+  private final int virtualNodes;
+  private final int replicationFactor;
+  private final TreeMap<Long, GroupMember> ring = new TreeMap<>();
+
+  public GroupHashRing(Hasher hasher, int virtualNodes, int replicationFactor) {
+    this.hasher = Assert.notNull(hasher, "hasher");
+    this.virtualNodes = Assert.argNot(virtualNodes, virtualNodes < 0, "virtualNodes must be positive");
+    this.replicationFactor = Assert.argNot(replicationFactor, replicationFactor <= 0, "replicationFactor must be positive");
+  }
+
+  /**
+   * Adds a member to the hash ring.
+   *
+   * @param member The member to add.
+   */
+  void addMember(GroupMember member) {
+    if (!ring.values().contains(member)) {
+      for (int i = 0; i < virtualNodes; i++) {
+        ring.put(hasher.hash64(member.id() + i), member);
+      }
+    }
+  }
+
+  /**
+   * Removes a member from the hash ring.
+   *
+   * @param member The member to remove.
+   */
+  void removeMember(GroupMember member) {
+    if (ring.values().contains(member)) {
+      for (int i = 0; i < virtualNodes; i++) {
+        ring.remove(hasher.hash64(member.id() + i));
+      }
+    }
+  }
+
+  /**
+   * Hashes the given key to a group member.
+   *
+   * @param key The key to hash.
+   * @return The group member to which the key maps.
+   */
+  public GroupMember member(byte[] key) {
+    if (ring.isEmpty())
+      return null;
+
+    long hash = hasher.hash64(key);
+    Map.Entry<Long, GroupMember> entry = ring.ceilingEntry(hash);
+    if (entry == null) {
+      return ring.firstEntry().getValue();
+    }
+    return entry.getValue();
+  }
+
+  /**
+   * Hashes the given key to a set of group members.
+   *
+   * @param key The key to hash.
+   * @return The group members to which the key hashes according to the given replication factor.
+   */
+  public List<GroupMember> members(byte[] key) {
+    List<GroupMember> members = new ArrayList<>();
+    Iterator<GroupMember> iterator = iterator(key);
+    while (iterator.hasNext()) {
+      members.add(iterator.next());
+    }
+    return members;
+  }
+
+  /**
+   * Returns an iterator for the given key.
+   *
+   * @param key The key for which to return an iterator.
+   * @return The member iterator.
+   */
+  public Iterator<GroupMember> iterator(byte[] key) {
+    return new HashRingIterator(key);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+
+  /**
+   * Hash ring iterator.
+   */
+  private class HashRingIterator implements Iterator<GroupMember> {
+    private final Map.Entry<Long, GroupMember> firstEntry;
+    private final Set<GroupMember> members = new HashSet<>();
+    private Map.Entry<Long, GroupMember> next;
+    private int count;
+
+    private HashRingIterator(byte[] key) {
+      long hash = hasher.hash64(key);
+      Map.Entry<Long, GroupMember> firstEntry = ring.ceilingEntry(hash);
+      if (firstEntry == null) {
+        firstEntry = ring.firstEntry();
+      }
+      this.firstEntry = firstEntry;
+
+      this.next = firstEntry;
+      if (next != null) {
+        members.add(next.getValue());
+        count = 1;
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return next != null;
+    }
+
+    @Override
+    public GroupMember next() {
+      Map.Entry<Long, GroupMember> entry = next;
+      if (entry == null) {
+        throw new NoSuchElementException();
+      }
+
+      next = null;
+
+      // If the replication factor has already been met, return the next (last) element.
+      if (count == replicationFactor) {
+        return entry.getValue();
+      }
+
+      // Get the next entry in the ring. If the entry is null, go back to the start.
+      // If the next entry is equivalent to any iterated group member, skip it.
+      next = ring.higherEntry(entry.getKey());
+      while (next == null || (members.contains(next.getValue()) && !next.getKey().equals(firstEntry.getKey()))) {
+        if (next == null) {
+          next = ring.firstEntry();
+        } else {
+          next = ring.higherEntry(next.getKey());
+        }
+      }
+
+      // If the next entry is equal to the first entry, that indicates that the total number of members
+      // available is less than the replication factor. Reset the members list to add the same members again.
+      if (next.getKey().equals(firstEntry.getKey())) {
+        members.clear();
+      }
+
+      members.add(next.getValue());
+      count++;
+
+      return entry.getValue();
+    }
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupMember.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupMember.java
@@ -15,34 +15,33 @@
  */
 package io.atomix.coordination;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.concurrent.CompletableFuture;
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.util.Assert;
 
 /**
  * A {@link DistributedGroup} member representing a member of the group controlled by a local
  * or remote process.
- * <p>
- * A {@code GroupMember} represents a reference to a single instance of a resource which has
- * {@link DistributedGroup#join() joined} a membership group. Each member is guaranteed to
- * have a unique {@link #id()} throughout the lifetime of the distributed resource. Group members
- * can {@link #schedule(Duration, Runnable) schedule} or {@link #execute(Runnable) execute} callbacks
- * remotely on member nodes.
- * <p>
- * Group members support direct messaging via the {@link #send(String, Object)} method. Messages
- * sent between group members must be associated with a {@link String} topic. The topic is used
- * to identify the type of message being sent.
- * <pre>
- *   {@code
- *   group.member("foo").send("bar", "Hello world!");
- *   }
- * </pre>
- * Messages sent between group members are persisted and replicated in the cluster and are guaranteed
- * to be received by the member as long as its session remains open.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public interface GroupMember {
+public class GroupMember {
+  protected final String memberId;
+  protected final Address address;
+  protected final DistributedGroup group;
+  private final GroupProperties properties;
+  private final GroupTaskQueue tasks;
+  private final GroupScheduler scheduler;
+  private final GroupConnection connection;
+
+  GroupMember(GroupMemberInfo info, DistributedGroup group) {
+    this.memberId = info.memberId();
+    this.address = info.address();
+    this.group = Assert.notNull(group, "group");
+    this.properties = new GroupProperties(memberId, group);
+    this.tasks = new GroupTaskQueue(memberId, group);
+    this.scheduler = new GroupScheduler(memberId, group);
+    this.connection = new GroupConnection(memberId, address, group.connections);
+  }
 
   /**
    * Returns the member ID.
@@ -52,7 +51,18 @@ public interface GroupMember {
    *
    * @return The member ID.
    */
-  String id();
+  public String id() {
+    return memberId;
+  }
+
+  /**
+   * Returns the member address.
+   *
+   * @return The member address.
+   */
+  public Address address() {
+    return address;
+  }
 
   /**
    * Returns a boolean value indicating whether this member is the current leader.
@@ -63,66 +73,29 @@ public interface GroupMember {
    *
    * @return Indicates whether this member is the current leader.
    */
-  boolean isLeader();
+  public boolean isLeader() {
+    return group.election().leader != null && group.election().leader.equals(memberId);
+  }
 
-  /**
-   * Gets the value of a property of the member.
-   * <p>
-   * Properties are identified by a {@link String} name. Properties may only be set by the local member but
-   * can be accessed by any instance of the {@link DistributedGroup}.
-   *
-   * @param property The property to get.
-   * @param <T> The property type.
-   * @return A completable future to be completed with the value of the property.
-   */
-  <T> CompletableFuture<T> get(String property);
+  public GroupProperties properties() {
+    return properties;
+  }
 
-  /**
-   * Sends a message to the member.
-   * <p>
-   * Group messaging guarantees sequential consistency such that members are guaranteed to receive messages
-   * in the order in which they were sent. Messages will be sent according to the parent {@link DistributedGroup}'s
-   * {@link io.atomix.resource.WriteConsistency consistency} level. If the consistency level is
-   * {@link io.atomix.resource.WriteConsistency#ATOMIC} (the default), the returned {@link CompletableFuture} will
-   * be completed once the member has received the message or has left the group. Note that the completion of
-   * the returned future does not necessarily guarantee that the message was received and processed, only that
-   * it was <em>either</em> received and processed <em>or</em> the member left the group or disconnected.
-   * <pre>
-   *   {@code
-   *   group.member("foo").send("bar", "Hello world!");
-   *   }
-   * </pre>
-   *
-   * @param topic The message topic.
-   * @param message The message to send.
-   * @return A completable future to be completed once the message has been received by the member.
-   */
-  CompletableFuture<Void> send(String topic, Object message);
+  public GroupConnection connection() {
+    return connection;
+  }
 
-  /**
-   * Schedules a callback to run at the given instant.
-   *
-   * @param instant The instant at which to run the callback.
-   * @param callback The callback to run.
-   * @return A completable future to be completed once the callback has been scheduled.
-   */
-  CompletableFuture<Void> schedule(Instant instant, Runnable callback);
+  public GroupTaskQueue tasks() {
+    return tasks;
+  }
 
-  /**
-   * Schedules a callback to run after the given delay on the member.
-   *
-   * @param delay The delay after which to run the callback.
-   * @param callback The callback to run.
-   * @return A completable future to be completed once the callback has been scheduled.
-   */
-  CompletableFuture<Void> schedule(Duration delay, Runnable callback);
+  public GroupScheduler scheduler() {
+    return scheduler;
+  }
 
-  /**
-   * Executes a callback on the group member.
-   *
-   * @param callback The callback to execute.
-   * @return A completable future to be completed once the callback has completed.
-   */
-  CompletableFuture<Void> execute(Runnable callback);
+  @Override
+  public String toString() {
+    return String.format("%s[id=%s, address=%s]", getClass().getSimpleName(), memberId, address);
+  }
 
 }

--- a/coordination/src/main/java/io/atomix/coordination/GroupMemberInfo.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupMemberInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.util.Assert;
+
+/**
+ * Group member info.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupMemberInfo implements CatalystSerializable {
+  private String memberId;
+  private Address address;
+
+  public GroupMemberInfo() {
+  }
+
+  public GroupMemberInfo(String memberId, Address address) {
+    this.memberId = Assert.notNull(memberId, "memberId");
+    this.address = address;
+  }
+
+  public String memberId() {
+    return memberId;
+  }
+
+  public Address address() {
+    return address;
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    buffer.writeString(memberId);
+    serializer.writeObject(address, buffer);
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    memberId = buffer.readString();
+    address = serializer.readObject(buffer);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[member=%s, address=%s]", getClass().getSimpleName(), memberId, address);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupMessage.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupMessage.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.Serializer;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Group member message.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupMessage<T> implements CatalystSerializable {
+  private String member;
+  private String topic;
+  private T body;
+  private CompletableFuture<Object> future;
+
+  public GroupMessage() {
+  }
+
+  public GroupMessage(String member, String topic, T body) {
+    this.member = member;
+    this.topic = topic;
+    this.body = body;
+  }
+
+  GroupMessage<T> setFuture(CompletableFuture<Object> future) {
+    this.future = future;
+    return this;
+  }
+
+  String member() {
+    return member;
+  }
+
+  public String topic() {
+    return topic;
+  }
+
+  public T body() {
+    return body;
+  }
+
+  public void reply(Object reply) {
+    future.complete(reply);
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    buffer.writeString(member);
+    buffer.writeString(topic);
+    serializer.writeObject(body, buffer);
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    member = buffer.readString();
+    topic = buffer.readString();
+    body = serializer.readObject(buffer);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[member=%s, topic=%s]", getClass().getSimpleName(), member, topic);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupPartition.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupPartition.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Assert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+/**
+ * Group partition.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupPartition implements Iterable<GroupMember> {
+  private final int id;
+  private volatile Collection<GroupMember> members = new ArrayList<>(0);
+
+  GroupPartition(int id) {
+    this.id = id;
+  }
+
+  /**
+   * Returns the partition ID.
+   *
+   * @return The partition ID.
+   */
+  public int id() {
+    return id;
+  }
+
+  /**
+   * Returns a collection of members for the partition.
+   *
+   * @return A collection of members for the partition.
+   */
+  public Collection<GroupMember> members() {
+    return members;
+  }
+
+  /**
+   * Updates the partition with the given number of group members.
+   */
+  void handleRepartition(Collection<GroupMember> members) {
+    this.members = Assert.notNull(members, "members");
+  }
+
+  @Override
+  public Iterator<GroupMember> iterator() {
+    return members.iterator();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[id=%d]", getClass().getSimpleName(), id);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupPartitioner.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupPartitioner.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+/**
+ * Group partitioner.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public interface GroupPartitioner {
+
+  /**
+   * Returns the partition for the given value.
+   *
+   * @param value The value to partition.
+   * @param partitions The total number of partitions.
+   * @return The partition for the given value.
+   */
+  int partition(Object value, int partitions);
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupPartitions.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupPartitions.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Group partitions.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupPartitions implements Iterable<GroupPartition> {
+  final List<GroupPartition> partitions = new ArrayList<>();
+  GroupPartitioner partitioner = (value, partitions) -> -1;
+
+  GroupPartitions() {
+  }
+
+  /**
+   * Returns a partition by ID.
+   *
+   * @param partitionId The partition ID.
+   * @return The group partition.
+   * @throws IndexOutOfBoundsException if the given {@code partitionId} is greater than the range of partitions in the group
+   */
+  public GroupPartition partition(int partitionId) {
+    return partitions.get(partitionId);
+  }
+
+  /**
+   * Returns a partition for the given value.
+   *
+   * @param value The value for which to return a partition.
+   * @return The partition for the given value or {@code null} if the value was not mapped to any partition.
+   */
+  public GroupPartition partition(Object value) {
+    int partitionId = partitioner.partition(value, partitions.size());
+    return partitionId != -1 ? partitions.get(partitionId) : null;
+  }
+
+  /**
+   * Returns an ordered list of partitions in the group.
+   *
+   * @return A list of partitions in the group. The position of each partition in the returned {@link List} is the partition's unique ID.
+   */
+  public List<GroupPartition> partitions() {
+    return partitions;
+  }
+
+  @Override
+  public Iterator<GroupPartition> iterator() {
+    return partitions.iterator();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[partitions=%d]", getClass().getSimpleName(), partitions.size());
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupProperties.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupProperties.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Assert;
+import io.atomix.coordination.state.GroupCommands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Group properties.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupProperties {
+  private final String memberId;
+  private final DistributedGroup group;
+
+  protected GroupProperties(String memberId, DistributedGroup group) {
+    this.memberId = memberId;
+    this.group = Assert.notNull(group, "group");
+  }
+
+  public CompletableFuture<Void> set(String property, Object value) {
+    return group.submit(new GroupCommands.SetProperty(memberId, property, value));
+  }
+
+  public <T> CompletableFuture<T> get(String property) {
+    return get(property, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> CompletableFuture<T> get(String property, T defaultValue) {
+    return group.submit(new GroupCommands.GetProperty(memberId, property)).thenApply(result -> {
+      if (result == null) {
+        result = defaultValue;
+      }
+      return (T) result;
+    });
+  }
+
+  public CompletableFuture<Void> remove(String property) {
+    return group.submit(new GroupCommands.RemoveProperty(memberId, property));
+  }
+
+  @Override
+  public String toString() {
+    if (memberId == null) {
+      return getClass().getSimpleName();
+    }
+    return String.format("%s[member=%s]", getClass().getSimpleName(), memberId);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupScheduler.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupScheduler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Assert;
+import io.atomix.coordination.state.GroupCommands;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Group scheduler.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupScheduler {
+  private final String memberId;
+  private final DistributedGroup group;
+
+  protected GroupScheduler(String memberId, DistributedGroup group) {
+    this.memberId = memberId;
+    this.group = Assert.notNull(group, "group");
+  }
+
+  public CompletableFuture<Void> schedule(Duration delay, Runnable callback) {
+    return group.submit(new GroupCommands.Schedule(memberId, delay.toMillis(), callback));
+  }
+
+  public CompletableFuture<Void> execute(Runnable callback) {
+    return group.submit(new GroupCommands.Execute(memberId, callback));
+  }
+
+  @Override
+  public String toString() {
+    if (memberId == null) {
+      return getClass().getSimpleName();
+    }
+    return String.format("%s[member=%s]", getClass().getSimpleName(), memberId);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupTask.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupTask.java
@@ -29,7 +29,7 @@ public class GroupTask<T> implements CatalystSerializable {
   private long id;
   private String member;
   private T value;
-  private CompletableFuture<Void> future;
+  private CompletableFuture<Boolean> future;
 
   public GroupTask() {
   }
@@ -40,12 +40,17 @@ public class GroupTask<T> implements CatalystSerializable {
     this.value = value;
   }
 
-  GroupTask<T> setFuture(CompletableFuture<Void> future) {
+  GroupTask<T> setFuture(CompletableFuture<Boolean> future) {
     this.future = future;
     return this;
   }
 
-  long id() {
+  /**
+   * Returns the task ID.
+   *
+   * @return The unique task ID.
+   */
+  public long id() {
     return id;
   }
 
@@ -58,17 +63,23 @@ public class GroupTask<T> implements CatalystSerializable {
   }
 
   public void ack() {
-    future.complete(null);
+    future.complete(true);
+  }
+
+  public void fail() {
+    future.complete(false);
   }
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    buffer.writeLong(id);
     buffer.writeString(member);
     serializer.writeObject(value, buffer);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    id = buffer.readLong();
     member = buffer.readString();
     value = serializer.readObject(buffer);
   }

--- a/coordination/src/main/java/io/atomix/coordination/GroupTask.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupTask.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.Serializer;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupTask<T> implements CatalystSerializable {
+  private long id;
+  private String member;
+  private T value;
+  private CompletableFuture<Void> future;
+
+  public GroupTask() {
+  }
+
+  public GroupTask(long id, String member, T value) {
+    this.id = id;
+    this.member = member;
+    this.value = value;
+  }
+
+  GroupTask<T> setFuture(CompletableFuture<Void> future) {
+    this.future = future;
+    return this;
+  }
+
+  long id() {
+    return id;
+  }
+
+  String member() {
+    return member;
+  }
+
+  public T value() {
+    return value;
+  }
+
+  public void ack() {
+    future.complete(null);
+  }
+
+  @Override
+  public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+    buffer.writeString(member);
+    serializer.writeObject(value, buffer);
+  }
+
+  @Override
+  public void readObject(BufferInput<?> buffer, Serializer serializer) {
+    member = buffer.readString();
+    value = serializer.readObject(buffer);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[member=%s]", getClass().getSimpleName(), member);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/GroupTaskQueue.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupTaskQueue.java
@@ -34,7 +34,7 @@ public class GroupTaskQueue {
   private final Map<Long, CompletableFuture<Void>> taskFutures = new ConcurrentHashMap<>();
 
   protected GroupTaskQueue(String memberId, DistributedGroup group) {
-    this.memberId = Assert.notNull(memberId, "memberId");
+    this.memberId = memberId;
     this.group = Assert.notNull(group, "group");
   }
 
@@ -64,6 +64,16 @@ public class GroupTaskQueue {
     CompletableFuture<Void> future = taskFutures.remove(taskId);
     if (future != null) {
       future.complete(null);
+    }
+  }
+
+  /**
+   * Handles a task failure.
+   */
+  void handleFail(long taskId) {
+    CompletableFuture<Void> future = taskFutures.remove(taskId);
+    if (future != null) {
+      future.completeExceptionally(new TaskFailedException());
     }
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/GroupTaskQueue.java
+++ b/coordination/src/main/java/io/atomix/coordination/GroupTaskQueue.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Assert;
+import io.atomix.coordination.state.GroupCommands;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Group task queue.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class GroupTaskQueue {
+  private final String memberId;
+  private final DistributedGroup group;
+  private long taskId;
+  private final Map<Long, CompletableFuture<Void>> taskFutures = new ConcurrentHashMap<>();
+
+  protected GroupTaskQueue(String memberId, DistributedGroup group) {
+    this.memberId = Assert.notNull(memberId, "memberId");
+    this.group = Assert.notNull(group, "group");
+  }
+
+  /**
+   * Submits a task.
+   *
+   * @param task The task to submit.
+   * @return A completable future to be completed once the task has been acknowledged.
+   */
+  public CompletableFuture<Void> submit(Object task) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    final long taskId = ++this.taskId;
+    taskFutures.put(taskId, future);
+    group.submit(new GroupCommands.Submit(taskId, memberId, task)).whenComplete((result, error) -> {
+      if (error != null) {
+        taskFutures.remove(taskId);
+        future.completeExceptionally(error);
+      }
+    });
+    return future;
+  }
+
+  /**
+   * Handles a task acknowledgement.
+   */
+  void handleAck(long taskId) {
+    CompletableFuture<Void> future = taskFutures.remove(taskId);
+    if (future != null) {
+      future.complete(null);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s[member=%s]", getClass().getSimpleName(), memberId);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/HashPartitioner.java
+++ b/coordination/src/main/java/io/atomix/coordination/HashPartitioner.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+/**
+ * Hash code partitioner.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class HashPartitioner implements GroupPartitioner {
+
+  @Override
+  public int partition(Object value, int partitions) {
+    return value.hashCode() % partitions;
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/LocalGroupConnection.java
+++ b/coordination/src/main/java/io/atomix/coordination/LocalGroupConnection.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.transport.Address;
+import io.atomix.catalyst.util.Listener;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * Local group connection.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class LocalGroupConnection extends GroupConnection {
+  private final Map<String, MessageListenerHolder> messageListeners = new ConcurrentHashMap<>();
+
+  public LocalGroupConnection(String memberId, Address address, GroupConnectionManager connections) {
+    super(memberId, address, connections);
+  }
+
+  /**
+   * Registers a consumer for messages sent to the local member.
+   * <p>
+   * The provided message consumer will be called when a message sent to the local member
+   * is received for the given {@code topic}.
+   *
+   * @param topic The message topic.
+   * @param consumer The message consumer.
+   * @param <T> The message type.
+   * @return The message listener.
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Listener<GroupMessage<T>> onMessage(String topic, Consumer<GroupMessage<T>> consumer) {
+    MessageListenerHolder listener = new MessageListenerHolder(consumer);
+    messageListeners.put(topic, listener);
+    return listener;
+  }
+
+  /**
+   * Handles a message to the member.
+   */
+  void handleMessage(GroupMessage message) {
+    MessageListenerHolder listener = messageListeners.get(message.topic());
+    if (listener != null) {
+      listener.accept(message);
+    }
+  }
+
+  /**
+   * Listener holder.
+   */
+  @SuppressWarnings("unchecked")
+  private class MessageListenerHolder implements Listener {
+    private final Consumer consumer;
+
+    private MessageListenerHolder(Consumer consumer) {
+      this.consumer = consumer;
+    }
+
+    @Override
+    public void accept(Object message) {
+      consumer.accept(message);
+    }
+
+    @Override
+    public void close() {
+      messageListeners.remove(this);
+    }
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/LocalGroupTaskQueue.java
+++ b/coordination/src/main/java/io/atomix/coordination/LocalGroupTaskQueue.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.catalyst.util.Listener;
+import io.atomix.catalyst.util.Listeners;
+
+import java.util.function.Consumer;
+
+/**
+ * Local group task queue.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class LocalGroupTaskQueue extends GroupTaskQueue {
+  private final Listeners<GroupTask<Object>> taskListeners = new Listeners<>();
+
+  public LocalGroupTaskQueue(String memberId, DistributedGroup group) {
+    super(memberId, group);
+  }
+
+  /**
+   * Registers a consumer for tasks send to the local member.
+   *
+   * @param consumer The task consumer.
+   * @param <T> The task type.
+   * @return The task listener.
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Listener<GroupTask<T>> onTask(Consumer<GroupTask<T>> consumer) {
+    return (Listener) taskListeners.add((Consumer) consumer);
+  }
+
+  /**
+   * Handles a task.
+   */
+  @SuppressWarnings("unchecked")
+  void handleTask(GroupTask task) {
+    taskListeners.accept(task);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/RoundRobinPartitioner.java
+++ b/coordination/src/main/java/io/atomix/coordination/RoundRobinPartitioner.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Round-robin partitioner.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class RoundRobinPartitioner implements GroupPartitioner {
+  private final AtomicInteger counter = new AtomicInteger();
+
+  @Override
+  public int partition(Object object, int partitions) {
+    return counter.incrementAndGet() % partitions;
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/TaskFailedException.java
+++ b/coordination/src/main/java/io/atomix/coordination/TaskFailedException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.coordination;
+
+import io.atomix.resource.ResourceException;
+
+/**
+ * Group task failed exception.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class TaskFailedException extends ResourceException {
+
+  public TaskFailedException() {
+  }
+
+  public TaskFailedException(String message) {
+    super(message);
+  }
+
+  public TaskFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TaskFailedException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/coordination/src/main/java/io/atomix/coordination/state/GroupCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/GroupCommands.java
@@ -489,12 +489,15 @@ public final class GroupCommands {
    */
   public static class Ack extends MemberCommand<Object> {
     private long id;
+    private boolean succeeded;
 
     public Ack() {
     }
 
-    public Ack(long id) {
+    public Ack(long id, String member, boolean succeeded) {
+      super(member);
       this.id = id;
+      this.succeeded = succeeded;
     }
 
     /**
@@ -506,16 +509,26 @@ public final class GroupCommands {
       return id;
     }
 
+    /**
+     * Returns a boolean value indicating whether the task succeeded.
+     *
+     * @return Indicates whether the task was successfully processed.
+     */
+    public boolean succeeded() {
+      return succeeded;
+    }
+
     @Override
     public void writeObject(BufferOutput buffer, Serializer serializer) {
       super.writeObject(buffer, serializer);
-      buffer.writeLong(id);
+      buffer.writeLong(id).writeBoolean(succeeded);
     }
 
     @Override
     public void readObject(BufferInput buffer, Serializer serializer) {
       super.readObject(buffer, serializer);
       id = buffer.readLong();
+      succeeded = buffer.readBoolean();
     }
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/state/GroupCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/GroupCommands.java
@@ -549,8 +549,8 @@ public final class GroupCommands {
       registry.register(RemoveProperty.class, -138);
       registry.register(Submit.class, -139);
       registry.register(GroupMessage.class, -140);
-      registry.register(GroupTask.class, -141);
-      registry.register(Ack.class, -142);
+      registry.register(GroupTask.class, -158);
+      registry.register(Ack.class, -159);
     }
   }
 

--- a/coordination/src/main/java/io/atomix/coordination/state/LockCommands.java
+++ b/coordination/src/main/java/io/atomix/coordination/state/LockCommands.java
@@ -203,9 +203,9 @@ public final class LockCommands {
   public static class TypeResolver implements SerializableTypeResolver {
     @Override
     public void resolve(SerializerRegistry registry) {
-      registry.register(Lock.class, -141);
-      registry.register(Unlock.class, -142);
-      registry.register(LockEvent.class, -143);
+      registry.register(Lock.class, -143);
+      registry.register(Unlock.class, -144);
+      registry.register(LockEvent.class, -145);
     }
   }
 

--- a/coordination/src/test/java/io/atomix/coordination/DistributedGroupTest.java
+++ b/coordination/src/test/java/io/atomix/coordination/DistributedGroupTest.java
@@ -250,7 +250,7 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
     DistributedGroup group2 = createResource(new DistributedGroup.Options().withAddress(new Address("localhost", 6001)));
 
     group1.join().thenAccept(member -> {
-      member.onMessage("foo", message -> {
+      member.connection().onMessage("foo", message -> {
         threadAssertEquals(message.body(), "Hello world!");
         message.reply("bar");
         resume();
@@ -283,7 +283,7 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
     assertEquals(group1.members().size(), 1);
     assertEquals(group2.members().size(), 1);
 
-    member.onTask(task -> {
+    member.tasks().onTask(task -> {
       threadAssertEquals(task.value(), "Hello world!");
       task.ack();
       resume();
@@ -308,19 +308,19 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
     assertEquals(group1.members().size(), 3);
     assertEquals(group2.members().size(), 3);
 
-    member1.onTask(task -> {
+    member1.tasks().onTask(task -> {
       threadAssertEquals(task.value(), "Hello world!");
       System.out.println("RECTASK 1");
       task.ack();
       resume();
     });
-    member2.onTask(task -> {
+    member2.tasks().onTask(task -> {
       threadAssertEquals(task.value(), "Hello world!");
       System.out.println("RECTASK 2");
       task.ack();
       resume();
     });
-    member3.onTask(task -> {
+    member3.tasks().onTask(task -> {
       threadAssertEquals(task.value(), "Hello world!");
       System.out.println("RECTASK 3");
       task.ack();

--- a/coordination/src/test/resources/logback.xml
+++ b/coordination/src/test/resources/logback.xml
@@ -21,7 +21,7 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/examples/distributed-group/src/main/java/io/atomix/examples/group/DistributedGroupExample.java
+++ b/examples/distributed-group/src/main/java/io/atomix/examples/group/DistributedGroupExample.java
@@ -73,7 +73,7 @@ public class DistributedGroupExample {
       System.out.println(member.id() + " joined the group!");
 
       String id = member.id();
-      member.execute((Serializable & Runnable) () -> System.out.println("Executing on member " + id));
+      member.scheduler().execute((Serializable & Runnable) () -> System.out.println("Executing on member " + id));
     });
 
     while (atomix.isOpen()) {


### PR DESCRIPTION
This PR is a significant refactoring of the `DistributedGroup` API. DGroup will become a fundamental resource on which other resources can be built. It rewrites the resource to include persistent messaging, direct messaging, and partitioning of group members. Users can use a group to communicate with specific nodes either synchronously or asynchronously, and that is a component that has been missing from Atomix. The partitioning feature allows things like distributed caches or partitioned databases to be easily build on the group.

This PR ignores documentation for many of the group features. Documentation will be provided separately before the next release.