### PR TITLE
Support for map getAllPresent operation.

### DIFF
--- a/primitives/src/main/java/io/atomix/primitives/map/AsyncConsistentMap.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/AsyncConsistentMap.java
@@ -25,6 +25,7 @@ import io.atomix.primitives.map.impl.MapUpdate;
 import io.atomix.time.Versioned;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
@@ -111,6 +112,18 @@ public interface AsyncConsistentMap<K, V> extends AsyncPrimitive, Transactional<
    * this map contains no mapping for the key
    */
   CompletableFuture<Versioned<V>> get(K key);
+
+  /**
+   * Returns a map of the values associated with the {@code keys} in this map. The returned map
+   * will only contain entries which already exist in the map.
+   * <p>
+   * Note that duplicate elements in {@code keys}, as determined by {@link Object#equals}, will be
+   * ignored.
+   *
+   * @param keys the keys whose associated values are to be returned
+   * @return the unmodifiable mapping of keys to values for the specified keys found in the map
+   */
+  CompletableFuture<Map<K, Versioned<V>>> getAllPresent(Iterable<K> keys);
 
   /**
    * Returns the value (and version) to which the specified key is mapped, or the provided

--- a/primitives/src/main/java/io/atomix/primitives/map/impl/DelegatingAsyncConsistentMap.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/impl/DelegatingAsyncConsistentMap.java
@@ -26,6 +26,7 @@ import io.atomix.time.Version;
 import io.atomix.time.Versioned;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -69,6 +70,11 @@ public class DelegatingAsyncConsistentMap<K, V>
   @Override
   public CompletableFuture<Versioned<V>> get(K key) {
     return delegateMap.get(key);
+  }
+
+  @Override
+  public CompletableFuture<Map<K, Versioned<V>>> getAllPresent(Iterable<K> keys) {
+    return delegateMap.getAllPresent(keys);
   }
 
   @Override

--- a/primitives/src/main/java/io/atomix/primitives/map/impl/DelegatingAsyncConsistentTreeMap.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/impl/DelegatingAsyncConsistentTreeMap.java
@@ -158,6 +158,11 @@ public class DelegatingAsyncConsistentTreeMap<K, V>
   }
 
   @Override
+  public CompletableFuture<Map<K, Versioned<V>>> getAllPresent(Iterable<K> keys) {
+    return delegateMap.getAllPresent(keys);
+  }
+
+  @Override
   public CompletableFuture<Versioned<V>> getOrDefault(K key, V defaultValue) {
     return delegateMap.getOrDefault(key, defaultValue);
   }

--- a/primitives/src/main/java/io/atomix/primitives/map/impl/NotNullAsyncConsistentMap.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/impl/NotNullAsyncConsistentMap.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.primitives.map.impl;
 
+import com.google.common.collect.ImmutableMap;
 import io.atomix.primitives.map.AsyncConsistentMap;
 import io.atomix.time.Versioned;
 
@@ -45,6 +46,13 @@ public class NotNullAsyncConsistentMap<K, V> extends DelegatingAsyncConsistentMa
   @Override
   public CompletableFuture<Versioned<V>> get(K key) {
     return super.get(key).thenApply(v -> v != null && v.value() == null ? null : v);
+  }
+
+  @Override
+  public CompletableFuture<Map<K, Versioned<V>>> getAllPresent(Iterable<K> keys) {
+    return super.getAllPresent(keys).thenApply(m -> ImmutableMap.copyOf(m.entrySet()
+            .stream().filter(e -> e.getValue().value() != null)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
   }
 
   @Override

--- a/primitives/src/main/java/io/atomix/primitives/map/impl/PartitionedAsyncConsistentMap.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/impl/PartitionedAsyncConsistentMap.java
@@ -16,6 +16,7 @@
 package io.atomix.primitives.map.impl;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.atomix.primitives.AsyncPrimitive;
@@ -30,6 +31,7 @@ import io.atomix.utils.Match;
 import io.atomix.utils.concurrent.Futures;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -94,6 +96,19 @@ public class PartitionedAsyncConsistentMap<K, V> implements AsyncConsistentMap<K
   @Override
   public CompletableFuture<Versioned<V>> get(K key) {
     return getMap(key).get(key);
+  }
+
+  @Override
+  public CompletableFuture<Map<K, Versioned<V>>> getAllPresent(Iterable<K> keys) {
+    return Futures.allOf(getMaps().stream().map(m -> m.getAllPresent(keys))
+            .collect(Collectors.toList()))
+            .thenApply(maps -> {
+      Map<K, Versioned<V>> result = new HashMap<>();
+      for (Map<K, Versioned<V>> map : maps) {
+        result.putAll(map);
+      }
+      return ImmutableMap.copyOf(result);
+    });
   }
 
   @Override

--- a/primitives/src/main/java/io/atomix/primitives/map/impl/RaftConsistentMap.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/impl/RaftConsistentMap.java
@@ -25,6 +25,7 @@ import io.atomix.primitives.map.MapEventListener;
 import io.atomix.primitives.map.impl.RaftConsistentMapOperations.ContainsKey;
 import io.atomix.primitives.map.impl.RaftConsistentMapOperations.ContainsValue;
 import io.atomix.primitives.map.impl.RaftConsistentMapOperations.Get;
+import io.atomix.primitives.map.impl.RaftConsistentMapOperations.GetAllPresent;
 import io.atomix.primitives.map.impl.RaftConsistentMapOperations.GetOrDefault;
 import io.atomix.primitives.map.impl.RaftConsistentMapOperations.Put;
 import io.atomix.primitives.map.impl.RaftConsistentMapOperations.Remove;
@@ -48,6 +49,7 @@ import io.atomix.utils.concurrent.Futures;
 
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -67,6 +69,7 @@ import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.CONTAINS
 import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.CONTAINS_VALUE;
 import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.ENTRY_SET;
 import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.GET;
+import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.GET_ALL_PRESENT;
 import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.GET_OR_DEFAULT;
 import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.IS_EMPTY;
 import static io.atomix.primitives.map.impl.RaftConsistentMapOperations.KEY_SET;
@@ -141,6 +144,19 @@ public class RaftConsistentMap extends AbstractRaftPrimitive implements AsyncCon
   @Override
   public CompletableFuture<Versioned<byte[]>> get(String key) {
     return proxy.invoke(GET, serializer()::encode, new Get(key), serializer()::decode);
+  }
+
+  @Override
+  public CompletableFuture<Map<String, Versioned<byte[]>>> getAllPresent(Iterable<String> keys) {
+    Set<String> uniqueKeys = new HashSet<>();
+    for (String key : keys) {
+      uniqueKeys.add(key);
+    }
+    return proxy.invoke(
+            GET_ALL_PRESENT,
+            serializer()::encode,
+            new GetAllPresent(uniqueKeys),
+            serializer()::decode);
   }
 
   @Override

--- a/primitives/src/main/java/io/atomix/primitives/map/impl/RaftConsistentMapOperations.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/impl/RaftConsistentMapOperations.java
@@ -24,6 +24,8 @@ import io.atomix.serializer.kryo.KryoNamespaces;
 import io.atomix.time.Versioned;
 import io.atomix.utils.ArraySizeHashPrinter;
 
+import java.util.Set;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -36,6 +38,7 @@ public enum RaftConsistentMapOperations implements OperationId {
   CONTAINS_KEY("containsKey", OperationType.QUERY),
   CONTAINS_VALUE("containsValue", OperationType.QUERY),
   GET("get", OperationType.QUERY),
+  GET_ALL_PRESENT("getAllPresent", OperationType.QUERY),
   GET_OR_DEFAULT("getOrDefault", OperationType.QUERY),
   KEY_SET("keySet", OperationType.QUERY),
   VALUES("values", OperationType.QUERY),
@@ -82,6 +85,7 @@ public enum RaftConsistentMapOperations implements OperationId {
       .register(ContainsKey.class)
       .register(ContainsValue.class)
       .register(Get.class)
+      .register(GetAllPresent.class)
       .register(GetOrDefault.class)
       .register(Put.class)
       .register(Remove.class)
@@ -531,6 +535,37 @@ public enum RaftConsistentMapOperations implements OperationId {
 
     public Get(String key) {
       super(key);
+    }
+  }
+
+  /**
+   * Get all present query.
+   */
+  @SuppressWarnings("serial")
+  public static class GetAllPresent extends MapOperation {
+    private Set<String> keys;
+
+    public GetAllPresent() {
+    }
+
+    public GetAllPresent(Set<String> keys) {
+      this.keys = keys;
+    }
+
+    /**
+     * Returns the keys.
+     *
+     * @return the keys
+     */
+    public Set<String> keys() {
+      return keys;
+    }
+
+    @Override
+    public String toString() {
+      return toStringHelper(this)
+              .add("keys", keys)
+              .toString();
     }
   }
 

--- a/primitives/src/main/java/io/atomix/primitives/map/impl/TranscodingAsyncConsistentMap.java
+++ b/primitives/src/main/java/io/atomix/primitives/map/impl/TranscodingAsyncConsistentMap.java
@@ -16,6 +16,7 @@
 
 package io.atomix.primitives.map.impl;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.atomix.primitives.TransactionId;
 import io.atomix.primitives.TransactionLog;
@@ -27,6 +28,7 @@ import io.atomix.time.Versioned;
 import io.atomix.utils.concurrent.Futures;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -103,6 +105,22 @@ public class TranscodingAsyncConsistentMap<K1, V1, K2, V2> implements AsyncConsi
   public CompletableFuture<Versioned<V1>> get(K1 key) {
     try {
       return backingMap.get(keyEncoder.apply(key)).thenApply(versionedValueTransform);
+    } catch (Exception e) {
+      return Futures.exceptionalFuture(e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Map<K1, Versioned<V1>>> getAllPresent(Iterable<K1> keys) {
+    try {
+      Set<K2> uniqueKeys = new HashSet<>();
+      for (K1 key : keys) {
+        uniqueKeys.add(keyEncoder.apply(key));
+      }
+      return backingMap.getAllPresent(uniqueKeys).thenApply(
+              entries -> ImmutableMap.copyOf(entries.entrySet().stream()
+                      .collect(Collectors.toMap(o -> keyDecoder.apply(o.getKey()),
+                              o -> versionedValueTransform.apply(o.getValue())))));
     } catch (Exception e) {
       return Futures.exceptionalFuture(e);
     }

--- a/primitives/src/test/java/io/atomix/primitives/map/impl/RaftConsistentMapTest.java
+++ b/primitives/src/test/java/io/atomix/primitives/map/impl/RaftConsistentMapTest.java
@@ -29,6 +29,7 @@ import io.atomix.time.Versioned;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -172,6 +173,12 @@ public class RaftConsistentMapTest extends AbstractRaftPrimitiveTest<RaftConsist
     map.putIfAbsent("foo", "Hello foo again!".getBytes()).thenAccept(result -> {
       assertNotNull(result);
       assertTrue(Arrays.equals(Versioned.valueOrElse(result, null), rawFooValue));
+    }).join();
+
+    map.getAllPresent(Collections.singleton("foo")).thenAccept(result -> {
+      assertNotNull(result);
+      assertTrue(result.size() == 1);
+      assertTrue(Arrays.equals(result.get("foo").value(), rawFooValue));
     }).join();
 
     map.putIfAbsent("bar", rawBarValue).thenAccept(result -> {

--- a/primitives/src/test/java/io/atomix/primitives/map/impl/RaftConsistentTreeMapTest.java
+++ b/primitives/src/test/java/io/atomix/primitives/map/impl/RaftConsistentTreeMapTest.java
@@ -97,6 +97,11 @@ public class RaftConsistentTreeMapTest extends AbstractRaftPrimitiveTest<RaftCon
     allKeys.forEach(key -> map.get(key).
         thenAccept(result -> assertNull(result)).join());
 
+    // test getAllPresent
+    map.getAllPresent(allKeys).thenAccept(m -> {
+      assertTrue(m.isEmpty());
+    }).join();
+
     //test getOrDefault
     allKeys.forEach(key -> map.getOrDefault(key, null).thenAccept(result -> {
       assertEquals(0, result.version());
@@ -124,6 +129,13 @@ public class RaftConsistentTreeMapTest extends AbstractRaftPrimitiveTest<RaftCon
     allKeys.forEach(key -> map.get(key).thenAccept(result -> {
       assertArrayEquals(allValues.get(allKeys.indexOf(key)), result.value());
     }).join());
+
+    // test getAllPresent
+    map.getAllPresent(allKeys).thenAccept(m -> {
+      allKeys.forEach(key -> {
+        assertArrayEquals(allValues.get(allKeys.indexOf(key)), m.get(key).value());
+      });
+    }).join();
 
     allKeys.forEach(key -> map.getOrDefault(key, null).thenAccept(result -> {
       assertNotEquals(0, result.version());


### PR DESCRIPTION
In cases where one needs to check hundreds of entries are contained and / or what their values are in a distributed map iterating and collecting all futures is not optimal and can instead be done in a single operation (getAllPresent).