### PR TITLE
Fix missing key parameter when registering key event listeners in DistributedMap

### DIFF
--- a/collections/src/main/java/io/atomix/collections/DistributedMap.java
+++ b/collections/src/main/java/io/atomix/collections/DistributedMap.java
@@ -1155,7 +1155,7 @@ public class DistributedMap<K, V> extends AbstractResource<DistributedMap<K, V>>
    * @return The event listener context.
    */
   public CompletableFuture<Listener<EntryEvent<K, V>>> onAdd(K key, Consumer<EntryEvent<K, V>> callback) {
-    return onEvent(Events.ADD, callback);
+    return onEvent(key, Events.ADD, callback);
   }
 
   /**
@@ -1175,7 +1175,7 @@ public class DistributedMap<K, V> extends AbstractResource<DistributedMap<K, V>>
    * @return The event listener context.
    */
   public CompletableFuture<Listener<EntryEvent<K, V>>> onUpdate(K key, Consumer<EntryEvent<K, V>> callback) {
-    return onEvent(Events.UPDATE, callback);
+    return onEvent(key, Events.UPDATE, callback);
   }
 
   /**
@@ -1195,7 +1195,7 @@ public class DistributedMap<K, V> extends AbstractResource<DistributedMap<K, V>>
    * @return The event listener context.
    */
   public CompletableFuture<Listener<EntryEvent<K, V>>> onRemove(K key, Consumer<EntryEvent<K, V>> callback) {
-    return onEvent(Events.REMOVE, callback);
+    return onEvent(key, Events.REMOVE, callback);
   }
 
   @Override


### PR DESCRIPTION
This PR fixes a bug wherein the `key` was not used while registering map key event listeners.