### PR TITLE
Ignore server shutdown errors in tests

### DIFF
--- a/core/src/test/java/io/atomix/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/AbstractAtomixTest.java
@@ -22,6 +22,9 @@ import io.atomix.copycat.server.storage.Storage;
 import io.atomix.copycat.server.storage.StorageLevel;
 import io.atomix.resource.Resource;
 import io.atomix.resource.ResourceType;
+import net.jodah.concurrentunit.ConcurrentTestCase;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,11 +32,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-
-import net.jodah.concurrentunit.ConcurrentTestCase;
-
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 
 /**
  * Abstract Atomix test.
@@ -67,11 +65,11 @@ public abstract class AbstractAtomixTest extends ConcurrentTestCase {
 
   protected void cleanup() throws Throwable {
     for (AtomixClient client : clients) {
-      client.close().thenRun(this::resume);
+      client.close().whenComplete((result, error) -> resume());
       await(30000);
     }
     for (AtomixReplica replica : replicas) {
-      replica.leave().thenRun(this::resume);
+      replica.leave().whenComplete((result, error) -> resume());
       await(30000);
     }
 


### PR DESCRIPTION
This PR resolves an issue with tests wherein failed replica `leave()` calls result in test timeouts. This change simply allows errors in replica `leave`s, which can occur for a variety of reasons. But once the `leave()` future completes that indicates that the replica has at least been removed from the cluster, so it's safe to complete the test.