### PR TITLE
Clean up Atomix APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ a series of high-level primitives for building distributed systems. These primit
 * [REST API](#rest-api)
 * [Interactive CLI](#interactive-cli)
 
+## Background
+
+Atomix was originally conceived in 2014 along with its sister project [Copycat](http://github.com/atomix/copycat)
+(deprecated) as a hobby project. Over time, Copycat grew into a mature implementation of the Raft consensus
+protocol, and both Copycat and Atomix were put into use in various projects. In 2017, development of a new version
+was begun, and Copycat and Atomix were combined in Atomix 2.x. Additionally, significant extensions to the projects
+originally developed for use in [ONOS](http://onosproject.org) were migrated into Atomix 2.x. Atomix is now
+maintained as a core component of ONOS by the [Open Networking Foundation](http://opennetworking.org).
+
 ## Architecture
 
 At its core, Atomix is built on a series of replicated state machines backed by consensus and primary-backup

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ about all nodes in the cluster, including the local node, data nodes, and client
 To get the set of nodes in the cluster, use the `ClusterService`:
 
 ```java
-Set<Node> nodes = atomix.getClusterService().getNodes();
+Set<Node> nodes = atomix.cluster().getNodes();
 ```
 
 ### Failure detection
@@ -132,14 +132,14 @@ liveliness of the given node. The cluster service uses a phi accrual failure det
 internally to detect failures, and nodes' states are updated as failures are detected:
 
 ```java
-Node.State state = atomix.getClusterService().getNode(NodeId.from("foo")).state();
+Node.State state = atomix.cluster().getNode(NodeId.from("foo")).state();
 ```
 
 Additionally, listeners can be added to the `ClusterService` to react to changes to both the set
 of nodes in the cluster and the states of individual nodes:
 
 ```java
-atomix.getClusterService().addListener(event -> {
+atomix.cluster().addListener(event -> {
   if (event.type() == ClusterEvent.Type.NODE_ACTIVATED) {
     // A node's state was changed to ACTIVE
   } else if (event.type() == ClusterEvent.Type.NODE_DEACTIVATED) {
@@ -178,7 +178,7 @@ private static final MessageSubject TEST_SUBJECT = new MessageSubject("test");
 To register a message subscriber, use the `addSubscriber` methods:
 
 ```java
-atomix.getCommunicationService().addSubscriber(TEST_SUBJECT, message -> {
+atomix.communicator().addSubscriber(TEST_SUBJECT, message -> {
   return CompletableFuture.completedFuture(message);
 });
 ```
@@ -198,7 +198,7 @@ As noted above, messages can be sent using a variety of different communication 
 
 ```java
 // Send a request-reply message to node "foo"
-atomix.getCommunicationService().sendAndReceive(TEST_SUBJECT, "Hello world!", NodeId.from("foo")).thenAccept(response -> {
+atomix.communicator().sendAndReceive(TEST_SUBJECT, "Hello world!", NodeId.from("foo")).thenAccept(response -> {
   System.out.println("Received " + response);
 });
 ```
@@ -216,8 +216,8 @@ Serializer serializer = Serializer.using(KryoNamespace.builder()
   .register(ClusterHeartbeat.class)
   .build());
 
-ClusterHeartbeat heartbeat = new ClusterHeartbeat(atomix.getClusterService().getLocalNode().id());
-atomix.getCommunicationService().sendAndReceive(TEST_SUBJECT, heartbeat, serializer::encode, serializer::decode, someNodeId).thenAccept(response -> {
+ClusterHeartbeat heartbeat = new ClusterHeartbeat(atomix.cluster().getLocalNode().id());
+atomix.communicator().sendAndReceive(TEST_SUBJECT, heartbeat, serializer::encode, serializer::decode, someNodeId).thenAccept(response -> {
   ...
 });
 ```
@@ -234,17 +234,17 @@ senders.
 
 ```java
 // Add an event service subscriber
-atomix.getEventService().addSubscriber(TEST_SUBJECT, message -> {
+atomix.event().addSubscriber(TEST_SUBJECT, message -> {
   return CompletableFuture.completedFuture(message);
 });
 
 // Send a request-reply message via the event service
-atomix.getEventService().sendAndReceive(TEST_SUBJECT, "Hello world!").thenAccept(response -> {
+atomix.event().sendAndReceive(TEST_SUBJECT, "Hello world!").thenAccept(response -> {
   System.out.println("Received " + response);
 });
 
 // Broadcast a message to all event subscribers
-atomix.getEventService().broadcast(TEST_SUBJECT, "Hello world!");
+atomix.event().broadcast(TEST_SUBJECT, "Hello world!");
 ```
 
 ## Coordination primitives
@@ -317,8 +317,8 @@ AsyncLeaderElector<NodeId> asyncElector = elector.async();
 To enter into an election, use the `run` method:
 
 ```java
-asyncElector.run("foo", atomix.getClusterService().getLocalNode().id()).thenAccept(leadership -> {
-  if (leadership.leader().id().equals(atomix.getClusterService().getLocalNode().id())) {
+asyncElector.run("foo", atomix.cluster().getLocalNode().id()).thenAccept(leadership -> {
+  if (leadership.leader().id().equals(atomix.cluster().getLocalNode().id())) {
     // Local node elected leader!
   }
 });

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ protocol uses the core Raft cluster to elect and balance primaries and backups f
 Primitives can be configured for consistency, persistence, and replication, modifying the underlying
 protocol according to desired semantics.
 
+### The Atomix cluster
+
+Atomix clusters consist of two types of nodes:
+* `DATA` nodes store persistent and ephemeral primitive state
+* `CLIENT` nodes do not store any state but must connect to `DATA` nodes to store state remotely
+
+Primitive partitions (both Raft and primary-backup) are evenly distributed among the `DATA` nodes
+in a cluster. Initially, an Atomix cluster is formed by bootstrapping a set of `DATA` nodes. Thereafter,
+additional `DATA` or `CLIENT` nodes may join and leave the cluster at will by simply starting and
+stopping `Atomix` instances. Atomix provides a `ClusterService` that can be used to learn about new
+`CLIENT` and `DATA` nodes joining and leaving the cluster.
+
 ## Java API
 
 ### Bootstrapping an Atomix cluster
@@ -48,27 +60,27 @@ Atomix.Builder builder = Atomix.builder();
 The builder should be configured with the local node configuration:
 
 ```java
-builder.withLocalNode(Node.builder()
-  .withId("foo")
+builder.withLocalNode(Node.builder("server1")
   .withType(Node.Type.DATA)
   .withEndpoint(Endpoint.from("localhost", 5000))
   .build());
 ```
 
-To initialize an Atomix cluster, at least one instance must be configured as a _bootstrap_ node.
-Each instance should provide the same set of bootstrap nodes:
+In addition to configuring the local node information, each instance must be configured with a
+set of _bootstrap nodes_ from which to form a cluster. When first starting a cluster, all instances
+should provide the same set of bootstrap nodes. Bootstrap nodes _must_ be `DATA` nodes:
 
 ```java
 builder.withBootstrapNodes(
-  Node.builder("foo")
+  Node.builder("server1")
     .withType(Node.Type.DATA)
     .withEndpoint(Endpoint.from("localhost", 5000)
     .build(),
-  Node.builder("bar")
+  Node.builder("server2")
     .withType(Node.Type.DATA)
     .withEndpoint(Endpoint.from("localhost", 5001)
     .build(),
-  Node.builder("baz")
+  Node.builder("server3")
     .withType(Node.Type.DATA)
     .withEndpoint(Endpoint.from("localhost", 5002)
     .build());
@@ -82,8 +94,16 @@ been configured, build the instance by calling `build()`:
 Atomix atomix = builder.build();
 ```
 
-Note that in order to form a cluster, a majority of instance must be created simultaneously
-to allow Raft partitions to form a quorum.
+Finally, call `start()` on the instance to start the node:
+
+```java
+atomix.start().join();
+```
+
+**Note that in order to form a cluster, a majority of instances must be started concurrently
+to allow Raft partitions to form a quorum.** The future returned by the `start()` method will
+not be completed until all partitions are able to form. If your `Atomix` instance is blocking
+indefinitely at startup, ensure you enable `DEBUG` logging to debug the issue.
 
 ### Connecting a client node
 
@@ -98,20 +118,26 @@ Atomix atomix = Atomix.builder()
     .withEndpoint(Endpoint.from("localhost", 5003))
     .build())
   .withBootstrapNodes(
-      Node.builder("foo")
+      Node.builder("server1")
         .withType(Node.Type.DATA)
         .withEndpoint(Endpoint.from("localhost", 5000)
         .build(),
-      Node.builder("bar")
+      Node.builder("server2")
         .withType(Node.Type.DATA)
         .withEndpoint(Endpoint.from("localhost", 5001)
         .build(),
-      Node.builder("baz")
+      Node.builder("server3")
         .withType(Node.Type.DATA)
         .withEndpoint(Endpoint.from("localhost", 5002)
         .build())
   .build();
+
+atomix.start().join();
 ```
+
+This example connects a client node aptly named `client` to a set of data nodes. Once the instance
+is started, the client node will be visible to all data nodes and vice versa, and primitives created
+by the client node will be managed by the data nodes.
 
 ## Cluster management
 

--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -134,7 +134,7 @@ public class AtomixAgent {
         .withDataDirectory(dataDir)
         .build();
 
-    atomix.open().join();
+    atomix.start().join();
 
     LOGGER.info("Atomix listening at {}:{}", localNode.endpoint().host().getHostAddress(), localNode.endpoint().port());
 
@@ -143,12 +143,12 @@ public class AtomixAgent {
         .withEndpoint(Endpoint.from(localNode.endpoint().host().getHostAddress(), httpPort))
         .build();
 
-    rest.open().join();
+    rest.start().join();
 
     LOGGER.info("Server listening at {}:{}", localNode.endpoint().host().getHostAddress(), httpPort);
 
     synchronized (Atomix.class) {
-      while (atomix.isOpen()) {
+      while (atomix.isRunning()) {
         Atomix.class.wait();
       }
     }

--- a/cluster/src/main/java/io/atomix/cluster/messaging/ClusterEventsService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/ClusterEventsService.java
@@ -25,7 +25,7 @@ import static io.atomix.utils.serializer.serializers.DefaultSerializers.BASIC;
 /**
  * Cluster event service.
  */
-public interface ClusterEventService {
+public interface ClusterEventsService {
 
   /**
    * Broadcasts a message to all controller nodes.

--- a/cluster/src/main/java/io/atomix/cluster/messaging/ManagedClusterEventsService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/ManagedClusterEventsService.java
@@ -20,5 +20,5 @@ import io.atomix.utils.Managed;
 /**
  * Managed cluster event service.
  */
-public interface ManagedClusterEventService extends ClusterEventService, Managed<ClusterEventService> {
+public interface ManagedClusterEventsService extends ClusterEventsService, Managed<ClusterEventsService> {
 }

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterCommunicationService.java
@@ -51,38 +51,12 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
   protected final ClusterService cluster;
   protected final MessagingService messagingService;
   private final NodeId localNodeId;
-  private final AtomicBoolean open = new AtomicBoolean();
+  private final AtomicBoolean started = new AtomicBoolean();
 
   public DefaultClusterCommunicationService(ClusterService cluster, MessagingService messagingService) {
     this.cluster = checkNotNull(cluster, "clusterService cannot be null");
     this.messagingService = checkNotNull(messagingService, "messagingService cannot be null");
     this.localNodeId = cluster.getLocalNode().id();
-  }
-
-  @Override
-  public CompletableFuture<ClusterCommunicationService> open() {
-    if (open.compareAndSet(false, true)) {
-      log.info("Started");
-    }
-    return CompletableFuture.completedFuture(this);
-  }
-
-  @Override
-  public boolean isOpen() {
-    return open.get();
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !isOpen();
-  }
-
-  @Override
-  public CompletableFuture<Void> close() {
-    if (open.compareAndSet(true, false)) {
-      log.info("Stopped");
-    }
-    return CompletableFuture.completedFuture(null);
   }
 
   @Override
@@ -214,6 +188,27 @@ public class DefaultClusterCommunicationService implements ManagedClusterCommuni
     messagingService.registerHandler(subject.toString(),
         new InternalMessageConsumer<>(decoder, handler),
         executor);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<ClusterCommunicationService> start() {
+    if (started.compareAndSet(false, true)) {
+      log.info("Started");
+    }
+    return CompletableFuture.completedFuture(this);
+  }
+
+  @Override
+  public boolean isRunning() {
+    return started.get();
+  }
+
+  @Override
+  public CompletableFuture<Void> stop() {
+    if (started.compareAndSet(true, false)) {
+      log.info("Stopped");
+    }
     return CompletableFuture.completedFuture(null);
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventsService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterEventsService.java
@@ -21,8 +21,8 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.Node.State;
 import io.atomix.cluster.NodeId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.cluster.messaging.ClusterEventService;
-import io.atomix.cluster.messaging.ManagedClusterEventService;
+import io.atomix.cluster.messaging.ClusterEventsService;
+import io.atomix.cluster.messaging.ManagedClusterEventsService;
 import io.atomix.cluster.messaging.MessageSubject;
 import io.atomix.messaging.MessagingException;
 import io.atomix.utils.concurrent.Futures;
@@ -57,8 +57,8 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
 /**
  * Cluster event service.
  */
-public class DefaultClusterEventService implements ManagedClusterEventService {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClusterEventService.class);
+public class DefaultClusterEventsService implements ManagedClusterEventsService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClusterEventsService.class);
 
   private static final Serializer SERIALIZER = Serializer.using(KryoNamespace.builder()
       .register(KryoNamespaces.BASIC)
@@ -84,7 +84,7 @@ public class DefaultClusterEventService implements ManagedClusterEventService {
   private final Map<MessageSubject, SubscriberIterator> subjectIterators = Maps.newConcurrentMap();
   private final AtomicBoolean open = new AtomicBoolean();
 
-  public DefaultClusterEventService(ClusterService clusterService, ClusterCommunicationService clusterCommunicator) {
+  public DefaultClusterEventsService(ClusterService clusterService, ClusterCommunicationService clusterCommunicator) {
     this.clusterService = clusterService;
     this.clusterCommunicator = clusterCommunicator;
     this.localNodeId = clusterService.getLocalNode().id();
@@ -315,7 +315,7 @@ public class DefaultClusterEventService implements ManagedClusterEventService {
   }
 
   @Override
-  public CompletableFuture<ClusterEventService> open() {
+  public CompletableFuture<ClusterEventsService> open() {
     gossipExecutor = Executors.newSingleThreadScheduledExecutor(
         namedThreads("atomix-cluster-event-executor-%d", LOGGER));
     gossipExecutor.scheduleAtFixedRate(

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
@@ -59,20 +59,20 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode1 = buildNode(1, Node.Type.DATA);
     ManagedClusterMetadataService metadataService1 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.endpoint()).open().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
 
     Node localNode2 = buildNode(2, Node.Type.DATA);
     ManagedClusterMetadataService metadataService2 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.endpoint()).open().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
 
     Node localNode3 = buildNode(3, Node.Type.DATA);
     ManagedClusterMetadataService metadataService3 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode3.endpoint()).open().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode3.endpoint()).start().join());
 
     List<CompletableFuture<ClusterMetadataService>> futures = new ArrayList<>();
-    futures.add(metadataService1.open());
-    futures.add(metadataService2.open());
-    futures.add(metadataService3.open());
+    futures.add(metadataService1.start());
+    futures.add(metadataService2.start());
+    futures.add(metadataService3.start());
     Futures.allOf(futures).join();
 
     assertEquals(3, metadataService1.getMetadata().bootstrapNodes().size());
@@ -81,8 +81,8 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode4 = buildNode(4, Node.Type.DATA);
     ManagedClusterMetadataService metadataService4 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode4.endpoint()).open().join());
-    metadataService4.open().join();
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode4.endpoint()).start().join());
+    metadataService4.start().join();
 
     assertEquals(3, metadataService4.getMetadata().bootstrapNodes().size());
 
@@ -111,8 +111,8 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode5 = buildNode(5, Node.Type.DATA);
     ManagedClusterMetadataService metadataService5 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode5.endpoint()).open().join());
-    metadataService5.open().join();
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode5.endpoint()).start().join());
+    metadataService5.start().join();
     assertEquals(4, metadataService5.getMetadata().bootstrapNodes().size());
   }
 

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterServiceTest.java
@@ -76,28 +76,28 @@ public class DefaultClusterServiceTest {
     ManagedClusterService clusterService1 = new DefaultClusterService(
         localNode1,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(localNode1.endpoint()).open().join());
+        messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
 
     Node localNode2 = buildNode(2, Node.Type.DATA);
     ManagedClusterService clusterService2 = new DefaultClusterService(
         localNode2,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(localNode2.endpoint()).open().join());
+        messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
 
     Node localNode3 = buildNode(3, Node.Type.DATA);
     ManagedClusterService clusterService3 = new DefaultClusterService(
         localNode3,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(localNode3.endpoint()).open().join());
+        messagingServiceFactory.newMessagingService(localNode3.endpoint()).start().join());
 
     assertNull(clusterService1.getNode(NodeId.from("1")));
     assertNull(clusterService1.getNode(NodeId.from("2")));
     assertNull(clusterService1.getNode(NodeId.from("3")));
 
     CompletableFuture<ClusterService>[] futures = new CompletableFuture[3];
-    futures[0] = clusterService1.open();
-    futures[1] = clusterService2.open();
-    futures[2] = clusterService3.open();
+    futures[0] = clusterService1.start();
+    futures[1] = clusterService2.start();
+    futures[2] = clusterService3.start();
 
     CompletableFuture.allOf(futures).join();
 
@@ -122,7 +122,7 @@ public class DefaultClusterServiceTest {
     ManagedClusterService clientClusterService = new DefaultClusterService(
         clientNode,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(clientNode.endpoint()).open().join());
+        messagingServiceFactory.newMessagingService(clientNode.endpoint()).start().join());
 
     assertEquals(State.INACTIVE, clientClusterService.getLocalNode().state());
 
@@ -131,7 +131,7 @@ public class DefaultClusterServiceTest {
     assertNull(clientClusterService.getNode(NodeId.from("3")));
     assertNull(clientClusterService.getNode(NodeId.from("4")));
 
-    clientClusterService.open().join();
+    clientClusterService.start().join();
 
     Thread.sleep(100);
 
@@ -156,7 +156,7 @@ public class DefaultClusterServiceTest {
 
     Thread.sleep(2500);
 
-    clusterService1.close().join();
+    clusterService1.stop().join();
 
     Thread.sleep(2500);
 
@@ -173,7 +173,7 @@ public class DefaultClusterServiceTest {
     assertEquals(State.ACTIVE, clientClusterService.getNode(NodeId.from("3")).state());
     assertEquals(State.ACTIVE, clientClusterService.getNode(NodeId.from("4")).state());
 
-    clientClusterService.close().join();
+    clientClusterService.stop().join();
 
     Thread.sleep(2500);
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventsServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventsServiceTest.java
@@ -79,22 +79,22 @@ public class DefaultClusterEventsServiceTest {
     ClusterMetadata clusterMetadata = buildClusterMetadata(1, 1, 2, 3);
 
     Node localNode1 = buildNode(1, Node.Type.DATA);
-    MessagingService messagingService1 = factory.newMessagingService(localNode1.endpoint()).open().join();
-    ClusterService clusterService1 = new DefaultClusterService(localNode1, new TestClusterMetadataService(clusterMetadata), messagingService1).open().join();
-    ClusterCommunicationService clusterCommunicator1 = new DefaultClusterCommunicationService(clusterService1, messagingService1).open().join();
-    ClusterEventsService eventService1 = new DefaultClusterEventsService(clusterService1, clusterCommunicator1).open().join();
+    MessagingService messagingService1 = factory.newMessagingService(localNode1.endpoint()).start().join();
+    ClusterService clusterService1 = new DefaultClusterService(localNode1, new TestClusterMetadataService(clusterMetadata), messagingService1).start().join();
+    ClusterCommunicationService clusterCommunicator1 = new DefaultClusterCommunicationService(clusterService1, messagingService1).start().join();
+    ClusterEventsService eventService1 = new DefaultClusterEventsService(clusterService1, clusterCommunicator1).start().join();
 
     Node localNode2 = buildNode(2, Node.Type.DATA);
-    MessagingService messagingService2 = factory.newMessagingService(localNode2.endpoint()).open().join();
-    ClusterService clusterService2 = new DefaultClusterService(localNode2, new TestClusterMetadataService(clusterMetadata), messagingService2).open().join();
-    ClusterCommunicationService clusterCommunicator2 = new DefaultClusterCommunicationService(clusterService2, messagingService2).open().join();
-    ClusterEventsService eventService2 = new DefaultClusterEventsService(clusterService2, clusterCommunicator2).open().join();
+    MessagingService messagingService2 = factory.newMessagingService(localNode2.endpoint()).start().join();
+    ClusterService clusterService2 = new DefaultClusterService(localNode2, new TestClusterMetadataService(clusterMetadata), messagingService2).start().join();
+    ClusterCommunicationService clusterCommunicator2 = new DefaultClusterCommunicationService(clusterService2, messagingService2).start().join();
+    ClusterEventsService eventService2 = new DefaultClusterEventsService(clusterService2, clusterCommunicator2).start().join();
 
     Node localNode3 = buildNode(3, Node.Type.DATA);
-    MessagingService messagingService3 = factory.newMessagingService(localNode3.endpoint()).open().join();
-    ClusterService clusterService3 = new DefaultClusterService(localNode3, new TestClusterMetadataService(clusterMetadata), messagingService3).open().join();
-    ClusterCommunicationService clusterCommunicator3 = new DefaultClusterCommunicationService(clusterService3, messagingService3).open().join();
-    ClusterEventsService eventService3 = new DefaultClusterEventsService(clusterService3, clusterCommunicator3).open().join();
+    MessagingService messagingService3 = factory.newMessagingService(localNode3.endpoint()).start().join();
+    ClusterService clusterService3 = new DefaultClusterService(localNode3, new TestClusterMetadataService(clusterMetadata), messagingService3).start().join();
+    ClusterCommunicationService clusterCommunicator3 = new DefaultClusterCommunicationService(clusterService3, messagingService3).start().join();
+    ClusterEventsService eventService3 = new DefaultClusterEventsService(clusterService3, clusterCommunicator3).start().join();
 
     Thread.sleep(100);
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventsServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventsServiceTest.java
@@ -22,7 +22,7 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.impl.DefaultClusterService;
 import io.atomix.cluster.impl.TestClusterMetadataService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.ClusterEventsService;
 import io.atomix.cluster.messaging.MessageSubject;
 import io.atomix.messaging.Endpoint;
 import io.atomix.messaging.MessagingService;
@@ -42,11 +42,11 @@ import static org.junit.Assert.assertNull;
 /**
  * Cluster event service test.
  */
-public class DefaultClusterEventServiceTest {
+public class DefaultClusterEventsServiceTest {
   private static final Serializer SERIALIZER = Serializer.using(KryoNamespaces.BASIC);
   private final InetAddress localhost;
 
-  public DefaultClusterEventServiceTest() {
+  public DefaultClusterEventsServiceTest() {
     try {
       localhost = InetAddress.getByName("127.0.0.1");
     } catch (UnknownHostException e) {
@@ -82,19 +82,19 @@ public class DefaultClusterEventServiceTest {
     MessagingService messagingService1 = factory.newMessagingService(localNode1.endpoint()).open().join();
     ClusterService clusterService1 = new DefaultClusterService(localNode1, new TestClusterMetadataService(clusterMetadata), messagingService1).open().join();
     ClusterCommunicationService clusterCommunicator1 = new DefaultClusterCommunicationService(clusterService1, messagingService1).open().join();
-    ClusterEventService eventService1 = new DefaultClusterEventService(clusterService1, clusterCommunicator1).open().join();
+    ClusterEventsService eventService1 = new DefaultClusterEventsService(clusterService1, clusterCommunicator1).open().join();
 
     Node localNode2 = buildNode(2, Node.Type.DATA);
     MessagingService messagingService2 = factory.newMessagingService(localNode2.endpoint()).open().join();
     ClusterService clusterService2 = new DefaultClusterService(localNode2, new TestClusterMetadataService(clusterMetadata), messagingService2).open().join();
     ClusterCommunicationService clusterCommunicator2 = new DefaultClusterCommunicationService(clusterService2, messagingService2).open().join();
-    ClusterEventService eventService2 = new DefaultClusterEventService(clusterService2, clusterCommunicator2).open().join();
+    ClusterEventsService eventService2 = new DefaultClusterEventsService(clusterService2, clusterCommunicator2).open().join();
 
     Node localNode3 = buildNode(3, Node.Type.DATA);
     MessagingService messagingService3 = factory.newMessagingService(localNode3.endpoint()).open().join();
     ClusterService clusterService3 = new DefaultClusterService(localNode3, new TestClusterMetadataService(clusterMetadata), messagingService3).open().join();
     ClusterCommunicationService clusterCommunicator3 = new DefaultClusterCommunicationService(clusterService3, messagingService3).open().join();
-    ClusterEventService eventService3 = new DefaultClusterEventService(clusterService3, clusterCommunicator3).open().join();
+    ClusterEventsService eventService3 = new DefaultClusterEventsService(clusterService3, clusterCommunicator3).open().join();
 
     Thread.sleep(100);
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
@@ -40,7 +40,7 @@ public class TestMessagingService implements ManagedMessagingService {
   private final Endpoint endpoint;
   private final Map<Endpoint, TestMessagingService> services;
   private final Map<String, BiFunction<Endpoint, byte[], CompletableFuture<byte[]>>> handlers = new ConcurrentHashMap<>();
-  private final AtomicBoolean open = new AtomicBoolean();
+  private final AtomicBoolean started = new AtomicBoolean();
 
   public TestMessagingService(Endpoint endpoint, Map<Endpoint, TestMessagingService> services) {
     this.endpoint = endpoint;
@@ -134,26 +134,21 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<MessagingService> open() {
+  public CompletableFuture<MessagingService> start() {
     services.put(endpoint, this);
-    open.set(true);
+    started.set(true);
     return CompletableFuture.completedFuture(this);
   }
 
   @Override
-  public boolean isOpen() {
-    return open.get();
+  public boolean isRunning() {
+    return started.get();
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     services.remove(endpoint);
-    open.set(false);
+    started.set(false);
     return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !open.get();
   }
 }

--- a/core/src/main/java/io/atomix/Atomix.java
+++ b/core/src/main/java/io/atomix/Atomix.java
@@ -63,6 +63,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -512,7 +513,16 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
               .withEndpoint(new Endpoint(address, NettyMessagingService.DEFAULT_PORT))
               .build();
         } catch (UnknownHostException e) {
-          throw new IllegalArgumentException("Cannot configure local node", e);
+          throw new ConfigurationException("Cannot configure local node", e);
+        }
+      }
+
+      // If the bootstrap nodes have not been configured, default to the local node if possible.
+      if (bootstrapNodes == null) {
+        if (localNode.type() == Node.Type.DATA) {
+          bootstrapNodes = Collections.singleton(localNode);
+        } else {
+          throw new ConfigurationException("No bootstrap nodes configured");
         }
       }
 

--- a/core/src/main/java/io/atomix/Atomix.java
+++ b/core/src/main/java/io/atomix/Atomix.java
@@ -24,11 +24,11 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.impl.DefaultClusterMetadataService;
 import io.atomix.cluster.impl.DefaultClusterService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.ClusterEventsService;
 import io.atomix.cluster.messaging.ManagedClusterCommunicationService;
-import io.atomix.cluster.messaging.ManagedClusterEventService;
+import io.atomix.cluster.messaging.ManagedClusterEventsService;
 import io.atomix.cluster.messaging.impl.DefaultClusterCommunicationService;
-import io.atomix.cluster.messaging.impl.DefaultClusterEventService;
+import io.atomix.cluster.messaging.impl.DefaultClusterEventsService;
 import io.atomix.election.impl.LeaderElectorPrimaryElectionService;
 import io.atomix.generator.impl.IdGeneratorSessionIdService;
 import io.atomix.impl.CorePrimitivesService;
@@ -92,7 +92,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
   private final ManagedClusterMetadataService metadataService;
   private final ManagedClusterService clusterService;
   private final ManagedClusterCommunicationService clusterCommunicator;
-  private final ManagedClusterEventService clusterEventService;
+  private final ManagedClusterEventsService clusterEventService;
   private final ManagedPartitionGroup corePartitionGroup;
   private final ManagedPartitionService partitions;
   private final ManagedPrimitivesService primitives;
@@ -107,7 +107,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
       ManagedClusterMetadataService metadataService,
       ManagedClusterService cluster,
       ManagedClusterCommunicationService clusterCommunicator,
-      ManagedClusterEventService clusterEventService,
+      ManagedClusterEventsService clusterEventService,
       ManagedPartitionGroup corePartitionGroup,
       ManagedPartitionService partitions,
       PrimitiveTypeRegistry primitiveTypes) {
@@ -128,7 +128,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    *
    * @return the messaging service
    */
-  public MessagingService getMessagingService() {
+  public MessagingService messaging() {
     return messagingService;
   }
 
@@ -137,7 +137,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    *
    * @return the cluster metadata service
    */
-  public ClusterMetadataService getMetadataService() {
+  public ClusterMetadataService metadata() {
     return metadataService;
   }
 
@@ -146,7 +146,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    *
    * @return the cluster service
    */
-  public ClusterService getClusterService() {
+  public ClusterService cluster() {
     return clusterService;
   }
 
@@ -155,7 +155,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    *
    * @return the cluster communication service
    */
-  public ClusterCommunicationService getCommunicationService() {
+  public ClusterCommunicationService communicator() {
     return clusterCommunicator;
   }
 
@@ -164,7 +164,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    *
    * @return the cluster event service
    */
-  public ClusterEventService getEventService() {
+  public ClusterEventsService events() {
     return clusterEventService;
   }
 
@@ -173,7 +173,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    *
    * @return the partition service
    */
-  public PartitionService getPartitionService() {
+  public PartitionService partitions() {
     return partitions;
   }
 
@@ -182,7 +182,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    *
    * @return the primitives service
    */
-  public PrimitivesService getPrimitivesService() {
+  public PrimitivesService primitives() {
     return primitives;
   }
 
@@ -283,7 +283,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
   @Override
   public String toString() {
     return toStringHelper(this)
-        .add("partitions", getPartitionService())
+        .add("partitions", partitions())
         .toString();
   }
 
@@ -520,7 +520,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
       ManagedClusterMetadataService metadataService = buildClusterMetadataService(messagingService);
       ManagedClusterService clusterService = buildClusterService(metadataService, messagingService);
       ManagedClusterCommunicationService clusterCommunicator = buildClusterCommunicationService(clusterService, messagingService);
-      ManagedClusterEventService clusterEventService = buildClusterEventService(clusterService, clusterCommunicator);
+      ManagedClusterEventsService clusterEventService = buildClusterEventService(clusterService, clusterCommunicator);
       ManagedPartitionGroup corePartitionGroup = buildCorePartitionGroup();
       ManagedPartitionService partitionService = buildPartitionService();
       return new Atomix(
@@ -569,9 +569,9 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
     /**
      * Builds a cluster event service.
      */
-    protected ManagedClusterEventService buildClusterEventService(
+    protected ManagedClusterEventsService buildClusterEventService(
         ClusterService clusterService, ClusterCommunicationService clusterCommunicator) {
-      return new DefaultClusterEventService(clusterService, clusterCommunicator);
+      return new DefaultClusterEventsService(clusterService, clusterCommunicator);
     }
 
     /**

--- a/core/src/main/java/io/atomix/ConfigurationException.java
+++ b/core/src/main/java/io/atomix/ConfigurationException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix;
+
+import io.atomix.utils.AtomixRuntimeException;
+
+/**
+ * Atomix configuration exception.
+ */
+public class ConfigurationException extends AtomixRuntimeException {
+  public ConfigurationException(String message) {
+    super(message);
+  }
+
+  public ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/main/java/io/atomix/counter/impl/AtomicCounterProxyBuilder.java
+++ b/core/src/main/java/io/atomix/counter/impl/AtomicCounterProxyBuilder.java
@@ -44,7 +44,7 @@ public class AtomicCounterProxyBuilder extends AtomicCounterBuilder {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> new AtomicCounterProxy(proxy).sync());
   }
 }

--- a/core/src/main/java/io/atomix/counter/impl/AtomicCounterProxyBuilder.java
+++ b/core/src/main/java/io/atomix/counter/impl/AtomicCounterProxyBuilder.java
@@ -44,7 +44,7 @@ public class AtomicCounterProxyBuilder extends AtomicCounterBuilder {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> new AtomicCounterProxy(proxy).sync());
   }
 }

--- a/core/src/main/java/io/atomix/election/impl/LeaderElectionProxyBuilder.java
+++ b/core/src/main/java/io/atomix/election/impl/LeaderElectionProxyBuilder.java
@@ -44,7 +44,7 @@ public class LeaderElectionProxyBuilder<T> extends LeaderElectionBuilder<T> {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> new TranscodingAsyncLeaderElection<T, byte[]>(new LeaderElectionProxy(proxy), serializer()::encode, serializer()::decode).sync());
   }
 }

--- a/core/src/main/java/io/atomix/election/impl/LeaderElectionProxyBuilder.java
+++ b/core/src/main/java/io/atomix/election/impl/LeaderElectionProxyBuilder.java
@@ -44,7 +44,7 @@ public class LeaderElectionProxyBuilder<T> extends LeaderElectionBuilder<T> {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> new TranscodingAsyncLeaderElection<T, byte[]>(new LeaderElectionProxy(proxy), serializer()::encode, serializer()::decode).sync());
   }
 }

--- a/core/src/main/java/io/atomix/election/impl/LeaderElectorPrimaryElectionService.java
+++ b/core/src/main/java/io/atomix/election/impl/LeaderElectorPrimaryElectionService.java
@@ -97,7 +97,7 @@ public class LeaderElectorPrimaryElectionService implements ManagedPrimaryElecti
             .withRecoveryStrategy(Recovery.RECOVER)
             .withMaxRetries(5)
             .build());
-    AsyncLeaderElector<byte[]> leaderElector = new LeaderElectorProxy(proxy.start().join());
+    AsyncLeaderElector<byte[]> leaderElector = new LeaderElectorProxy(proxy.connect().join());
     return new TranscodingAsyncLeaderElector<>(leaderElector, SERIALIZER::encode, SERIALIZER::decode);
   }
 

--- a/core/src/main/java/io/atomix/election/impl/LeaderElectorProxyBuilder.java
+++ b/core/src/main/java/io/atomix/election/impl/LeaderElectorProxyBuilder.java
@@ -46,7 +46,7 @@ public class LeaderElectorProxyBuilder<T> extends LeaderElectorBuilder<T> {
   }
 
   private CompletableFuture<AsyncLeaderElector<T>> newLeaderElector(PrimitiveProxy proxy) {
-    return proxy.open()
+    return proxy.start()
         .thenApply(p -> new TranscodingAsyncLeaderElector<T, byte[]>(
             new LeaderElectorProxy(proxy), serializer()::encode, serializer()::decode));
   }

--- a/core/src/main/java/io/atomix/election/impl/LeaderElectorProxyBuilder.java
+++ b/core/src/main/java/io/atomix/election/impl/LeaderElectorProxyBuilder.java
@@ -46,7 +46,7 @@ public class LeaderElectorProxyBuilder<T> extends LeaderElectorBuilder<T> {
   }
 
   private CompletableFuture<AsyncLeaderElector<T>> newLeaderElector(PrimitiveProxy proxy) {
-    return proxy.start()
+    return proxy.connect()
         .thenApply(p -> new TranscodingAsyncLeaderElector<T, byte[]>(
             new LeaderElectorProxy(proxy), serializer()::encode, serializer()::decode));
   }

--- a/core/src/main/java/io/atomix/generator/impl/DelegatingIdGeneratorBuilder.java
+++ b/core/src/main/java/io/atomix/generator/impl/DelegatingIdGeneratorBuilder.java
@@ -45,7 +45,7 @@ public class DelegatingIdGeneratorBuilder extends AtomicIdGeneratorBuilder {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> new DelegatingIdGenerator(new AtomicCounterProxy(proxy)).sync());
   }
 }

--- a/core/src/main/java/io/atomix/generator/impl/DelegatingIdGeneratorBuilder.java
+++ b/core/src/main/java/io/atomix/generator/impl/DelegatingIdGeneratorBuilder.java
@@ -45,7 +45,7 @@ public class DelegatingIdGeneratorBuilder extends AtomicIdGeneratorBuilder {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> new DelegatingIdGenerator(new AtomicCounterProxy(proxy)).sync());
   }
 }

--- a/core/src/main/java/io/atomix/generator/impl/IdGeneratorSessionIdService.java
+++ b/core/src/main/java/io/atomix/generator/impl/IdGeneratorSessionIdService.java
@@ -66,7 +66,7 @@ public class IdGeneratorSessionIdService implements ManagedSessionIdService {
             .withRecoveryStrategy(Recovery.RECOVER)
             .withMaxRetries(5)
             .build());
-    return proxy.start()
+    return proxy.connect()
         .thenApply(v -> {
           idGenerator = new DelegatingIdGenerator(new AtomicCounterProxy(proxy));
           started.set(true);

--- a/core/src/main/java/io/atomix/impl/CorePrimitiveManagementService.java
+++ b/core/src/main/java/io/atomix/impl/CorePrimitiveManagementService.java
@@ -17,7 +17,7 @@ package io.atomix.impl;
 
 import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.ClusterEventsService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.partition.PartitionService;
 
@@ -27,13 +27,13 @@ import io.atomix.primitive.partition.PartitionService;
 public class CorePrimitiveManagementService implements PrimitiveManagementService {
   private final ClusterService clusterService;
   private final ClusterCommunicationService communicationService;
-  private final ClusterEventService eventService;
+  private final ClusterEventsService eventService;
   private final PartitionService partitionService;
 
   public CorePrimitiveManagementService(
       ClusterService clusterService,
       ClusterCommunicationService communicationService,
-      ClusterEventService eventService,
+      ClusterEventsService eventService,
       PartitionService partitionService) {
     this.clusterService = clusterService;
     this.communicationService = communicationService;
@@ -52,7 +52,7 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
   }
 
   @Override
-  public ClusterEventService getEventService() {
+  public ClusterEventsService getEventService() {
     return eventService;
   }
 

--- a/core/src/main/java/io/atomix/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/impl/CorePrimitivesService.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 public class CorePrimitivesService implements ManagedPrimitivesService {
   private final PrimitiveManagementService managementService;
   private final ManagedTransactionService transactionService;
-  private final AtomicBoolean open = new AtomicBoolean();
+  private final AtomicBoolean started = new AtomicBoolean();
 
   public CorePrimitivesService(
       ClusterService clusterService,
@@ -85,25 +85,20 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
   }
 
   @Override
-  public CompletableFuture<PrimitivesService> open() {
-    return transactionService.open()
-        .thenRun(() -> open.set(true))
+  public CompletableFuture<PrimitivesService> start() {
+    return transactionService.start()
+        .thenRun(() -> started.set(true))
         .thenApply(v -> this);
   }
 
   @Override
-  public boolean isOpen() {
-    return open.get();
+  public boolean isRunning() {
+    return started.get();
   }
 
   @Override
-  public CompletableFuture<Void> close() {
-    return transactionService.close()
-        .whenComplete((r, e) -> open.set(false));
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !open.get();
+  public CompletableFuture<Void> stop() {
+    return transactionService.stop()
+        .whenComplete((r, e) -> started.set(false));
   }
 }

--- a/core/src/main/java/io/atomix/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/impl/CorePrimitivesService.java
@@ -21,7 +21,7 @@ import io.atomix.ManagedPrimitivesService;
 import io.atomix.PrimitivesService;
 import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.ClusterEventsService;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
@@ -49,7 +49,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
   public CorePrimitivesService(
       ClusterService clusterService,
       ClusterCommunicationService communicationService,
-      ClusterEventService eventService,
+      ClusterEventsService eventService,
       PartitionService partitionService) {
     this.managementService = new CorePrimitiveManagementService(
         clusterService,

--- a/core/src/main/java/io/atomix/lock/impl/DistributedLockProxyBuilder.java
+++ b/core/src/main/java/io/atomix/lock/impl/DistributedLockProxyBuilder.java
@@ -44,7 +44,7 @@ public class DistributedLockProxyBuilder extends DistributedLockBuilder {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> new DistributedLockProxy(proxy).sync());
   }
 }

--- a/core/src/main/java/io/atomix/lock/impl/DistributedLockProxyBuilder.java
+++ b/core/src/main/java/io/atomix/lock/impl/DistributedLockProxyBuilder.java
@@ -44,7 +44,7 @@ public class DistributedLockProxyBuilder extends DistributedLockBuilder {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> new DistributedLockProxy(proxy).sync());
   }
 }

--- a/core/src/main/java/io/atomix/map/impl/AtomicCounterMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/map/impl/AtomicCounterMapProxyBuilder.java
@@ -46,7 +46,7 @@ public class AtomicCounterMapProxyBuilder<K> extends AtomicCounterMapBuilder<K> 
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> {
           AtomicCounterMapProxy rawMap = new AtomicCounterMapProxy(proxy);
           Serializer serializer = serializer();

--- a/core/src/main/java/io/atomix/map/impl/AtomicCounterMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/map/impl/AtomicCounterMapProxyBuilder.java
@@ -46,7 +46,7 @@ public class AtomicCounterMapProxyBuilder<K> extends AtomicCounterMapBuilder<K> 
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> {
           AtomicCounterMapProxy rawMap = new AtomicCounterMapProxy(proxy);
           Serializer serializer = serializer();

--- a/core/src/main/java/io/atomix/map/impl/ConsistentMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/map/impl/ConsistentMapProxyBuilder.java
@@ -62,7 +62,7 @@ public class ConsistentMapProxyBuilder<K, V> extends ConsistentMapBuilder<K, V> 
     for (Partition partition : partitions.getPartitions()) {
       maps.put(partition.id(), partition.getPrimitiveClient()
           .newProxy(name(), primitiveType(), protocol)
-          .open()
+          .start()
           .thenApply(proxy -> new TranscodingAsyncConsistentMap<>(
               new ConsistentMapProxy(proxy),
               BaseEncoding.base16()::encode,

--- a/core/src/main/java/io/atomix/map/impl/ConsistentMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/map/impl/ConsistentMapProxyBuilder.java
@@ -62,7 +62,7 @@ public class ConsistentMapProxyBuilder<K, V> extends ConsistentMapBuilder<K, V> 
     for (Partition partition : partitions.getPartitions()) {
       maps.put(partition.id(), partition.getPrimitiveClient()
           .newProxy(name(), primitiveType(), protocol)
-          .start()
+          .connect()
           .thenApply(proxy -> new TranscodingAsyncConsistentMap<>(
               new ConsistentMapProxy(proxy),
               BaseEncoding.base16()::encode,

--- a/core/src/main/java/io/atomix/map/impl/ConsistentTreeMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/map/impl/ConsistentTreeMapProxyBuilder.java
@@ -48,7 +48,7 @@ public class ConsistentTreeMapProxyBuilder<V> extends ConsistentTreeMapBuilder<V
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> {
           ConsistentTreeMapProxy rawMap = new ConsistentTreeMapProxy(proxy);
           Serializer serializer = serializer();

--- a/core/src/main/java/io/atomix/map/impl/ConsistentTreeMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/map/impl/ConsistentTreeMapProxyBuilder.java
@@ -48,7 +48,7 @@ public class ConsistentTreeMapProxyBuilder<V> extends ConsistentTreeMapBuilder<V
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> {
           ConsistentTreeMapProxy rawMap = new ConsistentTreeMapProxy(proxy);
           Serializer serializer = serializer();

--- a/core/src/main/java/io/atomix/multimap/impl/ConsistentMultimapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/multimap/impl/ConsistentMultimapProxyBuilder.java
@@ -48,7 +48,7 @@ public class ConsistentMultimapProxyBuilder<K, V> extends ConsistentMultimapBuil
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> {
           AsyncConsistentMultimap<String, byte[]> rawMap = new ConsistentSetMultimapProxy(proxy);
           Serializer serializer = serializer();

--- a/core/src/main/java/io/atomix/multimap/impl/ConsistentMultimapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/multimap/impl/ConsistentMultimapProxyBuilder.java
@@ -48,7 +48,7 @@ public class ConsistentMultimapProxyBuilder<K, V> extends ConsistentMultimapBuil
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> {
           AsyncConsistentMultimap<String, byte[]> rawMap = new ConsistentSetMultimapProxy(proxy);
           Serializer serializer = serializer();

--- a/core/src/main/java/io/atomix/queue/impl/WorkQueueProxyBuilder.java
+++ b/core/src/main/java/io/atomix/queue/impl/WorkQueueProxyBuilder.java
@@ -44,7 +44,7 @@ public class WorkQueueProxyBuilder<E> extends WorkQueueBuilder<E> {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> new TranscodingAsyncWorkQueue<E, byte[]>(new WorkQueueProxy(proxy), serializer()::encode, serializer()::decode).sync());
   }
 }

--- a/core/src/main/java/io/atomix/queue/impl/WorkQueueProxyBuilder.java
+++ b/core/src/main/java/io/atomix/queue/impl/WorkQueueProxyBuilder.java
@@ -44,7 +44,7 @@ public class WorkQueueProxyBuilder<E> extends WorkQueueBuilder<E> {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> new TranscodingAsyncWorkQueue<E, byte[]>(new WorkQueueProxy(proxy), serializer()::encode, serializer()::decode).sync());
   }
 }

--- a/core/src/main/java/io/atomix/tree/impl/DocumentTreeProxyBuilder.java
+++ b/core/src/main/java/io/atomix/tree/impl/DocumentTreeProxyBuilder.java
@@ -60,7 +60,7 @@ public class DocumentTreeProxyBuilder<V> extends DocumentTreeBuilder<V> {
     for (Partition partition : partitions.getPartitions()) {
       trees.put(partition.id(), partition.getPrimitiveClient()
           .newProxy(name(), primitiveType(), protocol)
-          .start()
+          .connect()
           .thenApply(proxy -> {
             DocumentTreeProxy rawTree = new DocumentTreeProxy(proxy);
             return new TranscodingAsyncDocumentTree<>(

--- a/core/src/main/java/io/atomix/tree/impl/DocumentTreeProxyBuilder.java
+++ b/core/src/main/java/io/atomix/tree/impl/DocumentTreeProxyBuilder.java
@@ -60,7 +60,7 @@ public class DocumentTreeProxyBuilder<V> extends DocumentTreeBuilder<V> {
     for (Partition partition : partitions.getPartitions()) {
       trees.put(partition.id(), partition.getPrimitiveClient()
           .newProxy(name(), primitiveType(), protocol)
-          .open()
+          .start()
           .thenApply(proxy -> {
             DocumentTreeProxy rawTree = new DocumentTreeProxy(proxy);
             return new TranscodingAsyncDocumentTree<>(

--- a/core/src/main/java/io/atomix/value/impl/AtomicValueProxyBuilder.java
+++ b/core/src/main/java/io/atomix/value/impl/AtomicValueProxyBuilder.java
@@ -46,7 +46,7 @@ public class AtomicValueProxyBuilder<V> extends AtomicValueBuilder<V> {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .start()
+        .connect()
         .thenApply(proxy -> {
           AtomicValueProxy value = new AtomicValueProxy(proxy);
           return new TranscodingAsyncAtomicValue<V, byte[]>(

--- a/core/src/main/java/io/atomix/value/impl/AtomicValueProxyBuilder.java
+++ b/core/src/main/java/io/atomix/value/impl/AtomicValueProxyBuilder.java
@@ -46,7 +46,7 @@ public class AtomicValueProxyBuilder<V> extends AtomicValueBuilder<V> {
         .getPartition(name())
         .getPrimitiveClient()
         .newProxy(name(), primitiveType(), protocol)
-        .open()
+        .start()
         .thenApply(proxy -> {
           AtomicValueProxy value = new AtomicValueProxy(proxy);
           return new TranscodingAsyncAtomicValue<V, byte[]>(

--- a/core/src/test/java/io/atomix/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/AbstractAtomixTest.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,8 +65,8 @@ public abstract class AbstractAtomixTest {
    *
    * @return a new Atomix instance.
    */
-  protected Atomix atomix() {
-    Atomix instance = createAtomix(Node.Type.CLIENT, id++, 1, 2, 3).join();
+  protected Atomix atomix() throws Exception {
+    Atomix instance = createAtomix(Node.Type.CLIENT, id++, 1, 2, 3).start().get(10, TimeUnit.SECONDS);
     instances.add(instance);
     return instance;
   }
@@ -76,26 +77,17 @@ public abstract class AbstractAtomixTest {
     messagingServiceFactory = new TestMessagingServiceFactory();
     endpoints = new HashMap<>();
     instances = new ArrayList<>();
-    List<CompletableFuture<Atomix>> futures = new ArrayList<>();
-    futures.add(createAtomix(Node.Type.DATA, 1, 1, 2, 3).thenApply(instance -> {
-      instances.add(instance);
-      return instance;
-    }));
-    futures.add(createAtomix(Node.Type.DATA, 2, 1, 2, 3).thenApply(instance -> {
-      instances.add(instance);
-      return instance;
-    }));
-    futures.add(createAtomix(Node.Type.DATA, 3, 1, 2, 3).thenApply(instance -> {
-      instances.add(instance);
-      return instance;
-    }));
-    CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+    instances.add(createAtomix(Node.Type.DATA, 1, 1, 2, 3));
+    instances.add(createAtomix(Node.Type.DATA, 2, 1, 2, 3));
+    instances.add(createAtomix(Node.Type.DATA, 3, 1, 2, 3));
+    List<CompletableFuture<Atomix>> futures = instances.stream().map(Atomix::start).collect(Collectors.toList());
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(30, TimeUnit.SECONDS);
   }
 
   /**
    * Creates an Atomix instance.
    */
-  private static CompletableFuture<Atomix> createAtomix(Node.Type type, int id, Integer... ids) {
+  private static Atomix createAtomix(Node.Type type, int id, Integer... ids) {
     Node localNode = Node.builder(String.valueOf(id))
         .withType(type)
         .withEndpoint(endpoints.computeIfAbsent(id, i -> Endpoint.from("localhost", BASE_PORT + id)))
@@ -114,7 +106,7 @@ public abstract class AbstractAtomixTest {
         .withLocalNode(localNode)
         .withBootstrapNodes(bootstrapNodes)
         .withDataPartitions(3) // Lower number of partitions for faster testing
-        .buildAsync();
+        .build();
   }
 
   @AfterClass

--- a/core/src/test/java/io/atomix/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/AbstractAtomixTest.java
@@ -19,7 +19,7 @@ import io.atomix.cluster.ManagedClusterMetadataService;
 import io.atomix.cluster.ManagedClusterService;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.messaging.ManagedClusterCommunicationService;
-import io.atomix.cluster.messaging.ManagedClusterEventService;
+import io.atomix.cluster.messaging.ManagedClusterEventsService;
 import io.atomix.messaging.Endpoint;
 import io.atomix.messaging.ManagedMessagingService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
@@ -154,7 +154,7 @@ public abstract class AbstractAtomixTest {
    * Atomix implementation used for testing.
    */
   static class TestAtomix extends Atomix {
-    TestAtomix(ManagedMessagingService messagingService, ManagedClusterMetadataService metadataService, ManagedClusterService clusterService, ManagedClusterCommunicationService clusterCommunicator, ManagedClusterEventService clusterEventService, ManagedPartitionGroup corePartitionGroup, ManagedPartitionService partitions, PrimitiveTypeRegistry primitiveTypes) {
+    TestAtomix(ManagedMessagingService messagingService, ManagedClusterMetadataService metadataService, ManagedClusterService clusterService, ManagedClusterCommunicationService clusterCommunicator, ManagedClusterEventsService clusterEventService, ManagedPartitionGroup corePartitionGroup, ManagedPartitionService partitions, PrimitiveTypeRegistry primitiveTypes) {
       super(messagingService, metadataService, clusterService, clusterCommunicator, clusterEventService, corePartitionGroup, partitions, primitiveTypes);
     }
 

--- a/core/src/test/java/io/atomix/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/AbstractAtomixTest.java
@@ -119,7 +119,7 @@ public abstract class AbstractAtomixTest {
 
   @AfterClass
   public static void teardownAtomix() throws Exception {
-    List<CompletableFuture<Void>> futures = instances.stream().map(Atomix::close).collect(Collectors.toList());
+    List<CompletableFuture<Void>> futures = instances.stream().map(Atomix::stop).collect(Collectors.toList());
     try {
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
     } catch (Exception e) {

--- a/core/src/test/java/io/atomix/TestMessagingService.java
+++ b/core/src/test/java/io/atomix/TestMessagingService.java
@@ -40,7 +40,7 @@ public class TestMessagingService implements ManagedMessagingService {
   private final Endpoint endpoint;
   private final Map<Endpoint, TestMessagingService> services;
   private final Map<String, BiFunction<Endpoint, byte[], CompletableFuture<byte[]>>> handlers = new ConcurrentHashMap<>();
-  private final AtomicBoolean open = new AtomicBoolean();
+  private final AtomicBoolean started = new AtomicBoolean();
 
   public TestMessagingService(Endpoint endpoint, Map<Endpoint, TestMessagingService> services) {
     this.endpoint = endpoint;
@@ -134,26 +134,21 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<MessagingService> open() {
+  public CompletableFuture<MessagingService> start() {
     services.put(endpoint, this);
-    open.set(true);
+    started.set(true);
     return CompletableFuture.completedFuture(this);
   }
 
   @Override
-  public boolean isOpen() {
-    return open.get();
+  public boolean isRunning() {
+    return started.get();
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     services.remove(endpoint);
-    open.set(false);
+    started.set(false);
     return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !open.get();
   }
 }

--- a/core/src/test/java/io/atomix/queue/impl/WorkQueueTest.java
+++ b/core/src/test/java/io/atomix/queue/impl/WorkQueueTest.java
@@ -157,7 +157,7 @@ public class WorkQueueTest extends AbstractAtomixTest {
   }
 
   @Test
-  public void testDestroy() {
+  public void testDestroy() throws Exception {
     String queueName = UUID.randomUUID().toString();
     AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
     String item = DEFAULT_PAYLOAD;
@@ -181,7 +181,7 @@ public class WorkQueueTest extends AbstractAtomixTest {
   }
 
   @Test
-  public void testCompleteAttemptWithIncorrectSession() {
+  public void testCompleteAttemptWithIncorrectSession() throws Exception {
     String queueName = UUID.randomUUID().toString();
     AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
     String item = DEFAULT_PAYLOAD;

--- a/core/src/test/java/io/atomix/tree/impl/DocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/tree/impl/DocumentTreeTest.java
@@ -46,11 +46,11 @@ import static org.junit.Assert.fail;
  */
 public class DocumentTreeTest extends AbstractAtomixTest {
 
-  protected AsyncDocumentTree<String> newTree(String name) {
+  protected AsyncDocumentTree<String> newTree(String name) throws Exception {
     return newTree(name, null);
   }
 
-  protected AsyncDocumentTree<String> newTree(String name, Ordering ordering) {
+  protected AsyncDocumentTree<String> newTree(String name, Ordering ordering) throws Exception {
     return atomix().<String>documentTreeBuilder(name)
         .withOrdering(ordering)
         .withMaxRetries(5)
@@ -325,7 +325,7 @@ public class DocumentTreeTest extends AbstractAtomixTest {
    * Tests destroy.
    */
   @Test
-  public void testClear() {
+  public void testClear() throws Exception {
     AsyncDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
     tree.create(path("root.a"), "a").join();
     tree.create(path("root.a.b"), "ab").join();

--- a/messaging/src/main/java/io/atomix/messaging/impl/NettyMessagingService.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/NettyMessagingService.java
@@ -208,7 +208,7 @@ public class NettyMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<MessagingService> open() {
+  public CompletableFuture<MessagingService> start() {
     getTlsParameters();
     if (started.get()) {
       log.warn("Already running at local endpoint: {}", localEndpoint);
@@ -236,13 +236,8 @@ public class NettyMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return started.get();
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !isOpen();
   }
 
   private boolean loadKeyStores() {
@@ -586,7 +581,7 @@ public class NettyMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     if (started.get()) {
       serverGroup.shutdownGracefully();
       clientGroup.shutdownGracefully();

--- a/messaging/src/test/java/io/atomix/messaging/impl/NettyMessagingServiceTest.java
+++ b/messaging/src/test/java/io/atomix/messaging/impl/NettyMessagingServiceTest.java
@@ -66,14 +66,14 @@ public class NettyMessagingServiceTest {
     netty1 = (ManagedMessagingService) NettyMessagingService.builder()
         .withEndpoint(ep1)
         .build()
-        .open()
+        .start()
         .join();
 
     ep2 = new Endpoint(InetAddress.getByName("127.0.0.1"), findAvailablePort(5003));
     netty2 = (ManagedMessagingService) NettyMessagingService.builder()
         .withEndpoint(ep2)
         .build()
-        .open()
+        .start()
         .join();
 
     invalidEndPoint = new Endpoint(InetAddress.getByName(IP_STRING), 5003);
@@ -90,11 +90,11 @@ public class NettyMessagingServiceTest {
   @After
   public void tearDown() throws Exception {
     if (netty1 != null) {
-      netty1.close();
+      netty1.stop();
     }
 
     if (netty2 != null) {
-      netty2.close();
+      netty2.stop();
     }
   }
 

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveManagementService.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveManagementService.java
@@ -17,7 +17,7 @@ package io.atomix.primitive;
 
 import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.ClusterEventsService;
 import io.atomix.primitive.partition.PartitionService;
 
 /**
@@ -44,7 +44,7 @@ public interface PrimitiveManagementService {
    *
    * @return the cluster event service
    */
-  ClusterEventService getEventService();
+  ClusterEventsService getEventService();
 
   /**
    * Returns the partition service.

--- a/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitive.java
@@ -85,7 +85,7 @@ public abstract class AbstractAsyncPrimitive implements AsyncPrimitive {
 
   @Override
   public CompletableFuture<Void> close() {
-    return proxy.stop();
+    return proxy.close();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitive.java
@@ -85,7 +85,7 @@ public abstract class AbstractAsyncPrimitive implements AsyncPrimitive {
 
   @Override
   public CompletableFuture<Void> close() {
-    return proxy.close();
+    return proxy.stop();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/proxy/PrimitiveProxy.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/PrimitiveProxy.java
@@ -20,7 +20,6 @@ import io.atomix.primitive.event.EventType;
 import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.session.SessionId;
-import io.atomix.utils.Managed;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -29,7 +28,7 @@ import java.util.function.Function;
 /**
  * Raft client proxy.
  */
-public interface PrimitiveProxy extends PrimitiveProxyExecutor, Managed<PrimitiveProxy> {
+public interface PrimitiveProxy extends PrimitiveProxyExecutor {
 
   /**
    * Indicates the state of the client's communication with the Raft cluster.
@@ -205,4 +204,18 @@ public interface PrimitiveProxy extends PrimitiveProxyExecutor, Managed<Primitiv
    * @param listener  the event listener to remove
    */
   void removeEventListener(EventType eventType, Consumer listener);
+
+  /**
+   * Connects the primitive proxy.
+   *
+   * @return a future to be completed once the proxy has been connected
+   */
+  CompletableFuture<PrimitiveProxy> connect();
+
+  /**
+   * Closes the primitive proxy.
+   *
+   * @return a future to be completed once the proxy has been closed
+   */
+  CompletableFuture<Void> close();
 }

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DelegatingPrimitiveProxy.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DelegatingPrimitiveProxy.java
@@ -138,18 +138,13 @@ public class DelegatingPrimitiveProxy implements PrimitiveProxy {
   }
 
   @Override
-  public CompletableFuture<PrimitiveProxy> start() {
-    return proxy.start().thenApply(c -> this);
+  public CompletableFuture<PrimitiveProxy> connect() {
+    return proxy.connect().thenApply(c -> this);
   }
 
   @Override
-  public boolean isRunning() {
-    return proxy.isRunning();
-  }
-
-  @Override
-  public CompletableFuture<Void> stop() {
-    return proxy.stop();
+  public CompletableFuture<Void> close() {
+    return proxy.close();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DelegatingPrimitiveProxy.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DelegatingPrimitiveProxy.java
@@ -138,23 +138,18 @@ public class DelegatingPrimitiveProxy implements PrimitiveProxy {
   }
 
   @Override
-  public CompletableFuture<PrimitiveProxy> open() {
-    return proxy.open().thenApply(c -> this);
+  public CompletableFuture<PrimitiveProxy> start() {
+    return proxy.start().thenApply(c -> this);
   }
 
   @Override
-  public boolean isOpen() {
-    return proxy.isOpen();
+  public boolean isRunning() {
+    return proxy.isRunning();
   }
 
   @Override
-  public CompletableFuture<Void> close() {
-    return proxy.close();
-  }
-
-  @Override
-  public boolean isClosed() {
-    return proxy.isClosed();
+  public CompletableFuture<Void> stop() {
+    return proxy.stop();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/RecoveringPrimitiveProxy.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/RecoveringPrimitiveProxy.java
@@ -55,7 +55,7 @@ public class RecoveringPrimitiveProxy extends AbstractPrimitiveProxy {
   private final Set<Consumer<PrimitiveProxy.State>> stateChangeListeners = Sets.newCopyOnWriteArraySet();
   private final Set<Consumer<PrimitiveEvent>> eventListeners = Sets.newCopyOnWriteArraySet();
   private Scheduled recoverTask;
-  private volatile boolean open = false;
+  private volatile boolean connected = false;
 
   public RecoveringPrimitiveProxy(String clientId, String name, PrimitiveType primitiveType, Supplier<PrimitiveProxy> proxyFactory, Scheduler scheduler) {
     this.name = checkNotNull(name);
@@ -96,7 +96,7 @@ public class RecoveringPrimitiveProxy extends AbstractPrimitiveProxy {
   private synchronized void onStateChange(PrimitiveProxy.State state) {
     if (this.state != state) {
       if (state == PrimitiveProxy.State.CLOSED) {
-        if (open) {
+        if (connected) {
           onStateChange(PrimitiveProxy.State.SUSPENDED);
           recover();
         } else {
@@ -126,7 +126,7 @@ public class RecoveringPrimitiveProxy extends AbstractPrimitiveProxy {
    * Verifies that the client is open.
    */
   private void checkOpen() {
-    checkState(isRunning(), "client not open");
+    checkState(connected, "client not open");
   }
 
   /**
@@ -143,7 +143,7 @@ public class RecoveringPrimitiveProxy extends AbstractPrimitiveProxy {
    * @return a future to be completed once the client has been opened
    */
   private CompletableFuture<PrimitiveProxy> openProxy() {
-    if (open) {
+    if (connected) {
       log.debug("Opening proxy session");
 
       clientFuture = new OrderedFuture<>();
@@ -173,7 +173,7 @@ public class RecoveringPrimitiveProxy extends AbstractPrimitiveProxy {
    * @param future the future to be completed once the client is opened
    */
   private void openProxy(CompletableFuture<PrimitiveProxy> future) {
-    proxyFactory.get().start().whenComplete((proxy, error) -> {
+    proxyFactory.get().connect().whenComplete((proxy, error) -> {
       if (error == null) {
         future.complete(proxy);
       } else {
@@ -214,32 +214,27 @@ public class RecoveringPrimitiveProxy extends AbstractPrimitiveProxy {
   }
 
   @Override
-  public synchronized CompletableFuture<PrimitiveProxy> start() {
-    if (!open) {
-      open = true;
+  public synchronized CompletableFuture<PrimitiveProxy> connect() {
+    if (!connected) {
+      connected = true;
       return openProxy().thenApply(c -> this);
     }
     return CompletableFuture.completedFuture(this);
   }
 
   @Override
-  public boolean isRunning() {
-    return open;
-  }
-
-  @Override
-  public synchronized CompletableFuture<Void> stop() {
-    if (open) {
-      open = false;
+  public synchronized CompletableFuture<Void> close() {
+    if (connected) {
+      connected = false;
       if (recoverTask != null) {
         recoverTask.cancel();
       }
 
       PrimitiveProxy proxy = this.proxy;
       if (proxy != null) {
-        return proxy.stop();
+        return proxy.close();
       } else {
-        return clientFuture.thenCompose(c -> c.stop());
+        return clientFuture.thenCompose(c -> c.close());
       }
     }
     return CompletableFuture.completedFuture(null);

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupServer.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupServer.java
@@ -86,27 +86,22 @@ public class PrimaryBackupServer implements Managed<PrimaryBackupServer> {
   }
 
   @Override
-  public CompletableFuture<PrimaryBackupServer> open() {
+  public CompletableFuture<PrimaryBackupServer> start() {
     context.open();
     open.set(true);
     return CompletableFuture.completedFuture(this);
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return open.get();
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     open.set(false);
     context.close();
     return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !open.get();
   }
 
   /**

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
@@ -87,7 +87,7 @@ public class PrimaryBackupPartition implements Partition<MultiPrimaryProtocol> {
     election = managementService.getElectionService().getElectionFor(partitionId);
     server = new PrimaryBackupPartitionServer(this, managementService, threadFactory);
     client = new PrimaryBackupPartitionClient(this, managementService, threadFactory);
-    return server.open().thenCompose(v -> client.open()).thenApply(v -> this);
+    return server.start().thenCompose(v -> client.start()).thenApply(v -> this);
   }
 
   /**
@@ -99,8 +99,8 @@ public class PrimaryBackupPartition implements Partition<MultiPrimaryProtocol> {
     }
 
     CompletableFuture<Void> future = new CompletableFuture<>();
-    client.close().whenComplete((clientResult, clientError) -> {
-      server.close().whenComplete((serverResult, serverError) -> {
+    client.stop().whenComplete((clientResult, clientError) -> {
+      server.stop().whenComplete((serverResult, serverError) -> {
         future.complete(null);
       });
     });

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionClient.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionClient.java
@@ -62,7 +62,7 @@ public class PrimaryBackupPartitionClient implements PrimitiveClient<MultiPrimar
   }
 
   @Override
-  public CompletableFuture<PrimaryBackupPartitionClient> open() {
+  public CompletableFuture<PrimaryBackupPartitionClient> start() {
     synchronized (PrimaryBackupPartitionClient.this) {
       client = newClient();
       log.info("Successfully started client for {}", partition.id());
@@ -85,17 +85,12 @@ public class PrimaryBackupPartitionClient implements PrimitiveClient<MultiPrimar
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return client != null;
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     return client != null ? client.close() : CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public boolean isClosed() {
-    return client == null;
   }
 }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
@@ -217,7 +217,7 @@ public class PrimaryBackupProxy extends AbstractPrimitiveProxy {
   }
 
   @Override
-  public CompletableFuture<PrimitiveProxy> start() {
+  public CompletableFuture<PrimitiveProxy> connect() {
     CompletableFuture<PrimitiveProxy> future = new CompletableFuture<>();
     threadContext.execute(() -> {
       primaryElection.getTerm().whenCompleteAsync((term, error) -> {
@@ -238,12 +238,7 @@ public class PrimaryBackupProxy extends AbstractPrimitiveProxy {
   }
 
   @Override
-  public boolean isRunning() {
-    return state != State.CLOSED;
-  }
-
-  @Override
-  public CompletableFuture<Void> stop() {
+  public CompletableFuture<Void> close() {
     CompletableFuture<Void> future = new CompletableFuture<>();
     if (term.primary() != null) {
       protocol.close(term.primary(), new CloseRequest(descriptor, sessionId.id()))

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
@@ -217,7 +217,7 @@ public class PrimaryBackupProxy extends AbstractPrimitiveProxy {
   }
 
   @Override
-  public CompletableFuture<PrimitiveProxy> open() {
+  public CompletableFuture<PrimitiveProxy> start() {
     CompletableFuture<PrimitiveProxy> future = new CompletableFuture<>();
     threadContext.execute(() -> {
       primaryElection.getTerm().whenCompleteAsync((term, error) -> {
@@ -238,12 +238,12 @@ public class PrimaryBackupProxy extends AbstractPrimitiveProxy {
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return state != State.CLOSED;
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     CompletableFuture<Void> future = new CompletableFuture<>();
     if (term.primary() != null) {
       protocol.close(term.primary(), new CloseRequest(descriptor, sessionId.id()))
@@ -257,10 +257,5 @@ public class PrimaryBackupProxy extends AbstractPrimitiveProxy {
       future.complete(null);
     }
     return future;
-  }
-
-  @Override
-  public boolean isClosed() {
-    return state == State.CLOSED;
   }
 }

--- a/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
+++ b/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
@@ -275,7 +275,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
     }
 
     PrimaryBackupServer leader = servers.stream().filter(s -> s.getRole() == Role.PRIMARY).findFirst().get();
-    leader.close().get(10, TimeUnit.SECONDS);
+    leader.stop().get(10, TimeUnit.SECONDS);
 
     for (int i = 0; i < 10; i++) {
       session.invoke(EVENT, SERIALIZER::encode, true).thenRun(this::resume);
@@ -361,7 +361,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
     PrimitiveProxy session2 = createProxy(client2, 2, replication);
     session2.invoke(READ).thenRun(this::resume);
     await(5000);
-    session2.close().thenRun(this::resume);
+    session2.stop().thenRun(this::resume);
     await(Duration.ofSeconds(10).toMillis(), 2);
   }
 
@@ -390,7 +390,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
     for (int i = 0; i < count; i++) {
       nodes.add(nextNodeId());
       PrimaryBackupServer server = createServer(nodes.get(i));
-      server.open().thenRun(this::resume);
+      server.start().thenRun(this::resume);
       servers.add(server);
     }
 
@@ -438,7 +438,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
         .withBackups(backups)
         .withReplication(replication)
         .build())
-        .open()
+        .start()
         .join();
   }
 

--- a/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
+++ b/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
@@ -361,7 +361,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
     PrimitiveProxy session2 = createProxy(client2, 2, replication);
     session2.invoke(READ).thenRun(this::resume);
     await(5000);
-    session2.stop().thenRun(this::resume);
+    session2.close().thenRun(this::resume);
     await(Duration.ofSeconds(10).toMillis(), 2);
   }
 
@@ -438,7 +438,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
         .withBackups(backups)
         .withReplication(replication)
         .build())
-        .start()
+        .connect()
         .join();
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -854,7 +854,7 @@ public class RaftContext implements AutoCloseable {
 
     // Close the old state.
     try {
-      this.role.close().get();
+      this.role.stop().get();
     } catch (InterruptedException | ExecutionException e) {
       throw new IllegalStateException("failed to close Raft state", e);
     }
@@ -862,7 +862,7 @@ public class RaftContext implements AutoCloseable {
     // Force state transitions to occur synchronously in order to prevent race conditions.
     try {
       this.role = createRole(role);
-      this.role.open().get();
+      this.role.start().get();
     } catch (InterruptedException | ExecutionException e) {
       throw new IllegalStateException("failed to initialize Raft state", e);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionClient.java
@@ -78,7 +78,7 @@ public class RaftPartitionClient implements PrimitiveClient<RaftProtocol>, Manag
   }
 
   @Override
-  public CompletableFuture<RaftPartitionClient> open() {
+  public CompletableFuture<RaftPartitionClient> start() {
     synchronized (RaftPartitionClient.this) {
       client = newRaftClient(protocol);
     }
@@ -92,18 +92,13 @@ public class RaftPartitionClient implements PrimitiveClient<RaftProtocol>, Manag
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     return client != null ? client.close() : CompletableFuture.completedFuture(null);
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return client != null;
-  }
-
-  @Override
-  public boolean isClosed() {
-    return client == null;
   }
 
   private RaftClient newRaftClient(RaftClientProtocol protocol) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -67,7 +67,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   }
 
   @Override
-  public CompletableFuture<RaftPartitionServer> open() {
+  public CompletableFuture<RaftPartitionServer> start() {
     log.info("Starting server for partition {}", partition.id());
     CompletableFuture<RaftServer> serverOpenFuture;
     if (partition.members().contains(localNodeId)) {
@@ -91,7 +91,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     return server.shutdown();
   }
 
@@ -160,12 +160,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return server.isRunning();
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !isOpen();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
@@ -15,11 +15,11 @@
  */
 package io.atomix.protocols.raft.proxy.impl;
 
+import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.proxy.PrimitiveProxy;
 import io.atomix.primitive.proxy.impl.AbstractPrimitiveProxy;
-import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
@@ -150,7 +150,7 @@ public class DefaultRaftProxy extends AbstractPrimitiveProxy implements RaftProx
   }
 
   @Override
-  public CompletableFuture<PrimitiveProxy> open() {
+  public CompletableFuture<PrimitiveProxy> start() {
     return sessionManager.openSession(
         serviceName,
         primitiveType,
@@ -202,22 +202,18 @@ public class DefaultRaftProxy extends AbstractPrimitiveProxy implements RaftProx
   }
 
   @Override
-  public boolean isOpen() {
-    return state.getState() != PrimitiveProxy.State.CLOSED;
+  public boolean isRunning() {
+    RaftProxyState state = this.state;
+    return state != null && state.getState() != PrimitiveProxy.State.CLOSED;
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     if (state != null) {
       return sessionManager.closeSession(state.getSessionId())
           .whenComplete((result, error) -> state.setState(PrimitiveProxy.State.CLOSED));
     }
     return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public boolean isClosed() {
-    return state == null || state.getState() == PrimitiveProxy.State.CLOSED;
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
@@ -150,7 +150,7 @@ public class DefaultRaftProxy extends AbstractPrimitiveProxy implements RaftProx
   }
 
   @Override
-  public CompletableFuture<PrimitiveProxy> start() {
+  public CompletableFuture<PrimitiveProxy> connect() {
     return sessionManager.openSession(
         serviceName,
         primitiveType,
@@ -202,13 +202,7 @@ public class DefaultRaftProxy extends AbstractPrimitiveProxy implements RaftProx
   }
 
   @Override
-  public boolean isRunning() {
-    RaftProxyState state = this.state;
-    return state != null && state.getState() != PrimitiveProxy.State.CLOSED;
-  }
-
-  @Override
-  public CompletableFuture<Void> stop() {
+  public CompletableFuture<Void> close() {
     if (state != null) {
       return sessionManager.closeSession(state.getSessionId())
           .whenComplete((result, error) -> state.setState(PrimitiveProxy.State.CLOSED));

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
@@ -72,14 +72,14 @@ public abstract class AbstractRole implements RaftRole {
   }
 
   @Override
-  public CompletableFuture<RaftRole> open() {
+  public CompletableFuture<RaftRole> start() {
     raft.checkThread();
     open = true;
     return CompletableFuture.completedFuture(null);
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return open;
   }
 
@@ -126,15 +126,10 @@ public abstract class AbstractRole implements RaftRole {
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     raft.checkThread();
     open = false;
     return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !open;
   }
 
   @Override
@@ -143,5 +138,4 @@ public abstract class AbstractRole implements RaftRole {
         .add("context", raft)
         .toString();
   }
-
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/CandidateRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/CandidateRole.java
@@ -55,8 +55,8 @@ public final class CandidateRole extends ActiveRole {
   }
 
   @Override
-  public synchronized CompletableFuture<RaftRole> open() {
-    return super.open().thenRun(this::startElection).thenApply(v -> this);
+  public synchronized CompletableFuture<RaftRole> start() {
+    return super.start().thenRun(this::startElection).thenApply(v -> this);
   }
 
   /**
@@ -75,7 +75,7 @@ public final class CandidateRole extends ActiveRole {
 
     // Because of asynchronous execution, the candidate state could have already been closed. In that case,
     // simply skip the election.
-    if (isClosed()) {
+    if (!isRunning()) {
       return;
     }
 
@@ -151,7 +151,7 @@ public final class CandidateRole extends ActiveRole {
 
       raft.getProtocol().vote(member.nodeId(), request).whenCompleteAsync((response, error) -> {
         raft.checkThread();
-        if (isOpen() && !complete.get()) {
+        if (isRunning() && !complete.get()) {
           if (error != null) {
             log.warn(error.getMessage());
             quorum.fail();
@@ -235,8 +235,8 @@ public final class CandidateRole extends ActiveRole {
   }
 
   @Override
-  public synchronized CompletableFuture<Void> close() {
-    return super.close().thenRun(this::cancelElection);
+  public synchronized CompletableFuture<Void> stop() {
+    return super.stop().thenRun(this::cancelElection);
   }
 
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -84,8 +84,8 @@ public class PassiveRole extends InactiveRole {
   }
 
   @Override
-  public CompletableFuture<RaftRole> open() {
-    return super.open()
+  public CompletableFuture<RaftRole> start() {
+    return super.start()
         .thenRun(this::truncateUncommittedEntries)
         .thenApply(v -> this);
   }
@@ -738,11 +738,11 @@ public class PassiveRole extends InactiveRole {
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     for (PendingSnapshot pendingSnapshot : pendingSnapshots.values()) {
       pendingSnapshot.rollback();
     }
-    return super.close();
+    return super.stop();
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1131,7 +1131,7 @@ public class RaftTest extends ConcurrentTestCase {
     session1.invoke(CLOSE).thenRun(this::resume);
     await(Duration.ofSeconds(10).toMillis(), 1);
     session1.addEventListener(CLOSE_EVENT, this::resume);
-    createSession(client2).close().thenRun(this::resume);
+    createSession(client2).stop().thenRun(this::resume);
     await(Duration.ofSeconds(10).toMillis(), 2);
   }
 
@@ -1255,7 +1255,7 @@ public class RaftTest extends ConcurrentTestCase {
         .withMinTimeout(Duration.ofMillis(250))
         .withMaxTimeout(Duration.ofSeconds(5))
         .build())
-        .open()
+        .start()
         .get(5, TimeUnit.SECONDS);
   }
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1131,7 +1131,7 @@ public class RaftTest extends ConcurrentTestCase {
     session1.invoke(CLOSE).thenRun(this::resume);
     await(Duration.ofSeconds(10).toMillis(), 1);
     session1.addEventListener(CLOSE_EVENT, this::resume);
-    createSession(client2).stop().thenRun(this::resume);
+    createSession(client2).close().thenRun(this::resume);
     await(Duration.ofSeconds(10).toMillis(), 2);
   }
 
@@ -1255,7 +1255,7 @@ public class RaftTest extends ConcurrentTestCase {
         .withMinTimeout(Duration.ofMillis(250))
         .withMaxTimeout(Duration.ofSeconds(5))
         .build())
-        .start()
+        .connect()
         .get(5, TimeUnit.SECONDS);
   }
 

--- a/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
+++ b/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
@@ -19,7 +19,7 @@ import io.atomix.Atomix;
 import io.atomix.PrimitivesService;
 import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.cluster.messaging.ClusterEventsService;
 import io.atomix.messaging.Endpoint;
 import io.atomix.rest.ManagedRestService;
 import io.atomix.rest.RestService;
@@ -68,15 +68,15 @@ public class VertxRestService implements ManagedRestService {
     deployment.start();
 
     deployment.getDispatcher().getDefaultContextObjects()
-        .put(ClusterService.class, atomix.getClusterService());
+        .put(ClusterService.class, atomix.cluster());
     deployment.getDispatcher().getDefaultContextObjects()
-        .put(ClusterCommunicationService.class, atomix.getCommunicationService());
+        .put(ClusterCommunicationService.class, atomix.communicator());
     deployment.getDispatcher().getDefaultContextObjects()
-        .put(ClusterEventService.class, atomix.getEventService());
+        .put(ClusterEventsService.class, atomix.events());
     deployment.getDispatcher().getDefaultContextObjects()
-        .put(PrimitivesService.class, atomix.getPrimitivesService());
+        .put(PrimitivesService.class, atomix.primitives());
     deployment.getDispatcher().getDefaultContextObjects()
-        .put(PrimitiveCache.class, new PrimitiveCache(atomix.getPrimitivesService(), PRIMITIVE_CACHE_SIZE));
+        .put(PrimitiveCache.class, new PrimitiveCache(atomix.primitives(), PRIMITIVE_CACHE_SIZE));
     deployment.getDispatcher().getDefaultContextObjects()
         .put(EventManager.class, new EventManager());
 

--- a/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
+++ b/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
@@ -62,7 +62,7 @@ public class VertxRestService implements ManagedRestService {
   }
 
   @Override
-  public CompletableFuture<RestService> open() {
+  public CompletableFuture<RestService> start() {
     server = vertx.createHttpServer();
     deployment = new VertxResteasyDeployment();
     deployment.start();
@@ -101,12 +101,12 @@ public class VertxRestService implements ManagedRestService {
   }
 
   @Override
-  public boolean isOpen() {
+  public boolean isRunning() {
     return open.get();
   }
 
   @Override
-  public CompletableFuture<Void> close() {
+  public CompletableFuture<Void> stop() {
     if (server != null) {
       CompletableFuture<Void> future = new CompletableFuture<>();
       server.close(result -> {
@@ -118,11 +118,6 @@ public class VertxRestService implements ManagedRestService {
     }
     open.set(false);
     return CompletableFuture.completedFuture(null);
-  }
-
-  @Override
-  public boolean isClosed() {
-    return !open.get();
   }
 
   /**

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftFuzzTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftFuzzTest.java
@@ -560,7 +560,7 @@ public class RaftFuzzTest implements Runnable {
     if (USE_NETTY) {
       try {
         Endpoint endpoint = new Endpoint(InetAddress.getLocalHost(), ++port);
-        MessagingService messagingManager = NettyMessagingService.builder().withEndpoint(endpoint).build().open().join();
+        MessagingService messagingManager = NettyMessagingService.builder().withEndpoint(endpoint).build().start().join();
         messagingServices.add(messagingManager);
         endpointMap.put(member.nodeId(), endpoint);
         protocol = new RaftServerMessagingProtocol(messagingManager, protocolSerializer, endpointMap::get);
@@ -595,7 +595,7 @@ public class RaftFuzzTest implements Runnable {
     RaftClientProtocol protocol;
     if (USE_NETTY) {
       Endpoint endpoint = new Endpoint(InetAddress.getLocalHost(), ++port);
-      MessagingService messagingManager = NettyMessagingService.builder().withEndpoint(endpoint).build().open().join();
+      MessagingService messagingManager = NettyMessagingService.builder().withEndpoint(endpoint).build().start().join();
       endpointMap.put(nodeId, endpoint);
       protocol = new RaftClientMessagingProtocol(messagingManager, protocolSerializer, endpointMap::get);
     } else {
@@ -620,7 +620,7 @@ public class RaftFuzzTest implements Runnable {
         .withReadConsistency(consistency)
         .withCommunicationStrategy(COMMUNICATION_STRATEGY)
         .build())
-        .open()
+        .start()
         .join();
   }
 

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftFuzzTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftFuzzTest.java
@@ -620,7 +620,7 @@ public class RaftFuzzTest implements Runnable {
         .withReadConsistency(consistency)
         .withCommunicationStrategy(COMMUNICATION_STRATEGY)
         .build())
-        .start()
+        .connect()
         .join();
   }
 

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
@@ -293,7 +293,7 @@ public class RaftPerformanceTest implements Runnable {
     for (int i = 0; i < NUM_CLIENTS; i++) {
       CompletableFuture<Void> future = new CompletableFuture<>();
       clients[i] = createClient();
-      proxies[i] = createProxy(clients[i]).start().join();
+      proxies[i] = createProxy(clients[i]).connect().join();
       futures[i] = future;
     }
 

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
@@ -293,7 +293,7 @@ public class RaftPerformanceTest implements Runnable {
     for (int i = 0; i < NUM_CLIENTS; i++) {
       CompletableFuture<Void> future = new CompletableFuture<>();
       clients[i] = createClient();
-      proxies[i] = createProxy(clients[i]).open().join();
+      proxies[i] = createProxy(clients[i]).start().join();
       futures[i] = future;
     }
 
@@ -378,7 +378,7 @@ public class RaftPerformanceTest implements Runnable {
 
     messagingServices.forEach(m -> {
       try {
-        m.close();
+        m.stop();
       } catch (Exception e) {
       }
     });
@@ -453,7 +453,7 @@ public class RaftPerformanceTest implements Runnable {
     RaftServerProtocol protocol;
     if (USE_NETTY) {
       Endpoint endpoint = new Endpoint(InetAddress.getLocalHost(), ++port);
-      ManagedMessagingService messagingService = (ManagedMessagingService) NettyMessagingService.builder().withEndpoint(endpoint).build().open().join();
+      ManagedMessagingService messagingService = (ManagedMessagingService) NettyMessagingService.builder().withEndpoint(endpoint).build().start().join();
       messagingServices.add(messagingService);
       endpointMap.put(nodeId, endpoint);
       protocol = new RaftServerMessagingProtocol(messagingService, protocolSerializer, endpointMap::get);
@@ -487,7 +487,7 @@ public class RaftPerformanceTest implements Runnable {
     RaftClientProtocol protocol;
     if (USE_NETTY) {
       Endpoint endpoint = new Endpoint(InetAddress.getLocalHost(), ++port);
-      MessagingService messagingService = NettyMessagingService.builder().withEndpoint(endpoint).build().open().join();
+      MessagingService messagingService = NettyMessagingService.builder().withEndpoint(endpoint).build().start().join();
       endpointMap.put(nodeId, endpoint);
       protocol = new RaftClientMessagingProtocol(messagingService, protocolSerializer, endpointMap::get);
     } else {

--- a/utils/src/main/java/io/atomix/utils/Managed.java
+++ b/utils/src/main/java/io/atomix/utils/Managed.java
@@ -25,31 +25,24 @@ import java.util.concurrent.CompletableFuture;
 public interface Managed<T> {
 
   /**
-   * Opens the managed object.
+   * Starts the managed object.
    *
-   * @return A completable future to be completed once the object has been opened.
+   * @return A completable future to be completed once the object has been started.
    */
-  CompletableFuture<T> open();
+  CompletableFuture<T> start();
 
   /**
-   * Returns a boolean value indicating whether the managed object is open.
+   * Returns a boolean value indicating whether the managed object is running.
    *
-   * @return Indicates whether the managed object is open.
+   * @return Indicates whether the managed object is running.
    */
-  boolean isOpen();
+  boolean isRunning();
 
   /**
-   * Closes the managed object.
+   * Stops the managed object.
    *
-   * @return A completable future to be completed once the object has been closed.
+   * @return A completable future to be completed once the object has been stopped.
    */
-  CompletableFuture<Void> close();
-
-  /**
-   * Returns a boolean value indicating whether the managed object is closed.
-   *
-   * @return Indicates whether the managed object is closed.
-   */
-  boolean isClosed();
+  CompletableFuture<Void> stop();
 
 }

--- a/utils/src/main/java/io/atomix/utils/Managed.java
+++ b/utils/src/main/java/io/atomix/utils/Managed.java
@@ -18,7 +18,7 @@ package io.atomix.utils;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Interface for types that can be asynchronously opened and closed.
+ * Interface for types that can be asynchronously started and stopped.
  *
  * @param <T> managed type
  */


### PR DESCRIPTION
This PR cleans up various APIs within Atomix, changing the `Managed` interface method to `start()` and `stop()` rather than `open()` and `close()` and simplifying getters on the `Atomix` interface.