### PR TITLE
Reset connection leader after requests to all nodes fail.

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/MemberSelector.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/MemberSelector.java
@@ -15,13 +15,14 @@
  */
 package io.atomix.protocols.raft.proxy.impl;
 
+import com.google.common.collect.Lists;
 import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -68,7 +69,7 @@ public final class MemberSelector implements Iterator<MemberId>, AutoCloseable {
     this.members = checkNotNull(members, "servers cannot be null");
     this.strategy = checkNotNull(strategy, "strategy cannot be null");
     this.selectors = checkNotNull(selectors, "selectors cannot be null");
-    this.selections = strategy.selectConnections(leader, new ArrayList<>(members));
+    this.selections = strategy.selectConnections(leader, Lists.newLinkedList(members));
   }
 
   /**
@@ -120,7 +121,7 @@ public final class MemberSelector implements Iterator<MemberId>, AutoCloseable {
    */
   public MemberSelector reset() {
     if (selectionsIterator != null) {
-      this.selections = strategy.selectConnections(leader, new ArrayList<>(members));
+      this.selections = strategy.selectConnections(leader, Lists.newLinkedList(members));
       this.selectionsIterator = null;
     }
     return this;
@@ -136,7 +137,7 @@ public final class MemberSelector implements Iterator<MemberId>, AutoCloseable {
     if (changed(leader, members)) {
       this.leader = leader;
       this.members = members;
-      this.selections = strategy.selectConnections(leader, new ArrayList<>(members));
+      this.selections = strategy.selectConnections(leader, Lists.newLinkedList(members));
       this.selectionsIterator = null;
     }
     return this;
@@ -145,18 +146,15 @@ public final class MemberSelector implements Iterator<MemberId>, AutoCloseable {
   /**
    * Returns a boolean value indicating whether the selector state would be changed by the given members.
    */
-  private boolean changed(MemberId leader, Collection<MemberId> servers) {
-    checkNotNull(servers, "servers");
-    checkArgument(!servers.isEmpty(), "servers cannot be empty");
-    if (this.leader != null && leader == null) {
+  private boolean changed(MemberId leader, Collection<MemberId> members) {
+    checkNotNull(members, "servers");
+    checkArgument(!members.isEmpty(), "servers cannot be empty");
+    if (leader != null) {
+      checkArgument(members.contains(leader), "leader must be present in members list");
+    }
+    if (!Objects.equals(this.leader, leader)) {
       return true;
-    } else if (this.leader == null && leader != null) {
-      checkArgument(servers.contains(leader), "leader must be present in the servers list");
-      return true;
-    } else if (this.leader != null && !this.leader.equals(leader)) {
-      checkArgument(servers.contains(leader), "leader must be present in the servers list");
-      return true;
-    } else if (!matches(this.members, servers)) {
+    } else if (!matches(this.members, members)) {
       return true;
     }
     return false;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/MemberSelectorManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/MemberSelectorManager.java
@@ -15,12 +15,12 @@
  */
 package io.atomix.protocols.raft.proxy.impl;
 
+import com.google.common.collect.Lists;
 import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -77,8 +77,8 @@ public final class MemberSelectorManager {
    */
   public void resetAll(MemberId leader, Collection<MemberId> members) {
     this.leader = leader;
-    this.members = new LinkedList<>(members);
-    selectors.forEach(s -> s.reset(leader, members));
+    this.members = Lists.newLinkedList(members);
+    selectors.forEach(s -> s.reset(leader, this.members));
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
@@ -276,7 +276,7 @@ public class RaftProxyConnection {
 
     if (!selector.hasNext()) {
       log.debug("Failed to connect to the cluster");
-      selector.reset();
+      selector.reset(null, selector.members());
       return null;
     } else {
       this.member = selector.next();


### PR DESCRIPTION
This PR fixes an inefficiency in which clients that are connected to leaders fail to locate new leaders after an existing leader is unavailable. We forget about any existing leader in the event requests to all nodes fail to ensure the client attempts future requests to all nodes until a leader is rediscovered.