### PR TITLE
Refactored the Function<Long,Long> to LongUnaryOperator

### DIFF
--- a/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
+++ b/variables/src/test/java/io/atomix/variables/DistributedLongTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.LongUnaryOperator;
 
 /**
  * Distributed atomic long test.
@@ -106,11 +107,11 @@ public class DistributedLongTest extends AbstractCopycatTest<DistributedLong> {
   /**
    * Returns an atomic set/get test callback.
    */
-  private Consumer<DistributedLong> atomic(Function<DistributedLong, CompletableFuture<Long>> commandFunction, Function<Long, Long> resultFunction) {
+  private Consumer<DistributedLong> atomic(Function<DistributedLong, CompletableFuture<Long>> commandFunction, LongUnaryOperator resultFunction) {
     return (a) -> {
       a.get().thenAccept(value -> {
         commandFunction.apply(a).thenAccept(result -> {
-          threadAssertEquals(result, resultFunction.apply(value));
+          threadAssertEquals(result, resultFunction.applyAsLong(value));
           resume();
         });
       });


### PR DESCRIPTION
Hello,

I am graduate student at Oregon State University  and as part of my research and subject CS562 Applied Software Engineering project (Study and Refactoring of Functional Interface in Java), I have done refactoring of the Function<Long,Long> to LongUnaryOperator. My project and research deals with the boxing and unboxing of Wrapper class and the primitive data types. I want to know that whether the open source community is ready to accept these micro-optimizing refactorings or not. 

Thank you,
Harsh Thakor  