### PR TITLE
Ensure segment file loading is backwards compatible

### DIFF
--- a/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentFile.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentFile.java
@@ -66,7 +66,7 @@ public final class JournalSegmentFile {
       }
     }
 
-    return fileName.substring(0, partSeparator).equals(journalName);
+    return fileName.startsWith(journalName);
   }
 
   /**
@@ -91,12 +91,4 @@ public final class JournalSegmentFile {
   public File file() {
     return file;
   }
-
-  /**
-   * Returns the segment identifier.
-   */
-  public long id() {
-    return Long.valueOf(file.getName().substring(file.getName().lastIndexOf(PART_SEPARATOR) + 1, file.getName().lastIndexOf(EXTENSION_SEPARATOR)));
-  }
-
 }

--- a/storage/journal/src/test/java/io/atomix/storage/journal/JournalSegmentFileTest.java
+++ b/storage/journal/src/test/java/io/atomix/storage/journal/JournalSegmentFileTest.java
@@ -32,16 +32,13 @@ public class JournalSegmentFileTest {
   public void testIsSegmentFile() throws Exception {
     assertTrue(JournalSegmentFile.isSegmentFile("foo", "foo-1.log"));
     assertFalse(JournalSegmentFile.isSegmentFile("foo", "bar-1.log"));
-    assertFalse(JournalSegmentFile.isSegmentFile("foo", "foo-1-1.log"));
+    assertTrue(JournalSegmentFile.isSegmentFile("foo", "foo-1-1.log"));
   }
 
   @Test
   public void testCreateSegmentFile() throws Exception {
     File file = JournalSegmentFile.createSegmentFile("foo", new File(System.getProperty("user.dir")), 1);
     assertTrue(JournalSegmentFile.isSegmentFile("foo", file));
-
-    JournalSegmentFile segmentFile = new JournalSegmentFile(file);
-    assertEquals(1, segmentFile.id());
   }
 
 }


### PR DESCRIPTION
This PR ensures that loading segment files from disk is compatible with the previous segment file name format.