### PR TITLE
enable submitting of distributed group metadata

### DIFF
--- a/groups/src/main/java/io/atomix/group/DistributedGroup.java
+++ b/groups/src/main/java/io/atomix/group/DistributedGroup.java
@@ -481,6 +481,8 @@ public interface DistributedGroup extends Resource<DistributedGroup> {
    */
   CompletableFuture<LocalMember> join(String memberId);
 
+  CompletableFuture<LocalMember> join(String memberId, Object metadata);
+
   /**
    * Adds a listener for members joining the group.
    * <p>

--- a/groups/src/main/java/io/atomix/group/GroupMember.java
+++ b/groups/src/main/java/io/atomix/group/GroupMember.java
@@ -17,6 +17,8 @@ package io.atomix.group;
 
 import io.atomix.group.messaging.MessageClient;
 
+import java.util.Optional;
+
 /**
  * A {@link DistributedGroup} member representing a member of the group controlled by a local
  * or remote process.
@@ -51,5 +53,7 @@ public interface GroupMember {
    * @return The direct message client for this member.
    */
   MessageClient messaging();
+
+  <T> Optional<T> metadata();
 
 }

--- a/groups/src/main/java/io/atomix/group/internal/AbstractGroupMember.java
+++ b/groups/src/main/java/io/atomix/group/internal/AbstractGroupMember.java
@@ -19,6 +19,8 @@ import io.atomix.catalyst.util.Assert;
 import io.atomix.group.GroupMember;
 import io.atomix.group.messaging.internal.AbstractMessageClient;
 
+import java.util.Optional;
+
 /**
  * Abstract group member.
  *
@@ -27,10 +29,12 @@ import io.atomix.group.messaging.internal.AbstractMessageClient;
 public abstract class AbstractGroupMember implements GroupMember {
   protected final String memberId;
   protected final MembershipGroup group;
+  protected final Object metadata;
 
   public AbstractGroupMember(GroupMemberInfo info, MembershipGroup group) {
     this.memberId = info.memberId();
     this.group = Assert.notNull(group, "group");
+    this.metadata = info.metadata();
   }
 
   @Override
@@ -40,5 +44,12 @@ public abstract class AbstractGroupMember implements GroupMember {
 
   @Override
   public abstract AbstractMessageClient messaging();
+
+  @SuppressWarnings("unchecked")
+  public <T> Optional<T> metadata() {
+    return metadata == null
+        ? Optional.empty()
+        : Optional.of((T) metadata);
+  }
 
 }

--- a/groups/src/main/java/io/atomix/group/internal/GroupCommands.java
+++ b/groups/src/main/java/io/atomix/group/internal/GroupCommands.java
@@ -133,13 +133,15 @@ public final class GroupCommands {
    */
   public static class Join extends MemberCommand<GroupMemberInfo> {
     private boolean persist;
+    private Object metadata;
 
     public Join() {
     }
 
-    public Join(String member, boolean persist) {
+    public Join(String member, boolean persist, Object metadata) {
       super(member);
       this.persist = persist;
+      this.metadata = metadata;
     }
 
     /**
@@ -151,16 +153,22 @@ public final class GroupCommands {
       return persist;
     }
 
+    public Object metadata() {
+      return metadata;
+    }
+
     @Override
     public void writeObject(BufferOutput buffer, Serializer serializer) {
       super.writeObject(buffer, serializer);
       buffer.writeBoolean(persist);
+      serializer.writeObject(metadata, buffer);
     }
 
     @Override
     public void readObject(BufferInput buffer, Serializer serializer) {
       super.readObject(buffer, serializer);
       persist = buffer.readBoolean();
+      metadata = serializer.readObject(buffer);
     }
   }
 

--- a/groups/src/main/java/io/atomix/group/internal/GroupMemberInfo.java
+++ b/groups/src/main/java/io/atomix/group/internal/GroupMemberInfo.java
@@ -19,7 +19,10 @@ import io.atomix.catalyst.buffer.BufferInput;
 import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.CatalystSerializable;
 import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.Assert;
+
+import java.util.Optional;
 
 /**
  * Group member info.
@@ -29,13 +32,15 @@ import io.atomix.catalyst.util.Assert;
 public class GroupMemberInfo implements CatalystSerializable {
   private long index;
   private String memberId;
+  private Object metadata;
 
   public GroupMemberInfo() {
   }
 
-  public GroupMemberInfo(long index, String memberId) {
+  public GroupMemberInfo(long index, String memberId, Object metadata) {
     this.index = Assert.argNot(index, index <= 0, "index must be positive");
     this.memberId = Assert.notNull(memberId, "memberId");
+    this.metadata = metadata;
   }
 
   /**
@@ -56,15 +61,21 @@ public class GroupMemberInfo implements CatalystSerializable {
     return memberId;
   }
 
+  public Object metadata() {
+    return metadata;
+  }
+
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
     buffer.writeLong(index).writeString(memberId);
+    serializer.writeObject(metadata, buffer);
   }
 
   @Override
   public void readObject(BufferInput<?> buffer, Serializer serializer) {
     index = buffer.readLong();
     memberId = buffer.readString();
+    metadata = serializer.readObject(buffer);
   }
 
   @Override

--- a/groups/src/main/java/io/atomix/group/internal/MemberState.java
+++ b/groups/src/main/java/io/atomix/group/internal/MemberState.java
@@ -33,6 +33,7 @@ final class MemberState implements AutoCloseable {
   private final String memberId;
   private final boolean persistent;
   private ServerSession session;
+  private Object metadata;
   private final Map<Long, MessageState> messages = new LinkedHashMap<>();
 
   MemberState(Commit<GroupCommands.Join> commit) {
@@ -41,6 +42,7 @@ final class MemberState implements AutoCloseable {
     this.memberId = commit.operation().member();
     this.persistent = commit.operation().persist();
     this.session = commit.session();
+    this.metadata = commit.operation().metadata();
   }
 
   /**
@@ -61,7 +63,7 @@ final class MemberState implements AutoCloseable {
    * Returns group member info.
    */
   public GroupMemberInfo info() {
-    return new GroupMemberInfo(index, memberId);
+    return new GroupMemberInfo(index, memberId, metadata);
   }
 
   /**
@@ -88,6 +90,10 @@ final class MemberState implements AutoCloseable {
    */
   public boolean persistent() {
     return persistent;
+  }
+
+  public Object metadata() {
+    return metadata;
   }
 
   /**

--- a/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
+++ b/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
@@ -100,12 +100,17 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
 
   @Override
   public CompletableFuture<LocalMember> join() {
-    return join(UUID.randomUUID().toString(), false);
+    return join(UUID.randomUUID().toString(), false, null);
   }
 
   @Override
   public CompletableFuture<LocalMember> join(String memberId) {
-    return join(memberId, true);
+    return join(memberId, true, null);
+  }
+
+  @Override
+  public CompletableFuture<LocalMember> join(String memberId, Object metadata) {
+    return join(memberId == null ? UUID.randomUUID().toString() : memberId, false, metadata);
   }
 
   /**
@@ -115,10 +120,10 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
    * @param persistent Indicates whether the member ID is persistent.
    * @return A completable future to be completed once the member has joined the group.
    */
-  private CompletableFuture<LocalMember> join(String memberId, boolean persistent) {
+  private CompletableFuture<LocalMember> join(String memberId, boolean persistent, Object metadata) {
     // When joining a group, the join request is guaranteed to complete prior to the join
     // event being received.
-    return submit(new GroupCommands.Join(memberId, persistent)).thenApply(info -> {
+    return submit(new GroupCommands.Join(memberId, persistent, metadata)).thenApply(info -> {
       AbstractGroupMember member = members.get(info.memberId());
       if (member == null || !(member instanceof LocalGroupMember)) {
         member = new LocalGroupMember(info, this, producerService, consumerService);

--- a/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
+++ b/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group;
 
+import io.atomix.catalyst.transport.Address;
 import io.atomix.group.messaging.MessageFailedException;
 import io.atomix.group.messaging.MessageProducer;
 import io.atomix.testing.AbstractCopycatTest;
@@ -306,6 +307,26 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
     await(10000, 3);
   }
 
+  public void testMetadataGetsSubmitted() throws Throwable {
+    createServers(3);
+
+    final Address something = new Address("localhost", 1337);
+    DistributedGroup group = createResource(new DistributedGroup.Options());
+
+    group.onJoin(ignore -> {
+      threadAssertEquals(group.members().size(), 1);
+      group.members().forEach(member -> {
+        threadAssertTrue(member.metadata().isPresent());
+        final Address meta = member.<Address>metadata().get();
+        threadAssertEquals(meta, something);
+      });
+      resume();
+    });
+
+    group.join(null, something).get(10, TimeUnit.SECONDS);
+
+    await(5000, 1);
+  }
   /**
    * Tests that a message is failed when a member leaves before the message is processed.
    */


### PR DESCRIPTION
Hi, first of all, thanks for an amazing job you're doing with atomix!

We're currently trying to adopt it in a new project and we run into usability issues, when it comes to service discovery. I think it would be really helpful if we could submit metadata, when joining a distributed group. Metadata can contain additional info about node, e.g. host:port of some RPC and so on...

I made a POC, can you please go through it and let me know if this is a good approach?

Thanks,
D.