### PR TITLE
Fix log warning log format

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultRaftServiceExecutor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultRaftServiceExecutor.java
@@ -126,7 +126,7 @@ public class DefaultRaftServiceExecutor implements RaftServiceExecutor {
       try {
         return callback.apply(commit);
       } catch (Exception e) {
-        log.warn("State machine operation failed: {}", e);
+        log.warn("State machine operation failed: {}", e.getMessage());
         throw new RaftException.ApplicationException(e);
       } finally {
         runTasks();


### PR DESCRIPTION
Was leaving log entry like: 

 

> 2017-11-17 21:22:07,012 | WARN  | r-partition-1-18 | DefaultRaftServiceExecutor       | 90 - io.atomix - 2.0.6 | RaftService{645}{type=DOCUMENT_TREE-INSERTION, name=config-key-store} - State machine operation failed: {}