### PR TITLE
Add @Beta annotation to groups

### DIFF
--- a/groups/src/main/java/io/atomix/group/DistributedGroup.java
+++ b/groups/src/main/java/io/atomix/group/DistributedGroup.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group;
 
+import io.atomix.catalyst.annotations.Beta;
 import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
@@ -335,6 +336,7 @@ import java.util.function.Consumer;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Beta
 @ResourceTypeInfo(id=-20, factory=DistributedGroupFactory.class)
 public interface DistributedGroup extends Resource<DistributedGroup> {
 

--- a/groups/src/main/java/io/atomix/group/GroupMember.java
+++ b/groups/src/main/java/io/atomix/group/GroupMember.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group;
 
+import io.atomix.catalyst.annotations.Beta;
 import io.atomix.catalyst.annotations.Experimental;
 import io.atomix.catalyst.concurrent.Listener;
 import io.atomix.group.messaging.MessageClient;
@@ -28,6 +29,7 @@ import java.util.function.Consumer;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Beta
 public interface GroupMember {
 
   /**

--- a/groups/src/main/java/io/atomix/group/LocalMember.java
+++ b/groups/src/main/java/io/atomix/group/LocalMember.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.group;
 
+import io.atomix.catalyst.annotations.Beta;
 import io.atomix.catalyst.annotations.Experimental;
 import io.atomix.group.messaging.MessageService;
 
@@ -40,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
+@Beta
 public interface LocalMember extends GroupMember {
 
   /**


### PR DESCRIPTION
`DistributedGroup` is a pretty complex resource that's clearly still in progress. The API is stable, but the implementation may still have some bugs. This PR annotates the group and some related interfaces with the `@Beta` annotation to better indicate its state.