### PR TITLE
Add support for configuring Raft client/server thread models

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
@@ -165,6 +165,7 @@ public interface RaftClient {
     protected String clientId = UUID.randomUUID().toString();
     protected MemberId nodeId;
     protected RaftClientProtocol protocol;
+    protected ThreadModel threadModel = ThreadModel.SHARED_THREAD_POOL;
     protected int threadPoolSize = Runtime.getRuntime().availableProcessors();
 
     protected Builder(Collection<MemberId> cluster) {
@@ -207,6 +208,18 @@ public interface RaftClient {
      */
     public Builder withProtocol(RaftClientProtocol protocol) {
       this.protocol = checkNotNull(protocol, "protocol cannot be null");
+      return this;
+    }
+
+    /**
+     * Sets the client thread model.
+     *
+     * @param threadModel the client thread model
+     * @return the client builder
+     * @throws NullPointerException if the thread model is null
+     */
+    public Builder withThreadModel(ThreadModel threadModel) {
+      this.threadModel = checkNotNull(threadModel, "threadModel cannot be null");
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -534,6 +534,7 @@ public interface RaftServer {
     private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(750);
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
     private static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofMillis(5000);
+    private static final ThreadModel DEFAULT_THREAD_MODEL = ThreadModel.SHARED_THREAD_POOL;
     private static final int DEFAULT_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors();
 
     protected String name;
@@ -545,6 +546,7 @@ public interface RaftServer {
     protected Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
     protected Duration sessionTimeout = DEFAULT_SESSION_TIMEOUT;
     protected final RaftServiceRegistry serviceRegistry = new RaftServiceRegistry();
+    protected ThreadModel threadModel = DEFAULT_THREAD_MODEL;
     protected int threadPoolSize = DEFAULT_THREAD_POOL_SIZE;
 
     protected Builder(MemberId localMemberId) {
@@ -583,6 +585,17 @@ public interface RaftServer {
      */
     public Builder withProtocol(RaftServerProtocol protocol) {
       this.protocol = checkNotNull(protocol, "protocol cannot be null");
+      return this;
+    }
+
+    /**
+     * Sets the server thread model.
+     *
+     * @param threadModel the server thread model
+     * @return the server builder
+     */
+    public Builder withThreadModel(ThreadModel threadModel) {
+      this.threadModel = checkNotNull(threadModel, "threadModel cannot be null");
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/ThreadModel.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/ThreadModel.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft;
+
+import io.atomix.utils.concurrent.SingleThreadContextFactory;
+import io.atomix.utils.concurrent.ThreadContextFactory;
+import io.atomix.utils.concurrent.ThreadPoolContextFactory;
+import org.slf4j.Logger;
+
+/**
+ * Raft thread model.
+ */
+public enum ThreadModel {
+
+  /**
+   * A thread model that creates a thread pool to be shared by all services.
+   */
+  SHARED_THREAD_POOL {
+    @Override
+    public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
+      return new SingleThreadContextFactory(nameFormat, logger);
+    }
+  },
+
+  /**
+   * A thread model that creates a thread for each Raft service.
+   */
+  THREAD_PER_SERVICE {
+    @Override
+    public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
+      return new ThreadPoolContextFactory(nameFormat, threadPoolSize, logger);
+    }
+  };
+
+  /**
+   * Returns a thread context factory.
+   *
+   * @param nameFormat the thread name format
+   * @param threadPoolSize the thread pool size
+   * @param logger the thread logger
+   * @return the thread context factory
+   */
+  public abstract ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger);
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -253,7 +253,7 @@ public class DefaultRaftServer implements RaftServer {
         storage = RaftStorage.newBuilder().build();
       }
 
-      RaftContext raft = new RaftContext(name, type, localMemberId, protocol, storage, serviceRegistry, threadPoolSize);
+      RaftContext raft = new RaftContext(name, type, localMemberId, protocol, storage, serviceRegistry, threadModel, threadPoolSize);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
       raft.setSessionTimeout(sessionTimeout);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -31,7 +31,7 @@ import io.atomix.protocols.raft.session.RaftSessionEventListener;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.utils.TimestampPrinter;
 import io.atomix.utils.concurrent.ThreadContext;
-import io.atomix.utils.concurrent.ThreadPoolContext;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import org.slf4j.Logger;
@@ -44,7 +44,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
@@ -88,7 +87,7 @@ public class RaftSessionContext implements RaftSession {
       long timeout,
       DefaultServiceContext context,
       RaftContext server,
-      ScheduledExecutorService threadPool) {
+      ThreadContextFactory threadContextFactory) {
     this.sessionId = sessionId;
     this.member = member;
     this.name = name;
@@ -101,7 +100,7 @@ public class RaftSessionContext implements RaftSession {
     this.protocol = server.getProtocol();
     this.context = context;
     this.server = server;
-    this.eventExecutor = new ThreadPoolContext(threadPool);
+    this.eventExecutor = threadContextFactory.createContext();
     this.log = ContextualLoggerFactory.getLogger(getClass(), LoggerContext.builder(RaftSession.class)
         .addValue(sessionId)
         .add("type", context.serviceType())

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionManagerTest.java
@@ -26,6 +26,7 @@ import io.atomix.protocols.raft.session.RaftSession;
 import io.atomix.protocols.raft.session.RaftSessionListener;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import org.junit.Test;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -121,7 +122,7 @@ public class RaftSessionManagerTest {
         5000,
         context,
         server,
-        mock(ScheduledExecutorService.class));
+        mock(ThreadContextFactory.class));
   }
 
   private class TestSessionListener implements RaftSessionListener {

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
@@ -498,6 +498,7 @@ public class RaftPerformanceTest implements Runnable {
     RaftClient client = RaftClient.newBuilder()
         .withMemberId(memberId)
         .withProtocol(protocol)
+        .withThreadModel(ThreadModel.THREAD_PER_SERVICE)
         .build();
 
     client.connect(members.stream().map(RaftMember::memberId).collect(Collectors.toList())).join();

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
@@ -119,11 +119,11 @@ public class RaftPerformanceTest implements Runnable {
 
   private static final boolean USE_NETTY = true;
 
-  private static final int ITERATIONS = 10;
+  private static final int ITERATIONS = 1;
 
   private static final int TOTAL_OPERATIONS = 1000000;
   private static final int WRITE_RATIO = 10;
-  private static final int NUM_CLIENTS = 20;
+  private static final int NUM_CLIENTS = 5;
 
   private static final ReadConsistency READ_CONSISTENCY = ReadConsistency.LINEARIZABLE;
   private static final CommunicationStrategy COMMUNICATION_STRATEGY = CommunicationStrategy.ANY;
@@ -464,11 +464,13 @@ public class RaftPerformanceTest implements Runnable {
     RaftServer.Builder builder = RaftServer.newBuilder(member.memberId())
         .withType(member.getType())
         .withProtocol(protocol)
+        .withThreadModel(ThreadModel.THREAD_PER_SERVICE)
         .withStorage(RaftStorage.newBuilder()
-            .withStorageLevel(StorageLevel.DISK)
+            .withStorageLevel(StorageLevel.MAPPED)
             .withDirectory(new File(String.format("target/perf-logs/%s", member.memberId())))
             .withSerializer(storageSerializer)
-            .withMaxSegmentSize(1024 * 1024)
+            .withMaxEntriesPerSegment(32768)
+            .withMaxSegmentSize(1024 * 1024 * 64)
             .build())
         .addService("test", PerformanceStateMachine::new);
 

--- a/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
@@ -42,7 +42,7 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class SingleThreadContext implements ThreadContext {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadContext.class);
+  protected static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadContext.class);
   private final ScheduledExecutorService executor;
   private final Executor wrappedExecutor = new Executor() {
     @Override

--- a/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContextFactory.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContextFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.ThreadFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Single thread context factory.
+ */
+public class SingleThreadContextFactory implements ThreadContextFactory {
+  private final ThreadFactory threadFactory;
+
+  public SingleThreadContextFactory(String nameFormat, Logger logger) {
+    this(namedThreads(nameFormat, logger));
+  }
+
+  public SingleThreadContextFactory(ThreadFactory threadFactory) {
+    this.threadFactory = checkNotNull(threadFactory);
+  }
+
+  @Override
+  public ThreadContext createContext() {
+    return new SingleThreadContext(threadFactory);
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadContextFactory.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadContextFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+/**
+ * Thread context factory.
+ */
+public interface ThreadContextFactory {
+
+  /**
+   * Creates a new thread context.
+   *
+   * @return a new thread context
+   */
+  ThreadContext createContext();
+
+  /**
+   * Closes the factory.
+   */
+  default void close() {
+  }
+
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContextFactory.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContextFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Thread pool context factory.
+ */
+public class ThreadPoolContextFactory implements ThreadContextFactory {
+  private final ScheduledExecutorService executor;
+
+  public ThreadPoolContextFactory(String name, int threadPoolSize, Logger logger) {
+    this(threadPoolSize, namedThreads(name, logger));
+  }
+
+  public ThreadPoolContextFactory(int threadPoolSize, ThreadFactory threadFactory) {
+    this(Executors.newScheduledThreadPool(threadPoolSize, threadFactory));
+  }
+
+  public ThreadPoolContextFactory(ScheduledExecutorService executor) {
+    this.executor = executor;
+  }
+
+  @Override
+  public ThreadContext createContext() {
+    return new ThreadPoolContext(executor);
+  }
+
+  @Override
+  public void close() {
+    executor.shutdownNow();
+  }
+}


### PR DESCRIPTION
This PR adds an option to Raft client/server to configure the thread model to use a thread per service. This model can significantly reduce the locking done inside the server but obviously has disadvantages when large numbers of primitives are created.