### PR TITLE
Avoid repeated expiration of sessions on heartbeat failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
 branches:
   only:
     - master
+    - 2.0
 
 script:
   - mvn test -Droot.logging.level=INFO

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -449,7 +449,6 @@ public class RaftServiceManager implements AutoCloseable {
 
     // If the server session is null, the session either never existed or already expired.
     if (session == null) {
-      logger.warn("Unknown session: " + entry.entry().session());
       return Futures.exceptionalFuture(new RaftException.UnknownSession("Unknown session: " + entry.entry().session()));
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -292,7 +292,7 @@ public final class LeaderRole extends ActiveRole {
               if (isOpen()) {
                 if (commitError == null) {
                   raft.getStateMachine().<Long>apply(entry.index())
-                      .whenComplete((r, e) -> expiring.remove(session.sessionId()));
+                      .whenCompleteAsync((r, e) -> expiring.remove(session.sessionId()), raft.getThreadContext());
                 } else {
                   expiring.remove(session.sessionId());
                 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft.roles;
 
+import com.google.common.collect.Sets;
 import io.atomix.protocols.raft.RaftError;
 import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.RaftServer;
@@ -53,6 +54,7 @@ import io.atomix.protocols.raft.protocol.TransferRequest;
 import io.atomix.protocols.raft.protocol.TransferResponse;
 import io.atomix.protocols.raft.protocol.VoteRequest;
 import io.atomix.protocols.raft.protocol.VoteResponse;
+import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.protocols.raft.session.impl.RaftSessionContext;
 import io.atomix.protocols.raft.storage.log.entry.CloseSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.CommandEntry;
@@ -75,6 +77,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
@@ -88,6 +91,7 @@ public final class LeaderRole extends ActiveRole {
   private final LeaderAppender appender;
   private Scheduled appendTimer;
   private final Map<MemberId, Scheduled> heartbeatTimers = new HashMap<>();
+  private final Set<SessionId> expiring = Sets.newHashSet();
   private long configuring;
   private boolean transferring;
 
@@ -273,21 +277,29 @@ public final class LeaderRole extends ActiveRole {
    * Expires the given session.
    */
   private void expireSession(RaftSessionContext session) {
-    log.debug("Expiring session due to heartbeat failure: {}", session);
-    appendAndCompact(new CloseSessionEntry(raft.getTerm(), System.currentTimeMillis(), session.sessionId().id(), true))
-        .whenCompleteAsync((entry, error) -> {
-          if (error != null) {
-            return;
-          }
-
-          log.trace("Appended {}", entry);
-          appender.appendEntries(entry.index()).whenComplete((commitIndex, commitError) -> {
-            raft.checkThread();
-            if (isOpen() && commitError == null) {
-              raft.getStateMachine().<Long>apply(entry.index());
+    if (expiring.add(session.sessionId())) {
+      log.debug("Expiring session due to heartbeat failure: {}", session);
+      appendAndCompact(new CloseSessionEntry(raft.getTerm(), System.currentTimeMillis(), session.sessionId().id(), true))
+          .whenCompleteAsync((entry, error) -> {
+            if (error != null) {
+              expiring.remove(session.sessionId());
+              return;
             }
-          });
-        }, raft.getThreadContext());
+
+            log.trace("Appended {}", entry);
+            appender.appendEntries(entry.index()).whenComplete((commitIndex, commitError) -> {
+              raft.checkThread();
+              if (isOpen()) {
+                if (commitError == null) {
+                  raft.getStateMachine().<Long>apply(entry.index())
+                      .whenComplete((r, e) -> expiring.remove(session.sessionId()));
+                } else {
+                  expiring.remove(session.sessionId());
+                }
+              }
+            });
+          }, raft.getThreadContext());
+    }
   }
 
   /**


### PR DESCRIPTION
This PR ensures that leaders don't repeatedly attempt to expire the same session while waiting for an existing expiration change to be committed and applied. We do this by adding the `SessionId` to a `Set` prior to appending/replicating the `CloseSessionEntry` and only removing the `SessionId` once it has been committed/applied or failed to be committed.