### PR TITLE
Add support for empty argument service callbacks in RaftServiceExecutor

### DIFF
--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1327,7 +1327,7 @@ public class RaftTest extends ConcurrentTestCase {
       executor.register(WRITE, this::write, clientSerializer::encode);
       executor.register(READ, this::read, clientSerializer::encode);
       executor.register(EVENT, clientSerializer::decode, this::event, clientSerializer::encode);
-      executor.register(CLOSE, this::close);
+      executor.register(CLOSE, c -> close(c));
       executor.register(EXPIRE, this::expire);
     }
 


### PR DESCRIPTION
This PR adds additional default methods to `RaftServiceExecutor` to support state machine callbacks that take no `Commit` argument and return no result.