### PR TITLE
Ensure sessions created via snapshot are opened

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -426,7 +426,7 @@ public class RaftServiceManager implements AutoCloseable {
     }
 
     SessionId sessionId = SessionId.from(entry.index());
-    RaftSessionContext session = new RaftSessionContext(
+    RaftSessionContext session = raft.getSessions().addSession(new RaftSessionContext(
         sessionId,
         MemberId.from(entry.entry().memberId()),
         entry.entry().serviceName(),
@@ -437,8 +437,7 @@ public class RaftServiceManager implements AutoCloseable {
         entry.entry().timestamp(),
         service,
         raft,
-        threadContextFactory);
-    raft.getSessions().addSession(session);
+        threadContextFactory));
     return service.openSession(entry.index(), entry.entry().timestamp(), session);
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -267,24 +267,20 @@ public class DefaultServiceContext implements ServiceContext {
           long maxTimeout = reader.readLong();
           long sessionTimestamp = reader.readLong();
 
-          // Lookup the session in the global session registry and only create a new session if one does not already
-          // exist. A race condition exists such that a session created by a global snapshot may prevent the local
-          // session from being opened since local sessions cannot override global sessions.
-          RaftSessionContext session = raft.getSessions().getSession(sessionId);
-          if (session == null) {
-            session = new RaftSessionContext(
-                sessionId,
-                node,
-                serviceName,
-                serviceType,
-                readConsistency,
-                minTimeout,
-                maxTimeout,
-                sessionTimestamp,
-                this,
-                raft,
-                threadContextFactory);
-          }
+          // Only create a new session if one does not already exist. This is necessary to ensure only a single session
+          // is ever opened and exposed to the state machine.
+          RaftSessionContext session = sessions.addSession(new RaftSessionContext(
+              sessionId,
+              node,
+              serviceName,
+              serviceType,
+              readConsistency,
+              minTimeout,
+              maxTimeout,
+              sessionTimestamp,
+              this,
+              raft,
+              threadContextFactory));
 
           session.setRequestSequence(reader.readLong());
           session.setCommandSequence(reader.readLong());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessions.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessions.java
@@ -41,14 +41,24 @@ class DefaultServiceSessions implements RaftSessions {
   }
 
   /**
+   * Adds a session to the sessions set.
+   *
+   * @param session the session to add
+   * @return the added session or an existing session if the session already exists
+   */
+  RaftSessionContext addSession(RaftSessionContext session) {
+    return sessionManager.addSession(session);
+  }
+
+  /**
    * Adds a session to the sessions list.
    *
    * @param session The session to add.
    */
   void openSession(RaftSessionContext session) {
-    session.open();
-    sessionManager.addSession(session);
-    listeners.forEach(l -> l.onOpen(session));
+    final RaftSessionContext singletonSession = sessionManager.addSession(session);
+    singletonSession.open();
+    listeners.forEach(l -> l.onOpen(singletonSession));
   }
 
   /**
@@ -57,9 +67,9 @@ class DefaultServiceSessions implements RaftSessions {
    * @param session The session to remove.
    */
   void expireSession(RaftSessionContext session) {
-    session.expire();
-    sessionManager.removeSession(session.sessionId());
-    listeners.forEach(l -> l.onExpire(session));
+    final RaftSessionContext singletonSession = sessionManager.removeSession(session.sessionId());
+    singletonSession.expire();
+    listeners.forEach(l -> l.onExpire(singletonSession));
   }
 
   /**
@@ -68,9 +78,9 @@ class DefaultServiceSessions implements RaftSessions {
    * @param session The session to remove.
    */
   void closeSession(RaftSessionContext session) {
-    session.close();
-    sessionManager.removeSession(session.sessionId());
-    listeners.forEach(l -> l.onClose(session));
+    final RaftSessionContext singletonSession = sessionManager.removeSession(session.sessionId());
+    singletonSession.close();
+    listeners.forEach(l -> l.onClose(singletonSession));
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessions.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceSessions.java
@@ -68,8 +68,10 @@ class DefaultServiceSessions implements RaftSessions {
    */
   void expireSession(RaftSessionContext session) {
     final RaftSessionContext singletonSession = sessionManager.removeSession(session.sessionId());
-    singletonSession.expire();
-    listeners.forEach(l -> l.onExpire(singletonSession));
+    if (singletonSession != null) {
+      singletonSession.expire();
+      listeners.forEach(l -> l.onExpire(singletonSession));
+    }
   }
 
   /**
@@ -79,8 +81,10 @@ class DefaultServiceSessions implements RaftSessions {
    */
   void closeSession(RaftSessionContext session) {
     final RaftSessionContext singletonSession = sessionManager.removeSession(session.sessionId());
-    singletonSession.close();
-    listeners.forEach(l -> l.onClose(singletonSession));
+    if (singletonSession != null) {
+      singletonSession.close();
+      listeners.forEach(l -> l.onClose(singletonSession));
+    }
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistry.java
@@ -32,15 +32,16 @@ public class RaftSessionRegistry {
   /**
    * Adds a session.
    */
-  public void addSession(RaftSessionContext session) {
-    sessions.putIfAbsent(session.sessionId().id(), session);
+  public RaftSessionContext addSession(RaftSessionContext session) {
+    RaftSessionContext existingSession = sessions.putIfAbsent(session.sessionId().id(), session);
+    return existingSession != null ? existingSession : session;
   }
 
   /**
    * Removes a session.
    */
-  public void removeSession(SessionId sessionId) {
-    sessions.remove(sessionId.id());
+  public RaftSessionContext removeSession(SessionId sessionId) {
+    return sessions.remove(sessionId.id());
   }
 
   /**


### PR DESCRIPTION
This PR fixes a bug that can occur when recovering from a snapshot at startup. A race condition exists that presents the possibility that a session may never be opened. This is because sessions are first restored in the `RaftServiceManager` before operations are applied, and sessions in the global registry cannot be overridden by sessions installed in a local `ServiceContext`. If a session is restored, then a snapshot is installed from the `ServiceContext`, the session created within the `ServiceContext` that is `open()`ed will never actually be stored in the service `Sessions` object and thus is not visible to the state machine. The state machine will only see a session that has not yet been opened (the one created in `RaftServiceManager`). So, we need to ensure that only a single session is created when installing snapshots to ensure that the session that's created by a snapshot is the same session that's accessible to the state machine.