### PR TITLE
Move resource factories into util packages

### DIFF
--- a/collections/src/main/java/io/atomix/collections/DistributedMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMap.java
@@ -16,6 +16,7 @@
 package io.atomix.collections;
 
 import io.atomix.collections.state.MapCommands;
+import io.atomix.collections.util.DistributedMapFactory;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.ReadConsistency;

--- a/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMultiMap.java
@@ -16,6 +16,7 @@
 package io.atomix.collections;
 
 import io.atomix.collections.state.MultiMapCommands;
+import io.atomix.collections.util.DistributedMultiMapFactory;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.ReadConsistency;

--- a/collections/src/main/java/io/atomix/collections/DistributedQueue.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedQueue.java
@@ -16,6 +16,7 @@
 package io.atomix.collections;
 
 import io.atomix.collections.state.QueueCommands;
+import io.atomix.collections.util.DistributedQueueFactory;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.ReadConsistency;

--- a/collections/src/main/java/io/atomix/collections/DistributedSet.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedSet.java
@@ -16,6 +16,7 @@
 package io.atomix.collections;
 
 import io.atomix.collections.state.SetCommands;
+import io.atomix.collections.util.DistributedSetFactory;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.ReadConsistency;

--- a/collections/src/main/java/io/atomix/collections/util/DistributedMapFactory.java
+++ b/collections/src/main/java/io/atomix/collections/util/DistributedMapFactory.java
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.collections;
+package io.atomix.collections.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
-import io.atomix.collections.state.QueueCommands;
-import io.atomix.collections.state.QueueState;
+import io.atomix.collections.DistributedMap;
+import io.atomix.collections.state.MapCommands;
+import io.atomix.collections.state.MapState;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
@@ -25,25 +26,25 @@ import io.atomix.resource.ResourceStateMachine;
 import java.util.Properties;
 
 /**
- * Distributed queue factory.
+ * Distributed map factory.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class DistributedQueueFactory implements ResourceFactory<DistributedQueue<?>> {
+public class DistributedMapFactory implements ResourceFactory<DistributedMap<?, ?>> {
 
   @Override
   public SerializableTypeResolver createSerializableTypeResolver() {
-    return new QueueCommands.TypeResolver();
+    return new MapCommands.TypeResolver();
   }
 
   @Override
   public ResourceStateMachine createStateMachine(Properties config) {
-    return new QueueState(config);
+    return new MapState(config);
   }
 
   @Override
-  public DistributedQueue<?> createInstance(CopycatClient client, Properties options) {
-    return new DistributedQueue<>(client, options);
+  public DistributedMap<?, ?> createInstance(CopycatClient client, Properties options) {
+    return new DistributedMap<Object, Object>(client, options);
   }
 
 }

--- a/collections/src/main/java/io/atomix/collections/util/DistributedMultiMapFactory.java
+++ b/collections/src/main/java/io/atomix/collections/util/DistributedMultiMapFactory.java
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.variables;
+package io.atomix.collections.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
+import io.atomix.collections.DistributedMultiMap;
+import io.atomix.collections.state.MultiMapCommands;
+import io.atomix.collections.state.MultiMapState;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
-import io.atomix.variables.state.LongCommands;
-import io.atomix.variables.state.LongState;
 
 import java.util.Properties;
 
 /**
- * Distributed long factory.
+ * Distributed multi-map factory.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class DistributedLongFactory implements ResourceFactory<DistributedLong> {
+public class DistributedMultiMapFactory implements ResourceFactory<DistributedMultiMap<?, ?>> {
 
   @Override
   public SerializableTypeResolver createSerializableTypeResolver() {
-    return new LongCommands.TypeResolver();
+    return new MultiMapCommands.TypeResolver();
   }
 
   @Override
   public ResourceStateMachine createStateMachine(Properties config) {
-    return new LongState(config);
+    return new MultiMapState(config);
   }
 
   @Override
-  public DistributedLong createInstance(CopycatClient client, Properties options) {
-    return new DistributedLong(client, options);
+  public DistributedMultiMap<?, ?> createInstance(CopycatClient client, Properties options) {
+    return new DistributedMultiMap<>(client, options);
   }
 
 }

--- a/collections/src/main/java/io/atomix/collections/util/DistributedQueueFactory.java
+++ b/collections/src/main/java/io/atomix/collections/util/DistributedQueueFactory.java
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.group;
+package io.atomix.collections.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
+import io.atomix.collections.DistributedQueue;
+import io.atomix.collections.state.QueueCommands;
+import io.atomix.collections.state.QueueState;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.group.state.GroupCommands;
-import io.atomix.group.state.GroupState;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.util.Properties;
 
 /**
- * Distributed group factory.
+ * Distributed queue factory.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class DistributedGroupFactory implements ResourceFactory<DistributedGroup> {
+public class DistributedQueueFactory implements ResourceFactory<DistributedQueue<?>> {
 
   @Override
   public SerializableTypeResolver createSerializableTypeResolver() {
-    return new GroupCommands.TypeResolver();
+    return new QueueCommands.TypeResolver();
   }
 
   @Override
   public ResourceStateMachine createStateMachine(Properties config) {
-    return new GroupState(config);
+    return new QueueState(config);
   }
 
   @Override
-  public DistributedGroup createInstance(CopycatClient client, Properties options) {
-    return new DistributedGroup(client, options);
+  public DistributedQueue<?> createInstance(CopycatClient client, Properties options) {
+    return new DistributedQueue<>(client, options);
   }
 
 }

--- a/collections/src/main/java/io/atomix/collections/util/DistributedSetFactory.java
+++ b/collections/src/main/java/io/atomix/collections/util/DistributedSetFactory.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.collections;
+package io.atomix.collections.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
+import io.atomix.collections.DistributedSet;
 import io.atomix.collections.state.SetCommands;
 import io.atomix.collections.state.SetState;
 import io.atomix.copycat.client.CopycatClient;

--- a/concurrent/src/main/java/io/atomix/concurrent/DistributedLock.java
+++ b/concurrent/src/main/java/io/atomix/concurrent/DistributedLock.java
@@ -16,6 +16,7 @@
 package io.atomix.concurrent;
 
 import io.atomix.concurrent.state.LockCommands;
+import io.atomix.concurrent.util.DistributedLockFactory;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Resource;

--- a/concurrent/src/main/java/io/atomix/concurrent/util/DistributedLockFactory.java
+++ b/concurrent/src/main/java/io/atomix/concurrent/util/DistributedLockFactory.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.concurrent;
+package io.atomix.concurrent.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
+import io.atomix.concurrent.DistributedLock;
 import io.atomix.concurrent.state.LockCommands;
 import io.atomix.concurrent.state.LockState;
 import io.atomix.copycat.client.CopycatClient;

--- a/group/src/main/java/io/atomix/group/DistributedGroup.java
+++ b/group/src/main/java/io/atomix/group/DistributedGroup.java
@@ -26,6 +26,7 @@ import io.atomix.copycat.Command;
 import io.atomix.copycat.Query;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.group.state.GroupCommands;
+import io.atomix.group.util.DistributedGroupFactory;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceTypeInfo;

--- a/group/src/main/java/io/atomix/group/util/DistributedGroupFactory.java
+++ b/group/src/main/java/io/atomix/group/util/DistributedGroupFactory.java
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.collections;
+package io.atomix.group.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
-import io.atomix.collections.state.MapCommands;
-import io.atomix.collections.state.MapState;
 import io.atomix.copycat.client.CopycatClient;
+import io.atomix.group.DistributedGroup;
+import io.atomix.group.state.GroupCommands;
+import io.atomix.group.state.GroupState;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.util.Properties;
 
 /**
- * Distributed map factory.
+ * Distributed group factory.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class DistributedMapFactory implements ResourceFactory<DistributedMap<?, ?>> {
+public class DistributedGroupFactory implements ResourceFactory<DistributedGroup> {
 
   @Override
   public SerializableTypeResolver createSerializableTypeResolver() {
-    return new MapCommands.TypeResolver();
+    return new GroupCommands.TypeResolver();
   }
 
   @Override
   public ResourceStateMachine createStateMachine(Properties config) {
-    return new MapState(config);
+    return new GroupState(config);
   }
 
   @Override
-  public DistributedMap<?, ?> createInstance(CopycatClient client, Properties options) {
-    return new DistributedMap<Object, Object>(client, options);
+  public DistributedGroup createInstance(CopycatClient client, Properties options) {
+    return new DistributedGroup(client, options);
   }
 
 }

--- a/messaging/src/main/java/io/atomix/messaging/DistributedMessageBus.java
+++ b/messaging/src/main/java/io/atomix/messaging/DistributedMessageBus.java
@@ -23,6 +23,7 @@ import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.concurrent.Futures;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.messaging.state.MessageBusCommands;
+import io.atomix.messaging.util.DistributedMessageBusFactory;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceTypeInfo;

--- a/messaging/src/main/java/io/atomix/messaging/DistributedTaskQueue.java
+++ b/messaging/src/main/java/io/atomix/messaging/DistributedTaskQueue.java
@@ -18,6 +18,7 @@ package io.atomix.messaging;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.messaging.state.TaskQueueCommands;
+import io.atomix.messaging.util.DistributedTaskQueueFactory;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.resource.WriteConsistency;

--- a/messaging/src/main/java/io/atomix/messaging/DistributedTopic.java
+++ b/messaging/src/main/java/io/atomix/messaging/DistributedTopic.java
@@ -18,6 +18,7 @@ package io.atomix.messaging;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.messaging.state.TopicCommands;
+import io.atomix.messaging.util.DistributedTopicFactory;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.resource.WriteConsistency;

--- a/messaging/src/main/java/io/atomix/messaging/util/DistributedMessageBusFactory.java
+++ b/messaging/src/main/java/io/atomix/messaging/util/DistributedMessageBusFactory.java
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.collections;
+package io.atomix.messaging.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
-import io.atomix.collections.state.MultiMapCommands;
-import io.atomix.collections.state.MultiMapState;
 import io.atomix.copycat.client.CopycatClient;
+import io.atomix.messaging.DistributedMessageBus;
+import io.atomix.messaging.state.MessageBusCommands;
+import io.atomix.messaging.state.MessageBusState;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.util.Properties;
 
 /**
- * Distributed multi-map factory.
+ * Distributed message bus factory.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class DistributedMultiMapFactory implements ResourceFactory<DistributedMultiMap<?, ?>> {
+public class DistributedMessageBusFactory implements ResourceFactory<DistributedMessageBus> {
 
   @Override
   public SerializableTypeResolver createSerializableTypeResolver() {
-    return new MultiMapCommands.TypeResolver();
+    return new MessageBusCommands.TypeResolver();
   }
 
   @Override
   public ResourceStateMachine createStateMachine(Properties config) {
-    return new MultiMapState(config);
+    return new MessageBusState(config);
   }
 
   @Override
-  public DistributedMultiMap<?, ?> createInstance(CopycatClient client, Properties options) {
-    return new DistributedMultiMap<>(client, options);
+  public DistributedMessageBus createInstance(CopycatClient client, Properties options) {
+    return new DistributedMessageBus(client, options);
   }
 
 }

--- a/messaging/src/main/java/io/atomix/messaging/util/DistributedTaskQueueFactory.java
+++ b/messaging/src/main/java/io/atomix/messaging/util/DistributedTaskQueueFactory.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.messaging;
+package io.atomix.messaging.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
 import io.atomix.copycat.client.CopycatClient;
+import io.atomix.messaging.DistributedTaskQueue;
 import io.atomix.messaging.state.TaskQueueCommands;
 import io.atomix.messaging.state.TaskQueueState;
 import io.atomix.resource.ResourceFactory;

--- a/messaging/src/main/java/io/atomix/messaging/util/DistributedTopicFactory.java
+++ b/messaging/src/main/java/io/atomix/messaging/util/DistributedTopicFactory.java
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.messaging;
+package io.atomix.messaging.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.messaging.state.MessageBusCommands;
-import io.atomix.messaging.state.MessageBusState;
+import io.atomix.messaging.DistributedTopic;
+import io.atomix.messaging.state.TopicCommands;
+import io.atomix.messaging.state.TopicState;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
 
 import java.util.Properties;
 
 /**
- * Distributed message bus factory.
+ * Distributed topic factory.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class DistributedMessageBusFactory implements ResourceFactory<DistributedMessageBus> {
+public class DistributedTopicFactory implements ResourceFactory<DistributedTopic<?>> {
 
   @Override
   public SerializableTypeResolver createSerializableTypeResolver() {
-    return new MessageBusCommands.TypeResolver();
+    return new TopicCommands.TypeResolver();
   }
 
   @Override
   public ResourceStateMachine createStateMachine(Properties config) {
-    return new MessageBusState(config);
+    return new TopicState(config);
   }
 
   @Override
-  public DistributedMessageBus createInstance(CopycatClient client, Properties options) {
-    return new DistributedMessageBus(client, options);
+  public DistributedTopic<?> createInstance(CopycatClient client, Properties options) {
+    return new DistributedTopic<>(client, options);
   }
 
 }

--- a/variables/src/main/java/io/atomix/variables/DistributedLong.java
+++ b/variables/src/main/java/io/atomix/variables/DistributedLong.java
@@ -19,6 +19,7 @@ import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ReadConsistency;
 import io.atomix.resource.ResourceTypeInfo;
 import io.atomix.variables.state.LongCommands;
+import io.atomix.variables.util.DistributedLongFactory;
 
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;

--- a/variables/src/main/java/io/atomix/variables/DistributedValue.java
+++ b/variables/src/main/java/io/atomix/variables/DistributedValue.java
@@ -17,6 +17,7 @@ package io.atomix.variables;
 
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceTypeInfo;
+import io.atomix.variables.util.DistributedValueFactory;
 
 import java.util.Properties;
 

--- a/variables/src/main/java/io/atomix/variables/util/DistributedLongFactory.java
+++ b/variables/src/main/java/io/atomix/variables/util/DistributedLongFactory.java
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.messaging;
+package io.atomix.variables.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
 import io.atomix.copycat.client.CopycatClient;
-import io.atomix.messaging.state.TopicCommands;
-import io.atomix.messaging.state.TopicState;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
+import io.atomix.variables.DistributedLong;
+import io.atomix.variables.state.LongCommands;
+import io.atomix.variables.state.LongState;
 
 import java.util.Properties;
 
 /**
- * Distributed topic factory.
+ * Distributed long factory.
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class DistributedTopicFactory implements ResourceFactory<DistributedTopic<?>> {
+public class DistributedLongFactory implements ResourceFactory<DistributedLong> {
 
   @Override
   public SerializableTypeResolver createSerializableTypeResolver() {
-    return new TopicCommands.TypeResolver();
+    return new LongCommands.TypeResolver();
   }
 
   @Override
   public ResourceStateMachine createStateMachine(Properties config) {
-    return new TopicState(config);
+    return new LongState(config);
   }
 
   @Override
-  public DistributedTopic<?> createInstance(CopycatClient client, Properties options) {
-    return new DistributedTopic<>(client, options);
+  public DistributedLong createInstance(CopycatClient client, Properties options) {
+    return new DistributedLong(client, options);
   }
 
 }

--- a/variables/src/main/java/io/atomix/variables/util/DistributedValueFactory.java
+++ b/variables/src/main/java/io/atomix/variables/util/DistributedValueFactory.java
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package io.atomix.variables;
+package io.atomix.variables.util;
 
 import io.atomix.catalyst.serializer.SerializableTypeResolver;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.resource.ResourceFactory;
 import io.atomix.resource.ResourceStateMachine;
+import io.atomix.variables.DistributedValue;
 import io.atomix.variables.state.ValueCommands;
 import io.atomix.variables.state.ValueState;
 


### PR DESCRIPTION
This PR moves `ResourceFactory` implementations into `util` packages for each group of resources. This makes factories internal classes and hides them from Javadocs.