### PR TITLE
Clean up standalone server arguments and configuration

### DIFF
--- a/manager/src/main/java/io/atomix/manager/options/ServerOptions.java
+++ b/manager/src/main/java/io/atomix/manager/options/ServerOptions.java
@@ -56,7 +56,6 @@ public class ServerOptions extends AtomixOptions {
   private static final StorageLevel DEFAULT_STORAGE_LEVEL = StorageLevel.DISK;
   private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
   private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
-  private static final int DEFAULT_MAX_SNAPSHOT_SIZE = 1024 * 1024 * 32;
   private static final boolean DEFAULT_RETAIN_STALE_SNAPSHOTS = false;
   private static final int DEFAULT_COMPACTION_THREADS = Runtime.getRuntime().availableProcessors() / 2;
   private static final Duration DEFAULT_MINOR_COMPACTION_INTERVAL = Duration.ofMinutes(1);

--- a/standalone/standalone-server/conf/example.properties
+++ b/standalone/standalone-server/conf/example.properties
@@ -14,12 +14,6 @@
 # limitations under the License
 #
 
-# This is the address to which to bind the local server. This address may or may
-# not be present in the cluster.seed list below. If the address is present in the
-# seed list, this node will start as a full member of the cluster. If the address is
-# not present in the seed list, this node will join the cluster defined by the seeds.
-server.address=localhost:5000
-
 # This is the transport to use to communicate between replicas. The transport must
 # be the same class on all replicas.
 server.transport=io.atomix.catalyst.transport.NettyTransport
@@ -35,15 +29,6 @@ server.transport.acceptBacklog=1024
 
 # This property indicates whether SSL should be enabled for the transport.
 server.transport.ssl.enabled=false
-
-# This is a list of members of the cluster to which to connect. If the local member
-# is joining a cluster, its address will not be present in the seed list. If the
-# local member is forming a new cluster, its address will be present in the seed
-# list. The first time the cluster is started, n seed nodes should be started where
-# n is the size of the Raft quorum.
-cluster.seed.1=localhost:5000
-cluster.seed.2=localhost:5001
-cluster.seed.3=localhost:5002
 
 # This property indicates the desired size of the quorum. The quorum consists
 # of some set of nodes that participate in the Raft consensus algorithm. Writes to
@@ -68,9 +53,9 @@ cluster.backupCount=0
 # frequency of keep-alive requests from clients. Note that decreasing the sessionTimeout can
 # result in e.g. a lock held by a crashed node being released sooner, but decreasing the sessionTimeout
 # also implies more overhead for frequent keep-aive requests.
-cluster.electionTimeout=1000
-cluster.heartbeatInterval=500
-cluster.sessionTimeout=10000
+raft.electionTimeout=1000
+raft.heartbeatInterval=500
+raft.sessionTimeout=10000
 
 # These properties dictate how Raft logs are stored for this replica. By default, Atomix stores
 # logs on disk. Alternatively, the MAPPED and MEMORY storage.level can be used for greater efficiency

--- a/standalone/standalone-server/src/main/java/io/atomix/standalone/server/StandaloneServer.java
+++ b/standalone/standalone-server/src/main/java/io/atomix/standalone/server/StandaloneServer.java
@@ -19,7 +19,6 @@ import io.atomix.catalyst.transport.Address;
 import io.atomix.catalyst.util.PropertiesReader;
 import io.atomix.manager.ResourceServer;
 import net.sourceforge.argparse4j.ArgumentParsers;
-import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -38,16 +37,20 @@ public class StandaloneServer {
     ArgumentParser parser = ArgumentParsers.newArgumentParser("AtomixServer")
       .defaultHelp(true)
       .description("Atomix server");
-    parser.addArgument("address")
+    parser.addArgument("-address")
       .required(true)
+      .metavar("HOST:PORT")
       .help("The server address");
     parser.addArgument("-bootstrap")
       .nargs("*")
+      .metavar("HOST:PORT")
       .help("Bootstraps a new cluster");
     parser.addArgument("-join")
       .nargs("*")
+      .metavar("HOST:PORT")
       .help("Joins an existing cluster");
     parser.addArgument("-config")
+      .metavar("FILE")
       .help("Atomix configuration file");
 
     Namespace ns = null;
@@ -61,10 +64,13 @@ public class StandaloneServer {
     String address = ns.getString("address");
     String config = ns.getString("config");
 
-    Properties properties = PropertiesReader.load(config).properties();
-    ResourceServer.Builder builder = ResourceServer.builder(new Address(address), properties);
-
-    ResourceServer server = builder.build();
+    ResourceServer server;
+    if (config != null) {
+      Properties properties = PropertiesReader.load(config).properties();
+      server = ResourceServer.builder(new Address(address), properties).build();
+    } else {
+      server = ResourceServer.builder(new Address(address)).build();
+    }
 
     List<String> bootstrap = ns.getList("bootstrap");
     if (bootstrap != null) {

--- a/standalone/standalone-server/src/main/java/io/atomix/standalone/server/StandaloneServer.java
+++ b/standalone/standalone-server/src/main/java/io/atomix/standalone/server/StandaloneServer.java
@@ -46,7 +46,7 @@ public class StandaloneServer {
       .metavar("HOST:PORT")
       .help("Bootstraps a new cluster");
     parser.addArgument("-join")
-      .nargs("*")
+      .nargs("+")
       .metavar("HOST:PORT")
       .help("Joins an existing cluster");
     parser.addArgument("-config")


### PR DESCRIPTION
This PR cleans up the standalone server implementation and several bugs in how command line arguments are parsed. The standalone server is now started with an `-address` and a `-bootstrap` or `-join` flag. The `-bootstrap` and `-join` arguments both take an optional list of addresses representing the cluster configuration.