### PR TITLE
Group test fixes

### DIFF
--- a/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
+++ b/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
@@ -151,7 +151,10 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
   public CompletableFuture<Void> remove(String memberId) {
     return client.submit(new GroupCommands.Leave(memberId)).thenRun(() -> {
       joinCommands.remove(memberId);
-      members.remove(memberId);
+      GroupMember member = members.remove(memberId);
+      if (member != null) {
+        leaveListeners.accept(member);
+      }
     });
   }
 

--- a/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
+++ b/groups/src/main/java/io/atomix/group/internal/MembershipGroup.java
@@ -31,10 +31,7 @@ import io.atomix.group.messaging.internal.MessageProducerService;
 import io.atomix.resource.AbstractResource;
 import io.atomix.resource.ResourceType;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -60,7 +57,7 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
   private final Map<String, AbstractGroupMember> members = new ConcurrentHashMap<>();
   private final MessageProducerService producerService;
   private final MessageConsumerService consumerService;
-  private final Map<String, GroupCommands.Join> joinCommands = new ConcurrentHashMap<>();
+  private final Map<String, GroupCommands.Join> localJoins = new ConcurrentHashMap<>();
 
   public MembershipGroup(CopycatClient client, Properties options) {
     super(client, new ResourceType(DistributedGroup.class), options);
@@ -135,7 +132,7 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
       AbstractGroupMember member = members.get(info.memberId());
       if (member == null || !(member instanceof LocalGroupMember)) {
         member = new LocalGroupMember(info, this, producerService, consumerService);
-        joinCommands.put(memberId, cmd);
+        localJoins.put(memberId, cmd);
         members.put(info.memberId(), member);
       }
       return (LocalGroupMember) member;
@@ -150,7 +147,7 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
   @Override
   public CompletableFuture<Void> remove(String memberId) {
     return client.submit(new GroupCommands.Leave(memberId)).thenRun(() -> {
-      joinCommands.remove(memberId);
+      localJoins.remove(memberId);
       GroupMember member = members.remove(memberId);
       if (member != null) {
         leaveListeners.accept(member);
@@ -179,31 +176,40 @@ public class MembershipGroup extends AbstractResource<DistributedGroup> implemen
 
   @Override
   protected CompletableFuture<Void> recover(Integer attempt) {
-    final int persistentCount =
-        (int) joinCommands.values().stream().filter(v -> !v.persist()).count();
-    final CompletableFuture[] closeFutures = new CompletableFuture[persistentCount];
-    final CompletableFuture[] joinFutures = new CompletableFuture[joinCommands.size()];
-    int i = 0;
-    for (GroupCommands.Join cmd : joinCommands.values()) {
-      if (cmd.persist()) {
-        joinFutures[i] = join(cmd.member(), cmd.persist(), cmd.metadata());
-      } else {
-        closeFutures[i] = remove(cmd.member());
-        joinFutures[i] = join(cmd.metadata());
-      }
-      i++;
-    }
-    members.clear();
+    // When recovering the membership group, we need to ensure that all local non-persistent members are
+    // removed from the group prior to fetching the group membership from the cluster again, and prior to
+    // adding recovered members that the membership list is updated to ensure the list is consistent
+    // when join event handlers are called.
+    Map<String, GroupCommands.Join> joins = new HashMap<>(localJoins);
     return sync()
-      .thenCompose(v -> CompletableFuture.allOf(closeFutures))
-      .thenCompose(v -> CompletableFuture.allOf(joinFutures));
+      .thenCompose(v -> {
+        List<CompletableFuture> futures = new ArrayList<>(joins.size());
+        for (GroupCommands.Join join : joins.values()) {
+          if (!join.persist()) {
+            futures.add(remove(join.member()));
+          }
+        }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
+      })
+      .thenCompose(v -> sync())
+      .thenCompose(v -> {
+        List<CompletableFuture> futures = new ArrayList<>(joins.size());
+        for (GroupCommands.Join join : joins.values()) {
+          if (join.persist()) {
+            futures.add(join(join.member(), join.persist(), join.metadata()));
+          } else {
+            futures.add(join(join.metadata()));
+          }
+        }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]));
+      });
   }
 
   /**
    * Synchronizes the membership group.
    */
   private CompletableFuture<Void> sync() {
-    return client.submit(new GroupCommands.Listen()).thenAccept(status-> {
+    return client.submit(new GroupCommands.Listen()).thenAccept(status -> {
       for (GroupMemberInfo info : status.members()) {
         AbstractGroupMember member = this.members.get(info.memberId());
         if (member == null) {

--- a/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
+++ b/groups/src/test/java/io/atomix/group/DistributedGroupTest.java
@@ -598,7 +598,10 @@ public class DistributedGroupTest extends AbstractCopycatTest<DistributedGroup> 
     await(10000, 2);
   }
 
-  public void testRecovery2() throws Throwable {
+  /**
+   * Tests the recovery of a group resource/member in a group.
+   */
+  public void testRecovery() throws Throwable {
     createServers(3);
 
     final CopycatClient client1 = createCopycatClient();

--- a/groups/src/test/resources/logback.xml
+++ b/groups/src/test/resources/logback.xml
@@ -21,7 +21,7 @@
     </encoder>
   </appender>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/groups/src/test/resources/logback.xml
+++ b/groups/src/test/resources/logback.xml
@@ -21,7 +21,7 @@
     </encoder>
   </appender>
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>


### PR DESCRIPTION
This PR fixes some issues in group tests wherein the tests don't properly await events received on the clients. There seem to be some other issues in group tests that only show up in Travis, so I'll address those here in the test runs.