### PR TITLE
Reverse incorrect ThreadModel factories

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/ThreadModel.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/ThreadModel.java
@@ -31,7 +31,7 @@ public enum ThreadModel {
   SHARED_THREAD_POOL {
     @Override
     public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
-      return new SingleThreadContextFactory(nameFormat, logger);
+      return new ThreadPoolContextFactory(nameFormat, threadPoolSize, logger);
     }
   },
 
@@ -41,7 +41,7 @@ public enum ThreadModel {
   THREAD_PER_SERVICE {
     @Override
     public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
-      return new ThreadPoolContextFactory(nameFormat, threadPoolSize, logger);
+      return new SingleThreadContextFactory(nameFormat, logger);
     }
   };
 


### PR DESCRIPTION
This PR fixes a bug in the `ThreadModel` enum. The enum was creating a `SingleThreadContextFactory` and thus a lot of threads when the default `SHARED_THREAD_POOL` was used. This fixes the factories returned by the constants.