### PR TITLE
Add member status changes for persistent group members

### DIFF
--- a/groups/src/main/java/io/atomix/group/DistributedGroup.java
+++ b/groups/src/main/java/io/atomix/group/DistributedGroup.java
@@ -15,9 +15,9 @@
  */
 package io.atomix.group;
 
+import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
-import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.group.election.Election;
 import io.atomix.group.election.Term;
 import io.atomix.group.messaging.Message;
@@ -358,6 +358,31 @@ public interface DistributedGroup extends Resource<DistributedGroup> {
      */
     public Config withMemberExpiration(Duration expiration) {
       setProperty("expiration", String.valueOf(Assert.notNull(expiration, "expiration").toMillis()));
+      return this;
+    }
+  }
+
+  /**
+   * Distributed group options.
+   */
+  class Options extends Resource.Options {
+    private boolean autoRecover = true;
+
+    public Options() {
+    }
+
+    public Options(Properties defaults) {
+      super(defaults);
+    }
+
+    /**
+     * Sets whether to automatically recover sessions and client-side state.
+     *
+     * @param autoRecover Whether to automatically recover sessions and client-side state.
+     * @return The group options.
+     */
+    public Options withAutoRecover(boolean autoRecover) {
+      setProperty("recover", String.valueOf(autoRecover));
       return this;
     }
   }

--- a/groups/src/main/java/io/atomix/group/internal/SessionState.java
+++ b/groups/src/main/java/io/atomix/group/internal/SessionState.java
@@ -46,6 +46,24 @@ final class SessionState {
   }
 
   /**
+   * Indicates that the given member's status has changed to ALIVE.
+   */
+  public void alive(MemberState member) {
+    if (session.state().active()) {
+      session.publish("alive", member.id());
+    }
+  }
+
+  /**
+   * Indicates that the given member's status has changed to DEAD.
+   */
+  public void dead(MemberState member) {
+    if (session.state().active()) {
+      session.publish("dead", member.id());
+    }
+  }
+
+  /**
    * Sends a leave event to the session for the given member.
    */
   public void leave(MemberState member) {

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <java.version>1.8</java.version>
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
-    <catalyst.version>1.1.1</catalyst.version>
+    <catalyst.version>1.1.2-SNAPSHOT</catalyst.version>
     <copycat.version>1.1.5-SNAPSHOT</copycat.version>
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>


### PR DESCRIPTION
This PR modifies the way persistent members are treated in `DistributedGroup`. Currently, when a persistent member's instance session expires, a leave event is sent to all remaining group instances and the member is removed on clients but the state is persisted in the cluster. The rationale behind this was to allow clients to detect changes in the status of members without losing state. However, this makes it impossible to send messages or otherwise interact with persistent members while they're dead.

This PR solves that problem by adding a `GroupMember.Status` enum which indicates whether or not a persistent member's session is active. When a persistent member's session expires, the member's status is changed rather than removing the member from the group. When it rejoins with another session, the session is set back to `ALIVE`.