### PR TITLE
Use expire() method to more accurately test resource recovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
     <catalyst.version>1.1.1</catalyst.version>
-    <copycat.version>1.1.2</copycat.version>
+    <copycat.version>1.1.3-SNAPSHOT</copycat.version>
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>
     <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>


### PR DESCRIPTION
This PR fixes a bug in the resource recovery test. Because of how the test was written, clients were not transitioning states in the same way they would actually transition in practice, forcing the `RecoveryStrategy` to be called. We use the new `ClientSession.expire()` method to expire the session and ensure client states are consistent with practice during testing.