### PR TITLE
Remove version number from segment file name format

### DIFF
--- a/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentFile.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentFile.java
@@ -36,35 +36,44 @@ public final class JournalSegmentFile {
    * @throws NullPointerException if {@code file} is null
    */
   public static boolean isSegmentFile(String name, File file) {
-    checkNotNull(name, "name cannot be null");
-    checkNotNull(file, "file cannot be null");
-    String fileName = file.getName();
-    if (fileName.lastIndexOf(EXTENSION_SEPARATOR) == -1 || fileName.lastIndexOf(PART_SEPARATOR) == -1 || fileName.lastIndexOf(EXTENSION_SEPARATOR) < fileName.lastIndexOf(PART_SEPARATOR) || !fileName.endsWith(EXTENSION))
-      return false;
+    return isSegmentFile(name, file.getName());
+  }
 
-    for (int i = fileName.lastIndexOf(PART_SEPARATOR) + 1; i < fileName.lastIndexOf(EXTENSION_SEPARATOR); i++) {
+  /**
+   * Returns a boolean value indicating whether the given file appears to be a parsable segment file.
+   *
+   * @param journalName the name of the journal
+   * @param fileName the name of the file to check
+   * @throws NullPointerException if {@code file} is null
+   */
+  public static boolean isSegmentFile(String journalName, String fileName) {
+    checkNotNull(journalName, "journalName cannot be null");
+    checkNotNull(fileName, "fileName cannot be null");
+
+    int partSeparator = fileName.lastIndexOf(PART_SEPARATOR);
+    int extensionSeparator = fileName.lastIndexOf(EXTENSION_SEPARATOR);
+
+    if (extensionSeparator == -1
+        || partSeparator == -1
+        || extensionSeparator < partSeparator
+        || !fileName.endsWith(EXTENSION)) {
+      return false;
+    }
+
+    for (int i = partSeparator + 1; i < extensionSeparator; i++) {
       if (!Character.isDigit(fileName.charAt(i))) {
         return false;
       }
     }
 
-    if (fileName.lastIndexOf(PART_SEPARATOR, fileName.lastIndexOf(PART_SEPARATOR) - 1) == -1)
-      return false;
-
-    for (int i = fileName.lastIndexOf(PART_SEPARATOR, fileName.lastIndexOf(PART_SEPARATOR) - 1) + 1; i < fileName.lastIndexOf(PART_SEPARATOR); i++) {
-      if (!Character.isDigit(fileName.charAt(i))) {
-        return false;
-      }
-    }
-
-    return fileName.substring(0, fileName.lastIndexOf(PART_SEPARATOR, fileName.lastIndexOf(PART_SEPARATOR) - 1)).equals(name);
+    return fileName.substring(0, partSeparator).equals(journalName);
   }
 
   /**
    * Creates a segment file for the given directory, log name, segment ID, and segment version.
    */
-  static File createSegmentFile(String name, File directory, long id, long version) {
-    return new File(directory, String.format("%s-%d-%d.log", checkNotNull(name, "name cannot be null"), id, version));
+  static File createSegmentFile(String name, File directory, long id) {
+    return new File(directory, String.format("%s-%d.log", checkNotNull(name, "name cannot be null"), id));
   }
 
   /**
@@ -87,13 +96,6 @@ public final class JournalSegmentFile {
    * Returns the segment identifier.
    */
   public long id() {
-    return Long.valueOf(file.getName().substring(file.getName().lastIndexOf(PART_SEPARATOR, file.getName().lastIndexOf(PART_SEPARATOR) - 1) + 1, file.getName().lastIndexOf(PART_SEPARATOR)));
-  }
-
-  /**
-   * Returns the segment version.
-   */
-  public long version() {
     return Long.valueOf(file.getName().substring(file.getName().lastIndexOf(PART_SEPARATOR) + 1, file.getName().lastIndexOf(EXTENSION_SEPARATOR)));
   }
 

--- a/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -370,7 +370,7 @@ public class SegmentedJournal<E> implements Journal<E> {
    * Creates a new segment.
    */
   private JournalSegment<E> createDiskSegment(JournalSegmentDescriptor descriptor) {
-    File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id(), descriptor.version());
+    File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
     Buffer buffer = MappedBuffer.allocate(segmentFile, Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
     descriptor.copyTo(buffer);
     JournalSegment<E> segment = newSegment(new JournalSegmentFile(segmentFile), descriptor);
@@ -382,7 +382,7 @@ public class SegmentedJournal<E> implements Journal<E> {
    * Creates a new segment.
    */
   private JournalSegment<E> createMemorySegment(JournalSegmentDescriptor descriptor) {
-    File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id(), descriptor.version());
+    File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
     Buffer buffer = HeapBuffer.allocate(Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
     descriptor.copyTo(buffer);
     JournalSegment<E> segment = newSegment(new JournalSegmentFile(segmentFile), descriptor);
@@ -393,12 +393,12 @@ public class SegmentedJournal<E> implements Journal<E> {
   /**
    * Loads a segment.
    */
-  private JournalSegment<E> loadSegment(long segmentId, long segmentVersion) {
+  private JournalSegment<E> loadSegment(long segmentId) {
     switch (storageLevel) {
       case MEMORY:
-        return loadMemorySegment(segmentId, segmentVersion);
+        return loadMemorySegment(segmentId);
       case DISK:
-        return loadDiskSegment(segmentId, segmentVersion);
+        return loadDiskSegment(segmentId);
       default:
         throw new AssertionError();
     }
@@ -407,8 +407,8 @@ public class SegmentedJournal<E> implements Journal<E> {
   /**
    * Loads a segment.
    */
-  private JournalSegment<E> loadDiskSegment(long segmentId, long segmentVersion) {
-    File file = JournalSegmentFile.createSegmentFile(name, directory, segmentId, segmentVersion);
+  private JournalSegment<E> loadDiskSegment(long segmentId) {
+    File file = JournalSegmentFile.createSegmentFile(name, directory, segmentId);
     Buffer buffer = MappedBuffer.allocate(file, Math.min(DEFAULT_BUFFER_SIZE, maxSegmentSize), Integer.MAX_VALUE);
     JournalSegmentDescriptor descriptor = new JournalSegmentDescriptor(buffer);
     JournalSegment<E> segment = newSegment(new JournalSegmentFile(file), descriptor);
@@ -419,8 +419,8 @@ public class SegmentedJournal<E> implements Journal<E> {
   /**
    * Loads a segment.
    */
-  private JournalSegment<E> loadMemorySegment(long segmentId, long segmentVersion) {
-    File file = JournalSegmentFile.createSegmentFile(name, directory, segmentId, segmentVersion);
+  private JournalSegment<E> loadMemorySegment(long segmentId) {
+    File file = JournalSegmentFile.createSegmentFile(name, directory, segmentId);
     Buffer buffer = HeapBuffer.allocate(Math.min(DEFAULT_BUFFER_SIZE, maxSegmentSize), Integer.MAX_VALUE);
     JournalSegmentDescriptor descriptor = new JournalSegmentDescriptor(buffer);
     JournalSegment<E> segment = newSegment(new JournalSegmentFile(file), descriptor);
@@ -448,7 +448,7 @@ public class SegmentedJournal<E> implements Journal<E> {
         JournalSegmentDescriptor descriptor = new JournalSegmentDescriptor(FileBuffer.allocate(file, JournalSegmentDescriptor.BYTES));
 
         // Load the segment.
-        JournalSegment<E> segment = loadSegment(descriptor.id(), descriptor.version());
+        JournalSegment<E> segment = loadSegment(descriptor.id());
 
         // If a segment with an equal or lower index has already been loaded, ensure this segment is not superseded
         // by the earlier segment. This can occur due to segments being combined during log compaction.

--- a/storage/journal/src/test/java/io/atomix/storage/journal/JournalSegmentFileTest.java
+++ b/storage/journal/src/test/java/io/atomix/storage/journal/JournalSegmentFileTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.storage.journal;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Journal segment file test.
+ */
+public class JournalSegmentFileTest {
+
+  @Test
+  public void testIsSegmentFile() throws Exception {
+    assertTrue(JournalSegmentFile.isSegmentFile("foo", "foo-1.log"));
+    assertFalse(JournalSegmentFile.isSegmentFile("foo", "bar-1.log"));
+    assertFalse(JournalSegmentFile.isSegmentFile("foo", "foo-1-1.log"));
+  }
+
+  @Test
+  public void testCreateSegmentFile() throws Exception {
+    File file = JournalSegmentFile.createSegmentFile("foo", new File(System.getProperty("user.dir")), 1);
+    assertTrue(JournalSegmentFile.isSegmentFile("foo", file));
+
+    JournalSegmentFile segmentFile = new JournalSegmentFile(file);
+    assertEquals(1, segmentFile.id());
+  }
+
+}


### PR DESCRIPTION
Cleans up log segment files, removing the version number from the file name.