### PR TITLE
Ensure sessions are not expired prior to being registered

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -269,10 +269,10 @@ public class RaftServiceManager implements AutoCloseable {
         readConsistency,
         minTimeout,
         maxTimeout,
+        sessionTimestamp,
         service,
         raft,
         threadContextFactory);
-    session.setLastUpdated(sessionTimestamp);
     session.setRequestSequence(reader.readLong());
     session.setCommandSequence(reader.readLong());
     session.setEventIndex(reader.readLong());
@@ -434,10 +434,10 @@ public class RaftServiceManager implements AutoCloseable {
         entry.entry().readConsistency(),
         entry.entry().minTimeout(),
         entry.entry().maxTimeout(),
+        entry.entry().timestamp(),
         service,
         raft,
         threadContextFactory);
-    session.setLastUpdated(entry.entry().timestamp());
     raft.getSessions().addSession(session);
     return service.openSession(entry.index(), entry.entry().timestamp(), session);
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -236,7 +236,7 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Restores the sessions associated with the given snapshot and service.
    *
-   * @param reader the snapshot reader
+   * @param reader  the snapshot reader
    * @param service the restored service
    */
   private void restoreSessions(SnapshotReader reader, DefaultServiceContext service) {
@@ -250,7 +250,7 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Restores the next session in the given snapshot for the given service.
    *
-   * @param reader the snapshot reader
+   * @param reader  the snapshot reader
    * @param service the restored service
    */
   private void restoreSession(SnapshotReader reader, DefaultServiceContext service) {
@@ -278,7 +278,7 @@ public class RaftServiceManager implements AutoCloseable {
     session.setEventIndex(reader.readLong());
     session.setLastCompleted(reader.readLong());
     session.setLastApplied(reader.snapshot().index());
-    raft.getSessions().registerSession(session);
+    raft.getSessions().addSession(session);
   }
 
   /**
@@ -437,7 +437,8 @@ public class RaftServiceManager implements AutoCloseable {
         service,
         raft,
         threadContextFactory);
-    raft.getSessions().registerSession(session);
+    session.setLastUpdated(entry.entry().timestamp());
+    raft.getSessions().addSession(session);
     return service.openSession(entry.index(), entry.entry().timestamp(), session);
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -210,7 +210,7 @@ public class DefaultServiceContext implements ServiceContext {
     for (RaftSessionContext session : sessions.getSessions()) {
       if (session.isTimedOut(timestamp)) {
         log.debug("Session expired in {} milliseconds: {}", timestamp - session.getLastUpdated(), session);
-        log.debug("Closing session {}", session.sessionId());
+        session.expire();
         sessions.expireSession(session);
       }
     }
@@ -388,9 +388,6 @@ public class DefaultServiceContext implements ServiceContext {
     CompletableFuture<Long> future = new CompletableFuture<>();
     serviceExecutor.execute(() -> {
       log.debug("Opening session {}", session.sessionId());
-
-      // Open the session at the current timestamp.
-      session.open(timestamp);
 
       // Update the state machine index/timestamp.
       tick(index, timestamp);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -389,8 +389,8 @@ public class DefaultServiceContext implements ServiceContext {
     serviceExecutor.execute(() -> {
       log.debug("Opening session {}", session.sessionId());
 
-      // Update the session's timestamp to prevent it from being expired.
-      session.setLastUpdated(timestamp);
+      // Open the session at the current timestamp.
+      session.open(timestamp);
 
       // Update the state machine index/timestamp.
       tick(index, timestamp);
@@ -473,7 +473,7 @@ public class DefaultServiceContext implements ServiceContext {
   /**
    * Completes a keep-alive.
    *
-   * @param index the keep-alive index
+   * @param index     the keep-alive index
    * @param timestamp the keep-alive timestamp
    * @return future to be completed once the keep alive is completed
    */
@@ -500,7 +500,7 @@ public class DefaultServiceContext implements ServiceContext {
   /**
    * Keeps all sessions alive using the given timestamp.
    *
-   * @param index the index of the timestamp
+   * @param index     the index of the timestamp
    * @param timestamp the timestamp with which to reset session timeouts
    * @return future to be completed once all sessions have been preserved
    */
@@ -570,7 +570,7 @@ public class DefaultServiceContext implements ServiceContext {
    * @param timestamp The timestamp of the command.
    * @param sequence  The command sequence number.
    * @param session   The session that submitted the command.
-   * @param operation   The command to execute.
+   * @param operation The command to execute.
    * @return A future to be completed with the command result.
    */
   public CompletableFuture<OperationResult> executeCommand(long index, long sequence, long timestamp, RaftSessionContext session, RaftOperation operation) {
@@ -594,6 +594,7 @@ public class DefaultServiceContext implements ServiceContext {
 
     // If the session is not open, fail the request.
     if (!session.getState().active()) {
+      log.warn("Session not open: {}", session);
       future.completeExceptionally(new RaftException.UnknownSession("Unknown session: " + session.sessionId()));
       return;
     }
@@ -602,6 +603,7 @@ public class DefaultServiceContext implements ServiceContext {
     // we've received a command that was previously applied to the state machine. Ensure linearizability by
     // returning the cached response instead of applying it to the user defined state machine.
     if (sequence > 0 && sequence < session.nextCommandSequence()) {
+      log.trace("Returning cached result for command with sequence number {} < {}", sequence, session.nextCommandSequence());
       sequenceCommand(index, sequence, session, future);
     }
     // If we've made it this far, the command must have been applied in the proper order as sequenced by the
@@ -666,7 +668,7 @@ public class DefaultServiceContext implements ServiceContext {
    * @param sequence  The query sequence number.
    * @param timestamp The timestamp of the query.
    * @param session   The session that submitted the query.
-   * @param operation     The query to execute.
+   * @param operation The query to execute.
    * @return A future to be completed with the query result.
    */
   public CompletableFuture<OperationResult> executeQuery(long index, long sequence, long timestamp, RaftSessionContext session, RaftOperation operation) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -210,7 +210,6 @@ public class DefaultServiceContext implements ServiceContext {
     for (RaftSessionContext session : sessions.getSessions()) {
       if (session.isTimedOut(timestamp)) {
         log.debug("Session expired in {} milliseconds: {}", timestamp - session.getLastUpdated(), session);
-        session.expire();
         sessions.expireSession(session);
       }
     }
@@ -275,10 +274,10 @@ public class DefaultServiceContext implements ServiceContext {
               readConsistency,
               minTimeout,
               maxTimeout,
+              sessionTimestamp,
               this,
               raft,
               threadContextFactory);
-          session.setLastUpdated(sessionTimestamp);
           session.setRequestSequence(reader.readLong());
           session.setCommandSequence(reader.readLong());
           session.setEventIndex(reader.readLong());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -90,6 +90,7 @@ public class RaftSessionContext implements RaftSession {
       ReadConsistency readConsistency,
       long minTimeout,
       long maxTimeout,
+      long lastUpdated,
       DefaultServiceContext context,
       RaftContext server,
       ThreadContextFactory threadContextFactory) {
@@ -100,6 +101,7 @@ public class RaftSessionContext implements RaftSession {
     this.readConsistency = readConsistency;
     this.minTimeout = minTimeout;
     this.maxTimeout = maxTimeout;
+    this.lastUpdated = lastUpdated;
     this.eventIndex = sessionId.id();
     this.completeIndex = sessionId.id();
     this.lastApplied = sessionId.id();

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -564,9 +564,8 @@ public class RaftSessionContext implements RaftSession {
   /**
    * Opens the session.
    */
-  public void open(long timestamp) {
+  public void open() {
     setState(State.OPEN);
-    setLastUpdated(timestamp);
     protocol.registerResetListener(sessionId, request -> resendEvents(request.index()), context.executor());
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -65,7 +65,7 @@ public class RaftSessionContext implements RaftSession {
   private final DefaultServiceContext context;
   private final RaftContext server;
   private final ThreadContext eventExecutor;
-  private volatile State state = State.OPEN;
+  private volatile State state = State.CLOSED;
   private volatile long lastUpdated;
   private long lastHeartbeat;
   private PhiAccrualFailureDetector failureDetector = new PhiAccrualFailureDetector();
@@ -112,7 +112,6 @@ public class RaftSessionContext implements RaftSession {
         .add("type", context.serviceType())
         .add("name", context.serviceName())
         .build());
-    protocol.registerResetListener(sessionId, request -> resendEvents(request.index()), context.executor());
   }
 
   @Override
@@ -560,6 +559,15 @@ public class RaftSessionContext implements RaftSession {
         protocol.publish(member, request);
       });
     }
+  }
+
+  /**
+   * Opens the session.
+   */
+  public void open(long timestamp) {
+    setState(State.OPEN);
+    setLastUpdated(timestamp);
+    protocol.registerResetListener(sessionId, request -> resendEvents(request.index()), context.executor());
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistry.java
@@ -111,6 +111,7 @@ public class RaftSessionRegistry {
   public Collection<RaftSessionContext> getSessions(ServiceId serviceId) {
     return sessions.values().stream()
         .filter(session -> session.getService().serviceId().equals(serviceId))
+        .filter(session -> session.getState().active())
         .collect(Collectors.toSet());
   }
 
@@ -126,7 +127,7 @@ public class RaftSessionRegistry {
   /**
    * Adds a session listener.
    *
-   * @param serviceId the service ID for which to listen to sessions
+   * @param serviceId       the service ID for which to listen to sessions
    * @param sessionListener the session listener
    */
   public void addListener(ServiceId serviceId, RaftSessionListener sessionListener) {
@@ -137,7 +138,7 @@ public class RaftSessionRegistry {
   /**
    * Removes a session listener.
    *
-   * @param serviceId the service ID with which the listener is associated
+   * @param serviceId       the service ID with which the listener is associated
    * @param sessionListener the session listener
    */
   public void removeListener(ServiceId serviceId, RaftSessionListener sessionListener) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistry.java
@@ -16,14 +16,11 @@
 package io.atomix.protocols.raft.session.impl;
 
 import io.atomix.protocols.raft.service.ServiceId;
-import io.atomix.protocols.raft.session.RaftSessionListener;
 import io.atomix.protocols.raft.session.SessionId;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 
 /**
@@ -31,46 +28,19 @@ import java.util.stream.Collectors;
  */
 public class RaftSessionRegistry {
   private final Map<Long, RaftSessionContext> sessions = new ConcurrentHashMap<>();
-  private final Map<ServiceId, Set<RaftSessionListener>> listeners = new ConcurrentHashMap<>();
 
   /**
-   * Registers a session.
+   * Adds a session.
    */
-  public void registerSession(RaftSessionContext session) {
-    if (sessions.putIfAbsent(session.sessionId().id(), session) == null) {
-      Set<RaftSessionListener> listeners = this.listeners.get(session.getService().serviceId());
-      if (listeners != null) {
-        listeners.forEach(l -> l.onOpen(session));
-      }
-    }
+  public void addSession(RaftSessionContext session) {
+    sessions.put(session.sessionId().id(), session);
   }
 
   /**
-   * Expires a session.
+   * Removes a session.
    */
-  public void expireSession(SessionId sessionId) {
-    RaftSessionContext session = sessions.remove(sessionId.id());
-    if (session != null) {
-      Set<RaftSessionListener> listeners = this.listeners.get(session.getService().serviceId());
-      if (listeners != null) {
-        listeners.forEach(l -> l.onExpire(session));
-      }
-      session.expire();
-    }
-  }
-
-  /**
-   * Closes a session.
-   */
-  public void closeSession(SessionId sessionId) {
-    RaftSessionContext session = sessions.remove(sessionId.id());
-    if (session != null) {
-      Set<RaftSessionListener> listeners = this.listeners.get(session.getService().serviceId());
-      if (listeners != null) {
-        listeners.forEach(l -> l.onClose(session));
-      }
-      session.close();
-    }
+  public void removeSession(SessionId sessionId) {
+    sessions.remove(sessionId.id());
   }
 
   /**
@@ -122,32 +92,5 @@ public class RaftSessionRegistry {
    */
   public void removeSessions(ServiceId serviceId) {
     sessions.entrySet().removeIf(e -> e.getValue().getService().serviceId().equals(serviceId));
-  }
-
-  /**
-   * Adds a session listener.
-   *
-   * @param serviceId       the service ID for which to listen to sessions
-   * @param sessionListener the session listener
-   */
-  public void addListener(ServiceId serviceId, RaftSessionListener sessionListener) {
-    Set<RaftSessionListener> sessionListeners = listeners.computeIfAbsent(serviceId, k -> new CopyOnWriteArraySet<>());
-    sessionListeners.add(sessionListener);
-  }
-
-  /**
-   * Removes a session listener.
-   *
-   * @param serviceId       the service ID with which the listener is associated
-   * @param sessionListener the session listener
-   */
-  public void removeListener(ServiceId serviceId, RaftSessionListener sessionListener) {
-    Set<RaftSessionListener> sessionListeners = listeners.get(serviceId);
-    if (sessionListeners != null) {
-      sessionListeners.remove(sessionListener);
-      if (sessionListeners.isEmpty()) {
-        listeners.remove(serviceId);
-      }
-    }
   }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessionsTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessionsTest.java
@@ -94,6 +94,7 @@ public class DefaultServiceSessionsTest {
         ReadConsistency.LINEARIZABLE,
         100,
         5000,
+        System.currentTimeMillis(),
         context,
         server,
         mock(ThreadContextFactory.class));

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessionsTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessionsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.service.impl;
+
+import io.atomix.protocols.raft.ReadConsistency;
+import io.atomix.protocols.raft.cluster.MemberId;
+import io.atomix.protocols.raft.impl.RaftContext;
+import io.atomix.protocols.raft.protocol.RaftServerProtocol;
+import io.atomix.protocols.raft.service.ServiceId;
+import io.atomix.protocols.raft.service.ServiceType;
+import io.atomix.protocols.raft.session.RaftSession;
+import io.atomix.protocols.raft.session.RaftSession.State;
+import io.atomix.protocols.raft.session.RaftSessionListener;
+import io.atomix.protocols.raft.session.SessionId;
+import io.atomix.protocols.raft.session.impl.RaftSessionContext;
+import io.atomix.protocols.raft.session.impl.RaftSessionRegistry;
+import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.ThreadContextFactory;
+import org.junit.Test;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Default service sessions test.
+ */
+public class DefaultServiceSessionsTest {
+  @Test
+  public void testSessions() throws Exception {
+    RaftSessionRegistry sessionManager = new RaftSessionRegistry();
+    DefaultServiceSessions sessions = new DefaultServiceSessions(ServiceId.from(1), sessionManager);
+    TestSessionListener listener = new TestSessionListener();
+    sessions.addListener(listener);
+
+    RaftSessionContext session1 = createSession(1);
+    sessionManager.addSession(session1);
+    assertNull(sessions.getSession(1));
+    sessions.openSession(session1);
+    assertNotNull(sessions.getSession(1));
+    assertEquals(session1.getState(), State.OPEN);
+    assertTrue(listener.eventReceived());
+    assertTrue(listener.isOpened());
+    sessions.closeSession(session1);
+    assertEquals(session1.getState(), State.CLOSED);
+    assertTrue(listener.eventReceived());
+    assertTrue(listener.isClosed());
+
+    RaftSessionContext session2 = createSession(2);
+    sessions.openSession(session2);
+    assertEquals(session2.getState(), State.OPEN);
+    assertTrue(listener.eventReceived());
+    assertTrue(listener.isOpened());
+    sessions.expireSession(session2);
+    assertEquals(session2.getState(), State.EXPIRED);
+    assertTrue(listener.eventReceived());
+    assertTrue(listener.isExpired());
+  }
+
+  private RaftSessionContext createSession(long sessionId) {
+    DefaultServiceContext context = mock(DefaultServiceContext.class);
+    when(context.serviceType()).thenReturn(ServiceType.from("test"));
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(ServiceId.from(1));
+    when(context.executor()).thenReturn(mock(ThreadContext.class));
+
+    RaftContext server = mock(RaftContext.class);
+    when(server.getProtocol()).thenReturn(mock(RaftServerProtocol.class));
+
+    return new RaftSessionContext(
+        SessionId.from(sessionId),
+        MemberId.from("1"),
+        "test",
+        ServiceType.from("test"),
+        ReadConsistency.LINEARIZABLE,
+        100,
+        5000,
+        context,
+        server,
+        mock(ThreadContextFactory.class));
+  }
+
+  private class TestSessionListener implements RaftSessionListener {
+    private final BlockingQueue<String> queue = new ArrayBlockingQueue<>(1);
+
+    @Override
+    public void onOpen(RaftSession session) {
+      queue.add("open");
+    }
+
+    @Override
+    public void onExpire(RaftSession session) {
+      queue.add("expire");
+    }
+
+    @Override
+    public void onClose(RaftSession session) {
+      queue.add("close");
+    }
+
+    public boolean eventReceived() {
+      return !queue.isEmpty();
+    }
+
+    public String event() throws InterruptedException {
+      return queue.take();
+    }
+
+    public boolean isOpened() throws InterruptedException {
+      return event().equals("open");
+    }
+
+    public boolean isClosed() throws InterruptedException {
+      return event().equals("close");
+    }
+
+    public boolean isExpired() throws InterruptedException {
+      return event().equals("expire");
+    }
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
@@ -69,6 +69,7 @@ public class RaftSessionRegistryTest {
         ReadConsistency.LINEARIZABLE,
         100,
         5000,
+        System.currentTimeMillis(),
         context,
         server,
         mock(ThreadContextFactory.class));

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
@@ -22,22 +22,14 @@ import io.atomix.protocols.raft.protocol.RaftServerProtocol;
 import io.atomix.protocols.raft.service.ServiceId;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.service.impl.DefaultServiceContext;
-import io.atomix.protocols.raft.session.RaftSession;
-import io.atomix.protocols.raft.session.RaftSessionListener;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import org.junit.Test;
 
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,60 +38,17 @@ import static org.mockito.Mockito.when;
  */
 public class RaftSessionRegistryTest {
 
-  /**
-   * Tests that the same session can be registered twice without replacing the original session.
-   */
   @Test
-  public void testRegisterIdempotent() throws Exception {
-    RaftSessionRegistry sessionManager = new RaftSessionRegistry();
-    RaftSessionContext session1 = createSession(1);
-    RaftSessionContext session2 = createSession(1);
-    sessionManager.registerSession(session1);
-    sessionManager.registerSession(session2);
-    assertSame(session1, sessionManager.getSession(1));
-  }
-
-  @Test
-  public void testUnregisterSession() throws Exception {
+  public void testAddRemoveSession() throws Exception {
     RaftSessionRegistry sessionManager = new RaftSessionRegistry();
     RaftSessionContext session = createSession(1);
-    sessionManager.registerSession(session);
+    sessionManager.addSession(session);
     assertNotNull(sessionManager.getSession(1));
+    assertEquals(0, sessionManager.getSessions(ServiceId.from(1)).size());
+    session.open();
     assertEquals(1, sessionManager.getSessions(ServiceId.from(1)).size());
-    sessionManager.closeSession(SessionId.from(1));
+    sessionManager.removeSession(SessionId.from(1));
     assertNull(sessionManager.getSession(1));
-  }
-
-  @Test
-  public void testSessionListeners() throws Exception {
-    RaftSessionRegistry sessionManager = new RaftSessionRegistry();
-    TestSessionListener listener = new TestSessionListener();
-    sessionManager.addListener(ServiceId.from(1), listener);
-
-    RaftSessionContext session1 = createSession(1);
-    sessionManager.registerSession(session1);
-    assertTrue(listener.eventReceived());
-    assertTrue(listener.isOpened());
-    sessionManager.closeSession(session1.sessionId());
-    assertTrue(listener.eventReceived());
-    assertTrue(listener.isClosed());
-
-    RaftSessionContext session2 = createSession(2);
-    sessionManager.registerSession(session2);
-    assertTrue(listener.eventReceived());
-    assertTrue(listener.isOpened());
-    sessionManager.expireSession(session2.sessionId());
-    assertTrue(listener.eventReceived());
-    assertTrue(listener.isExpired());
-    sessionManager.expireSession(session2.sessionId());
-    assertFalse(listener.eventReceived());
-
-    RaftSessionContext session3 = createSession(3);
-    sessionManager.registerSession(session3);
-    assertTrue(listener.eventReceived());
-    assertTrue(listener.isOpened());
-    sessionManager.registerSession(session3);
-    assertFalse(listener.eventReceived());
   }
 
   private RaftSessionContext createSession(long sessionId) {
@@ -123,44 +72,5 @@ public class RaftSessionRegistryTest {
         context,
         server,
         mock(ThreadContextFactory.class));
-  }
-
-  private class TestSessionListener implements RaftSessionListener {
-    private final BlockingQueue<String> queue = new ArrayBlockingQueue<>(1);
-
-    @Override
-    public void onOpen(RaftSession session) {
-      queue.add("open");
-    }
-
-    @Override
-    public void onExpire(RaftSession session) {
-      queue.add("expire");
-    }
-
-    @Override
-    public void onClose(RaftSession session) {
-      queue.add("close");
-    }
-
-    public boolean eventReceived() {
-      return !queue.isEmpty();
-    }
-
-    public String event() throws InterruptedException {
-      return queue.take();
-    }
-
-    public boolean isOpened() throws InterruptedException {
-      return event().equals("open");
-    }
-
-    public boolean isClosed() throws InterruptedException {
-      return event().equals("close");
-    }
-
-    public boolean isExpired() throws InterruptedException {
-      return event().equals("expire");
-    }
   }
 }


### PR DESCRIPTION
This PR fixes a bug in managing sessions in the Raft state machine. The problem is, when a session is first created it's visible to the primitive state machine's context before the session is open. In the event a command is executed on the state machine thread with a timestamp large enough to expire the session, the session may be expired before it's registered. This can lead to commands never being applied for the session. This bug primarily occurs when a node is replaying commands from the log, resulting in enough commands being applied to the state machine between the time the session is created and the time it's registered for it to be expired. The solution is to prevent unregistered sessions from being visible on the state machine thread.