### PR TITLE
Ensure leader elections occur when persistent members leave the group

### DIFF
--- a/groups/src/main/java/io/atomix/group/internal/GroupState.java
+++ b/groups/src/main/java/io/atomix/group/internal/GroupState.java
@@ -102,6 +102,7 @@ public class GroupState extends ResourceStateMachine implements SessionListener 
       sessions.values().forEach(s -> s.leave(member));
     });
   }
+
   /**
    * Increments the term.
    */

--- a/groups/src/main/java/io/atomix/group/internal/GroupState.java
+++ b/groups/src/main/java/io/atomix/group/internal/GroupState.java
@@ -50,6 +50,7 @@ public class GroupState extends ResourceStateMachine implements SessionListener 
     sessions.remove(session.id());
 
     // Iterate through all open members.
+    boolean elect = false;
     Iterator<MemberState> iterator = members.iterator();
     while (iterator.hasNext()) {
       // If the member is associated with the closed session, remove it from the members list.
@@ -77,13 +78,18 @@ public class GroupState extends ResourceStateMachine implements SessionListener 
             });
           }
         }
+
+        // If the member is the current leader, resign its leadership.
+        if (leader.equals(member)) {
+          resignLeader(false);
+          elect = true;
+        }
       }
     }
 
-    // If the current leader is one of the members that left the cluster, resign the leadership
-    // and elect a new leader. This must be done after all the removed members are removed from internal state.
-    if (leader != null && left.containsKey(leader.index())) {
-      resignLeader(false);
+    // If a new election needs to take place, increment the term and elect a new leader. This must be done
+    // after all removed members are removed from the internal state to ensure a member being removed is not elected.
+    if (elect) {
       incrementTerm();
       electLeader();
     }

--- a/groups/src/main/java/io/atomix/group/internal/GroupState.java
+++ b/groups/src/main/java/io/atomix/group/internal/GroupState.java
@@ -80,7 +80,7 @@ public class GroupState extends ResourceStateMachine implements SessionListener 
         }
 
         // If the member is the current leader, resign its leadership.
-        if (leader.equals(member)) {
+        if (leader != null && leader.equals(member)) {
           resignLeader(false);
           elect = true;
         }

--- a/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
+++ b/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
@@ -144,6 +144,32 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
   }
 
   /**
+   * Tests that a new leader is elected when a persistent member is expired.
+   */
+  public void testPersistentExpireElectLeader() throws Throwable {
+    createServers(3);
+
+    DistributedGroup group1 = createResource();
+    DistributedGroup group2 = createResource();
+
+    group1.election().onElection(term -> {
+      if (term.leader().id().equals("a")) {
+        group1.close().thenRun(this::resume);
+      }
+    });
+    group2.election().onElection(term -> {
+      if (term.leader().id().equals("b")) {
+        resume();
+      }
+    });
+
+    group1.join("a").join();
+    group2.join("b").join();
+
+    await(5000, 2);
+  }
+
+  /**
    * Tests electing a group leader.
    */
   public void testElectLeave() throws Throwable {

--- a/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
+++ b/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
@@ -184,7 +184,7 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
       }
     });
     group2.onJoin(member -> {
-      if (group1.members().size() == 2) {
+      if (group2.members().size() == 2) {
         resume();
       }
     });

--- a/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
+++ b/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
@@ -170,6 +170,41 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
   }
 
   /**
+   * Tests that a persistent member is removed from the members list.
+   */
+  public void testPersistentMemberLeave() throws Throwable {
+    createServers(3);
+
+    DistributedGroup group1 = createResource();
+    DistributedGroup group2 = createResource();
+
+    group1.onJoin(member -> {
+      if (group1.members().size() == 2) {
+        resume();
+      }
+    });
+    group2.onJoin(member -> {
+      if (group1.members().size() == 2) {
+        resume();
+      }
+    });
+
+    group1.join("a").join();
+    group2.join("b").join();
+
+    await(5000, 2);
+
+    group2.onLeave(member -> {
+      threadAssertEquals(group2.members().size(), 1);
+      resume();
+    });
+
+    group1.close().thenRun(this::resume);
+
+    await(5000, 2);
+  }
+
+  /**
    * Tests electing a group leader.
    */
   public void testElectLeave() throws Throwable {
@@ -177,7 +212,6 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
 
     DistributedGroup group1 = createResource();
     DistributedGroup group2 = createResource();
-
 
     LocalMember localMember2 = group2.join().get();
     group2.election().onElection(term -> {


### PR DESCRIPTION
This PR resolves a bug when handling persistent members in `DistributedGroup` to ensure that elections properly occur when a persistent member is removed from the group. Additionally, it adds tests to ensure that member lists for remaining `DistributedGroup` instances are properly updated when a persistent member leaves the group.