### PR TITLE
Synchronize ResourceClient.close()

### DIFF
--- a/manager/src/main/java/io/atomix/manager/ResourceClient.java
+++ b/manager/src/main/java/io/atomix/manager/ResourceClient.java
@@ -300,7 +300,7 @@ public class ResourceClient implements ResourceManager<ResourceClient> {
    *
    * @return A completable future to be completed once the client has been closed.
    */
-  public CompletableFuture<Void> close() {
+  public synchronized CompletableFuture<Void> close() {
     CompletableFuture<?>[] futures = new CompletableFuture[instances.size()];
     int i = 0;
     for (Resource<?> instance : instances.values()) {


### PR DESCRIPTION
This is a simple PR to make `ResourceClient.close()` `synchronized` to prevent `ConcurrentModificationException` in the underlying `HashMap`