### PR TITLE
Ensure producer message ID is incremented when asynchronous message is sent

### DIFF
--- a/groups/src/main/java/io/atomix/group/messaging/internal/AbstractMessageProducer.java
+++ b/groups/src/main/java/io/atomix/group/messaging/internal/AbstractMessageProducer.java
@@ -114,7 +114,7 @@ public abstract class AbstractMessageProducer<T> implements MessageProducer<T> {
    * Sends a sequential message.
    */
   private CompletableFuture sendAsync(String member, T message) {
-    return client.producerService().send(new GroupCommands.Message(member, id, name, messageId, message, delivery, execution));
+    return client.producerService().send(new GroupCommands.Message(member, id, name, ++messageId, message, delivery, execution));
   }
 
   @Override


### PR DESCRIPTION
This PR fixes a bug in the base group message producer. `messageId` was not being incremented when `ASYNC` messages were sent.