### PR TITLE
Remove replica balancer lock

### DIFF
--- a/core/src/main/java/io/atomix/AtomixReplica.java
+++ b/core/src/main/java/io/atomix/AtomixReplica.java
@@ -22,7 +22,6 @@ import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.Listener;
 import io.atomix.catalyst.util.PropertiesReader;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
-import io.atomix.concurrent.DistributedLock;
 import io.atomix.copycat.Command;
 import io.atomix.copycat.Query;
 import io.atomix.copycat.client.*;
@@ -357,8 +356,6 @@ public final class AtomixReplica extends Atomix {
 
   private final ResourceServer server;
   private final ClusterBalancer balancer;
-  private DistributedLock lock;
-  private boolean locking;
 
   public AtomixReplica(Properties properties) {
     this(builder(properties));
@@ -398,11 +395,8 @@ public final class AtomixReplica extends Atomix {
    * Balances the cluster.
    */
   private void balance() {
-    if (lock != null && !locking && server.server().cluster().member().equals(server.server().cluster().leader())) {
-      locking = true;
-      lock.lock()
-        .thenCompose(v -> balancer.balance(server.server().cluster()))
-        .whenComplete((r1, e1) -> lock.unlock().whenComplete((r2, e2) -> locking = false));
+    if (server.server().cluster().member().equals(server.server().cluster().leader())) {
+      balancer.balance(server.server().cluster());
     }
   }
 
@@ -410,34 +404,12 @@ public final class AtomixReplica extends Atomix {
   public CompletableFuture<Atomix> open() {
     return server.open()
       .thenRun(this::registerListeners)
-      .thenCompose(v -> super.open())
-      .thenCompose(v -> client.getResource("", DistributedLock.class))
-      .thenApply(lock -> {
-        this.lock = lock;
-        return this;
-      });
+      .thenCompose(v -> super.open());
   }
 
   @Override
   public CompletableFuture<Void> close() {
-    CompletableFuture<Void> future = new CompletableFuture<>();
-    lock.lock()
-      .thenCompose(v -> balancer.replace(server.server().cluster()))
-      .whenComplete((r1, e1) -> {
-        balancer.close();
-        lock.unlock().whenComplete((r2, e2) -> {
-          super.close().whenComplete((r3, e3) -> {
-            server.close().whenComplete((r4, e4) -> {
-              if (e4 == null) {
-                future.complete(null);
-              } else {
-                future.completeExceptionally(e4);
-              }
-            });
-          });
-        });
-      });
-    return future;
+    return super.close().thenCompose(v -> server.close());
   }
 
   /**


### PR DESCRIPTION
Replicas currently acquire a lock to balance the cluster in order to prevent multiple replicas that believe themselves to be the leader from attempting to balance the cluster concurrently. But https://github.com/atomix/copycat/pull/177 refactored Copycat's configuration change algorithm to ensure only a single leader can succeed at reconfiguring the cluster using term/index checks. Thus, a lock is no longer necessary here and the lower level consistency checks are safer.