### PR TITLE
Bump Copycat dependency version to 1.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <slf4j.version>1.7.7</slf4j.version>
     <logback.version>1.1.2</logback.version>
     <catalyst.version>1.2.0</catalyst.version>
-    <copycat.version>1.2.6</copycat.version>
+    <copycat.version>1.2.7</copycat.version>
 
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.0</maven.compiler.plugin.version>


### PR DESCRIPTION
This isn't actually in Central yet, but should be in a few. I'll restart the tests when it gets there.