### PR TITLE
Remove pausing of member messages when members disconnect

### DIFF
--- a/groups/src/main/java/io/atomix/group/internal/MemberState.java
+++ b/groups/src/main/java/io/atomix/group/internal/MemberState.java
@@ -32,7 +32,6 @@ final class MemberState implements AutoCloseable {
   private final long index;
   private final String memberId;
   private final boolean persistent;
-  private boolean paused = true;
   private ServerSession session;
   private final Map<Long, MessageState> messages = new LinkedHashMap<>();
 
@@ -77,7 +76,7 @@ final class MemberState implements AutoCloseable {
    */
   public void setSession(ServerSession session) {
     this.session = session;
-    if (!paused && session != null && session.state().active()) {
+    if (session != null && session.state().active()) {
       for (MessageState message : messages.values()) {
         session.publish("message", new GroupMessage<>(message.index(), memberId, message.queue(), message.message()));
       }
@@ -92,32 +91,11 @@ final class MemberState implements AutoCloseable {
   }
 
   /**
-   * Pauses messaging in the member.
-   */
-  public void pause() {
-    paused = true;
-  }
-
-  /**
-   * Resumes messaging in the member.
-   */
-  public void resume() {
-    if (paused) {
-      paused = false;
-      if (session != null && session.state().active()) {
-        for (MessageState message : messages.values()) {
-          session.publish("message", new GroupMessage<>(message.index(), memberId, message.queue(), message.message()));
-        }
-      }
-    }
-  }
-
-  /**
    * Submits the given message to be processed by the member.
    */
   public void submit(MessageState message) {
     messages.put(message.index(), message);
-    if (!paused && session != null && session.state().active()) {
+    if (session != null && session.state().active()) {
       session.publish("message", new GroupMessage<>(message.index(), memberId, message.queue(), message.message()));
     }
   }

--- a/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
+++ b/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
@@ -124,9 +124,6 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
         member = new LocalGroupMember(info, this, producerService, consumerService);
         members.put(info.memberId(), member);
       }
-
-      // Notify the cluster that the member is listening for events.
-      submit(new GroupCommands.Listen(info.memberId()));
       return (LocalGroupMember) member;
     });
   }


### PR DESCRIPTION
This behavior is no longer needed with sequential-only events.