### PR TITLE
Retain persistent group members

### DIFF
--- a/core/src/main/java/io/atomix/cluster/BalancingClusterManager.java
+++ b/core/src/main/java/io/atomix/cluster/BalancingClusterManager.java
@@ -16,6 +16,7 @@
 package io.atomix.cluster;
 
 import io.atomix.AtomixReplica;
+import io.atomix.catalyst.annotations.Experimental;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.copycat.error.ConfigurationException;
 import io.atomix.copycat.server.cluster.Cluster;
@@ -35,6 +36,7 @@ import java.util.stream.Collectors;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Experimental
 public class BalancingClusterManager implements ClusterManager {
 
   /**

--- a/groups/src/main/java/io/atomix/group/GroupMember.java
+++ b/groups/src/main/java/io/atomix/group/GroupMember.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group;
 
+import io.atomix.catalyst.annotations.Experimental;
 import io.atomix.group.messaging.MessageClient;
 
 import java.util.Optional;
@@ -52,6 +53,7 @@ public interface GroupMember {
    *
    * @return The direct message client for this member.
    */
+  @Experimental
   MessageClient messaging();
 
   /**

--- a/groups/src/main/java/io/atomix/group/LocalMember.java
+++ b/groups/src/main/java/io/atomix/group/LocalMember.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group;
 
+import io.atomix.catalyst.annotations.Experimental;
 import io.atomix.group.messaging.MessageService;
 
 import java.util.concurrent.CompletableFuture;
@@ -59,6 +60,7 @@ public interface LocalMember extends GroupMember {
    * @return The local member message service.
    */
   @Override
+  @Experimental
   MessageService messaging();
 
   /**

--- a/groups/src/main/java/io/atomix/group/messaging/MessageClient.java
+++ b/groups/src/main/java/io/atomix/group/messaging/MessageClient.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.group.messaging;
 
+import io.atomix.catalyst.annotations.Experimental;
+
 /**
  * Provides an interface for producing messages to a group or a member of a group.
  * <p>
@@ -38,6 +40,7 @@ package io.atomix.group.messaging;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Experimental
 public interface MessageClient {
 
   /**

--- a/groups/src/main/java/io/atomix/group/messaging/MessageConsumer.java
+++ b/groups/src/main/java/io/atomix/group/messaging/MessageConsumer.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group.messaging;
 
+import io.atomix.catalyst.annotations.Experimental;
 import io.atomix.catalyst.concurrent.Listener;
 
 import java.util.function.Consumer;
@@ -43,6 +44,7 @@ import java.util.function.Consumer;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Experimental
 public interface MessageConsumer<T> extends AutoCloseable {
 
   /**

--- a/groups/src/main/java/io/atomix/group/messaging/MessageProducer.java
+++ b/groups/src/main/java/io/atomix/group/messaging/MessageProducer.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group.messaging;
 
+import io.atomix.catalyst.annotations.Experimental;
 import io.atomix.catalyst.util.Assert;
 
 import java.util.concurrent.CompletableFuture;
@@ -72,6 +73,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Experimental
 public interface MessageProducer<T> extends AutoCloseable {
 
   /**

--- a/groups/src/main/java/io/atomix/group/messaging/MessageService.java
+++ b/groups/src/main/java/io/atomix/group/messaging/MessageService.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.group.messaging;
 
+import io.atomix.catalyst.annotations.Experimental;
+
 /**
  * Provides an interface for consuming messages sent either directly or indirectly to a group member.
  * <p>
@@ -49,6 +51,7 @@ package io.atomix.group.messaging;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Experimental
 public interface MessageService extends MessageClient {
 
   /**


### PR DESCRIPTION
This PR modifies the way persistent members are treated in `DistributedGroup`. Currently, when a persistent member's instance session expires, a `leave` event is sent to all remaining group instances and the member is removed on clients but the state is persisted in the cluster. The rationale behind this was to allow clients to detect changes in the status of members without losing state. However, this makes it impossible to send messages or otherwise interact with persistent members while they're dead.

This PR solves that problem by adding a `GroupMember.Status` enum which indicates whether or not a persistent member's session is active. When a persistent member's session expires, the member's status is changed rather than removing the member from the group. When it rejoins with another session, the session is set back to `ALIVE`.