### PR TITLE
Ensure group term/leader is initialized when a new group instance is created

### DIFF
--- a/groups/src/main/java/io/atomix/group/election/internal/GroupElection.java
+++ b/groups/src/main/java/io/atomix/group/election/internal/GroupElection.java
@@ -54,10 +54,24 @@ public class GroupElection implements Election {
   }
 
   /**
+   * Sets the group term.
+   */
+  public synchronized void setTerm(long term) {
+    onTerm(term);
+  }
+
+  /**
    * Called when the term changes.
    */
   public synchronized void onTerm(long term) {
     this.term = new GroupTerm(term);
+  }
+
+  /**
+   * Sets the group leader.
+   */
+  public synchronized void setLeader(GroupMember leader) {
+    term.setLeader(leader);
   }
 
   /**

--- a/groups/src/main/java/io/atomix/group/internal/GroupCommands.java
+++ b/groups/src/main/java/io/atomix/group/internal/GroupCommands.java
@@ -197,7 +197,7 @@ public final class GroupCommands {
   /**
    * List command.
    */
-  public static class Listen extends MemberCommand<Set<GroupMemberInfo>> {
+  public static class Listen extends MemberCommand<GroupStatus> {
     public Listen() {
     }
 
@@ -208,6 +208,49 @@ public final class GroupCommands {
     @Override
     public CompactionMode compaction() {
       return CompactionMode.QUORUM;
+    }
+  }
+
+  /**
+   * Group status.
+   */
+  public static class GroupStatus implements CatalystSerializable {
+    private long term;
+    private String leader;
+    private Set<GroupMemberInfo> members;
+
+    public GroupStatus() {
+    }
+
+    public GroupStatus(long term, String leader, Set<GroupMemberInfo> members) {
+      this.term = term;
+      this.leader = leader;
+      this.members = members;
+    }
+
+    public long term() {
+      return term;
+    }
+
+    public String leader() {
+      return leader;
+    }
+
+    public Set<GroupMemberInfo> members() {
+      return members;
+    }
+
+    @Override
+    public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
+      buffer.writeLong(term).writeString(leader);
+      serializer.writeObject(members, buffer);
+    }
+
+    @Override
+    public void readObject(BufferInput<?> buffer, Serializer serializer) {
+      term = buffer.readLong();
+      leader = buffer.readString();
+      members = serializer.readObject(buffer);
     }
   }
 
@@ -525,6 +568,7 @@ public final class GroupCommands {
       registry.register(Ack.class, -139);
       registry.register(GroupMessage.class, -140);
       registry.register(GroupMemberInfo.class, -158);
+      registry.register(GroupStatus.class, -159);
     }
   }
 

--- a/groups/src/main/java/io/atomix/group/internal/GroupState.java
+++ b/groups/src/main/java/io/atomix/group/internal/GroupState.java
@@ -244,7 +244,7 @@ public class GroupState extends ResourceStateMachine implements SessionListener 
   /**
    * Handles a listen commit.
    */
-  public Set<GroupMemberInfo> listen(Commit<GroupCommands.Listen> commit) {
+  public GroupCommands.GroupStatus listen(Commit<GroupCommands.Listen> commit) {
     try {
       sessions.put(commit.session().id(), new SessionState(commit.session()));
 
@@ -254,7 +254,7 @@ public class GroupState extends ResourceStateMachine implements SessionListener 
           members.add(member.info());
         }
       }
-      return members;
+      return new GroupCommands.GroupStatus(term, leader != null ? leader.id() : null, members);
     } finally {
       commit.close();
     }


### PR DESCRIPTION
This PR fixes a bug wherein `DistributedGroup` leader/term information is not properly initialized upon creation of a new group. To initialize leader/term information, the `sync` method is updated to grab leader, term, and group members in a single atomic operation.