### PR TITLE
Ensure CLIENT nodes do not attempt to join cluster metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The builder should be configured with the local node configuration:
 builder.withLocalNode(Node.builder()
   .withId("foo")
   .withType(Node.Type.DATA)
-  .withEndpoint(Endpoint.endpoint("localhost", 5000))
+  .withEndpoint(Endpoint.from("localhost", 5000))
   .build());
 ```
 
@@ -62,15 +62,15 @@ Each instance should provide the same set of bootstrap nodes:
 builder.withBootstrapNodes(
   Node.builder("foo")
     .withType(Node.Type.DATA)
-    .withEndpoint(Endpoint.endpoint("localhost", 5000)
+    .withEndpoint(Endpoint.from("localhost", 5000)
     .build(),
   Node.builder("bar")
     .withType(Node.Type.DATA)
-    .withEndpoint(Endpoint.endpoint("localhost", 5001)
+    .withEndpoint(Endpoint.from("localhost", 5001)
     .build(),
   Node.builder("baz")
     .withType(Node.Type.DATA)
-    .withEndpoint(Endpoint.endpoint("localhost", 5002)
+    .withEndpoint(Endpoint.from("localhost", 5002)
     .build());
 ```
 
@@ -82,13 +82,7 @@ been configured, build the instance by calling `build()`:
 Atomix atomix = builder.build();
 ```
 
-Finally, connect the instance by calling `open()`:
-
-```java
-atomix.open().join();
-```
-
-Note that in order to form a cluster, a majority of instance must be `open()`ed simultaneously
+Note that in order to form a cluster, a majority of instance must be created simultaneously
 to allow Raft partitions to form a quorum.
 
 ### Connecting a client node
@@ -101,24 +95,22 @@ node builder that the node is a `CLIENT`:
 Atomix atomix = Atomix.builder()
   .withLocalNode(Node.builder("client")
     .withType(Node.Type.CLIENT)
-    .withEndpoint(Endpoint.endpoint("localhost", 5003))
+    .withEndpoint(Endpoint.from("localhost", 5003))
     .build())
   .withBootstrapNodes(
       Node.builder("foo")
         .withType(Node.Type.DATA)
-        .withEndpoint(Endpoint.endpoint("localhost", 5000)
+        .withEndpoint(Endpoint.from("localhost", 5000)
         .build(),
       Node.builder("bar")
         .withType(Node.Type.DATA)
-        .withEndpoint(Endpoint.endpoint("localhost", 5001)
+        .withEndpoint(Endpoint.from("localhost", 5001)
         .build(),
       Node.builder("baz")
         .withType(Node.Type.DATA)
-        .withEndpoint(Endpoint.endpoint("localhost", 5002)
+        .withEndpoint(Endpoint.from("localhost", 5002)
         .build())
   .build();
-
-atomix.open().join();
 ```
 
 ## Cluster management

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMetadataService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMetadataService.java
@@ -112,13 +112,15 @@ public class DefaultClusterMetadataService
 
   @Override
   public void addNode(Node node) {
-    ReplicatedNode replicatedNode = nodes.get(node.id());
-    if (replicatedNode == null) {
-      LogicalTimestamp timestamp = clock.increment();
-      replicatedNode = new ReplicatedNode(node.id(), node.type(), node.endpoint(), timestamp, false);
-      nodes.put(replicatedNode.id(), replicatedNode);
-      broadcastUpdate(new NodeUpdate(replicatedNode, timestamp));
-      post(new ClusterMetadataEvent(ClusterMetadataEvent.Type.METADATA_CHANGED, getMetadata()));
+    if (node.type() != Node.Type.CLIENT) {
+      ReplicatedNode replicatedNode = nodes.get(node.id());
+      if (replicatedNode == null) {
+        LogicalTimestamp timestamp = clock.increment();
+        replicatedNode = new ReplicatedNode(node.id(), node.type(), node.endpoint(), timestamp, false);
+        nodes.put(replicatedNode.id(), replicatedNode);
+        broadcastUpdate(new NodeUpdate(replicatedNode, timestamp));
+        post(new ClusterMetadataEvent(ClusterMetadataEvent.Type.METADATA_CHANGED, getMetadata()));
+      }
     }
   }
 

--- a/core/src/main/java/io/atomix/Atomix.java
+++ b/core/src/main/java/io/atomix/Atomix.java
@@ -50,6 +50,7 @@ import io.atomix.primitive.session.ManagedSessionIdService;
 import io.atomix.protocols.backup.partition.PrimaryBackupPartitionGroup;
 import io.atomix.protocols.raft.partition.RaftPartitionGroup;
 import io.atomix.transaction.TransactionBuilder;
+import io.atomix.utils.AtomixRuntimeException;
 import io.atomix.utils.Managed;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -64,6 +65,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -479,7 +481,11 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
      */
     @Override
     public Atomix build() {
-      return buildInstance().open().join();
+      try {
+        return buildInstance().open().join();
+      } catch (CompletionException e) {
+        throw new AtomixRuntimeException(e.getCause());
+      }
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug where client nodes could be added to the cluster metadata. The `ClusterMetadataService` prevents `CLIENT` nodes from being added by simply ignoring such attempts.