### PR TITLE
Fix missing snapshot file exceptions

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -188,9 +188,11 @@ final class LeaderAppender extends AbstractAppender {
       }
     }
     // If there's a snapshot at the member's nextIndex, replicate the snapshot.
-    else if (member.getMember().getType() == RaftMember.Type.ACTIVE || member.getMember().getType() == RaftMember.Type.PASSIVE) {
+    else if (member.getMember().getType() == RaftMember.Type.ACTIVE
+        || member.getMember().getType() == RaftMember.Type.PROMOTABLE
+        || member.getMember().getType() == RaftMember.Type.PASSIVE) {
       long currentIndex = member.getLogReader().getCurrentIndex();
-      Collection<Snapshot> snapshots = raft.getSnapshotStore().getSnapshotsByIndex(member.getLogReader().getCurrentIndex());
+      Collection<Snapshot> snapshots = raft.getSnapshotStore().getSnapshotsByIndex(currentIndex);
       if (snapshots != null && member.getSnapshotIndex() <= currentIndex) {
         if (!member.canInstall()) {
           return;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -328,7 +328,7 @@ public class PassiveRole extends InactiveRole {
    * Returns a failed append response.
    *
    * @param lastLogIndex the last log index
-   * @param future the append response future
+   * @param future       the append response future
    * @return the append response status
    */
   protected boolean failAppend(long lastLogIndex, CompletableFuture<AppendResponse> future) {
@@ -339,7 +339,7 @@ public class PassiveRole extends InactiveRole {
    * Returns a successful append response.
    *
    * @param lastLogIndex the last log index
-   * @param future the append response future
+   * @param future       the append response future
    * @return the append response status
    */
   protected boolean succeedAppend(long lastLogIndex, CompletableFuture<AppendResponse> future) {
@@ -349,9 +349,9 @@ public class PassiveRole extends InactiveRole {
   /**
    * Returns a successful append response.
    *
-   * @param succeeded whether the append succeeded
+   * @param succeeded    whether the append succeeded
    * @param lastLogIndex the last log index
-   * @param future the append response future
+   * @param future       the append response future
    * @return the append response status
    */
   protected boolean completeAppend(boolean succeeded, long lastLogIndex, CompletableFuture<AppendResponse> future) {
@@ -520,10 +520,10 @@ public class PassiveRole extends InactiveRole {
       }
 
       Snapshot snapshot = raft.getSnapshotStore().newSnapshot(
-              ServiceId.from(request.serviceId()),
-              request.serviceName(),
-              request.snapshotIndex(),
-              WallClockTimestamp.from(request.snapshotTimestamp()));
+          ServiceId.from(request.serviceId()),
+          request.serviceName(),
+          request.snapshotIndex(),
+          WallClockTimestamp.from(request.snapshotTimestamp()));
       pendingSnapshot = new PendingSnapshot(snapshot);
     }
 
@@ -532,6 +532,12 @@ public class PassiveRole extends InactiveRole {
       return CompletableFuture.completedFuture(logResponse(InstallResponse.newBuilder()
           .withStatus(RaftResponse.Status.ERROR)
           .withError(RaftError.Type.ILLEGAL_MEMBER_STATE, "Request chunk offset does not match the next chunk offset")
+          .build()));
+    }
+    // If the request offset has already been written, return OK to skip to the next chunk.
+    else if (request.chunkOffset() < pendingSnapshot.nextOffset()) {
+      return CompletableFuture.completedFuture(logResponse(InstallResponse.newBuilder()
+          .withStatus(RaftResponse.Status.OK)
           .build()));
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -495,6 +495,15 @@ public class PassiveRole extends InactiveRole {
           .build()));
     }
 
+    // If the snapshot already exists locally, do not overwrite it with a replicated snapshot. Simply reply to the
+    // request successfully.
+    Snapshot existingSnapshot = raft.getSnapshotStore().getSnapshot(ServiceId.from(request.serviceId()), request.snapshotIndex());
+    if (existingSnapshot != null) {
+      return CompletableFuture.completedFuture(logResponse(InstallResponse.newBuilder()
+          .withStatus(RaftResponse.Status.OK)
+          .build()));
+    }
+
     // Get the pending snapshot for the associated snapshot ID.
     PendingSnapshot pendingSnapshot = pendingSnapshots.get(request.serviceId());
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -331,7 +331,6 @@ public class DefaultServiceContext implements ServiceContext {
 
       // Add the snapshot to the pending snapshots registry.
       PendingSnapshot pendingSnapshot = new PendingSnapshot(snapshot);
-      pendingSnapshots.put(snapshotIndex, pendingSnapshot);
       pendingSnapshot.future.whenComplete((r, e) -> pendingSnapshots.remove(snapshotIndex));
 
       // Serialize sessions to the in-memory snapshot and request a snapshot from the state machine.
@@ -360,6 +359,7 @@ public class DefaultServiceContext implements ServiceContext {
       // Persist the snapshot to disk in a background thread before completing the snapshot future.
       snapshotExecutor.execute(() -> {
         pendingSnapshot.persist();
+        pendingSnapshots.put(snapshotIndex, pendingSnapshot);
         future.complete(snapshotIndex);
       });
     });

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -319,7 +319,7 @@ public class DefaultServiceContext implements ServiceContext {
 
       // If there's already a snapshot taken at a higher index, skip the snapshot.
       Snapshot currentSnapshot = raft.getSnapshotStore().getSnapshotById(serviceId);
-      if (currentSnapshot != null && currentSnapshot.index() > index) {
+      if (currentSnapshot != null && currentSnapshot.index() >= index) {
         return;
       }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -317,21 +317,32 @@ public class DefaultServiceContext implements ServiceContext {
       // Compute the snapshot index as the greater of the compaction index and the last index applied to this service.
       long snapshotIndex = Math.max(index, currentIndex);
 
+      // If a snapshot is already persisted at this index, skip the snapshot.
+      Snapshot existingSnapshot = raft.getSnapshotStore().getSnapshot(serviceId, snapshotIndex);
+      if (existingSnapshot != null) {
+        return;
+      }
+
       // If there's already a snapshot taken at a higher index, skip the snapshot.
       Snapshot currentSnapshot = raft.getSnapshotStore().getSnapshotById(serviceId);
       if (currentSnapshot != null && currentSnapshot.index() >= index) {
         return;
       }
 
-      log.debug("Taking snapshot {}", snapshotIndex);
-
       // Create a temporary in-memory snapshot buffer.
       Snapshot snapshot = raft.getSnapshotStore()
           .newTemporarySnapshot(serviceId, serviceName, snapshotIndex, WallClockTimestamp.from(currentTimestamp));
 
-      // Add the snapshot to the pending snapshots registry.
+      // Add the snapshot to the pending snapshots registry. If a snapshot is already pending for this index,
+      // skip the snapshot.
       PendingSnapshot pendingSnapshot = new PendingSnapshot(snapshot);
+      if (pendingSnapshots.putIfAbsent(snapshotIndex, pendingSnapshot) != null) {
+        return;
+      }
+
       pendingSnapshot.future.whenComplete((r, e) -> pendingSnapshots.remove(snapshotIndex));
+
+      log.debug("Taking snapshot {}", snapshotIndex);
 
       // Serialize sessions to the in-memory snapshot and request a snapshot from the state machine.
       try (SnapshotWriter writer = snapshot.openWriter()) {
@@ -359,7 +370,6 @@ public class DefaultServiceContext implements ServiceContext {
       // Persist the snapshot to disk in a background thread before completing the snapshot future.
       snapshotExecutor.execute(() -> {
         pendingSnapshot.persist();
-        pendingSnapshots.put(snapshotIndex, pendingSnapshot);
         future.complete(snapshotIndex);
       });
     });

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
@@ -17,6 +17,8 @@ package io.atomix.protocols.raft.storage.snapshot;
 
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.FileBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -30,6 +32,7 @@ import static com.google.common.base.Preconditions.checkState;
  * File-based snapshot backed by a {@link FileBuffer}.
  */
 final class FileSnapshot extends Snapshot {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileSnapshot.class);
   private final SnapshotFile file;
 
   FileSnapshot(SnapshotFile file, SnapshotDescriptor descriptor, SnapshotStore store) {
@@ -88,6 +91,7 @@ final class FileSnapshot extends Snapshot {
    */
   @Override
   public void delete() {
+    LOGGER.debug("Deleting {}", this);
     Path path = file.file().toPath();
     if (Files.exists(path)) {
       try {
@@ -101,6 +105,8 @@ final class FileSnapshot extends Snapshot {
   public String toString() {
     return toStringHelper(this)
         .add("index", index())
+        .add("serviceId", serviceId())
+        .add("serviceName", serviceName())
         .toString();
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
@@ -110,6 +110,22 @@ public class SnapshotStore implements AutoCloseable {
   }
 
   /**
+   * Returns the snapshot for the given service at the given index.
+   *
+   * @param serviceId the service for which to lookup the snapshot
+   * @param index     the index for which to lookup the snapshot
+   * @return the snapshot for the given service at the given index or {@code null} if the snapshot doesn't exist
+   */
+  public Snapshot getSnapshot(ServiceId serviceId, long index) {
+    Collection<Snapshot> snapshots = indexSnapshots.get(index);
+    return snapshots == null ? null :
+        snapshots.stream()
+            .filter(s -> s.serviceId().equals(serviceId))
+            .findFirst()
+            .orElse(null);
+  }
+
+  /**
    * Returns the last snapshot for the given state machine identifier.
    *
    * @param id The state machine identifier for which to return the snapshot.
@@ -173,10 +189,10 @@ public class SnapshotStore implements AutoCloseable {
   /**
    * Creates a temporary in-memory snapshot.
    *
-   * @param serviceId The snapshot identifier.
+   * @param serviceId   The snapshot identifier.
    * @param serviceName The snapshot service name.
-   * @param index The snapshot index.
-   * @param timestamp The snapshot timestamp.
+   * @param index       The snapshot index.
+   * @param timestamp   The snapshot timestamp.
    * @return The snapshot.
    */
   public Snapshot newTemporarySnapshot(ServiceId serviceId, String serviceName, long index, WallClockTimestamp timestamp) {
@@ -191,10 +207,10 @@ public class SnapshotStore implements AutoCloseable {
   /**
    * Creates a new snapshot.
    *
-   * @param serviceId The snapshot identifier.
+   * @param serviceId   The snapshot identifier.
    * @param serviceName The snapshot service name.
-   * @param index The snapshot index.
-   * @param timestamp The snapshot timestamp.
+   * @param index       The snapshot index.
+   * @param timestamp   The snapshot timestamp.
    * @return The snapshot.
    */
   public Snapshot newSnapshot(ServiceId serviceId, String serviceName, long index, WallClockTimestamp timestamp) {

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
@@ -131,6 +131,29 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     }
   }
 
+  /**
+   * Tests writing multiple times to a snapshot designed to mimic chunked snapshots from leaders.
+   */
+  @Test
+  public void testStreamSnapshot() throws Exception {
+    SnapshotStore store = createSnapshotStore();
+
+    Snapshot snapshot = store.newSnapshot(ServiceId.from(1), "foo", 1, new WallClockTimestamp());
+    for (long i = 1; i <= 10; i++) {
+      try (SnapshotWriter writer = snapshot.openWriter()) {
+        writer.writeLong(i);
+      }
+    }
+    snapshot.complete();
+
+    snapshot = store.getSnapshotById(ServiceId.from(1));
+    try (SnapshotReader reader = snapshot.openReader()) {
+      for (long i = 1; i <= 10; i++) {
+        assertEquals(i, reader.readLong());
+      }
+    }
+  }
+
   @Before
   @After
   public void cleanupStorage() throws IOException {


### PR DESCRIPTION
This PR fixes various inconsistencies that can occur in snapshots replicated from leaders to followers. When a leader replicates a snapshot to a follower, if that snapshot is at the same index as an existing snapshot on the follower, this can ultimately to the snapshot file being deleted. This is because old snapshots may be deleted once newer snapshots are persisted. But because both snapshots reference the same file, the persisting the new snapshot can ultimately mean deleting it. This PR also fixes a bug in snapshot replication that allows duplicate chunks sent by the leader. And finally, it disallows leaders from sending duplicate snapshots just to be safe.