### PR TITLE
use correct generic type on AbstractDistributedValue.onChange

### DIFF
--- a/variables/src/main/java/io/atomix/variables/AbstractDistributedValue.java
+++ b/variables/src/main/java/io/atomix/variables/AbstractDistributedValue.java
@@ -54,7 +54,7 @@ public abstract class AbstractDistributedValue<T extends AbstractDistributedValu
    * @param callback The callback to be called when the value changes.
    * @return The change event.
    */
-  public synchronized CompletableFuture<Listener<ChangeEvent<T>>> onChange(Consumer<ChangeEvent<T>> callback) {
+  public synchronized CompletableFuture<Listener<ChangeEvent<U>>> onChange(Consumer<ChangeEvent<U>> callback) {
     return onEvent(Events.CHANGE, callback);
   }
 


### PR DESCRIPTION
`AbstractDistributedValue.onChange` declared the wrong generic type; this wasn't caught by tests due to the lack of type-safety of `threadAssertEquals` in the `DistributedLongTest`. Without this fix, the typo will make a mess of any real listener that uses this API.


