### PR TITLE
Modify log levels to reduce INFO/WARN log messages

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
@@ -262,7 +262,7 @@ abstract class AbstractAppender implements AutoCloseable {
     // when attempting to send entries to down followers.
     int failures = member.incrementFailureCount();
     if (failures <= 3 || failures % 100 == 0) {
-      log.warn("{} to {} failed: {}", request, member.getMember().memberId(), response.error() != null ? response.error() : "");
+      log.debug("{} to {} failed: {}", request, member.getMember().memberId(), response.error() != null ? response.error() : "");
     }
   }
 
@@ -283,7 +283,7 @@ abstract class AbstractAppender implements AutoCloseable {
     // when attempting to send entries to down followers.
     int failures = member.incrementFailureCount();
     if (failures <= 3 || failures % 100 == 0) {
-      log.warn("{} to {} failed: {}", request, member.getMember().memberId(), error.getMessage());
+      log.debug("{} to {} failed: {}", request, member.getMember().memberId(), error.getMessage());
     }
   }
 

--- a/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -612,9 +612,9 @@ public class SegmentedJournal<E> implements Journal<E> {
     if (segmentEntry != null) {
       SortedMap<Long, JournalSegment<E>> compactSegments = segments.headMap(segmentEntry.getValue().index());
       if (!compactSegments.isEmpty()) {
-        log.info("{} - Compacting {} segment(s)", name, compactSegments.size());
+        log.debug("{} - Compacting {} segment(s)", name, compactSegments.size());
         for (JournalSegment segment : compactSegments.values()) {
-          log.debug("Deleting segment: {}", segment);
+          log.trace("Deleting segment: {}", segment);
           segment.close();
           segment.delete();
         }


### PR DESCRIPTION
This PR reduces some INFO/WARN log messages to DEBUG to reduce the frequency of messages logged in the INFO and above log level that are indicative of regular periodic events. These regular events should be logged at DEBUG or lower to avoid clogging up logs.