### PR TITLE
Support configuring resource types in server/replica properties files

### DIFF
--- a/core/src/main/java/io/atomix/AtomixReplica.java
+++ b/core/src/main/java/io/atomix/AtomixReplica.java
@@ -291,6 +291,7 @@ public final class AtomixReplica extends Atomix {
     ServerOptions options = new ServerOptions(properties);
     return new Builder(clientAddress, serverAddress)
       .withTransport(options.transport())
+      .withResourceTypes(options.resourceTypes())
       .withStorage(Storage.builder()
         .withStorageLevel(options.storageLevel())
         .withDirectory(options.storageDirectory())

--- a/manager/src/main/java/io/atomix/manager/ResourceServer.java
+++ b/manager/src/main/java/io/atomix/manager/ResourceServer.java
@@ -133,24 +133,25 @@ public final class ResourceServer {
    * @throws NullPointerException if any argument is null
    */
   public static Builder builder(Address clientAddress, Address serverAddress, Properties properties) {
-    ServerOptions serverProperties = new ServerOptions(properties);
+    ServerOptions options = new ServerOptions(properties);
     return new Builder(clientAddress, serverAddress)
-      .withTransport(serverProperties.transport())
+      .withTransport(options.transport())
       .withStorage(Storage.builder()
-        .withStorageLevel(serverProperties.storageLevel())
-        .withDirectory(serverProperties.storageDirectory())
-        .withMaxSegmentSize(serverProperties.maxSegmentSize())
-        .withMaxEntriesPerSegment(serverProperties.maxEntriesPerSegment())
-        .withRetainStaleSnapshots(serverProperties.retainStaleSnapshots())
-        .withCompactionThreads(serverProperties.compactionThreads())
-        .withMinorCompactionInterval(serverProperties.minorCompactionInterval())
-        .withMajorCompactionInterval(serverProperties.majorCompactionInterval())
-        .withCompactionThreshold(serverProperties.compactionThreshold())
+        .withStorageLevel(options.storageLevel())
+        .withDirectory(options.storageDirectory())
+        .withMaxSegmentSize(options.maxSegmentSize())
+        .withMaxEntriesPerSegment(options.maxEntriesPerSegment())
+        .withRetainStaleSnapshots(options.retainStaleSnapshots())
+        .withCompactionThreads(options.compactionThreads())
+        .withMinorCompactionInterval(options.minorCompactionInterval())
+        .withMajorCompactionInterval(options.majorCompactionInterval())
+        .withCompactionThreshold(options.compactionThreshold())
         .build())
-      .withSerializer(serverProperties.serializer())
-      .withElectionTimeout(serverProperties.electionTimeout())
-      .withHeartbeatInterval(serverProperties.heartbeatInterval())
-      .withSessionTimeout(serverProperties.sessionTimeout());
+      .withSerializer(options.serializer())
+      .withResourceTypes(options.resourceTypes())
+      .withElectionTimeout(options.electionTimeout())
+      .withHeartbeatInterval(options.heartbeatInterval())
+      .withSessionTimeout(options.sessionTimeout());
   }
 
   private final CopycatServer server;

--- a/manager/src/main/java/io/atomix/manager/options/ServerOptions.java
+++ b/manager/src/main/java/io/atomix/manager/options/ServerOptions.java
@@ -19,10 +19,13 @@ import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.QualifiedProperties;
 import io.atomix.copycat.server.storage.StorageLevel;
+import io.atomix.resource.Resource;
+import io.atomix.resource.ResourceType;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Properties;
 
 /**
@@ -78,6 +81,16 @@ public class ServerOptions extends AtomixOptions {
     } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
       throw new ConfigurationException("failed to instantiate transport", e);
     }
+  }
+
+  /**
+   * Returns a collection of resource types to register.
+   *
+   * @return A collection of resource types to register.
+   */
+  @SuppressWarnings("unchecked")
+  public Collection<ResourceType> resourceTypes() {
+    return reader.getCollection("resource", resource -> new ResourceType((Class<? extends Resource>) reader.getClass(resource)));
   }
 
   /**

--- a/manager/src/test/java/io/atomix/manager/options/ServerOptionsTest.java
+++ b/manager/src/test/java/io/atomix/manager/options/ServerOptionsTest.java
@@ -18,7 +18,9 @@ package io.atomix.manager.options;
 import io.atomix.catalyst.transport.NettyTransport;
 import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.PropertiesReader;
+import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.server.storage.StorageLevel;
+import io.atomix.resource.*;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -81,6 +83,7 @@ public class ServerOptionsTest {
     properties.setProperty("storage.compaction.major", "10000");
     properties.setProperty("storage.compaction.threshold", "0.2");
     properties.setProperty("serializer.whitelist", "false");
+    properties.setProperty("resource.test", "io.atomix.manager.options.ServerOptionsTest$TestResource");
 
     ServerOptions config = new ServerOptions(properties);
     Transport transport = config.transport();
@@ -101,6 +104,9 @@ public class ServerOptionsTest {
     assertEquals(config.compactionThreshold(), 0.2);
 
     assertFalse(config.serializer().isWhitelistRequired());
+
+    assertEquals(config.resourceTypes().size(), 1);
+    assertEquals(config.resourceTypes().iterator().next().id(), 1);
   }
 
   /**
@@ -126,6 +132,27 @@ public class ServerOptionsTest {
     assertEquals(config.compactionThreshold(), 0.2);
 
     assertFalse(config.serializer().isWhitelistRequired());
+
+    assertEquals(config.resourceTypes().size(), 1);
+    assertEquals(config.resourceTypes().iterator().next().id(), 1);
+  }
+
+  @ResourceTypeInfo(id=1, factory=TestResourceFactory.class)
+  public static class TestResource extends AbstractResource<TestResource> {
+    public TestResource(CopycatClient client, ResourceType type, Properties options) {
+      super(client, type, options);
+    }
+  }
+
+  public static class TestResourceFactory implements ResourceFactory<TestResource> {
+    @Override
+    public ResourceStateMachine createStateMachine(Properties config) {
+      return null;
+    }
+    @Override
+    public TestResource createInstance(CopycatClient client, Properties options) {
+      return null;
+    }
   }
 
 }

--- a/manager/src/test/resources/server-test.properties
+++ b/manager/src/test/resources/server-test.properties
@@ -34,3 +34,5 @@ storage.compaction.major=10000
 storage.compaction.threshold=0.2
 
 serializer.whitelist=false
+
+resource.test = io.atomix.manager.options.ServerOptionsTest$TestResource


### PR DESCRIPTION
Add support for configuring custom resource types when configuring a server or replica via properties files.