### PR TITLE
Simplify ResourceFactory serialization logic

### DIFF
--- a/resource/src/main/java/io/atomix/resource/ResourceType.java
+++ b/resource/src/main/java/io/atomix/resource/ResourceType.java
@@ -18,7 +18,6 @@ package io.atomix.resource;
 import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.CatalystSerializable;
-import io.atomix.catalyst.serializer.SerializationException;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 
@@ -73,17 +72,14 @@ public class ResourceType implements CatalystSerializable {
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
-    buffer.writeInt(id).writeString(factory.getName());
+    buffer.writeInt(id);
+    serializer.writeObject(factory, buffer);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     id = buffer.readInt();
-    try {
-      factory = (Class<? extends ResourceFactory<?>>) Class.forName(buffer.readString());
-    } catch (ClassNotFoundException | ClassCastException e) {
-      throw new SerializationException(e);
-    }
+    factory = serializer.<Class<? extends ResourceFactory<?>>>readObject(buffer);
   }
 
   @Override


### PR DESCRIPTION
This PR simplifies the serialization logic for ResourceFactory by merely calling `readObject` and `writeObject` methods on the `Serializer`. The `ClassSerializer` will ensure the right ClassLoader is used for loading the class on derserialization.

This PR along with https://github.com/atomix/catalyst/pull/40 will address #153 