### PR TITLE
Ensure log writer positions are properly reset for empty segments

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -316,6 +316,7 @@ public class PassiveRole extends InactiveRole {
       Indexed<RaftLogEntry> indexed = writer.append(entry);
       log.trace("Appended {}", indexed);
     } catch (StorageException.OutOfDiskSpace e) {
+      log.trace("Append failed: {}", e);
       raft.getLogCompactor().compact();
       failAppend(index - 1, future);
       return false;

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -212,6 +213,33 @@ public abstract class AbstractLogTest {
     assertEquals(reader.getCurrentEntry(), closeSession);
     assertEquals(reader.getCurrentIndex(), 2);
     assertFalse(reader.hasNext());
+  }
+
+  @Test
+  public void testResetTruncateZero() throws Exception {
+    RaftLog log = createLog();
+    RaftLogWriter writer = log.writer();
+    RaftLogReader reader = log.openReader(1, RaftLogReader.Mode.ALL);
+
+    assertEquals(0, writer.getLastIndex());
+    writer.reset(1);
+    assertEquals(0, writer.getLastIndex());
+    writer.append(new InitializeEntry(1, System.currentTimeMillis()));
+    assertEquals(1, writer.getLastIndex());
+    assertEquals(1, writer.getLastEntry().index());
+
+    assertTrue(reader.hasNext());
+    assertEquals(1, reader.next().index());
+
+    writer.truncate(0);
+    assertEquals(0, writer.getLastIndex());
+    assertNull(writer.getLastEntry());
+    writer.append(new InitializeEntry(1, System.currentTimeMillis()));
+    assertEquals(1, writer.getLastIndex());
+    assertEquals(1, writer.getLastEntry().index());
+
+    assertTrue(reader.hasNext());
+    assertEquals(1, reader.next().index());
   }
 
   @Test

--- a/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
@@ -205,14 +205,14 @@ public class JournalSegmentWriter<E> implements JournalWriter<E> {
       return;
     }
 
+    // Reset the last entry.
+    lastEntry = null;
+
     // If the index is less than the segment index, clear the segment buffer.
     if (index < descriptor.index()) {
       buffer.zero().clear();
       return;
     }
-
-    // Reset the last entry.
-    lastEntry = null;
 
     // Reset the writer to the given index.
     reset(index);


### PR DESCRIPTION
This PR fixes a bug in the `RaftLog` wherein `RaftLogWriter`s do not properly reset indexes when `truncate`d to the beginning of a segment. This can result in inconsistencies in the Raft log when a follower has to truncate its log to the beginning of a segment. In that case, indexes in the log are no longer properly mapped until the node is restarted. The fix is simple: to ensure the `lastEntry` in the `JournalSegmentWriter` is `null` when the writer is truncated. 