### PR TITLE
Ensure standard resource types are registered

### DIFF
--- a/collections/src/main/java/io/atomix/collections/state/MapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/state/MapCommands.java
@@ -485,9 +485,9 @@ public class MapCommands {
       registry.register(RemoveIfPresent.class, -72);
       registry.register(Replace.class, -73);
       registry.register(ReplaceIfPresent.class, -74);
-      registry.register(Values.class, -154);
-      registry.register(KeySet.class, -155);
-      registry.register(EntrySet.class, -156);
+      registry.register(Values.class, -155);
+      registry.register(KeySet.class, -156);
+      registry.register(EntrySet.class, -157);
       registry.register(IsEmpty.class, -75);
       registry.register(Size.class, -76);
       registry.register(Clear.class, -77);

--- a/core/src/main/java/io/atomix/Atomix.java
+++ b/core/src/main/java/io/atomix/Atomix.java
@@ -35,6 +35,8 @@ import io.atomix.resource.ResourceType;
 import io.atomix.variables.DistributedLong;
 import io.atomix.variables.DistributedValue;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -54,6 +56,20 @@ import java.util.function.Consumer;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public abstract class Atomix implements ResourceManager<Atomix>, Managed<Atomix> {
+  static final Collection<ResourceType> RESOURCES = Arrays.asList(
+    new ResourceType(DistributedMap.class),
+    new ResourceType(DistributedMultiMap.class),
+    new ResourceType(DistributedSet.class),
+    new ResourceType(DistributedQueue.class),
+    new ResourceType(DistributedValue.class),
+    new ResourceType(DistributedLong.class),
+    new ResourceType(DistributedLock.class),
+    new ResourceType(DistributedGroup.class),
+    new ResourceType(DistributedTopic.class),
+    new ResourceType(DistributedTaskQueue.class),
+    new ResourceType(DistributedMessageBus.class)
+  );
+
   final ResourceClient client;
 
   protected Atomix(ResourceClient client) {

--- a/core/src/main/java/io/atomix/AtomixClient.java
+++ b/core/src/main/java/io/atomix/AtomixClient.java
@@ -203,7 +203,7 @@ public class AtomixClient extends Atomix {
     private final ResourceClient.Builder builder;
 
     private Builder(ResourceClient.Builder builder) {
-      this.builder = Assert.notNull(builder, "builder");
+      this.builder = Assert.notNull(builder, "builder").withResourceTypes(RESOURCES);
     }
 
     /**

--- a/core/src/main/java/io/atomix/AtomixReplica.java
+++ b/core/src/main/java/io/atomix/AtomixReplica.java
@@ -470,7 +470,7 @@ public final class AtomixReplica extends Atomix {
     private final Address clientAddress;
     private final CopycatClient.Builder clientBuilder;
     private final CopycatServer.Builder serverBuilder;
-    private final ResourceRegistry registry = new ResourceRegistry();
+    private final ResourceRegistry registry = new ResourceRegistry(RESOURCES);
     private Transport clientTransport;
     private Transport serverTransport;
     private final Collection<Address> members;

--- a/core/src/test/java/io/atomix/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/AbstractAtomixTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractAtomixTest extends ConcurrentTestCase {
   /**
    * Creates a resource factory for the given type.
    */
-  protected <T extends Resource<?>> Function<Atomix, T> get(String key, Class<? super T> type) {
+  protected <T extends Resource<?>> Function<Atomix, T> getResource(String key, Class<? super T> type) {
     return a -> {
       try {
         return a.<T>getResource(key, type).get(5, TimeUnit.SECONDS);

--- a/core/src/test/java/io/atomix/AtomixGroupTest.java
+++ b/core/src/test/java/io/atomix/AtomixGroupTest.java
@@ -40,11 +40,11 @@ public class AtomixGroupTest extends AbstractAtomixTest {
   public void testClientGroupGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testGroup(client1, client2, get("test-client-group-get", DistributedGroup.class));
+    testGroup(client1, client2, getResource("test-client-group-get", DistributedGroup.class));
   }
 
   public void testReplicaGroupGet() throws Throwable {
-    testGroup(replicas.get(0), replicas.get(1), get("test-replica-group-get", DistributedGroup.class));
+    testGroup(replicas.get(0), replicas.get(1), getResource("test-replica-group-get", DistributedGroup.class));
   }
 
   /**

--- a/core/src/test/java/io/atomix/AtomixLockTest.java
+++ b/core/src/test/java/io/atomix/AtomixLockTest.java
@@ -36,11 +36,11 @@ public class AtomixLockTest extends AbstractAtomixTest {
   public void testClientLockGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testLock(client1, client2, get("test-client-lock-get", DistributedLock.class));
+    testLock(client1, client2, getResource("test-client-lock-get", DistributedLock.class));
   }
 
   public void testReplicaLockGet() throws Throwable {
-    testLock(createClient(), replicas.get(0), get("test-replica-lock-get", DistributedLock.class));
+    testLock(createClient(), replicas.get(0), getResource("test-replica-lock-get", DistributedLock.class));
   }
 
   /**

--- a/core/src/test/java/io/atomix/AtomixLongTest.java
+++ b/core/src/test/java/io/atomix/AtomixLongTest.java
@@ -37,11 +37,11 @@ public class AtomixLongTest extends AbstractAtomixTest {
   public void testClientLongGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testLong(client1, client2, get("test-client-long-get", DistributedLong.class));
+    testLong(client1, client2, getResource("test-client-long-get", DistributedLong.class));
   }
 
   public void testReplicaLongGet() throws Throwable {
-    testLong(replicas.get(0), replicas.get(1), get("test-replica-long-get", DistributedLong.class));
+    testLong(replicas.get(0), replicas.get(1), getResource("test-replica-long-get", DistributedLong.class));
   }
 
   /**

--- a/core/src/test/java/io/atomix/AtomixMapTest.java
+++ b/core/src/test/java/io/atomix/AtomixMapTest.java
@@ -37,11 +37,11 @@ public class AtomixMapTest extends AbstractAtomixTest {
   public void testClientMapGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testMap(client1, client2, get("test-client-map-get", DistributedMap.class));
+    testMap(client1, client2, getResource("test-client-map-get", DistributedMap.class));
   }
 
   public void testReplicaMapGet() throws Throwable {
-    testMap(replicas.get(0), replicas.get(1), get("test-replica-map-get", DistributedMap.class));
+    testMap(replicas.get(0), replicas.get(1), getResource("test-replica-map-get", DistributedMap.class));
   }
 
   /**

--- a/core/src/test/java/io/atomix/AtomixMultiMapTest.java
+++ b/core/src/test/java/io/atomix/AtomixMultiMapTest.java
@@ -37,11 +37,11 @@ public class AtomixMultiMapTest extends AbstractAtomixTest {
   public void testClientMultiMapGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testMultiMap(client1, client2, get("test-client-multimap-get", DistributedMultiMap.class));
+    testMultiMap(client1, client2, getResource("test-client-multimap-get", DistributedMultiMap.class));
   }
 
   public void testReplicaMultiMapGet() throws Throwable {
-    testMultiMap(replicas.get(0), replicas.get(1), get("test-replica-multimap-get", DistributedMultiMap.class));
+    testMultiMap(replicas.get(0), replicas.get(1), getResource("test-replica-multimap-get", DistributedMultiMap.class));
   }
 
   /**

--- a/core/src/test/java/io/atomix/AtomixQueueTest.java
+++ b/core/src/test/java/io/atomix/AtomixQueueTest.java
@@ -37,11 +37,11 @@ public class AtomixQueueTest extends AbstractAtomixTest {
   public void testClientQueueGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testQueue(client1, client2, get("test-client-queue-get", DistributedQueue.class));
+    testQueue(client1, client2, getResource("test-client-queue-get", DistributedQueue.class));
   }
 
   public void testReplicaQueueGet() throws Throwable {
-    testQueue(replicas.get(0), replicas.get(1), get("test-replica-queue-get", DistributedQueue.class));
+    testQueue(replicas.get(0), replicas.get(1), getResource("test-replica-queue-get", DistributedQueue.class));
   }
 
   /**

--- a/core/src/test/java/io/atomix/AtomixSetTest.java
+++ b/core/src/test/java/io/atomix/AtomixSetTest.java
@@ -38,11 +38,11 @@ public class AtomixSetTest extends AbstractAtomixTest {
   public void testClientSetGet() throws Throwable {
     Atomix client1 = createClient();
     Atomix client2 = createClient();
-    testSet(client1, client2, get("test-client-set-get", DistributedSet.class));
+    testSet(client1, client2, getResource("test-client-set-get", DistributedSet.class));
   }
 
   public void testReplicaSetGet() throws Throwable {
-    testSet(replicas.get(0), replicas.get(1), get("test-replica-set-get", DistributedSet.class));
+    testSet(replicas.get(0), replicas.get(1), getResource("test-replica-set-get", DistributedSet.class));
   }
 
   /**

--- a/manager/src/main/java/io/atomix/manager/ResourceClient.java
+++ b/manager/src/main/java/io/atomix/manager/ResourceClient.java
@@ -15,16 +15,6 @@
  */
 package io.atomix.manager;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.Transport;
@@ -33,11 +23,7 @@ import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.PropertiesReader;
 import io.atomix.catalyst.util.concurrent.Futures;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
-import io.atomix.copycat.client.ConnectionStrategies;
-import io.atomix.copycat.client.CopycatClient;
-import io.atomix.copycat.client.RecoveryStrategies;
-import io.atomix.copycat.client.RetryStrategies;
-import io.atomix.copycat.client.ServerSelectionStrategies;
+import io.atomix.copycat.client.*;
 import io.atomix.manager.options.ClientOptions;
 import io.atomix.manager.state.GetResourceKeys;
 import io.atomix.manager.state.ResourceExists;
@@ -48,6 +34,11 @@ import io.atomix.resource.ResourceType;
 import io.atomix.resource.util.InstanceClient;
 import io.atomix.resource.util.ResourceInstance;
 import io.atomix.resource.util.ResourceRegistry;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Provides an interface for creating and operating on {@link io.atomix.resource.Resource}s remotely.

--- a/manager/src/main/java/io/atomix/resource/util/ResourceRegistry.java
+++ b/manager/src/main/java/io/atomix/resource/util/ResourceRegistry.java
@@ -30,6 +30,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public final class ResourceRegistry {
   private final Map<Integer, ResourceType> resourceTypes = new ConcurrentHashMap<>();
 
+  public ResourceRegistry() {
+  }
+
+  public ResourceRegistry(Collection<ResourceType> resources) {
+    resources.forEach(this::register);
+  }
+
   /**
    * Returns a collection of resource types.
    *

--- a/messaging/src/main/java/io/atomix/messaging/state/MessageBusCommands.java
+++ b/messaging/src/main/java/io/atomix/messaging/state/MessageBusCommands.java
@@ -231,11 +231,11 @@ public final class MessageBusCommands {
   public static class TypeResolver implements SerializableTypeResolver {
     @Override
     public void resolve(SerializerRegistry registry) {
-      registry.register(Join.class, -145);
-      registry.register(Leave.class, -146);
-      registry.register(Register.class, -147);
-      registry.register(Unregister.class, -148);
-      registry.register(ConsumerInfo.class, -149);
+      registry.register(Join.class, -146);
+      registry.register(Leave.class, -147);
+      registry.register(Register.class, -148);
+      registry.register(Unregister.class, -149);
+      registry.register(ConsumerInfo.class, -150);
       registry.register(Message.class, -106);
     }
   }

--- a/messaging/src/main/java/io/atomix/messaging/state/TaskQueueCommands.java
+++ b/messaging/src/main/java/io/atomix/messaging/state/TaskQueueCommands.java
@@ -153,8 +153,8 @@ public final class TaskQueueCommands {
   public static class TypeResolver implements SerializableTypeResolver {
     @Override
     public void resolve(SerializerRegistry registry) {
-      registry.register(Subscribe.class, -150);
-      registry.register(Unsubscribe.class, -151);
+      registry.register(Subscribe.class, -151);
+      registry.register(Unsubscribe.class, -152);
       registry.register(Submit.class, -107);
       registry.register(Ack.class, -108);
     }

--- a/messaging/src/main/java/io/atomix/messaging/state/TopicCommands.java
+++ b/messaging/src/main/java/io/atomix/messaging/state/TopicCommands.java
@@ -127,8 +127,8 @@ public final class TopicCommands {
   public static class TypeResolver implements SerializableTypeResolver {
     @Override
     public void resolve(SerializerRegistry registry) {
-      registry.register(Listen.class, -152);
-      registry.register(Unlisten.class, -153);
+      registry.register(Listen.class, -153);
+      registry.register(Unlisten.class, -154);
       registry.register(Publish.class, -109);
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
     <catalyst.version>1.0.4</catalyst.version>
-    <copycat.version>1.0.0-rc4</copycat.version>
+    <copycat.version>1.0.0-SNAPSHOT</copycat.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>


### PR DESCRIPTION
This PR resolves a bug wherein standard resource types are not registered when building an `Atomix` instance. This requires that users register a resource type before using it.

Fixes #160.