### PR TITLE
Some README fixes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ bin/atomix server a:localhost:5000 --bootstrap a:localhost:5000 b:localhost:5001
 ```
 
 ```
-bin/atomix server a:localhost:5001 --bootstrap a:localhost:5000 b:localhost:5001 c:localhost:5002 --http-port 6001 --data-dir data/b
+bin/atomix server b:localhost:5001 --bootstrap a:localhost:5000 b:localhost:5001 c:localhost:5002 --http-port 6001 --data-dir data/b
 ```
 
 ```
-bin/atomix server a:localhost:5002 --bootstrap a:localhost:5000 b:localhost:5001 c:localhost:5002 --http-port 6002 --data-dir data/c
+bin/atomix server c:localhost:5002 --bootstrap a:localhost:5000 b:localhost:5001 c:localhost:5002 --http-port 6002 --data-dir data/c
 ```
 
 #### Start a client node
@@ -151,22 +151,22 @@ curl -XDELETE http://localhost:5678/v1/primitives/locks/my-lock
 
 #### Set a value in a map
 ```
-curl -XPUT http://localhost:5678/primitives/maps/my-map/foo -d value="Hello world!" -H "Content-Type: text/plain"
+curl -XPUT http://localhost:5678/v1/primitives/maps/my-map/foo -d value="Hello world!" -H "Content-Type: text/plain"
 ```
 
 #### Get a value in a map
 ```
-curl -XGET http://localhost:5678/primitives/maps/my-map/foo
+curl -XGET http://localhost:5678/v1/primitives/maps/my-map/foo
 ```
 
 #### Send an event
 ```
-curl -XPOST http://localhost:5678/events/something-happened -d "Something happened!" -H "Content-Type: text/plain"
+curl -XPOST http://localhost:5678/v1/events/something-happened -d "Something happened!" -H "Content-Type: text/plain"
 ```
 
 #### Receive events
 ```
-curl -XGET http://localhost:5678/events/something-happened
+curl -XGET http://localhost:5678/v1/events/something-happened
 ```
 
 ### Docker


### PR DESCRIPTION
- Node IDs in cluster CLI commands are all 'a' instead of 'a', 'b', 'c'
- CLI examples for map primitives and events missing /v1/ path component