### PR TITLE
Add leadership transfer functionality

### DIFF
--- a/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftMessageContext.java
+++ b/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftMessageContext.java
@@ -33,6 +33,7 @@ class RaftMessageContext {
   final MessageSubject configureSubject;
   final MessageSubject reconfigureSubject;
   final MessageSubject installSubject;
+  final MessageSubject transferSubject;
   final MessageSubject pollSubject;
   final MessageSubject voteSubject;
   final MessageSubject appendSubject;
@@ -50,6 +51,7 @@ class RaftMessageContext {
     this.configureSubject = getSubject(prefix, "configure");
     this.reconfigureSubject = getSubject(prefix, "reconfigure");
     this.installSubject = getSubject(prefix, "install");
+    this.transferSubject = getSubject(prefix, "transfer");
     this.pollSubject = getSubject(prefix, "poll");
     this.voteSubject = getSubject(prefix, "vote");
     this.appendSubject = getSubject(prefix, "append");

--- a/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftServerCommunicator.java
+++ b/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftServerCommunicator.java
@@ -49,6 +49,8 @@ import io.atomix.protocols.raft.protocol.RaftServerProtocol;
 import io.atomix.protocols.raft.protocol.ReconfigureRequest;
 import io.atomix.protocols.raft.protocol.ReconfigureResponse;
 import io.atomix.protocols.raft.protocol.ResetRequest;
+import io.atomix.protocols.raft.protocol.TransferRequest;
+import io.atomix.protocols.raft.protocol.TransferResponse;
 import io.atomix.protocols.raft.protocol.VoteRequest;
 import io.atomix.protocols.raft.protocol.VoteResponse;
 import io.atomix.protocols.raft.session.SessionId;
@@ -134,6 +136,11 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public CompletableFuture<InstallResponse> install(MemberId memberId, InstallRequest request) {
     return sendAndReceive(context.installSubject, request, memberId);
+  }
+
+  @Override
+  public CompletableFuture<TransferResponse> transfer(MemberId memberId, TransferRequest request) {
+    return sendAndReceive(context.transferSubject, request, memberId);
   }
 
   @Override
@@ -264,6 +271,16 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public void unregisterInstallHandler() {
     clusterCommunicator.removeSubscriber(context.installSubject);
+  }
+
+  @Override
+  public void registerTransferHandler(Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
+    clusterCommunicator.addSubscriber(context.transferSubject, serializer::decode, handler, serializer::encode);
+  }
+
+  @Override
+  public void unregisterTransferHandler() {
+    clusterCommunicator.removeSubscriber(context.transferSubject);
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -296,6 +296,24 @@ public interface RaftServer {
   Role getRole();
 
   /**
+   * Returns whether the server is the leader.
+   *
+   * @return whether the server is the leader
+   */
+  default boolean isLeader() {
+    return getRole() == Role.LEADER;
+  }
+
+  /**
+   * Returns whether the server is a follower.
+   *
+   * @return whether the server is a follower
+   */
+  default boolean isFollower() {
+    return getRole() == Role.FOLLOWER;
+  }
+
+  /**
    * Adds a role change listener.
    *
    * @param listener The role change listener to add.
@@ -451,6 +469,13 @@ public interface RaftServer {
    * @return A completable future to be completed once the local server has joined the cluster.
    */
   CompletableFuture<RaftServer> join(Collection<MemberId> cluster);
+
+  /**
+   * Promotes the server to leader if possible.
+   *
+   * @return a future to be completed once the server has been promoted
+   */
+  CompletableFuture<RaftServer> promote();
 
   /**
    * Returns a boolean indicating whether the server is running.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -143,6 +143,11 @@ public class DefaultRaftServer implements RaftServer {
     });
   }
 
+  @Override
+  public CompletableFuture<RaftServer> promote() {
+    return context.anoint().thenApply(v -> this);
+  }
+
   /**
    * Returns a boolean indicating whether the server is running.
    *

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftServerProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftServerProtocol.java
@@ -128,6 +128,15 @@ public interface RaftServerProtocol {
   CompletableFuture<InstallResponse> install(MemberId memberId, InstallRequest request);
 
   /**
+   * Sends a transfer request to the given node.
+   *
+   * @param memberId  the node to which to send the request
+   * @param request the request to send
+   * @return a future to be completed with the response
+   */
+  CompletableFuture<TransferResponse> transfer(MemberId memberId, TransferRequest request);
+
+  /**
    * Sends a poll request to the given node.
    *
    * @param memberId  the node to which to send the request
@@ -257,6 +266,18 @@ public interface RaftServerProtocol {
    * Unregisters the leave request handler.
    */
   void unregisterLeaveHandler();
+
+  /**
+   * Registers a transfer request callback.
+   *
+   * @param handler the open session request handler to register
+   */
+  void registerTransferHandler(Function<TransferRequest, CompletableFuture<TransferResponse>> handler);
+
+  /**
+   * Unregisters the transfer request handler.
+   */
+  void unregisterTransferHandler();
 
   /**
    * Registers a configure request callback.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/TransferRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/TransferRequest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.protocol;
+
+import io.atomix.protocols.raft.cluster.MemberId;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Leadership transfer request.
+ */
+public class TransferRequest extends AbstractRaftRequest {
+
+  /**
+   * Returns a new transfer request builder.
+   *
+   * @return A new transfer request builder.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  protected final MemberId member;
+
+  protected TransferRequest(MemberId member) {
+    this.member = member;
+  }
+
+  /**
+   * Returns the member to which to transfer.
+   *
+   * @return The member to which to transfer.
+   */
+  public MemberId member() {
+    return member;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), member);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (getClass().isAssignableFrom(object.getClass())) {
+      return ((ConfigurationRequest) object).member.equals(member);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("member", member)
+        .toString();
+  }
+
+  /**
+   * Transfer request builder.
+   */
+  public static class Builder extends AbstractRaftRequest.Builder<Builder, TransferRequest> {
+    protected MemberId member;
+
+    /**
+     * Sets the request member.
+     *
+     * @param member The request member.
+     * @return The request builder.
+     * @throws NullPointerException if {@code member} is null
+     */
+    @SuppressWarnings("unchecked")
+    public Builder withMember(MemberId member) {
+      this.member = checkNotNull(member, "member cannot be null");
+      return this;
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkNotNull(member, "member cannot be null");
+    }
+
+    @Override
+    public TransferRequest build() {
+      return new TransferRequest(member);
+    }
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/TransferResponse.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/TransferResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-present Open Networking Laboratory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.protocol;
+
+import io.atomix.protocols.raft.RaftError;
+
+/**
+ * Leadership transfer response.
+ */
+public class TransferResponse extends AbstractRaftResponse {
+
+  /**
+   * Returns a new transfer response builder.
+   *
+   * @return A new transfer response builder.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public TransferResponse(Status status, RaftError error) {
+    super(status, error);
+  }
+
+  /**
+   * Join response builder.
+   */
+  public static class Builder extends AbstractRaftResponse.Builder<Builder, TransferResponse> {
+    @Override
+    public TransferResponse build() {
+      validate();
+      return new TransferResponse(status, error);
+    }
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/InactiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/InactiveRole.java
@@ -43,6 +43,8 @@ import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.protocols.raft.protocol.ReconfigureRequest;
 import io.atomix.protocols.raft.protocol.ReconfigureResponse;
+import io.atomix.protocols.raft.protocol.TransferRequest;
+import io.atomix.protocols.raft.protocol.TransferResponse;
 import io.atomix.protocols.raft.protocol.VoteRequest;
 import io.atomix.protocols.raft.protocol.VoteResponse;
 import io.atomix.protocols.raft.RaftServer;
@@ -126,6 +128,11 @@ public class InactiveRole extends AbstractRole {
 
   @Override
   public CompletableFuture<LeaveResponse> onLeave(LeaveRequest request) {
+    return Futures.exceptionalFuture(new IllegalStateException("inactive state"));
+  }
+
+  @Override
+  public CompletableFuture<TransferResponse> onTransfer(TransferRequest request) {
     return Futures.exceptionalFuture(new IllegalStateException("inactive state"));
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/RaftRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/RaftRole.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft.roles;
 
+import io.atomix.protocols.raft.RaftServer;
 import io.atomix.protocols.raft.protocol.AppendRequest;
 import io.atomix.protocols.raft.protocol.AppendResponse;
 import io.atomix.protocols.raft.protocol.CloseSessionRequest;
@@ -41,9 +42,10 @@ import io.atomix.protocols.raft.protocol.QueryRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.ReconfigureRequest;
 import io.atomix.protocols.raft.protocol.ReconfigureResponse;
+import io.atomix.protocols.raft.protocol.TransferRequest;
+import io.atomix.protocols.raft.protocol.TransferResponse;
 import io.atomix.protocols.raft.protocol.VoteRequest;
 import io.atomix.protocols.raft.protocol.VoteResponse;
-import io.atomix.protocols.raft.RaftServer;
 import io.atomix.utils.Managed;
 
 import java.util.concurrent.CompletableFuture;
@@ -131,6 +133,14 @@ public interface RaftRole extends Managed<RaftRole> {
    * @return A completable future to be completed with the request response.
    */
   CompletableFuture<LeaveResponse> onLeave(LeaveRequest request);
+
+  /**
+   * Handles a transfer request.
+   *
+   * @param request The request to handle.
+   * @return A completable future to be completed with the request response.
+   */
+  CompletableFuture<TransferResponse> onTransfer(TransferRequest request);
 
   /**
    * Handles an append request.

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -78,6 +78,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Raft test.
@@ -209,6 +210,24 @@ public class RaftTest extends ConcurrentTestCase {
     } else {
       resume();
     }
+  }
+
+  /**
+   * Tests transferring leadership.
+   */
+  @Test
+  public void testTransferLeadership() throws Throwable {
+    List<RaftServer> servers = createServers(3);
+    RaftClient client = createClient();
+    RaftProxy session = createSession(client);
+    submit(session, 0, 1000);
+    RaftServer follower = servers.stream()
+        .filter(RaftServer::isFollower)
+        .findFirst()
+        .get();
+    follower.promote().thenRun(this::resume);
+    await(10000, 2);
+    assertTrue(follower.isLeader());
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftServerProtocol.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftServerProtocol.java
@@ -42,6 +42,7 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   private Function<ConfigureRequest, CompletableFuture<ConfigureResponse>> configureHandler;
   private Function<ReconfigureRequest, CompletableFuture<ReconfigureResponse>> reconfigureHandler;
   private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
+  private Function<TransferRequest, CompletableFuture<TransferResponse>> transferHandler;
   private Function<PollRequest, CompletableFuture<PollResponse>> pollHandler;
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
   private Function<AppendRequest, CompletableFuture<AppendResponse>> appendHandler;
@@ -123,6 +124,11 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public CompletableFuture<InstallResponse> install(MemberId memberId, InstallRequest request) {
     return getServer(memberId).thenCompose(listener -> listener.install(request));
+  }
+
+  @Override
+  public CompletableFuture<TransferResponse> transfer(MemberId memberId, TransferRequest request) {
+    return getServer(memberId).thenCompose(listener -> listener.transfer(request));
   }
 
   @Override
@@ -341,6 +347,24 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public void unregisterInstallHandler() {
     this.installHandler = null;
+  }
+
+  CompletableFuture<TransferResponse> transfer(TransferRequest request) {
+    if (transferHandler != null) {
+      return transferHandler.apply(request);
+    } else {
+      return Futures.exceptionalFuture(new ConnectException());
+    }
+  }
+
+  @Override
+  public void registerTransferHandler(Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
+    this.transferHandler = handler;
+  }
+
+  @Override
+  public void unregisterTransferHandler() {
+    this.transferHandler = null;
   }
 
   CompletableFuture<PollResponse> poll(PollRequest request) {

--- a/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftServerMessagingProtocol.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftServerMessagingProtocol.java
@@ -90,6 +90,11 @@ public class RaftServerMessagingProtocol extends RaftMessagingProtocol implement
   }
 
   @Override
+  public CompletableFuture<TransferResponse> transfer(MemberId memberId, TransferRequest request) {
+    return sendAndReceive(memberId, "transfer", request);
+  }
+
+  @Override
   public CompletableFuture<PollResponse> poll(MemberId memberId, PollRequest request) {
     return sendAndReceive(memberId, "poll", request);
   }
@@ -217,6 +222,16 @@ public class RaftServerMessagingProtocol extends RaftMessagingProtocol implement
   @Override
   public void unregisterInstallHandler() {
     unregisterHandler("install");
+  }
+
+  @Override
+  public void registerTransferHandler(Function<TransferRequest, CompletableFuture<TransferResponse>> handler) {
+    registerHandler("transfer", handler);
+  }
+
+  @Override
+  public void unregisterTransferHandler() {
+    unregisterHandler("transfer");
   }
 
   @Override


### PR DESCRIPTION
This PR adds support for transferring leadership to a specific node. This is done by simply calling `promote()` on the `RaftServer` to which to transfer leadership. Leadership transfer is implemented by sending a `TransferRequest` to the leader which will then block writes and replicate the rest of its log to the follower before stepping down and responding to the request with a `TransferResponse`. Once the follower receives the response, it immediately transitions to the `CANDIDATE` role to get elected. If for some reason the follower is not the next node elected, the transfer will fail.