### PR TITLE
Reset connection but do not remove leader after disconnection

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
@@ -276,7 +276,7 @@ public class RaftProxyConnection {
 
     if (!selector.hasNext()) {
       log.debug("Failed to connect to the cluster");
-      selector.reset(null, selector.members());
+      selector.reset();
       return null;
     } else {
       this.member = selector.next();


### PR DESCRIPTION
The change to forget the leader after requests to all Raft nodes fails appears to in some cases cause hanging at startup. In the interest of stability and because this is merely an optimization, this one line should be reverted and the issue should be further investigated separately.