### PR TITLE
Fix bug in Atomix group test

### DIFF
--- a/core/src/test/java/io/atomix/AtomixGroupTest.java
+++ b/core/src/test/java/io/atomix/AtomixGroupTest.java
@@ -60,7 +60,7 @@ public class AtomixGroupTest extends AbstractAtomixTest {
       }
     });
     group2.onJoin(m -> {
-      if (group1.members().size() == 2) {
+      if (group2.members().size() == 2) {
         resume();
       }
     });


### PR DESCRIPTION
Member checks are done on the wrong group in the event callback.