### PR TITLE
Implement RandomAccessFile based storage

### DIFF
--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/DiskLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/DiskLogTest.java
@@ -16,54 +16,13 @@
 package io.atomix.protocols.raft.storage.log;
 
 import io.atomix.storage.StorageLevel;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Disk log test.
  */
-public class DiskLogTest extends AbstractLogTest {
+public class DiskLogTest extends PersistentLogTest {
   @Override
   protected StorageLevel storageLevel() {
     return StorageLevel.DISK;
-  }
-
-  /**
-   * Tests reading from a compacted log.
-   */
-  @Test
-  public void testCompactAndRecover() throws Exception {
-    RaftLog log = createLog();
-
-    // Write three segments to the log.
-    RaftLogWriter writer = log.writer();
-    for (int i = 0; i < MAX_ENTRIES_PER_SEGMENT * 3; i++) {
-      writer.append(new TestEntry(1, 1));
-    }
-
-    // Commit the entries and compact the first segment.
-    writer.commit(MAX_ENTRIES_PER_SEGMENT * 3);
-    log.compact(MAX_ENTRIES_PER_SEGMENT + 1);
-
-    // Close the log.
-    log.close();
-
-    // Reopen the log and create a reader.
-    log = createLog();
-    writer = log.writer();
-    RaftLogReader reader = log.openReader(1, RaftLogReader.Mode.COMMITS);
-    writer.append(new TestEntry(1, 1));
-    writer.append(new TestEntry(1, 1));
-    writer.commit(MAX_ENTRIES_PER_SEGMENT * 3);
-
-    // Ensure the reader starts at the first physical index in the log.
-    assertEquals(MAX_ENTRIES_PER_SEGMENT + 1, reader.getNextIndex());
-    assertEquals(reader.getFirstIndex(), reader.getNextIndex());
-    assertTrue(reader.hasNext());
-    assertEquals(MAX_ENTRIES_PER_SEGMENT + 1, reader.getNextIndex());
-    assertEquals(reader.getFirstIndex(), reader.getNextIndex());
-    assertEquals(MAX_ENTRIES_PER_SEGMENT + 1, reader.next().index());
   }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/MappedLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/MappedLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-present Open Networking Foundation
+ * Copyright 2017-present Open Networking Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,26 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.storage;
+package io.atomix.protocols.raft.storage.log;
+
+import io.atomix.storage.StorageLevel;
 
 /**
- * Storage level configuration values which control how logs are stored on disk or in memory.
+ * Disk log test.
  */
-public enum StorageLevel {
-
-  /**
-   * Stores data in memory only.
-   */
-  MEMORY,
-
-  /**
-   * Stores data in a memory-mapped file.
-   */
-  MAPPED,
-
-  /**
-   * Stores data on disk.
-   */
-  DISK
-
+public class MappedLogTest extends AbstractLogTest {
+  @Override
+  protected StorageLevel storageLevel() {
+    return StorageLevel.MAPPED;
+  }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/PersistentLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/PersistentLogTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.storage.log;
+
+import io.atomix.storage.StorageLevel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Disk log test.
+ */
+public abstract class PersistentLogTest extends AbstractLogTest {
+
+  /**
+   * Tests reading from a compacted log.
+   */
+  @Test
+  public void testCompactAndRecover() throws Exception {
+    RaftLog log = createLog();
+
+    // Write three segments to the log.
+    RaftLogWriter writer = log.writer();
+    for (int i = 0; i < MAX_ENTRIES_PER_SEGMENT * 3; i++) {
+      writer.append(new TestEntry(1, 1));
+    }
+
+    // Commit the entries and compact the first segment.
+    writer.commit(MAX_ENTRIES_PER_SEGMENT * 3);
+    log.compact(MAX_ENTRIES_PER_SEGMENT + 1);
+
+    // Close the log.
+    log.close();
+
+    // Reopen the log and create a reader.
+    log = createLog();
+    writer = log.writer();
+    RaftLogReader reader = log.openReader(1, RaftLogReader.Mode.COMMITS);
+    writer.append(new TestEntry(1, 1));
+    writer.append(new TestEntry(1, 1));
+    writer.commit(MAX_ENTRIES_PER_SEGMENT * 3);
+
+    // Ensure the reader starts at the first physical index in the log.
+    assertEquals(MAX_ENTRIES_PER_SEGMENT + 1, reader.getNextIndex());
+    assertEquals(reader.getFirstIndex(), reader.getNextIndex());
+    assertTrue(reader.hasNext());
+    assertEquals(MAX_ENTRIES_PER_SEGMENT + 1, reader.getNextIndex());
+    assertEquals(reader.getFirstIndex(), reader.getNextIndex());
+    assertEquals(MAX_ENTRIES_PER_SEGMENT + 1, reader.next().index());
+  }
+}

--- a/storage/buffer/src/main/java/io/atomix/storage/buffer/FileBytes.java
+++ b/storage/buffer/src/main/java/io/atomix/storage/buffer/FileBytes.java
@@ -214,6 +214,7 @@ public class FileBytes extends AbstractBytes {
   public Bytes zero() {
     try {
       randomAccessFile.setLength(0);
+      randomAccessFile.setLength(size);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -224,6 +225,7 @@ public class FileBytes extends AbstractBytes {
   public Bytes zero(int offset) {
     try {
       randomAccessFile.setLength(offset);
+      randomAccessFile.setLength(Math.max(offset, size));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
@@ -38,7 +38,7 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
   private Indexed<E> nextEntry;
 
   public JournalSegmentReader(JournalSegmentDescriptor descriptor, Serializer serializer) {
-    this.buffer = descriptor.buffer().slice();
+    this.buffer = descriptor.buffer().slice().duplicate();
     this.serializer = serializer;
     this.firstIndex = descriptor.index();
     readNext();


### PR DESCRIPTION
This PR implements the `DISK` based `StorageLevel` as a `RandomAccessFile` and adds a `MAPPED` storage level for memory mapped files.