### PR TITLE
Make Map, Set, MultiMap and Value commands with time-to-live to have EXPIRING compaction mode

### DIFF
--- a/collections/src/main/java/io/atomix/collections/internal/MapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/internal/MapCommands.java
@@ -262,7 +262,7 @@ public class MapCommands {
 
     @Override
     public CompactionMode compaction() {
-      return ttl > 0 ? CompactionMode.SEQUENTIAL : CompactionMode.QUORUM;
+      return ttl > 0 ? CompactionMode.EXPIRING : CompactionMode.QUORUM;
     }
 
     /**

--- a/collections/src/main/java/io/atomix/collections/internal/MultiMapCommands.java
+++ b/collections/src/main/java/io/atomix/collections/internal/MultiMapCommands.java
@@ -338,7 +338,7 @@ public class MultiMapCommands {
 
     @Override
     public CompactionMode compaction() {
-      return ttl > 0 ? CompactionMode.SEQUENTIAL : CompactionMode.QUORUM;
+      return ttl > 0 ? CompactionMode.EXPIRING : CompactionMode.QUORUM;
     }
 
     /**

--- a/collections/src/main/java/io/atomix/collections/internal/SetCommands.java
+++ b/collections/src/main/java/io/atomix/collections/internal/SetCommands.java
@@ -186,7 +186,7 @@ public class SetCommands {
 
     @Override
     public CompactionMode compaction() {
-      return ttl > 0 ? CompactionMode.SEQUENTIAL : CompactionMode.QUORUM;
+      return ttl > 0 ? CompactionMode.EXPIRING : CompactionMode.QUORUM;
     }
 
     /**

--- a/variables/src/main/java/io/atomix/variables/internal/ValueCommands.java
+++ b/variables/src/main/java/io/atomix/variables/internal/ValueCommands.java
@@ -51,7 +51,7 @@ public class ValueCommands {
 
     @Override
     public CompactionMode compaction() {
-      return ttl > 0 ? CompactionMode.SEQUENTIAL : CompactionMode.QUORUM;
+      return ttl > 0 ? CompactionMode.EXPIRING : CompactionMode.QUORUM;
     }
 
     /**


### PR DESCRIPTION
… instead of SEQUENTIAL, as suggested in the Copycat documentation