### PR TITLE
Remove max snapshot size configuration

### DIFF
--- a/core/src/main/java/io/atomix/AtomixReplica.java
+++ b/core/src/main/java/io/atomix/AtomixReplica.java
@@ -296,7 +296,6 @@ public final class AtomixReplica extends Atomix {
         .withDirectory(options.storageDirectory())
         .withMaxSegmentSize(options.maxSegmentSize())
         .withMaxEntriesPerSegment(options.maxEntriesPerSegment())
-        .withMaxSnapshotSize(options.maxSnapshotSize())
         .withRetainStaleSnapshots(options.retainStaleSnapshots())
         .withCompactionThreads(options.compactionThreads())
         .withMinorCompactionInterval(options.minorCompactionInterval())

--- a/manager/src/main/java/io/atomix/manager/ResourceServer.java
+++ b/manager/src/main/java/io/atomix/manager/ResourceServer.java
@@ -141,7 +141,6 @@ public final class ResourceServer {
         .withDirectory(serverProperties.storageDirectory())
         .withMaxSegmentSize(serverProperties.maxSegmentSize())
         .withMaxEntriesPerSegment(serverProperties.maxEntriesPerSegment())
-        .withMaxSnapshotSize(serverProperties.maxSnapshotSize())
         .withRetainStaleSnapshots(serverProperties.retainStaleSnapshots())
         .withCompactionThreads(serverProperties.compactionThreads())
         .withMinorCompactionInterval(serverProperties.minorCompactionInterval())

--- a/manager/src/main/java/io/atomix/manager/options/ServerOptions.java
+++ b/manager/src/main/java/io/atomix/manager/options/ServerOptions.java
@@ -39,7 +39,6 @@ public class ServerOptions extends AtomixOptions {
   public static final String STORAGE_LEVEL = "storage.level";
   public static final String MAX_SEGMENT_SIZE = "storage.maxSegmentSize";
   public static final String MAX_ENTRIES_PER_SEGMENT = "storage.maxEntriesPerSegment";
-  public static final String MAX_SNAPSHOT_SIZE = "storage.compaction.maxSnapshotSize";
   public static final String RETAIN_STALE_SNAPSHOTS = "storage.compaction.retainSnapshots";
   public static final String COMPACTION_THREADS = "storage.compaction.threads";
   public static final String MINOR_COMPACTION_INTERVAL = "storage.compaction.minor";
@@ -142,15 +141,6 @@ public class ServerOptions extends AtomixOptions {
    */
   public int maxEntriesPerSegment() {
     return reader.getInteger(MAX_ENTRIES_PER_SEGMENT, DEFAULT_MAX_ENTRIES_PER_SEGMENT);
-  }
-
-  /**
-   * Returns the maximum snapshot size in bytes.
-   *
-   * @return The maximum snapshot size in bytes.
-   */
-  public int maxSnapshotSize() {
-    return reader.getInteger(MAX_SNAPSHOT_SIZE, DEFAULT_MAX_SNAPSHOT_SIZE);
   }
 
   /**

--- a/manager/src/test/java/io/atomix/manager/options/ServerOptionsTest.java
+++ b/manager/src/test/java/io/atomix/manager/options/ServerOptionsTest.java
@@ -48,7 +48,6 @@ public class ServerOptionsTest {
     assertEquals(options.storageLevel(), StorageLevel.DISK);
     assertEquals(options.maxSegmentSize(), 1024 * 1024 * 32);
     assertEquals(options.maxEntriesPerSegment(), 1024 * 1024);
-    assertEquals(options.maxSnapshotSize(), 1024 * 1024 * 32);
     assertFalse(options.retainStaleSnapshots());
     assertEquals(options.compactionThreads(), Runtime.getRuntime().availableProcessors() / 2);
     assertEquals(options.minorCompactionInterval(), Duration.ofMinutes(1));
@@ -95,7 +94,6 @@ public class ServerOptionsTest {
     assertEquals(config.storageLevel(), StorageLevel.MEMORY);
     assertEquals(config.maxSegmentSize(), 1024);
     assertEquals(config.maxEntriesPerSegment(), 1024);
-    assertEquals(config.maxSnapshotSize(), 1024);
     assertTrue(config.retainStaleSnapshots());
     assertEquals(config.compactionThreads(), 1);
     assertEquals(config.minorCompactionInterval(), Duration.ofSeconds(1));
@@ -121,7 +119,6 @@ public class ServerOptionsTest {
     assertEquals(config.storageLevel(), StorageLevel.MEMORY);
     assertEquals(config.maxSegmentSize(), 1024);
     assertEquals(config.maxEntriesPerSegment(), 1024);
-    assertEquals(config.maxSnapshotSize(), 1024);
     assertTrue(config.retainStaleSnapshots());
     assertEquals(config.compactionThreads(), 1);
     assertEquals(config.minorCompactionInterval(), Duration.ofSeconds(1));


### PR DESCRIPTION
Removes maximum snapshot size options from `ResourceServer` and `AtomixReplica` as this option was removed in atomix/copycat#212