### PR TITLE
Allow specifying ConnectionStrategy for AtomixClient

### DIFF
--- a/core/src/main/java/io/atomix/AtomixClient.java
+++ b/core/src/main/java/io/atomix/AtomixClient.java
@@ -20,6 +20,7 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.transport.Transport;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.PropertiesReader;
+import io.atomix.copycat.client.ConnectionStrategy;
 import io.atomix.manager.ResourceClient;
 import io.atomix.manager.ResourceServer;
 import io.atomix.manager.options.ClientOptions;
@@ -202,6 +203,18 @@ public class AtomixClient extends Atomix {
      */
     public Builder withTransport(Transport transport) {
       builder.withTransport(transport);
+      return this;
+    }
+
+    /**
+     * Sets the Atomix connection strategy.
+     *
+     * @param connectionStrategy The Atomix connection strategy.
+     * @return The Atomix builder.
+     * @throws NullPointerException If the {@code connection strategy} is {@code null}
+     */
+    public Builder withConnectionStrategy(ConnectionStrategy connectionStrategy) {
+      builder.withConnectionStrategy(connectionStrategy);
       return this;
     }
 

--- a/manager/src/main/java/io/atomix/manager/ResourceClient.java
+++ b/manager/src/main/java/io/atomix/manager/ResourceClient.java
@@ -23,6 +23,7 @@ import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.concurrent.Futures;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.atomix.copycat.client.ConnectionStrategies;
+import io.atomix.copycat.client.ConnectionStrategy;
 import io.atomix.copycat.client.CopycatClient;
 import io.atomix.copycat.client.RecoveryStrategies;
 import io.atomix.copycat.client.ServerSelectionStrategies;
@@ -353,6 +354,18 @@ public class ResourceClient implements ResourceManager<ResourceClient> {
     public Builder withTransport(Transport transport) {
       clientBuilder.withTransport(transport);
       this.transport = transport;
+      return this;
+    }
+
+    /**
+     * Sets the Atomix connection strategy.
+     *
+     * @param connectionStrategy The client connection strategy.
+     * @return The Atomix builder.
+     * @throws NullPointerException If the {@code connection strategy} is {@code null}
+     */
+    public Builder withConnectionStrategy(ConnectionStrategy connectionStrategy) {
+      clientBuilder.withConnectionStrategy(connectionStrategy);
       return this;
     }
 


### PR DESCRIPTION
I've run into the case when I want to specify my own ConnectionStrategy for AtomixClient, but it wasn't exposed in the API. So I added required methods to the respective builders.