### PR TITLE
WIP: Distributed group recovery

### DIFF
--- a/resource/src/main/java/io/atomix/resource/Resource.java
+++ b/resource/src/main/java/io/atomix/resource/Resource.java
@@ -203,6 +203,14 @@ public interface Resource<T extends Resource<T>> extends Managed<T> {
   Listener<State> onStateChange(Consumer<State> callback);
 
   /**
+   * Registers a listener which gets called after the resource recovery process
+   *
+   * @param callback The callback to call when the resource finishes recovery process.
+   * @return The recovery listener.
+   */
+  Listener<Integer> onRecovery(Consumer<Integer> callback);
+
+  /**
    * Returns the resource thread context.
    *
    * @return The resource thread context.


### PR DESCRIPTION
Lets address some of the atomix client consistency guarantees. Let's take DistributedGroup for example. I create a new group and join it. Now the client's session expires for some reason. Default recoveryStrategy for atomix client is set to RECOVERY (cannot be overridden right now).

Now when client successfully recovers, it gets a brand new session id. The problem is, it is not a member of distributed group anymore.

Another problem is, that members of distributed group are cached. It does sync() when resource opens, but then updates its state based on onJoin and onLeave events. So with new session ID it doesn't receive those on reconnect and doesn't do any "resync" either.

I think that atomix client should be able to handle this. Unfortunately I'm not sure how to properly address this, so at least I'm adding a test case to replicate the issue.

What you guys think?

Thanks,
D.
