### PR TITLE
Add ability to get resource server

### DIFF
--- a/core/src/main/java/io/atomix/AtomixReplica.java
+++ b/core/src/main/java/io/atomix/AtomixReplica.java
@@ -321,6 +321,15 @@ public final class AtomixReplica extends Atomix {
   }
 
   /**
+   * Returns the underlying {@link ResourceServer}.
+   *
+   * @return the underlying {@link ResourceServer}.
+   */
+  public ResourceServer server() {
+    return server;
+  }
+
+  /**
    * Returns the replica type.
    * <p>
    * The replica type defines how the replica behaves within the Atomix cluster. {@link Type#ACTIVE} and


### PR DESCRIPTION
I have a use case where I need an ability to get the `ResourceServer` used by `AtomixReplica` to be able to register `onStateChange` listener to the underlying `CopycatServer` instance.
