### PR TITLE
atomix-storage-parent removed

### DIFF
--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -18,7 +18,7 @@
 
   <parent>
     <groupId>io.atomix</groupId>
-    <artifactId>atomix-storage-parent</artifactId>
+    <artifactId>atomix-parent</artifactId>
     <version>2.1.0-SNAPSHOT</version>
   </parent>
 


### PR DESCRIPTION
It looks like the atomix-storage-parent pom was removed, repointing to the atomix-parent.