### PR TITLE
Ensure operations are retried on 'ClosedSession' errors

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RetryingRaftProxyClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RetryingRaftProxyClient.java
@@ -49,7 +49,8 @@ public class RetryingRaftProxyClient extends DelegatingRaftProxyClient {
           || e instanceof ClosedChannelException
           || e instanceof RaftException.QueryFailure
           || e instanceof RaftException.UnknownClient
-          || e instanceof RaftException.UnknownSession;
+          || e instanceof RaftException.UnknownSession
+          || e instanceof RaftException.ClosedSession;
 
   public RetryingRaftProxyClient(RaftProxyClient delegate, Scheduler scheduler, int maxRetries, Duration delayBetweenRetries) {
     super(delegate);


### PR DESCRIPTION
Adds the `ClosedSession` exception to `RetryingRaftProxyClient` to ensure operations rejected after a session has been closed can be retried.