### PR TITLE
Make log compaction limits configurable

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -650,7 +650,7 @@ public class RaftServiceManager implements AutoCloseable {
       // Recursively snapshot remaining services, resetting the attempt count.
       return snapshotServices(services, force, 0, futures);
     } else {
-      return rescheduleSnapshots(services, force, attempt, futures);
+      return rescheduleSnapshots(services, attempt, futures);
     }
   }
 
@@ -658,19 +658,17 @@ public class RaftServiceManager implements AutoCloseable {
    * Reschedules an attempt to snapshot remaining services.
    *
    * @param services a list of services to snapshot
-   * @param force whether to force snapshotting all services to free disk space
    * @param attempt the current attempt count
    * @param futures reference to a list of futures for all service snapshots
    * @return future to be completed once all snapshots have been completed
    */
   private CompletableFuture<Void> rescheduleSnapshots(
       List<DefaultServiceContext> services,
-      boolean force,
       int attempt,
       List<CompletableFuture<Void>> futures) {
     ComposableFuture<Void> future = new ComposableFuture<>();
     threadContext.schedule(Duration.ofSeconds(Math.min(2 ^ attempt, 10)), () ->
-        snapshotServices(services, force, attempt + 1, futures).whenComplete(future));
+        snapshotServices(services, log.mustCompact(), attempt + 1, futures).whenComplete(future));
     return future;
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -68,7 +68,8 @@ public class RaftStorage {
   private final Serializer serializer;
   private final int maxSegmentSize;
   private final int maxEntriesPerSegment;
-  private final int entryBufferSize;
+  private final int segmentBufferFactor;
+  private final double freeDiskBuffer;
   private final boolean flushOnCommit;
   private final boolean retainStaleSnapshots;
 
@@ -79,7 +80,8 @@ public class RaftStorage {
       Serializer serializer,
       int maxSegmentSize,
       int maxEntriesPerSegment,
-      int entryBufferSize,
+      int segmentBufferFactor,
+      double freeDiskBuffer,
       boolean flushOnCommit,
       boolean retainStaleSnapshots) {
     this.prefix = prefix;
@@ -88,7 +90,8 @@ public class RaftStorage {
     this.serializer = serializer;
     this.maxSegmentSize = maxSegmentSize;
     this.maxEntriesPerSegment = maxEntriesPerSegment;
-    this.entryBufferSize = entryBufferSize;
+    this.segmentBufferFactor = segmentBufferFactor;
+    this.freeDiskBuffer = freeDiskBuffer;
     this.flushOnCommit = flushOnCommit;
     this.retainStaleSnapshots = retainStaleSnapshots;
     directory.mkdirs();
@@ -156,20 +159,26 @@ public class RaftStorage {
    *
    * @return The maximum number of entries per segment.
    */
-  public int maxLogEntriesPerSecond() {
+  public int maxLogEntriesPerSegment() {
     return maxEntriesPerSegment;
   }
 
   /**
-   * Returns the entry buffer size.
-   * <p>
-   * The entry buffer size dictates the number of entries that will be held in memory for read operations
-   * at the tail of the log.
+   * Returns the number of segments that must be able to fit on disk before log compaction is forced.
    *
-   * @return The entry buffer size.
+   * @return the number of segments that must be able to fit on disk before log compaction is forced
    */
-  public int logEntryBufferSize() {
-    return entryBufferSize;
+  public int segmentBufferFactor() {
+    return segmentBufferFactor;
+  }
+
+  /**
+   * Returns the percentage of disk space that must be available before log compaction is forced.
+   *
+   * @return the percentage of disk space that must be available before log compaction is forced
+   */
+  public double freeDiskBuffer() {
+    return freeDiskBuffer;
   }
 
   /**
@@ -251,13 +260,16 @@ public class RaftStorage {
    * @return The opened log.
    */
   public RaftLog openLog() {
-    return RaftLog.builder()
+    return RaftLog.newBuilder()
         .withName(prefix)
         .withDirectory(directory)
         .withStorageLevel(storageLevel)
         .withSerializer(serializer)
         .withMaxSegmentSize(maxSegmentSize)
         .withMaxEntriesPerSegment(maxEntriesPerSegment)
+        .withSegmentBufferFactor(segmentBufferFactor)
+        .withFreeDiskBuffer(freeDiskBuffer)
+        .withFlushOnCommit(flushOnCommit)
         .build();
   }
 
@@ -315,7 +327,8 @@ public class RaftStorage {
     private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
     private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
-    private static final int DEFAULT_ENTRY_BUFFER_SIZE = 1024;
+    private static final int DEFAULT_SEGMENT_BUFFER_FACTOR = 3;
+    private static final double DEFAULT_FREE_DISK_BUFFER = .25;
     private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
     private static final boolean DEFAULT_RETAIN_STALE_SNAPSHOTS = false;
 
@@ -325,7 +338,8 @@ public class RaftStorage {
     private Serializer serializer;
     private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
     private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
-    private int entryBufferSize = DEFAULT_ENTRY_BUFFER_SIZE;
+    private int segmentBufferFactor = DEFAULT_SEGMENT_BUFFER_FACTOR;
+    private double freeDiskBuffer = DEFAULT_FREE_DISK_BUFFER;
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
     private boolean retainStaleSnapshots = DEFAULT_RETAIN_STALE_SNAPSHOTS;
 
@@ -440,19 +454,27 @@ public class RaftStorage {
     }
 
     /**
-     * Sets the entry buffer size.
-     * <p>
-     * The entry buffer size dictates the number of entries to hold in memory at the tail of the log. Increasing
-     * the buffer size increases the number of entries that will be held in memory and thus implies greater memory
-     * consumption, but server performance may be improved due to reduced disk access.
+     * Sets the number of additional segments that must be able to fit on disk before log compaction is forced.
      *
-     * @param entryBufferSize The entry buffer size.
-     * @return The storage builder.
-     * @throws IllegalArgumentException if the buffer size is not positive
+     * @param segmentBufferFactor the segment buffer factor
+     * @return the Raft log builder
      */
-    public Builder withEntryBufferSize(int entryBufferSize) {
-      checkArgument(entryBufferSize > 0, "entryBufferSize must be positive");
-      this.entryBufferSize = entryBufferSize;
+    public Builder withSegmentBufferFactor(int segmentBufferFactor) {
+      checkArgument(segmentBufferFactor > 0, "segmentBufferFactor must be positive");
+      this.segmentBufferFactor = segmentBufferFactor;
+      return this;
+    }
+
+    /**
+     * Sets the percentage of free disk space that must be preserved before log compaction is forced.
+     *
+     * @param freeDiskBuffer the free disk percentage
+     * @return the Raft log builder
+     */
+    public Builder withFreeDiskBuffer(double freeDiskBuffer) {
+      checkArgument(freeDiskBuffer > 0, "freeDiskBuffer must be positive");
+      checkArgument(freeDiskBuffer < 1, "freeDiskBuffer must be less than 1");
+      this.freeDiskBuffer = freeDiskBuffer;
       return this;
     }
 
@@ -530,7 +552,8 @@ public class RaftStorage {
           serializer,
           maxSegmentSize,
           maxEntriesPerSegment,
-          entryBufferSize,
+          segmentBufferFactor,
+          freeDiskBuffer,
           flushOnCommit,
           retainStaleSnapshots);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -68,6 +68,7 @@ public class RaftStorage {
   private final Serializer serializer;
   private final int maxSegmentSize;
   private final int maxEntriesPerSegment;
+  private final boolean dynamicCompaction;
   private final int segmentBufferFactor;
   private final double freeDiskBuffer;
   private final boolean flushOnCommit;
@@ -80,6 +81,7 @@ public class RaftStorage {
       Serializer serializer,
       int maxSegmentSize,
       int maxEntriesPerSegment,
+      boolean dynamicCompaction,
       int segmentBufferFactor,
       double freeDiskBuffer,
       boolean flushOnCommit,
@@ -90,6 +92,7 @@ public class RaftStorage {
     this.serializer = serializer;
     this.maxSegmentSize = maxSegmentSize;
     this.maxEntriesPerSegment = maxEntriesPerSegment;
+    this.dynamicCompaction = dynamicCompaction;
     this.segmentBufferFactor = segmentBufferFactor;
     this.freeDiskBuffer = freeDiskBuffer;
     this.flushOnCommit = flushOnCommit;
@@ -161,6 +164,15 @@ public class RaftStorage {
    */
   public int maxLogEntriesPerSegment() {
     return maxEntriesPerSegment;
+  }
+
+  /**
+   * Returns whether dynamic log compaction is enabled.
+   *
+   * @return whether dynamic log compaction is enabled
+   */
+  public boolean dynamicCompaction() {
+    return dynamicCompaction;
   }
 
   /**
@@ -267,6 +279,7 @@ public class RaftStorage {
         .withSerializer(serializer)
         .withMaxSegmentSize(maxSegmentSize)
         .withMaxEntriesPerSegment(maxEntriesPerSegment)
+        .withDynamicCompaction(dynamicCompaction)
         .withSegmentBufferFactor(segmentBufferFactor)
         .withFreeDiskBuffer(freeDiskBuffer)
         .withFlushOnCommit(flushOnCommit)
@@ -327,6 +340,7 @@ public class RaftStorage {
     private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
     private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
+    private static final boolean DEFAULT_DYNAMIC_COMPACTION = true;
     private static final int DEFAULT_SEGMENT_BUFFER_FACTOR = 3;
     private static final double DEFAULT_FREE_DISK_BUFFER = .25;
     private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
@@ -338,6 +352,7 @@ public class RaftStorage {
     private Serializer serializer;
     private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
     private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
+    private boolean dynamicCompaction = DEFAULT_DYNAMIC_COMPACTION;
     private int segmentBufferFactor = DEFAULT_SEGMENT_BUFFER_FACTOR;
     private double freeDiskBuffer = DEFAULT_FREE_DISK_BUFFER;
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
@@ -454,6 +469,32 @@ public class RaftStorage {
     }
 
     /**
+     * Enables dynamic log compaction.
+     * <p>
+     * When dynamic compaction is enabled, logs will be compacted only during periods of low load on the cluster
+     * or when the cluster is running out of disk space.
+     *
+     * @return the Raft storage builder
+     */
+    public Builder withDynamicCompaction() {
+      return withDynamicCompaction(true);
+    }
+
+    /**
+     * Enables dynamic log compaction.
+     * <p>
+     * When dynamic compaction is enabled, logs will be compacted only during periods of low load on the cluster
+     * or when the cluster is running out of disk space.
+     *
+     * @param dynamicCompaction whether to enable dynamic compaction
+     * @return the Raft storage builder
+     */
+    public Builder withDynamicCompaction(boolean dynamicCompaction) {
+      this.dynamicCompaction = dynamicCompaction;
+      return this;
+    }
+
+    /**
      * Sets the number of additional segments that must be able to fit on disk before log compaction is forced.
      *
      * @param segmentBufferFactor the segment buffer factor
@@ -552,6 +593,7 @@ public class RaftStorage {
           serializer,
           maxSegmentSize,
           maxEntriesPerSegment,
+          dynamicCompaction,
           segmentBufferFactor,
           freeDiskBuffer,
           flushOnCommit,

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -146,8 +146,8 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
   public boolean mustCompact() {
     return !dynamicCompaction
         || journal.storageLevel() == StorageLevel.MEMORY
-        || journal.directory().getUsableSpace() < journal.maxSegmentSize() * (long) SEGMENT_BUFFER_FACTOR
-        || journal.directory().getUsableSpace() / (double) journal.directory().getTotalSpace() < FREE_DISK_BUFFER;
+        || journal.directory().getUsableSpace() < journal.maxSegmentSize() * (long) segmentBufferFactor
+        || journal.directory().getUsableSpace() / (double) journal.directory().getTotalSpace() < freeDiskBuffer;
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/RaftStorageTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/RaftStorageTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.storage;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Raft storage test.
+ */
+public class RaftStorageTest {
+
+  @Test
+  public void testDefaultConfiguration() throws Exception {
+    RaftStorage storage = RaftStorage.newBuilder().build();
+    assertEquals("atomix", storage.prefix());
+    assertEquals(new File(System.getProperty("user.dir")), storage.directory());
+    assertEquals(1024 * 1024 * 32, storage.maxLogSegmentSize());
+    assertEquals(1024 * 1024, storage.maxLogEntriesPerSegment());
+    assertEquals(3, storage.segmentBufferFactor());
+    assertEquals(.25, storage.freeDiskBuffer(), .01);
+    assertFalse(storage.isFlushOnCommit());
+    assertFalse(storage.isRetainStaleSnapshots());
+  }
+
+  @Test
+  public void testCustomConfiguration() throws Exception {
+    RaftStorage storage = RaftStorage.newBuilder()
+        .withPrefix("foo")
+        .withDirectory(new File(System.getProperty("user.dir"), "foo"))
+        .withMaxSegmentSize(1024 * 1024)
+        .withMaxEntriesPerSegment(1024)
+        .withSegmentBufferFactor(5)
+        .withFreeDiskBuffer(.5)
+        .withFlushOnCommit()
+        .withRetainStaleSnapshots()
+        .build();
+    assertEquals("foo", storage.prefix());
+    assertEquals(new File(System.getProperty("user.dir"), "foo"), storage.directory());
+    assertEquals(1024 * 1024, storage.maxLogSegmentSize());
+    assertEquals(1024, storage.maxLogEntriesPerSegment());
+    assertEquals(5, storage.segmentBufferFactor());
+    assertEquals(.5, storage.freeDiskBuffer(), .01);
+    assertTrue(storage.isFlushOnCommit());
+    assertTrue(storage.isRetainStaleSnapshots());
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/RaftStorageTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/RaftStorageTest.java
@@ -35,6 +35,7 @@ public class RaftStorageTest {
     assertEquals(new File(System.getProperty("user.dir")), storage.directory());
     assertEquals(1024 * 1024 * 32, storage.maxLogSegmentSize());
     assertEquals(1024 * 1024, storage.maxLogEntriesPerSegment());
+    assertTrue(storage.dynamicCompaction());
     assertEquals(3, storage.segmentBufferFactor());
     assertEquals(.25, storage.freeDiskBuffer(), .01);
     assertFalse(storage.isFlushOnCommit());
@@ -48,6 +49,7 @@ public class RaftStorageTest {
         .withDirectory(new File(System.getProperty("user.dir"), "foo"))
         .withMaxSegmentSize(1024 * 1024)
         .withMaxEntriesPerSegment(1024)
+        .withDynamicCompaction(false)
         .withSegmentBufferFactor(5)
         .withFreeDiskBuffer(.5)
         .withFlushOnCommit()

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractLogTest {
   protected abstract StorageLevel storageLevel();
 
   protected RaftLog createLog() {
-    return RaftLog.builder()
+    return RaftLog.newBuilder()
         .withName("test")
         .withDirectory(PATH.toFile())
         .withSerializer(serializer)


### PR DESCRIPTION
This PR makes log compaction limits in the `RaftLog` class configurable.