### PR TITLE
Use operation/event names in Raft sessions

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/event/EventType.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/event/EventType.java
@@ -32,4 +32,14 @@ public interface EventType extends Identifier<String> {
   static EventType from(String name) {
     return new DefaultEventType(name);
   }
+
+  /**
+   * Simplifies the given event type.
+   *
+   * @param eventType the event type to simplify
+   * @return the simplified event type
+   */
+  static EventType simplify(EventType eventType) {
+    return new DefaultEventType(eventType.id());
+  }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/event/impl/DefaultEventType.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/event/impl/DefaultEventType.java
@@ -28,4 +28,9 @@ public class DefaultEventType extends AbstractIdentifier<String> implements Even
   public DefaultEventType(String value) {
     super(value);
   }
+
+  @Override
+  public boolean equals(Object object) {
+    return object instanceof EventType && ((EventType) object).id().equals(id());
+  }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/operation/OperationId.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/operation/OperationId.java
@@ -55,6 +55,16 @@ public interface OperationId extends Identifier<String> {
   }
 
   /**
+   * Simplifies the given operation identifier.
+   *
+   * @param operationId the operation identifier to simplify
+   * @return the simplified operation identifier
+   */
+  static OperationId simplify(OperationId operationId) {
+    return new DefaultOperationId(operationId.id(), operationId.type());
+  }
+
+  /**
    * Returns the operation type.
    *
    * @return the operation type

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/operation/impl/DefaultOperationId.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/operation/impl/DefaultOperationId.java
@@ -19,8 +19,6 @@ import io.atomix.protocols.raft.operation.OperationId;
 import io.atomix.protocols.raft.operation.OperationType;
 import io.atomix.utils.AbstractIdentifier;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
 /**
  * Raft operation identifier.
  */
@@ -47,9 +45,6 @@ public class DefaultOperationId extends AbstractIdentifier<String> implements Op
 
   @Override
   public String toString() {
-    return toStringHelper(this)
-        .add("id", id())
-        .add("type", type())
-        .toString();
+    return id();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyExecutor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyExecutor.java
@@ -80,7 +80,7 @@ public interface RaftProxyExecutor {
    * @throws NullPointerException if {@code command} is null
    */
   default CompletableFuture<byte[]> execute(OperationId operationId) {
-    return execute(new RaftOperation(operationId, HeapBytes.EMPTY));
+    return execute(new RaftOperation(OperationId.simplify(operationId), HeapBytes.EMPTY));
   }
 
   /**
@@ -92,7 +92,7 @@ public interface RaftProxyExecutor {
    * @throws NullPointerException if {@code command} is null
    */
   default CompletableFuture<byte[]> execute(OperationId operationId, byte[] operation) {
-    return execute(new RaftOperation(operationId, operation));
+    return execute(new RaftOperation(OperationId.simplify(operationId), operation));
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DelegatingRaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DelegatingRaftProxy.java
@@ -90,7 +90,7 @@ public class DelegatingRaftProxy implements RaftProxy {
   @Override
   public void addEventListener(EventType eventType, Runnable listener) {
     Consumer<RaftEvent> wrappedListener = e -> {
-      if (e.type().equals(eventType)) {
+      if (e.type().id().equals(eventType.id())) {
         listener.run();
       }
     };
@@ -101,7 +101,7 @@ public class DelegatingRaftProxy implements RaftProxy {
   @Override
   public void addEventListener(EventType eventType, Consumer<byte[]> listener) {
     Consumer<RaftEvent> wrappedListener = e -> {
-      if (e.type().equals(eventType)) {
+      if (e.type().id().equals(eventType.id())) {
         listener.accept(e.value());
       }
     };
@@ -112,7 +112,7 @@ public class DelegatingRaftProxy implements RaftProxy {
   @Override
   public <T> void addEventListener(EventType eventType, Function<byte[], T> decoder, Consumer<T> listener) {
     Consumer<RaftEvent> wrappedListener = e -> {
-      if (e.type().equals(eventType)) {
+      if (e.type().id().equals(eventType.id())) {
         listener.accept(decoder.apply(e.value()));
       }
     };

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultRaftServiceExecutor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultRaftServiceExecutor.java
@@ -48,7 +48,7 @@ public class DefaultRaftServiceExecutor implements RaftServiceExecutor {
   private final Queue<Runnable> tasks = new LinkedList<>();
   private final List<ScheduledTask> scheduledTasks = new ArrayList<>();
   private final List<ScheduledTask> complete = new ArrayList<>();
-  private final Map<OperationId, Function<Commit<byte[]>, byte[]>> operations = new HashMap<>();
+  private final Map<String, Function<Commit<byte[]>, byte[]>> operations = new HashMap<>();
   private OperationType operationType;
   private long timestamp;
 
@@ -114,7 +114,7 @@ public class DefaultRaftServiceExecutor implements RaftServiceExecutor {
   public void handle(OperationId operationId, Function<Commit<byte[]>, byte[]> callback) {
     checkNotNull(operationId, "operationId cannot be null");
     checkNotNull(callback, "callback cannot be null");
-    operations.put(operationId, callback);
+    operations.put(operationId.id(), callback);
     log.debug("Registered operation callback {}", operationId);
   }
 
@@ -125,7 +125,7 @@ public class DefaultRaftServiceExecutor implements RaftServiceExecutor {
     prepareOperation(commit);
 
     // Look up the registered callback for the operation.
-    Function<Commit<byte[]>, byte[]> callback = operations.get(commit.operation());
+    Function<Commit<byte[]>, byte[]> callback = operations.get(commit.operation().id());
 
     if (callback == null) {
       throw new IllegalStateException("Unknown state machine operation: " + commit.operation());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -158,7 +158,7 @@ public interface RaftSession {
    * @throws NullPointerException if the event is {@code null}
    */
   default void publish(EventType eventType, byte[] event) {
-    publish(new RaftEvent(eventType, event));
+    publish(new RaftEvent(EventType.simplify(eventType), event));
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -781,7 +781,7 @@ public class RaftTest extends ConcurrentTestCase {
     AtomicLong index = new AtomicLong();
 
     RaftClient client = createClient();
-    RaftProxy session = createSession(client);
+    RaftProxy session = createSession(client, consistency);
     session.<Long>addEventListener(CHANGE_EVENT, clientSerializer::decode, event -> {
       threadAssertEquals(counter.incrementAndGet(), 3);
       threadAssertTrue(event >= index.get());


### PR DESCRIPTION
Use operation/event names rather than serializing `OperationId` and `EventType` objects to reduce the serialization configuration for Raft clients/servers. This is also necessary to ensure Atomix 2.0 is compatible with the changes coming in Atomix 2.1.