### PR TITLE
Clean up resource manager state machine

### DIFF
--- a/manager/src/main/java/io/atomix/manager/internal/ResourceManagerState.java
+++ b/manager/src/main/java/io/atomix/manager/internal/ResourceManagerState.java
@@ -212,6 +212,7 @@ public class ResourceManagerState extends StateMachine implements SessionListene
       // Delete the resource state machine and close the resource state machine executor.
       resource.stateMachine.delete();
       resource.executor.close();
+      resource.commit.close();
 
       keys.remove(resource.key);
       return true;
@@ -282,19 +283,6 @@ public class ResourceManagerState extends StateMachine implements SessionListene
       this.commit = commit;
       this.stateMachine = stateMachine;
       this.executor = executor;
-    }
-  }
-
-  /**
-   * Session holder.
-   */
-  private static class SessionHolder {
-    private final Commit commit;
-    private final ManagedResourceSession session;
-
-    private SessionHolder(Commit commit, ManagedResourceSession session) {
-      this.commit = commit;
-      this.session = session;
     }
   }
 


### PR DESCRIPTION
This PR is some minor cleanup of the `ResourceManagerStateMachine`. It removes an unused internal class and ensures that `GetResource` commits are properly compacted from the Raft log.