### PR TITLE
Block startup until the leader's initial commit index is applied

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -441,10 +441,7 @@ public class RaftContext implements AutoCloseable {
       if (configurationIndex > previousCommitIndex && configurationIndex <= commitIndex) {
         cluster.commit();
       }
-
-      if (firstCommitIndex == 0) {
-        firstCommitIndex = commitIndex;
-      }
+      setFirstCommitIndex(commitIndex);
     }
     return previousCommitIndex;
   }
@@ -456,6 +453,26 @@ public class RaftContext implements AutoCloseable {
    */
   public long getCommitIndex() {
     return commitIndex;
+  }
+
+  /**
+   * Sets the first commit index.
+   *
+   * @param firstCommitIndex The first commit index.
+   */
+  public void setFirstCommitIndex(long firstCommitIndex) {
+    if (this.firstCommitIndex == 0) {
+      this.firstCommitIndex = firstCommitIndex;
+    }
+  }
+
+  /**
+   * Returns the first commit index.
+   *
+   * @return The first commit index.
+   */
+  public long getFirstCommitIndex() {
+    return firstCommitIndex;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -267,6 +267,9 @@ public class PassiveRole extends ReserveRole {
       }
     }
 
+    // Set the first commit index.
+    raft.setFirstCommitIndex(request.commitIndex());
+
     // Update the context commit and global indices.
     long previousCommitIndex = raft.setCommitIndex(commitIndex);
     if (previousCommitIndex < commitIndex) {


### PR DESCRIPTION
This PR fixes a bug in blocking the server startup process. In order to ensure all the leader's entries are replicated before startup of a follower is completed, we have to store the `firstCommitIndex` separately from the first `commitIndex` stored because the first `commitIndex` is limited to the leader's `AppendRequest` last index.