### PR TITLE
Ensure shutdown/leave operations complete with exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
     <catalyst.version>1.1.1</catalyst.version>
-    <copycat.version>1.1.4</copycat.version>
+    <copycat.version>1.1.5-SNAPSHOT</copycat.version>
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>
     <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>


### PR DESCRIPTION
This PR modifies replica `shutdown` and `leave` operations to ensure they complete regardless of whether an exception occurs during the earlier stages of the operation. This is necessary to ensure a replica can be shutdown when a majority of the cluster is down. In that case, the client will throw an exception when shutting down. This ensures that the server is shutdown before completing the operation with the client exception.