### PR TITLE
Ensure dynamic leader election timer is recurring

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -67,7 +67,7 @@ public final class FollowerRole extends ActiveRole {
   private void startHeartbeatTimer() {
     log.trace("Starting heartbeat timer");
     AtomicLong lastHeartbeat = new AtomicLong();
-    heartbeatTimer = raft.getThreadContext().schedule(raft.getHeartbeatInterval(), () -> {
+    heartbeatTimer = raft.getThreadContext().schedule(raft.getHeartbeatInterval(), raft.getHeartbeatInterval(), () -> {
       if (raft.getLastHeartbeatTime() > lastHeartbeat.get()) {
         failureDetector.report(raft.getLastHeartbeatTime());
       }
@@ -84,7 +84,8 @@ public final class FollowerRole extends ActiveRole {
         .plus(Duration.ofMillis(random.nextInt((int) raft.getHeartbeatInterval().dividedBy(2).toMillis())));
     heartbeatTimeout = raft.getThreadContext().schedule(delay, () -> {
       if (isOpen()) {
-        if (System.currentTimeMillis() - raft.getLastHeartbeatTime() > raft.getElectionTimeout().toMillis() || failureDetector.phi() >= raft.getElectionThreshold()) {
+        if (System.currentTimeMillis() - raft.getLastHeartbeatTime() > raft.getElectionTimeout().toMillis()
+            || failureDetector.phi() >= raft.getElectionThreshold()) {
           log.debug("Heartbeat timed out in {}", System.currentTimeMillis() - raft.getLastHeartbeatTime());
           sendPollRequests();
         } else {


### PR DESCRIPTION
Currently, leader election timeouts based on the phi accrual failure detector are not working correctly because the failure timer is not properly recurring. This severely extends the time it takes to elect new Raft leaders and can lead to timeouts on clients. This PR simply changes the timer to a recurring one.