### PR TITLE
Use phi accrual failure detectors for Raft elections and session timeouts

### DIFF
--- a/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftClientCommunicator.java
+++ b/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftClientCommunicator.java
@@ -24,6 +24,8 @@ import io.atomix.protocols.raft.protocol.CloseSessionRequest;
 import io.atomix.protocols.raft.protocol.CloseSessionResponse;
 import io.atomix.protocols.raft.protocol.CommandRequest;
 import io.atomix.protocols.raft.protocol.CommandResponse;
+import io.atomix.protocols.raft.protocol.HeartbeatRequest;
+import io.atomix.protocols.raft.protocol.HeartbeatResponse;
 import io.atomix.protocols.raft.protocol.KeepAliveRequest;
 import io.atomix.protocols.raft.protocol.KeepAliveResponse;
 import io.atomix.protocols.raft.protocol.MetadataRequest;
@@ -43,6 +45,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -95,6 +98,16 @@ public class RaftClientCommunicator implements RaftClientProtocol {
   @Override
   public CompletableFuture<MetadataResponse> metadata(MemberId memberId, MetadataRequest request) {
     return sendAndReceive(context.metadataSubject, request, memberId);
+  }
+
+  @Override
+  public void registerHeartbeatHandler(Function<HeartbeatRequest, CompletableFuture<HeartbeatResponse>> handler) {
+    clusterCommunicator.addSubscriber(context.heartbeatSubject, serializer::decode, handler, serializer::encode);
+  }
+
+  @Override
+  public void unregisterHeartbeatHandler() {
+    clusterCommunicator.removeSubscriber(context.heartbeatSubject);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftMessageContext.java
+++ b/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftMessageContext.java
@@ -22,6 +22,7 @@ import io.atomix.cluster.messaging.MessageSubject;
  */
 class RaftMessageContext {
   private final String prefix;
+  final MessageSubject heartbeatSubject;
   final MessageSubject openSessionSubject;
   final MessageSubject closeSessionSubject;
   final MessageSubject keepAliveSubject;
@@ -40,6 +41,7 @@ class RaftMessageContext {
 
   RaftMessageContext(String prefix) {
     this.prefix = prefix;
+    this.heartbeatSubject = getSubject(prefix, "heartbeat");
     this.openSessionSubject = getSubject(prefix, "open");
     this.closeSessionSubject = getSubject(prefix, "close");
     this.keepAliveSubject = getSubject(prefix, "keep-alive");

--- a/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftServerCommunicator.java
+++ b/core/src/main/java/io/atomix/protocols/raft/protocol/messaging/RaftServerCommunicator.java
@@ -28,6 +28,8 @@ import io.atomix.protocols.raft.protocol.CommandRequest;
 import io.atomix.protocols.raft.protocol.CommandResponse;
 import io.atomix.protocols.raft.protocol.ConfigureRequest;
 import io.atomix.protocols.raft.protocol.ConfigureResponse;
+import io.atomix.protocols.raft.protocol.HeartbeatRequest;
+import io.atomix.protocols.raft.protocol.HeartbeatResponse;
 import io.atomix.protocols.raft.protocol.InstallRequest;
 import io.atomix.protocols.raft.protocol.InstallResponse;
 import io.atomix.protocols.raft.protocol.JoinRequest;
@@ -161,6 +163,11 @@ public class RaftServerCommunicator implements RaftServerProtocol {
   @Override
   public void publish(MemberId memberId, PublishRequest request) {
     clusterCommunicator.unicast(request, context.publishSubject(request.session()), serializer::encode, NodeId.from(memberId.id()));
+  }
+
+  @Override
+  public CompletableFuture<HeartbeatResponse> heartbeat(MemberId memberId, HeartbeatRequest request) {
+    return sendAndReceive(context.heartbeatSubject, request, memberId);
   }
 
   @Override

--- a/protocols/failure-detection/src/main/java/io/atomix/protocols/phi/PhiAccrualFailureDetector.java
+++ b/protocols/failure-detection/src/main/java/io/atomix/protocols/phi/PhiAccrualFailureDetector.java
@@ -15,11 +15,7 @@
  */
 package io.atomix.protocols.phi;
 
-import com.google.common.collect.Maps;
-import io.atomix.utils.Identifier;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-
-import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -29,28 +25,22 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>
  * Based on a paper titled: "The φ Accrual Failure Detector" by Hayashibara, et al.
  */
-public class PhiAccrualFailureDetector<T extends Identifier> {
-  private final Map<T, History> states = Maps.newConcurrentMap();
+public class PhiAccrualFailureDetector {
 
   // Default value
   private static final int DEFAULT_WINDOW_SIZE = 250;
   private static final int DEFAULT_MIN_SAMPLES = 25;
   private static final double DEFAULT_PHI_FACTOR = 1.0 / Math.log(10.0);
 
-  // If a node does not have any heartbeats, this is the phi
-  // value to report. Indicates the node is inactive (from the
-  // detectors perspective.
-  private static final double DEFAULT_BOOTSTRAP_PHI_VALUE = 100.0;
-
   private final int minSamples;
   private final double phiFactor;
-  private final double bootstrapPhiValue;
+  private final History history = new History();
 
   /**
    * Creates a new failure detector with the default configuration.
    */
   public PhiAccrualFailureDetector() {
-    this(DEFAULT_MIN_SAMPLES, DEFAULT_PHI_FACTOR, DEFAULT_BOOTSTRAP_PHI_VALUE);
+    this(DEFAULT_MIN_SAMPLES, DEFAULT_PHI_FACTOR);
   }
 
   /**
@@ -58,64 +48,46 @@ public class PhiAccrualFailureDetector<T extends Identifier> {
    *
    * @param minSamples the minimum number of samples required to compute phi
    * @param phiFactor the phi factor
-   * @param bootstrapPhiValue the phi value with which to bootstrap the detector
    */
-  public PhiAccrualFailureDetector(int minSamples, double phiFactor, double bootstrapPhiValue) {
+  public PhiAccrualFailureDetector(int minSamples, double phiFactor) {
     this.minSamples = minSamples;
     this.phiFactor = phiFactor;
-    this.bootstrapPhiValue = bootstrapPhiValue;
   }
 
   /**
    * Report a new heart beat for the specified node id.
-   *
-   * @param nodeId node id
    */
-  public void report(T nodeId) {
-    report(nodeId, System.currentTimeMillis());
+  public void report() {
+    report(System.currentTimeMillis());
   }
 
   /**
    * Report a new heart beat for the specified node id.
    *
-   * @param nodeId      node id
    * @param arrivalTime arrival time
    */
-  public void report(T nodeId, long arrivalTime) {
-    checkNotNull(nodeId, "NodeId must not be null");
+  public void report(long arrivalTime) {
+    checkNotNull("NodeId must not be null");
     checkArgument(arrivalTime >= 0, "arrivalTime must not be negative");
-
-    History nodeState = states.computeIfAbsent(nodeId, key -> new History());
-    synchronized (nodeState) {
-      long latestHeartbeat = nodeState.latestHeartbeatTime();
-      if (latestHeartbeat != -1) {
-        nodeState.samples().addValue(arrivalTime - latestHeartbeat);
-      }
-      nodeState.setLatestHeartbeatTime(arrivalTime);
+    long latestHeartbeat = history.latestHeartbeatTime();
+    if (latestHeartbeat != -1) {
+      history.samples().addValue(arrivalTime - latestHeartbeat);
     }
+    history.setLatestHeartbeatTime(arrivalTime);
   }
 
   /**
    * Compute phi for the specified node id.
    *
-   * @param nodeId node id
    * @return phi value
    */
-  public double phi(T nodeId) {
-    checkNotNull(nodeId, "NodeId must not be null");
-    if (!states.containsKey(nodeId)) {
-      return bootstrapPhiValue;
+  public double phi() {
+    long latestHeartbeat = history.latestHeartbeatTime();
+    DescriptiveStatistics samples = history.samples();
+    if (latestHeartbeat == -1 || samples.getN() < minSamples) {
+      return 0.0;
     }
-
-    History nodeState = states.get(nodeId);
-    synchronized (nodeState) {
-      long latestHeartbeat = nodeState.latestHeartbeatTime();
-      DescriptiveStatistics samples = nodeState.samples();
-      if (latestHeartbeat == -1 || samples.getN() < minSamples) {
-        return 0.0;
-      }
-      return computePhi(samples, latestHeartbeat, System.currentTimeMillis());
-    }
+    return computePhi(samples, latestHeartbeat, System.currentTimeMillis());
   }
 
   /**
@@ -131,7 +103,7 @@ public class PhiAccrualFailureDetector<T extends Identifier> {
     long t = currentTime - lastHeartbeat;
     return (size > 0)
         ? phiFactor * t / samples.getMean()
-        : bootstrapPhiValue;
+        : 100;
   }
 
   /**

--- a/protocols/raft/pom.xml
+++ b/protocols/raft/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>
+      <artifactId>atomix-failure-detection</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
       <artifactId>atomix-kryo</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -538,7 +538,7 @@ public interface RaftServer {
   abstract class Builder implements io.atomix.utils.Builder<RaftServer> {
     private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(750);
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
-    private static final int DEFAULT_ELECTION_THRESHOLD = 5;
+    private static final int DEFAULT_ELECTION_THRESHOLD = 3;
     private static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofMillis(5000);
     private static final int DEFAULT_SESSION_FAILURE_THRESHOLD = 3;
     private static final ThreadModel DEFAULT_THREAD_MODEL = ThreadModel.SHARED_THREAD_POOL;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -538,9 +538,9 @@ public interface RaftServer {
   abstract class Builder implements io.atomix.utils.Builder<RaftServer> {
     private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(750);
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
-    private static final int DEFAULT_ELECTION_THRESHOLD = 3;
+    private static final int DEFAULT_ELECTION_THRESHOLD = 5;
     private static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofMillis(5000);
-    private static final int DEFAULT_SESSION_FAILURE_THRESHOLD = 5;
+    private static final int DEFAULT_SESSION_FAILURE_THRESHOLD = 3;
     private static final ThreadModel DEFAULT_THREAD_MODEL = ThreadModel.SHARED_THREAD_POOL;
     private static final int DEFAULT_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors();
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
@@ -107,7 +107,7 @@ public class DefaultRaftClient implements RaftClient {
 
   @Override
   public RaftProxy.Builder newProxyBuilder() {
-    return new SessionBuilder();
+    return new ProxyBuilder();
   }
 
   @Override
@@ -125,14 +125,14 @@ public class DefaultRaftClient implements RaftClient {
   /**
    * Default Raft session builder.
    */
-  private class SessionBuilder extends RaftProxy.Builder {
+  private class ProxyBuilder extends RaftProxy.Builder {
     @Override
     public RaftProxy build() {
-      // Create a client builder that uses the session manager to open a session.
+      // Create a proxy builder that uses the session manager to open a session.
       RaftProxyClient.Builder clientBuilder = new RaftProxyClient.Builder() {
         @Override
         public CompletableFuture<RaftProxyClient> buildAsync() {
-          return sessionManager.openSession(name, serviceType, readConsistency, communicationStrategy, timeout);
+          return sessionManager.openSession(name, serviceType, readConsistency, communicationStrategy, minTimeout, maxTimeout);
         }
       };
 
@@ -144,7 +144,8 @@ public class DefaultRaftClient implements RaftClient {
           .withRetryDelay(retryDelay)
           .withCommunicationStrategy(communicationStrategy)
           .withRecoveryStrategy(recoveryStrategy)
-          .withTimeout(timeout);
+          .withMinTimeout(minTimeout)
+          .withMaxTimeout(maxTimeout);
 
       RaftProxyClient client;
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -241,7 +241,9 @@ public class DefaultRaftServer implements RaftServer {
       RaftContext raft = new RaftContext(name, localMemberId, protocol, storage, serviceRegistry, threadModel, threadPoolSize);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
+      raft.setElectionThreshold(electionThreshold);
       raft.setSessionTimeout(sessionTimeout);
+      raft.setSessionFailureThreshold(sessionFailureThreshold);
 
       return new DefaultRaftServer(raft);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -104,6 +104,7 @@ public class RaftContext implements AutoCloseable {
   private volatile MemberId leader;
   private volatile long term;
   private MemberId lastVotedFor;
+  private long lastHeartbeatTime;
   private long commitIndex;
   private volatile long firstCommitIndex;
   private volatile long lastApplied;
@@ -435,6 +436,31 @@ public class RaftContext implements AutoCloseable {
   }
 
   /**
+   * Returns the last time a request was received from the leader.
+   *
+   * @return The last time a request was received
+   */
+  public long getLastHeartbeatTime() {
+    return lastHeartbeatTime;
+  }
+
+  /**
+   * Sets the last time a request was received from the leader.
+   */
+  public void setLastHeartbeatTime() {
+    setLastHeartbeatTime(System.currentTimeMillis());
+  }
+
+  /**
+   * Sets the last time a request was received by the node.
+   *
+   * @param lastHeartbeatTime The last time a request was received
+   */
+  public void setLastHeartbeatTime(long lastHeartbeatTime) {
+    this.lastHeartbeatTime = lastHeartbeatTime;
+  }
+
+  /**
    * Returns the state last voted for candidate.
    *
    * @return The state last voted for candidate.
@@ -691,6 +717,7 @@ public class RaftContext implements AutoCloseable {
     protocol.unregisterJoinHandler();
     protocol.unregisterReconfigureHandler();
     protocol.unregisterLeaveHandler();
+    protocol.unregisterTransferHandler();
     protocol.unregisterAppendHandler();
     protocol.unregisterPollHandler();
     protocol.unregisterVoteHandler();

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -99,8 +99,10 @@ public class RaftContext implements AutoCloseable {
   private final ThreadContext compactionContext;
   protected RaftRole role = new InactiveRole(this);
   private Duration electionTimeout = Duration.ofMillis(500);
-  private Duration sessionTimeout = Duration.ofMillis(5000);
   private Duration heartbeatInterval = Duration.ofMillis(150);
+  private int electionThreshold = 3;
+  private Duration sessionTimeout = Duration.ofMillis(5000);
+  private int sessionFailureThreshold = 5;
   private volatile MemberId leader;
   private volatile long term;
   private MemberId lastVotedFor;
@@ -316,6 +318,24 @@ public class RaftContext implements AutoCloseable {
   }
 
   /**
+   * Sets the election threshold.
+   *
+   * @param electionThreshold the election threshold
+   */
+  public void setElectionThreshold(int electionThreshold) {
+    this.electionThreshold = electionThreshold;
+  }
+
+  /**
+   * Returns the election threshold.
+   *
+   * @return the election threshold
+   */
+  public int getElectionThreshold() {
+    return electionThreshold;
+  }
+
+  /**
    * Returns the session timeout.
    *
    * @return The session timeout.
@@ -331,6 +351,24 @@ public class RaftContext implements AutoCloseable {
    */
   public void setSessionTimeout(Duration sessionTimeout) {
     this.sessionTimeout = checkNotNull(sessionTimeout, "sessionTimeout cannot be null");
+  }
+
+  /**
+   * Returns the session failure threshold.
+   *
+   * @return the session failure threshold
+   */
+  public int getSessionFailureThreshold() {
+    return sessionFailureThreshold;
+  }
+
+  /**
+   * Sets the session failure threshold.
+   *
+   * @param sessionFailureThreshold the session failure threshold
+   */
+  public void setSessionFailureThreshold(int sessionFailureThreshold) {
+    this.sessionFailureThreshold = sessionFailureThreshold;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -258,7 +258,8 @@ public class RaftServiceManager implements AutoCloseable {
     logger.trace("Restoring session {} for {}", sessionId, service.serviceName());
     MemberId node = MemberId.from(reader.readString());
     ReadConsistency readConsistency = ReadConsistency.valueOf(reader.readString());
-    long sessionTimeout = reader.readLong();
+    long minTimeout = reader.readLong();
+    long maxTimeout = reader.readLong();
     long sessionTimestamp = reader.readLong();
     RaftSessionContext session = new RaftSessionContext(
         sessionId,
@@ -266,7 +267,8 @@ public class RaftServiceManager implements AutoCloseable {
         service.serviceName(),
         service.serviceType(),
         readConsistency,
-        sessionTimeout,
+        minTimeout,
+        maxTimeout,
         service,
         raft,
         threadContextFactory);
@@ -430,7 +432,8 @@ public class RaftServiceManager implements AutoCloseable {
         entry.entry().serviceName(),
         ServiceType.from(entry.entry().serviceType()),
         entry.entry().readConsistency(),
-        entry.entry().timeout(),
+        entry.entry().minTimeout(),
+        entry.entry().maxTimeout(),
         service,
         raft,
         threadContextFactory);
@@ -452,7 +455,7 @@ public class RaftServiceManager implements AutoCloseable {
 
     // Get the state machine executor associated with the session and unregister the session.
     DefaultServiceContext service = session.getService();
-    return service.closeSession(entry.index(), entry.entry().timestamp(), session);
+    return service.closeSession(entry.index(), entry.entry().timestamp(), session, entry.entry().expired());
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -272,7 +272,7 @@ public class RaftServiceManager implements AutoCloseable {
         service,
         raft,
         threadContextFactory);
-    session.setTimestamp(sessionTimestamp);
+    session.setLastUpdated(sessionTimestamp);
     session.setRequestSequence(reader.readLong());
     session.setCommandSequence(reader.readLong());
     session.setEventIndex(reader.readLong());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/HeartbeatRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/HeartbeatRequest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.protocol;
+
+import io.atomix.protocols.raft.cluster.MemberId;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Client heartbeat request.
+ */
+public class HeartbeatRequest extends AbstractRaftRequest {
+
+  /**
+   * Returns a new heartbeat request builder.
+   *
+   * @return A new heartbeat request builder.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  private final MemberId leader;
+  private final Collection<MemberId> members;
+
+  public HeartbeatRequest(MemberId leader, Collection<MemberId> members) {
+    this.leader = leader;
+    this.members = members;
+  }
+
+  /**
+   * Returns the cluster leader.
+   *
+   * @return The cluster leader.
+   */
+  public MemberId leader() {
+    return leader;
+  }
+
+  /**
+   * Returns the cluster members.
+   *
+   * @return The cluster members.
+   */
+  public Collection<MemberId> members() {
+    return members;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), leader, members);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object instanceof HeartbeatRequest) {
+      HeartbeatRequest request = (HeartbeatRequest) object;
+      return Objects.equals(request.leader, leader) && Objects.equals(request.members, members);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("leader", leader)
+        .add("members", members)
+        .toString();
+  }
+
+  /**
+   * Heartbeat request builder.
+   */
+  public static class Builder extends AbstractRaftRequest.Builder<Builder, HeartbeatRequest> {
+    private MemberId leader;
+    private Collection<MemberId> members;
+
+    /**
+     * Sets the request leader.
+     *
+     * @param leader The request leader.
+     * @return The request builder.
+     */
+    public Builder withLeader(MemberId leader) {
+      this.leader = leader;
+      return this;
+    }
+
+    /**
+     * Sets the request members.
+     *
+     * @param members The request members.
+     * @return The request builder.
+     * @throws NullPointerException if {@code members} is null
+     */
+    public Builder withMembers(Collection<MemberId> members) {
+      this.members = checkNotNull(members, "members cannot be null");
+      return this;
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkNotNull(members, "members cannot be null");
+    }
+
+    /**
+     * @throws IllegalStateException if status is OK and members is null
+     */
+    @Override
+    public HeartbeatRequest build() {
+      validate();
+      return new HeartbeatRequest(leader, members);
+    }
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/HeartbeatResponse.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/HeartbeatResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.protocol;
+
+import io.atomix.protocols.raft.RaftError;
+
+/**
+ * Client heartbeat response.
+ */
+public class HeartbeatResponse extends AbstractRaftResponse {
+
+  /**
+   * Returns a new heartbeat response builder.
+   *
+   * @return A new heartbeat response builder.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public HeartbeatResponse(Status status, RaftError error) {
+    super(status, error);
+  }
+
+  /**
+   * Heartbeat response builder.
+   */
+  public static class Builder extends AbstractRaftResponse.Builder<Builder, HeartbeatResponse> {
+    @Override
+    public HeartbeatResponse build() {
+      validate();
+      return new HeartbeatResponse(status, error);
+    }
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/OpenSessionRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/OpenSessionRequest.java
@@ -16,8 +16,8 @@
 package io.atomix.protocols.raft.protocol;
 
 import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.cluster.MemberId;
+import io.atomix.protocols.raft.service.ServiceType;
 
 import java.util.Objects;
 
@@ -43,14 +43,16 @@ public class OpenSessionRequest extends AbstractRaftRequest {
   private final String name;
   private final String typeName;
   private final ReadConsistency readConsistency;
-  private final long timeout;
+  private final long minTimeout;
+  private final long maxTimeout;
 
-  public OpenSessionRequest(String member, String name, String typeName, ReadConsistency readConsistency, long timeout) {
+  public OpenSessionRequest(String member, String name, String typeName, ReadConsistency readConsistency, long minTimeout, long maxTimeout) {
     this.member = member;
     this.name = name;
     this.typeName = typeName;
     this.readConsistency = readConsistency;
-    this.timeout = timeout;
+    this.minTimeout = minTimeout;
+    this.maxTimeout = maxTimeout;
   }
 
   /**
@@ -90,17 +92,26 @@ public class OpenSessionRequest extends AbstractRaftRequest {
   }
 
   /**
-   * Returns the session timeout.
+   * Returns the minimum session timeout.
    *
-   * @return The session timeout.
+   * @return The minimum session timeout.
    */
-  public long timeout() {
-    return timeout;
+  public long minTimeout() {
+    return minTimeout;
+  }
+
+  /**
+   * Returns the maximum session timeout.
+   *
+   * @return The maximum session timeout.
+   */
+  public long maxTimeout() {
+    return maxTimeout;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), name, typeName, timeout);
+    return Objects.hash(getClass(), name, typeName, minTimeout, maxTimeout);
   }
 
   @Override
@@ -111,7 +122,8 @@ public class OpenSessionRequest extends AbstractRaftRequest {
           && request.name.equals(name)
           && request.typeName.equals(typeName)
           && request.readConsistency == readConsistency
-          && request.timeout == timeout;
+          && request.minTimeout == minTimeout
+          && request.maxTimeout == maxTimeout;
     }
     return false;
   }
@@ -123,7 +135,8 @@ public class OpenSessionRequest extends AbstractRaftRequest {
         .add("serviceName", name)
         .add("serviceType", typeName)
         .add("readConsistency", readConsistency)
-        .add("timeout", timeout)
+        .add("minTimeout", minTimeout)
+        .add("maxTimeout", maxTimeout)
         .toString();
   }
 
@@ -135,7 +148,8 @@ public class OpenSessionRequest extends AbstractRaftRequest {
     private String serviceName;
     private String serviceType;
     private ReadConsistency readConsistency = ReadConsistency.LINEARIZABLE;
-    private long timeout;
+    private long minTimeout;
+    private long maxTimeout;
 
     /**
      * Sets the client node identifier.
@@ -186,15 +200,28 @@ public class OpenSessionRequest extends AbstractRaftRequest {
     }
 
     /**
-     * Sets the session timeout.
+     * Sets the minimum session timeout.
      *
-     * @param timeout The session timeout.
+     * @param timeout The minimum session timeout.
      * @return The open session request builder.
      * @throws IllegalArgumentException if {@code timeout} is not positive
      */
-    public Builder withTimeout(long timeout) {
+    public Builder withMinTimeout(long timeout) {
       checkArgument(timeout >= 0, "timeout must be positive");
-      this.timeout = timeout;
+      this.minTimeout = timeout;
+      return this;
+    }
+
+    /**
+     * Sets the maximum session timeout.
+     *
+     * @param timeout The maximum session timeout.
+     * @return The open session request builder.
+     * @throws IllegalArgumentException if {@code timeout} is not positive
+     */
+    public Builder withMaxTimeout(long timeout) {
+      checkArgument(timeout >= 0, "timeout must be positive");
+      this.maxTimeout = timeout;
       return this;
     }
 
@@ -204,7 +231,8 @@ public class OpenSessionRequest extends AbstractRaftRequest {
       checkNotNull(memberId, "client cannot be null");
       checkNotNull(serviceName, "name cannot be null");
       checkNotNull(serviceType, "typeName cannot be null");
-      checkArgument(timeout >= 0, "timeout must be positive");
+      checkArgument(minTimeout >= 0, "minTimeout must be positive");
+      checkArgument(maxTimeout >= 0, "maxTimeout must be positive");
     }
 
     /**
@@ -213,7 +241,7 @@ public class OpenSessionRequest extends AbstractRaftRequest {
     @Override
     public OpenSessionRequest build() {
       validate();
-      return new OpenSessionRequest(memberId, serviceName, serviceType, readConsistency, timeout);
+      return new OpenSessionRequest(memberId, serviceName, serviceType, readConsistency, minTimeout, maxTimeout);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftClientProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftClientProtocol.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Raft client protocol.
@@ -89,6 +90,18 @@ public interface RaftClientProtocol {
    * @param request the reset request to multicast
    */
   void reset(Collection<MemberId> members, ResetRequest request);
+
+  /**
+   * Registers a heartbeat request callback.
+   *
+   * @param handler the heartbeat request handler to register
+   */
+  void registerHeartbeatHandler(Function<HeartbeatRequest, CompletableFuture<HeartbeatResponse>> handler);
+
+  /**
+   * Unregisters the heartbeat request handler.
+   */
+  void unregisterHeartbeatHandler();
 
   /**
    * Registers a publish request listener.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftServerProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftServerProtocol.java
@@ -164,6 +164,15 @@ public interface RaftServerProtocol {
   CompletableFuture<AppendResponse> append(MemberId memberId, AppendRequest request);
 
   /**
+   * Sends a heartbeat request to the given node.
+   *
+   * @param memberId the node to which to send the request
+   * @param request the request to send
+   * @return a future to be completed with the response
+   */
+  CompletableFuture<HeartbeatResponse> heartbeat(MemberId memberId, HeartbeatRequest request);
+
+  /**
    * Unicasts a publish request to the given node.
    *
    * @param memberId  the node to which to send the request

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxy.java
@@ -196,7 +196,8 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
     protected Executor executor;
     protected CommunicationStrategy communicationStrategy = CommunicationStrategy.LEADER;
     protected RecoveryStrategy recoveryStrategy = RecoveryStrategy.RECOVER;
-    protected Duration timeout = Duration.ofMillis(0);
+    protected Duration minTimeout = Duration.ofMillis(250);
+    protected Duration maxTimeout = Duration.ofMillis(0);
 
     /**
      * Sets the session name.
@@ -318,8 +319,8 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
      * @return The session builder.
      * @throws IllegalArgumentException if the session timeout is not positive
      */
-    public Builder withTimeout(long timeoutMillis) {
-      return withTimeout(Duration.ofMillis(timeoutMillis));
+    public Builder withMinTimeout(long timeoutMillis) {
+      return withMinTimeout(Duration.ofMillis(timeoutMillis));
     }
 
     /**
@@ -330,9 +331,59 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
      * @throws IllegalArgumentException if the session timeout is not positive
      * @throws NullPointerException     if the timeout is null
      */
-    public Builder withTimeout(Duration timeout) {
+    public Builder withMinTimeout(Duration timeout) {
       checkArgument(!checkNotNull(timeout).isNegative(), "timeout must be positive");
-      this.timeout = timeout;
+      this.minTimeout = timeout;
+      return this;
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeoutMillis The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     */
+    @Deprecated
+    public Builder withTimeout(long timeoutMillis) {
+      return withMaxTimeout(Duration.ofMillis(timeoutMillis));
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeout The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     * @throws NullPointerException     if the timeout is null
+     */
+    @Deprecated
+    public Builder withTimeout(Duration timeout) {
+      return withMaxTimeout(timeout);
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeoutMillis The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     */
+    public Builder withMaxTimeout(long timeoutMillis) {
+      return withMaxTimeout(Duration.ofMillis(timeoutMillis));
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeout The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     * @throws NullPointerException     if the timeout is null
+     */
+    public Builder withMaxTimeout(Duration timeout) {
+      checkArgument(!checkNotNull(timeout).isNegative(), "timeout must be positive");
+      this.maxTimeout = timeout;
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyClient.java
@@ -46,7 +46,8 @@ public interface RaftProxyClient extends RaftProxyExecutor, Managed<RaftProxyCli
     protected Executor executor;
     protected CommunicationStrategy communicationStrategy = CommunicationStrategy.LEADER;
     protected RecoveryStrategy recoveryStrategy = RecoveryStrategy.RECOVER;
-    protected Duration timeout = Duration.ofMillis(0);
+    protected Duration minTimeout = Duration.ofMillis(250);
+    protected Duration maxTimeout = Duration.ofMillis(0);
 
     /**
      * Sets the session name.
@@ -168,8 +169,8 @@ public interface RaftProxyClient extends RaftProxyExecutor, Managed<RaftProxyCli
      * @return The session builder.
      * @throws IllegalArgumentException if the session timeout is not positive
      */
-    public Builder withTimeout(long timeoutMillis) {
-      return withTimeout(Duration.ofMillis(timeoutMillis));
+    public Builder withMinTimeout(long timeoutMillis) {
+      return withMinTimeout(Duration.ofMillis(timeoutMillis));
     }
 
     /**
@@ -180,9 +181,59 @@ public interface RaftProxyClient extends RaftProxyExecutor, Managed<RaftProxyCli
      * @throws IllegalArgumentException if the session timeout is not positive
      * @throws NullPointerException     if the timeout is null
      */
-    public Builder withTimeout(Duration timeout) {
+    public Builder withMinTimeout(Duration timeout) {
       checkArgument(!checkNotNull(timeout).isNegative(), "timeout must be positive");
-      this.timeout = timeout;
+      this.minTimeout = timeout;
+      return this;
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeoutMillis The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     */
+    @Deprecated
+    public Builder withTimeout(long timeoutMillis) {
+      return withMaxTimeout(Duration.ofMillis(timeoutMillis));
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeout The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     * @throws NullPointerException     if the timeout is null
+     */
+    @Deprecated
+    public Builder withTimeout(Duration timeout) {
+      return withMaxTimeout(timeout);
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeoutMillis The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     */
+    public Builder withMaxTimeout(long timeoutMillis) {
+      return withMaxTimeout(Duration.ofMillis(timeoutMillis));
+    }
+
+    /**
+     * Sets the session timeout.
+     *
+     * @param timeout The session timeout.
+     * @return The session builder.
+     * @throws IllegalArgumentException if the session timeout is not positive
+     * @throws NullPointerException     if the timeout is null
+     */
+    public Builder withMaxTimeout(Duration timeout) {
+      checkArgument(!checkNotNull(timeout).isNegative(), "timeout must be positive");
+      this.maxTimeout = timeout;
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
@@ -117,6 +117,11 @@ public abstract class AbstractRole implements RaftRole {
       raft.getCluster().reset();
       return true;
     }
+
+    // If the leader is non-null, update the last heartbeat time.
+    if (leader != null) {
+      raft.setLastHeartbeatTime();
+    }
     return false;
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -15,16 +15,12 @@
  */
 package io.atomix.protocols.raft.roles;
 
+import io.atomix.protocols.phi.PhiAccrualFailureDetector;
 import io.atomix.protocols.raft.RaftServer;
+import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.protocols.raft.cluster.impl.RaftMemberContext;
 import io.atomix.protocols.raft.impl.RaftContext;
-import io.atomix.protocols.raft.protocol.AppendRequest;
-import io.atomix.protocols.raft.protocol.AppendResponse;
-import io.atomix.protocols.raft.protocol.ConfigureRequest;
-import io.atomix.protocols.raft.protocol.ConfigureResponse;
-import io.atomix.protocols.raft.protocol.InstallRequest;
-import io.atomix.protocols.raft.protocol.InstallResponse;
 import io.atomix.protocols.raft.protocol.PollRequest;
 import io.atomix.protocols.raft.protocol.VoteRequest;
 import io.atomix.protocols.raft.protocol.VoteResponse;
@@ -45,6 +41,7 @@ import java.util.stream.Collectors;
  * Follower state.
  */
 public final class FollowerRole extends ActiveRole {
+  private final PhiAccrualFailureDetector failureDetector = new PhiAccrualFailureDetector();
   private final Random random = new Random();
   private Scheduled heartbeatTimer;
 
@@ -59,41 +56,40 @@ public final class FollowerRole extends ActiveRole {
 
   @Override
   public synchronized CompletableFuture<RaftRole> open() {
-    return super.open().thenRun(this::startHeartbeatTimeout).thenApply(v -> this);
+    raft.setLastHeartbeatTime();
+    return super.open().thenRun(this::startHeartbeatTimer).thenApply(v -> this);
   }
 
   /**
    * Starts the heartbeat timer.
    */
-  private void startHeartbeatTimeout() {
+  private void startHeartbeatTimer() {
     log.trace("Starting heartbeat timer");
-    resetHeartbeatTimeout();
+    resetHeartbeatTimer();
   }
 
   /**
    * Resets the heartbeat timer.
    */
-  private void resetHeartbeatTimeout() {
-    raft.checkThread();
-    if (isClosed())
-      return;
-
-    // If a timer is already set, cancel the timer.
-    if (heartbeatTimer != null) {
-      heartbeatTimer.cancel();
-    }
-
-    // Set the election timeout in a semi-random fashion with the random range
-    // being election timeout and 2 * election timeout.
-    Duration delay = raft.getElectionTimeout().plus(Duration.ofMillis(random.nextInt((int) raft.getElectionTimeout().toMillis())));
+  private void resetHeartbeatTimer() {
+    Duration delay = raft.getHeartbeatInterval().dividedBy(2)
+        .plus(Duration.ofMillis(random.nextInt((int) raft.getHeartbeatInterval().dividedBy(2).toMillis())));
     heartbeatTimer = raft.getThreadContext().schedule(delay, () -> {
-      heartbeatTimer = null;
       if (isOpen()) {
-        raft.setLeader(null);
-        log.debug("Heartbeat timed out in {}", delay);
-        sendPollRequests();
+        if (System.currentTimeMillis() - raft.getLastHeartbeatTime() > raft.getElectionTimeout().toMillis() || failureDetector.phi() >= raft.getElectionThreshold()) {
+          log.debug("Heartbeat timed out in {}", System.currentTimeMillis() - raft.getLastHeartbeatTime());
+          sendPollRequests();
+        } else {
+          resetHeartbeatTimer();
+        }
       }
     });
+  }
+
+  @Override
+  protected boolean updateTermAndLeader(long term, MemberId leader) {
+    failureDetector.report();
+    return super.updateTermAndLeader(term, leader);
   }
 
   /**
@@ -103,7 +99,7 @@ public final class FollowerRole extends ActiveRole {
     // Set a new timer within which other nodes must respond in order for this node to transition to candidate.
     heartbeatTimer = raft.getThreadContext().schedule(raft.getElectionTimeout(), () -> {
       log.debug("Failed to poll a majority of the cluster in {}", raft.getElectionTimeout());
-      resetHeartbeatTimeout();
+      resetHeartbeatTimer();
     });
 
     // Create a quorum that will track the number of nodes that have responded to the poll request.
@@ -112,6 +108,7 @@ public final class FollowerRole extends ActiveRole {
 
     // If there are no other members in the cluster, immediately transition to leader.
     if (votingMembers.isEmpty()) {
+      raft.setLeader(null);
       raft.transition(RaftServer.Role.CANDIDATE);
       return;
     }
@@ -120,9 +117,10 @@ public final class FollowerRole extends ActiveRole {
       // If a majority of the cluster indicated they would vote for us then transition to candidate.
       complete.set(true);
       if (elected) {
+        raft.setLeader(null);
         raft.transition(RaftServer.Role.CANDIDATE);
       } else {
-        resetHeartbeatTimeout();
+        resetHeartbeatTimer();
       }
     });
 
@@ -136,6 +134,8 @@ public final class FollowerRole extends ActiveRole {
     } else {
       lastTerm = 0;
     }
+
+    final DefaultRaftMember leader = raft.getLeader();
 
     log.debug("Polling members {}", votingMembers);
 
@@ -162,7 +162,12 @@ public final class FollowerRole extends ActiveRole {
 
             if (!response.accepted()) {
               log.debug("Received rejected poll from {}", member);
-              quorum.fail();
+              if (leader != null && response.term() == raft.getTerm() && member.memberId().equals(leader.memberId())) {
+                quorum.cancel();
+                resetHeartbeatTimer();
+              } else {
+                quorum.fail();
+              }
             } else if (response.term() != raft.getTerm()) {
               log.debug("Received accepted poll for a different term from {}", member);
               quorum.fail();
@@ -177,42 +182,19 @@ public final class FollowerRole extends ActiveRole {
   }
 
   @Override
-  public CompletableFuture<InstallResponse> onInstall(InstallRequest request) {
-    CompletableFuture<InstallResponse> future = super.onInstall(request);
-    resetHeartbeatTimeout();
-    return future;
-  }
-
-  @Override
-  public CompletableFuture<ConfigureResponse> onConfigure(ConfigureRequest request) {
-    CompletableFuture<ConfigureResponse> future = super.onConfigure(request);
-    resetHeartbeatTimeout();
-    return future;
-  }
-
-  @Override
-  public CompletableFuture<AppendResponse> onAppend(AppendRequest request) {
-    CompletableFuture<AppendResponse> future = super.onAppend(request);
-
-    // Reset the heartbeat timeout.
-    resetHeartbeatTimeout();
-    return future;
-  }
-
-  @Override
   protected VoteResponse handleVote(VoteRequest request) {
     // Reset the heartbeat timeout if we voted for another candidate.
     VoteResponse response = super.handleVote(request);
     if (response.voted()) {
-      resetHeartbeatTimeout();
+      failureDetector.report();
     }
     return response;
   }
 
   /**
-   * Cancels the heartbeat timeout.
+   * Cancels the heartbeat timer.
    */
-  private void cancelHeartbeatTimeout() {
+  private void cancelHeartbeatTimer() {
     if (heartbeatTimer != null) {
       log.trace("Cancelling heartbeat timer");
       heartbeatTimer.cancel();
@@ -221,7 +203,7 @@ public final class FollowerRole extends ActiveRole {
 
   @Override
   public synchronized CompletableFuture<Void> close() {
-    return super.close().thenRun(this::cancelHeartbeatTimeout);
+    return super.close().thenRun(this::cancelHeartbeatTimer);
   }
 
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -257,7 +257,7 @@ public final class LeaderRole extends ActiveRole {
           }
         }
         // Otherwise, if the session is still active but has failed according to the failure detector, expire the session.
-        else if (session.getState().active() && session.isFailed()) {
+        else if (session.getState().active() && session.isFailed(raft.getSessionFailureThreshold())) {
           expireSession(session);
         }
       }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -30,6 +30,7 @@ import io.atomix.protocols.raft.protocol.CloseSessionRequest;
 import io.atomix.protocols.raft.protocol.CloseSessionResponse;
 import io.atomix.protocols.raft.protocol.CommandRequest;
 import io.atomix.protocols.raft.protocol.CommandResponse;
+import io.atomix.protocols.raft.protocol.HeartbeatRequest;
 import io.atomix.protocols.raft.protocol.JoinRequest;
 import io.atomix.protocols.raft.protocol.JoinResponse;
 import io.atomix.protocols.raft.protocol.KeepAliveRequest;
@@ -70,6 +71,9 @@ import io.atomix.utils.concurrent.Scheduled;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -82,6 +86,7 @@ public final class LeaderRole extends ActiveRole {
 
   private final LeaderAppender appender;
   private Scheduled appendTimer;
+  private final Map<String, Scheduled> heartbeatTimers = new HashMap<>();
   private long configuring;
   private boolean transferring;
 
@@ -108,6 +113,7 @@ public final class LeaderRole extends ActiveRole {
 
     return super.open()
         .thenRun(this::startAppendTimer)
+        .thenRun(this::startHeartbeatTimer)
         .thenApply(v -> this);
   }
 
@@ -176,6 +182,102 @@ public final class LeaderRole extends ActiveRole {
     if (isOpen()) {
       appender.appendEntries();
     }
+  }
+
+  /**
+   * Starts checking for session heartbeat timeouts.
+   */
+  private void startHeartbeatTimer() {
+    raft.getSessions().getSessions().forEach(s -> s.resetHeartbeats());
+    log.trace("Starting heartbeat timers");
+    raft.getSessions().getSessions().stream()
+        .map(s -> s.memberId().id())
+        .distinct()
+        .forEach(this::resetHeartbeatTimer);
+  }
+
+  /**
+   * Resets the heartbeat timer.
+   */
+  private void resetHeartbeatTimer(String member) {
+    // Compute the smallest timeout of all open sessions for the member.
+    OptionalLong minTimeout = raft.getSessions().getSessions().stream()
+        .filter(s -> s.memberId().id().equals(member))
+        .mapToLong(s -> s.minTimeout())
+        .min();
+
+    Scheduled oldTimer;
+    if (minTimeout.isPresent()) {
+      Scheduled newTimer = raft.getThreadContext().schedule(
+          Duration.ZERO,
+          Duration.ofMillis(minTimeout.getAsLong()),
+          () -> sendHeartbeats(member));
+      oldTimer = heartbeatTimers.put(member, newTimer);
+    } else {
+      oldTimer = heartbeatTimers.remove(member);
+    }
+
+    // Cancel the old timer if one exists.
+    if (oldTimer != null) {
+      oldTimer.cancel();
+    }
+  }
+
+  /**
+   * Sends heartbeats to sessions of the given member.
+   *
+   * @param member the member to which to send heartbeats
+   */
+  private void sendHeartbeats(String member) {
+    raft.getSessions().getSessions().stream()
+        .filter(s -> s.memberId().id().equals(member))
+        .forEach(this::sendHeartbeat);
+  }
+
+  /**
+   * Attempts to send a heartbeat to the given session.
+   */
+  private void sendHeartbeat(RaftSessionContext session) {
+    long timestamp = System.currentTimeMillis();
+    HeartbeatRequest request = HeartbeatRequest.newBuilder()
+        .withLeader(raft.getCluster().getMember().memberId())
+        .withMembers(raft.getCluster().getMembers().stream()
+            .map(RaftMember::memberId)
+            .filter(m -> m != null)
+            .collect(Collectors.toList()))
+        .build();
+    raft.getProtocol().heartbeat(session.memberId(), request).whenCompleteAsync((response, error) -> {
+      if (error == null && response.status() == RaftResponse.Status.OK) {
+        session.setHeartbeat(timestamp);
+      } else {
+        // If no heartbeats have been received, use the session's minimum timeout.
+        if (session.getHeartbeat() == 0) {
+          if (timestamp - raft.getLastHeartbeatTime() > session.minTimeout()) {
+            expireSession(session);
+          }
+        }
+        // Otherwise, if the session is still active but has failed according to the failure detector, expire the session.
+        else if (session.getState().active() && session.isFailed()) {
+          expireSession(session);
+        }
+      }
+    }, raft.getThreadContext());
+  }
+
+  /**
+   * Expires the given session.
+   */
+  private void expireSession(RaftSessionContext session) {
+    log.debug("Expiring session due to heartbeat failure: {}", session);
+    appendAndCompact(new CloseSessionEntry(raft.getTerm(), System.currentTimeMillis(), session.sessionId().id(), true))
+        .whenCompleteAsync((entry, error) -> {
+          if (error != null) {
+            return;
+          }
+
+          log.trace("Appended {}", entry);
+          appender.appendEntries(entry.index());
+        }, raft.getThreadContext());
   }
 
   /**
@@ -725,21 +827,22 @@ public final class LeaderRole extends ActiveRole {
   public CompletableFuture<OpenSessionResponse> onOpenSession(OpenSessionRequest request) {
     final long term = raft.getTerm();
     final long timestamp = System.currentTimeMillis();
+    final long minTimeout = request.minTimeout();
 
     // If the client submitted a session timeout, use the client's timeout, otherwise use the configured
     // default server session timeout.
-    final long timeout;
-    if (request.timeout() != 0) {
-      timeout = request.timeout();
+    final long maxTimeout;
+    if (request.maxTimeout() != 0) {
+      maxTimeout = request.maxTimeout();
     } else {
-      timeout = raft.getSessionTimeout().toMillis();
+      maxTimeout = raft.getSessionTimeout().toMillis();
     }
 
     raft.checkThread();
     logRequest(request);
 
     CompletableFuture<OpenSessionResponse> future = new CompletableFuture<>();
-    appendAndCompact(new OpenSessionEntry(term, timestamp, request.member(), request.serviceName(), request.serviceType(), request.readConsistency(), timeout))
+    appendAndCompact(new OpenSessionEntry(term, timestamp, request.member(), request.serviceName(), request.serviceType(), request.readConsistency(), minTimeout, maxTimeout))
         .whenCompleteAsync((entry, error) -> {
           if (error != null) {
             future.complete(logResponse(OpenSessionResponse.newBuilder()
@@ -757,10 +860,11 @@ public final class LeaderRole extends ActiveRole {
               if (commitError == null) {
                 raft.getStateMachine().<Long>apply(entry.index()).whenComplete((sessionId, sessionError) -> {
                   if (sessionError == null) {
+                    resetHeartbeatTimer(request.member());
                     future.complete(logResponse(OpenSessionResponse.newBuilder()
                         .withStatus(RaftResponse.Status.OK)
                         .withSession(sessionId)
-                        .withTimeout(timeout)
+                        .withTimeout(maxTimeout)
                         .build()));
                   } else if (sessionError instanceof CompletionException && sessionError.getCause() instanceof RaftException) {
                     future.complete(logResponse(OpenSessionResponse.newBuilder()
@@ -884,7 +988,7 @@ public final class LeaderRole extends ActiveRole {
     logRequest(request);
 
     CompletableFuture<CloseSessionResponse> future = new CompletableFuture<>();
-    appendAndCompact(new CloseSessionEntry(term, timestamp, request.session()))
+    appendAndCompact(new CloseSessionEntry(term, timestamp, request.session(), false))
         .whenCompleteAsync((entry, error) -> {
           if (error != null) {
             future.complete(logResponse(CloseSessionResponse.newBuilder()
@@ -982,6 +1086,14 @@ public final class LeaderRole extends ActiveRole {
   }
 
   /**
+   * Cancels the heartbeat timers.
+   */
+  private void cancelHeartbeatTimers() {
+    log.trace("Cancelling heartbeat timers");
+    heartbeatTimers.values().forEach(Scheduled::cancel);
+  }
+
+  /**
    * Ensures the local server is not the leader.
    */
   private void stepDown() {
@@ -995,6 +1107,7 @@ public final class LeaderRole extends ActiveRole {
     return super.close()
         .thenRun(appender::close)
         .thenRun(this::cancelAppendTimer)
+        .thenRun(this::cancelHeartbeatTimers)
         .thenRun(this::stepDown);
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -246,11 +246,11 @@ public final class LeaderRole extends ActiveRole {
             .filter(m -> m != null)
             .collect(Collectors.toList()))
         .build();
-    log.trace("Sending {}", request);
+    log.trace("Sending {} to {}", request, member);
     raft.getProtocol().heartbeat(member, request).whenCompleteAsync((response, error) -> {
       long timestamp = System.currentTimeMillis();
       if (error == null && response.status() == RaftResponse.Status.OK) {
-        log.trace("Received {}", response);
+        log.trace("Received {} from {}", response, member);
         sessions.forEach(s -> s.setLastHeartbeat(timestamp));
       } else {
         sessions.forEach(session -> {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -15,11 +15,11 @@
  */
 package io.atomix.protocols.raft.session;
 
+import io.atomix.protocols.raft.ReadConsistency;
+import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.event.EventType;
 import io.atomix.protocols.raft.event.RaftEvent;
-import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.service.ServiceType;
-import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.storage.buffer.HeapBytes;
 
 import java.util.function.Function;
@@ -89,7 +89,24 @@ public interface RaftSession {
    *
    * @return The session timeout.
    */
-  long timeout();
+  @Deprecated
+  default long timeout() {
+    return maxTimeout();
+  }
+
+  /**
+   * Returns the minimum session timeout.
+   *
+   * @return The minimum session timeout.
+   */
+  long minTimeout();
+
+  /**
+   * Returns the maximum session timeout.
+   *
+   * @return The maximum session timeout.
+   */
+  long maxTimeout();
 
   /**
    * Returns the session state.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -53,7 +53,6 @@ import static com.google.common.base.Preconditions.checkState;
  * Raft session.
  */
 public class RaftSessionContext implements RaftSession {
-  private static final int PHI_FAILURE_THRESHOLD = 10;
   private final Logger log;
   private final SessionId sessionId;
   private final MemberId member;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -185,7 +185,8 @@ public class RaftSessionContext implements RaftSession {
    * @return indicates whether the session is timed out
    */
   public boolean isTimedOut(long timestamp) {
-    return timestamp - this.timestamp > maxTimeout;
+    long lastUpdated = this.timestamp;
+    return lastUpdated > 0 && timestamp - lastUpdated > maxTimeout;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -218,10 +218,11 @@ public class RaftSessionContext implements RaftSession {
   /**
    * Returns a boolean indicating whether the session appears to have failed due to lack of heartbeats.
    *
+   * @param threshold The phi failure threshold
    * @return Indicates whether the session has failed.
    */
-  public boolean isFailed() {
-    return failureDetector.phi() >= PHI_FAILURE_THRESHOLD;
+  public boolean isFailed(int threshold) {
+    return failureDetector.phi() >= threshold;
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/CloseSessionEntry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/CloseSessionEntry.java
@@ -23,8 +23,20 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Close session entry.
  */
 public class CloseSessionEntry extends SessionEntry {
-  public CloseSessionEntry(long term, long timestamp, long session) {
+  private final boolean expired;
+
+  public CloseSessionEntry(long term, long timestamp, long session, boolean expired) {
     super(term, timestamp, session);
+    this.expired = expired;
+  }
+
+  /**
+   * Returns whether the session is expired.
+   *
+   * @return Indicates whether the session is expired.
+   */
+  public boolean expired() {
+    return expired;
   }
 
   @Override
@@ -33,6 +45,7 @@ public class CloseSessionEntry extends SessionEntry {
         .add("term", term)
         .add("timestamp", new TimestampPrinter(timestamp))
         .add("session", session)
+        .add("expired", expired)
         .toString();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/OpenSessionEntry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/OpenSessionEntry.java
@@ -28,15 +28,17 @@ public class OpenSessionEntry extends TimestampedEntry {
   private final String serviceName;
   private final String serviceType;
   private final ReadConsistency readConsistency;
-  private final long timeout;
+  private final long minTimeout;
+  private final long maxTimeout;
 
-  public OpenSessionEntry(long term, long timestamp, String memberId, String serviceName, String serviceType, ReadConsistency readConsistency, long timeout) {
+  public OpenSessionEntry(long term, long timestamp, String memberId, String serviceName, String serviceType, ReadConsistency readConsistency, long minTimeout, long maxTimeout) {
     super(term, timestamp);
     this.memberId = memberId;
     this.serviceName = serviceName;
     this.serviceType = serviceType;
     this.readConsistency = readConsistency;
-    this.timeout = timeout;
+    this.minTimeout = minTimeout;
+    this.maxTimeout = maxTimeout;
   }
 
   /**
@@ -76,12 +78,21 @@ public class OpenSessionEntry extends TimestampedEntry {
   }
 
   /**
-   * Returns the session timeout.
+   * Returns the minimum session timeout.
    *
-   * @return The session timeout.
+   * @return The minimum session timeout.
    */
-  public long timeout() {
-    return timeout;
+  public long minTimeout() {
+    return minTimeout;
+  }
+
+  /**
+   * Returns the maximum session timeout.
+   *
+   * @return The maximum session timeout.
+   */
+  public long maxTimeout() {
+    return maxTimeout;
   }
 
   @Override
@@ -93,7 +104,8 @@ public class OpenSessionEntry extends TimestampedEntry {
         .add("serviceName", serviceName)
         .add("serviceType", serviceType)
         .add("readConsistency", readConsistency)
-        .add("timeout", timeout)
+        .add("minTimeout", minTimeout)
+        .add("maxTimeout", maxTimeout)
         .toString();
   }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftServerProtocol.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftServerProtocol.java
@@ -151,6 +151,11 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
     getClient(memberId).thenAccept(protocol -> protocol.publish(request));
   }
 
+  @Override
+  public CompletableFuture<HeartbeatResponse> heartbeat(MemberId memberId, HeartbeatRequest request) {
+    return getClient(memberId).thenCompose(protocol -> protocol.heartbeat(request));
+  }
+
   CompletableFuture<OpenSessionResponse> openSession(OpenSessionRequest request) {
     if (openSessionHandler != null) {
       return openSessionHandler.apply(request);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
@@ -118,6 +118,7 @@ public class RaftSessionRegistryTest {
         "test",
         ServiceType.from("test"),
         ReadConsistency.LINEARIZABLE,
+        100,
         5000,
         context,
         server,

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -106,11 +106,11 @@ public abstract class AbstractLogTest {
     // Append a couple entries.
     Indexed<RaftLogEntry> indexed;
     assertEquals(writer.getNextIndex(), 1);
-    indexed = writer.append(new OpenSessionEntry(1, System.currentTimeMillis(), "client", "test1", "test", ReadConsistency.LINEARIZABLE, 1000));
+    indexed = writer.append(new OpenSessionEntry(1, System.currentTimeMillis(), "client", "test1", "test", ReadConsistency.LINEARIZABLE, 100, 1000));
     assertEquals(indexed.index(), 1);
 
     assertEquals(writer.getNextIndex(), 2);
-    writer.append(new Indexed<>(2, new CloseSessionEntry(1, System.currentTimeMillis(), 1), 0));
+    writer.append(new Indexed<>(2, new CloseSessionEntry(1, System.currentTimeMillis(), 1, false), 0));
     reader.reset(2);
     indexed = reader.next();
     assertEquals(indexed.index(), 2);
@@ -124,7 +124,7 @@ public abstract class AbstractLogTest {
     assertEquals(openSession.entry().term(), 1);
     assertEquals(openSession.entry().serviceName(), "test1");
     assertEquals(openSession.entry().serviceType(), "test");
-    assertEquals(openSession.entry().timeout(), 1000);
+    assertEquals(openSession.entry().maxTimeout(), 1000);
     assertEquals(reader.getCurrentEntry(), openSession);
     assertEquals(reader.getCurrentIndex(), 1);
 
@@ -148,7 +148,7 @@ public abstract class AbstractLogTest {
     assertEquals(openSession.entry().term(), 1);
     assertEquals(openSession.entry().serviceName(), "test1");
     assertEquals(openSession.entry().serviceType(), "test");
-    assertEquals(openSession.entry().timeout(), 1000);
+    assertEquals(openSession.entry().maxTimeout(), 1000);
     assertEquals(reader.getCurrentEntry(), openSession);
     assertEquals(reader.getCurrentIndex(), 1);
     assertTrue(reader.hasNext());
@@ -174,7 +174,7 @@ public abstract class AbstractLogTest {
     assertEquals(openSession.entry().term(), 1);
     assertEquals(openSession.entry().serviceName(), "test1");
     assertEquals(openSession.entry().serviceType(), "test");
-    assertEquals(openSession.entry().timeout(), 1000);
+    assertEquals(openSession.entry().maxTimeout(), 1000);
     assertEquals(reader.getCurrentEntry(), openSession);
     assertEquals(reader.getCurrentIndex(), 1);
     assertTrue(reader.hasNext());
@@ -192,7 +192,7 @@ public abstract class AbstractLogTest {
     // Truncate the log and write a different entry.
     writer.truncate(1);
     assertEquals(writer.getNextIndex(), 2);
-    writer.append(new Indexed<>(2, new CloseSessionEntry(2, System.currentTimeMillis(), 1), 0));
+    writer.append(new Indexed<>(2, new CloseSessionEntry(2, System.currentTimeMillis(), 1, false), 0));
     reader.reset(2);
     indexed = reader.next();
     assertEquals(indexed.index(), 2);

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
@@ -33,6 +33,8 @@ import io.atomix.protocols.raft.protocol.CommandRequest;
 import io.atomix.protocols.raft.protocol.CommandResponse;
 import io.atomix.protocols.raft.protocol.ConfigureRequest;
 import io.atomix.protocols.raft.protocol.ConfigureResponse;
+import io.atomix.protocols.raft.protocol.HeartbeatRequest;
+import io.atomix.protocols.raft.protocol.HeartbeatResponse;
 import io.atomix.protocols.raft.protocol.InstallRequest;
 import io.atomix.protocols.raft.protocol.InstallResponse;
 import io.atomix.protocols.raft.protocol.JoinRequest;
@@ -135,6 +137,8 @@ public class RaftPerformanceTest implements Runnable {
   }
 
   private static final Serializer protocolSerializer = Serializer.using(KryoNamespace.newBuilder()
+      .register(HeartbeatRequest.class)
+      .register(HeartbeatResponse.class)
       .register(OpenSessionRequest.class)
       .register(OpenSessionResponse.class)
       .register(CloseSessionRequest.class)

--- a/tests/src/main/java/io/atomix/protocols/raft/protocol/LocalRaftServerProtocol.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/protocol/LocalRaftServerProtocol.java
@@ -152,6 +152,11 @@ public class LocalRaftServerProtocol extends LocalRaftProtocol implements RaftSe
     getClient(memberId).thenAccept(protocol -> protocol.publish(request.session(), encode(request)));
   }
 
+  @Override
+  public CompletableFuture<HeartbeatResponse> heartbeat(MemberId memberId, HeartbeatRequest request) {
+    return getClient(memberId).thenCompose(protocol -> protocol.heartbeat(encode(request))).thenApply(this::decode);
+  }
+
   CompletableFuture<byte[]> openSession(byte[] request) {
     if (openSessionHandler != null) {
       return openSessionHandler.apply(decode(request)).thenApply(this::encode);

--- a/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftClientMessagingProtocol.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftClientMessagingProtocol.java
@@ -66,6 +66,16 @@ public class RaftClientMessagingProtocol extends RaftMessagingProtocol implement
   }
 
   @Override
+  public void registerHeartbeatHandler(Function<HeartbeatRequest, CompletableFuture<HeartbeatResponse>> handler) {
+    registerHandler("heartbeat", handler);
+  }
+
+  @Override
+  public void unregisterHeartbeatHandler() {
+    unregisterHandler("heartbeat");
+  }
+
+  @Override
   public void reset(Collection<MemberId> members, ResetRequest request) {
     for (MemberId memberId : members) {
       sendAsync(memberId, String.format("reset-%d", request.session()), request);

--- a/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftServerMessagingProtocol.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftServerMessagingProtocol.java
@@ -115,6 +115,11 @@ public class RaftServerMessagingProtocol extends RaftMessagingProtocol implement
   }
 
   @Override
+  public CompletableFuture<HeartbeatResponse> heartbeat(MemberId memberId, HeartbeatRequest request) {
+    return sendAndReceive(memberId, "heartbeat", request);
+  }
+
+  @Override
   public void registerOpenSessionHandler(Function<OpenSessionRequest, CompletableFuture<OpenSessionResponse>> handler) {
     registerHandler("open-session", handler);
   }


### PR DESCRIPTION
This PR refactors how leadership elections and session expirations are handled in Raft.

It adds a phi accrual failure detector used to determine when to start a new election. In order to avoid multiple servers starting an election at the same time, randomized timers are used to check the current phi value. The Raft election timeout is used as a fallback to ensure the timeout doesn't surpass that point.

Sessions are also expired using phi accrual failure detectors. This is done by the leader sending heartbeats to clients. New sessions are opened with a minimum timeout, and the leader sends heartbeats to the clients at the rate of the minimum session timeout. Sending heartbeats from the leader to clients also ensures clients resolve new leaders as soon as possible. In order to account for the time period during which an old leader crash was being detected and a new leader was being elected, nodes track the last heartbeat time and subtract that time from session timeouts. This means sessions can be expired via the failure detector immediately after a leader change if the client can't be reached by the leader.