### PR TITLE
Wrap StateMachineContext and Sessions to expose ManagedResourceSession to ResourceStateMachines

### DIFF
--- a/manager/src/main/java/io/atomix/manager/internal/ManagedResourceSession.java
+++ b/manager/src/main/java/io/atomix/manager/internal/ManagedResourceSession.java
@@ -16,6 +16,7 @@
 package io.atomix.manager.internal;
 
 import io.atomix.catalyst.concurrent.Listener;
+import io.atomix.copycat.server.Commit;
 import io.atomix.copycat.server.session.ServerSession;
 import io.atomix.copycat.session.Session;
 import io.atomix.manager.resource.internal.InstanceEvent;
@@ -29,10 +30,12 @@ import java.util.function.Consumer;
  */
 final class ManagedResourceSession implements ServerSession {
   private final long resource;
+  final Commit commit;
   private final ServerSession parent;
 
-  public ManagedResourceSession(long resource, ServerSession parent) {
+  public ManagedResourceSession(long resource, Commit commit, ServerSession parent) {
     this.resource = resource;
+    this.commit = commit;
     this.parent = parent;
   }
 

--- a/manager/src/main/java/io/atomix/manager/internal/ResourceManagerSessions.java
+++ b/manager/src/main/java/io/atomix/manager/internal/ResourceManagerSessions.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.manager.internal;
+
+import io.atomix.catalyst.util.Assert;
+import io.atomix.copycat.server.session.ServerSession;
+import io.atomix.copycat.server.session.SessionListener;
+import io.atomix.copycat.server.session.Sessions;
+
+import java.util.*;
+
+/**
+ * Resource manager sessions.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class ResourceManagerSessions implements Sessions, AutoCloseable {
+  private ManagedResourceSession first;
+  private final Map<Long, ManagedResourceSession> sessions = new HashMap<>();
+  private final Set<SessionListener> listeners = new HashSet<>();
+
+  @Override
+  public ManagedResourceSession session(long sessionId) {
+    return sessions.get(sessionId);
+  }
+
+  void register(ManagedResourceSession session) {
+    // If this is the first registered session, store it so it can be removed once all sessions are removed.
+    if (first == null)
+      first = session;
+
+    // If a session was already registered for the session ID, release the new commit.
+    if (sessions.containsKey(session.id())) {
+      session.commit.close();
+    } else {
+      sessions.put(session.id(), session);
+      for (SessionListener listener : listeners) {
+        listener.register(session);
+      }
+    }
+  }
+
+  void unregister(long sessionId) {
+    ManagedResourceSession session = sessions.get(sessionId);
+    if (session != null) {
+      for (SessionListener listener : listeners) {
+        listener.unregister(session);
+      }
+    }
+  }
+
+  void expire(long sessionId) {
+    ManagedResourceSession session = sessions.get(sessionId);
+    if (session != null) {
+      for (SessionListener listener : listeners) {
+        listener.expire(session);
+      }
+    }
+  }
+
+  void close(long sessionId) {
+    ManagedResourceSession session = sessions.remove(sessionId);
+    if (session != null) {
+      for (SessionListener listener : listeners) {
+        listener.close(session);
+      }
+      if (session.commit != first.commit) {
+        session.commit.close();
+      }
+    }
+  }
+
+  @Override
+  public Sessions addListener(SessionListener listener) {
+    listeners.add(Assert.notNull(listener, "listener"));
+    return this;
+  }
+
+  @Override
+  public Sessions removeListener(SessionListener listener) {
+    listeners.remove(Assert.notNull(listener, "listener"));
+    return this;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Iterator<ServerSession> iterator() {
+    return (Iterator) sessions.values().iterator();
+  }
+
+  @Override
+  public void close() {
+    for (ManagedResourceSession session : sessions.values()) {
+      session.commit.close();
+    }
+  }
+
+}

--- a/manager/src/main/java/io/atomix/manager/internal/ResourceManagerStateMachineContext.java
+++ b/manager/src/main/java/io/atomix/manager/internal/ResourceManagerStateMachineContext.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.manager.internal;
+
+import io.atomix.copycat.server.StateMachineContext;
+import io.atomix.copycat.server.session.Sessions;
+
+import java.time.Clock;
+
+/**
+ * Resource state machine context.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+class ResourceManagerStateMachineContext implements StateMachineContext, AutoCloseable {
+  private final StateMachineContext parent;
+  final ResourceManagerSessions sessions = new ResourceManagerSessions();
+
+  ResourceManagerStateMachineContext(StateMachineContext parent) {
+    this.parent = parent;
+  }
+
+  @Override
+  public long index() {
+    return parent.index();
+  }
+
+  @Override
+  public Clock clock() {
+    return parent.clock();
+  }
+
+  @Override
+  public Sessions sessions() {
+    return sessions;
+  }
+
+  @Override
+  public void close() {
+    sessions.close();
+  }
+
+}

--- a/resource/src/main/java/io/atomix/resource/ResourceStateMachine.java
+++ b/resource/src/main/java/io/atomix/resource/ResourceStateMachine.java
@@ -122,6 +122,8 @@ public abstract class ResourceStateMachine extends StateMachine implements Sessi
     executor.serializer().register(ResourceQuery.Config.class, -52);
     executor.serializer().register(ResourceCommand.Delete.class, -53);
 
+    executor.context().sessions().addListener(this);
+
     ResourceStateMachineExecutor wrappedExecutor = new ResourceStateMachineExecutor(executor);
     wrappedExecutor.register(ResourceQuery.Config.class, this::config);
     wrappedExecutor.<ResourceCommand.Delete>register(ResourceCommand.Delete.class, this::delete);


### PR DESCRIPTION
This PR resolves a bug in `ResourceStateMachine` where the protected `sessions` field was exposing Copycat `ServerSession`s rather than `ManagedResourceSession`s. This resulted in events sent via the sessions provided by the `Sessions` field not being properly wrapped with the resource ID. To resolve this issue, this PR adds a `ResourceManagerStateMachineContext` and `ResourceManagerSessions` to properly expose `ManagedResourceSessions` to `ResourceStateMachine`.