### PR TITLE
Cluster reconfiguration tests

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMetadataService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMetadataService.java
@@ -145,6 +145,10 @@ public class DefaultClusterMetadataService
         .filter(endpoint -> !endpoint.equals(messagingService.endpoint()))
         .collect(Collectors.toSet());
     final int totalPeers = peers.size();
+    if (totalPeers == 0) {
+      return CompletableFuture.completedFuture(null);
+    }
+
     AtomicBoolean successful = new AtomicBoolean();
     AtomicInteger totalCount = new AtomicInteger();
     AtomicReference<Throwable> lastError = new AtomicReference<>();

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
@@ -52,6 +52,29 @@ public class DefaultClusterMetadataServiceTest {
   }
 
   @Test
+  public void testSingleNodeBootstrap() throws Exception {
+    TestMessagingServiceFactory messagingServiceFactory = new TestMessagingServiceFactory();
+
+    ClusterMetadata clusterMetadata = buildClusterMetadata(1);
+
+    Node localNode1 = buildNode(1, Node.Type.DATA);
+    ManagedClusterMetadataService metadataService1 = new DefaultClusterMetadataService(
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
+
+    metadataService1.start().join();
+
+    assertEquals(1, metadataService1.getMetadata().bootstrapNodes().size());
+
+    Node localNode2 = buildNode(2, Node.Type.DATA);
+    ManagedClusterMetadataService metadataService2 = new DefaultClusterMetadataService(
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
+    metadataService2.start().join();
+    metadataService2.addNode(localNode2);
+
+    assertEquals(2, metadataService2.getMetadata().bootstrapNodes().size());
+  }
+
+  @Test
   public void testClusterMetadataService() throws Exception {
     TestMessagingServiceFactory messagingServiceFactory = new TestMessagingServiceFactory();
 

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -61,6 +61,13 @@ public abstract class AbstractAtomixTest {
    * Creates an Atomix instance.
    */
   protected static Atomix createAtomix(Node.Type type, int id, Integer... ids) {
+    return createAtomix(ids.length, type, id, ids);
+  }
+
+  /**
+   * Creates an Atomix instance.
+   */
+  protected static Atomix createAtomix(int numPartitions, Node.Type type, int id, Integer... ids) {
     Node localNode = Node.builder(String.valueOf(id))
         .withType(type)
         .withEndpoint(Endpoint.from("localhost", BASE_PORT + id))
@@ -78,6 +85,7 @@ public abstract class AbstractAtomixTest {
         .withDataDirectory(new File("target/test-logs/" + id))
         .withLocalNode(localNode)
         .withBootstrapNodes(bootstrapNodes)
+        .withCoordinationPartitions(numPartitions)
         .withDataPartitions(3) // Lower number of partitions for faster testing
         .build();
   }

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -18,9 +18,8 @@ package io.atomix.core;
 import io.atomix.cluster.ManagedClusterMetadataService;
 import io.atomix.cluster.ManagedClusterService;
 import io.atomix.cluster.Node;
-import io.atomix.cluster.messaging.ManagedClusterMessagingService;
-import io.atomix.core.Atomix;
 import io.atomix.cluster.messaging.ManagedClusterEventingService;
+import io.atomix.cluster.messaging.ManagedClusterMessagingService;
 import io.atomix.messaging.Endpoint;
 import io.atomix.messaging.ManagedMessagingService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
@@ -41,13 +40,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -57,47 +50,26 @@ import java.util.stream.Stream;
 public abstract class AbstractAtomixTest {
   private static final int BASE_PORT = 5000;
   private static TestMessagingServiceFactory messagingServiceFactory;
-  private static List<Atomix> instances;
-  private static Map<Integer, Endpoint> endpoints;
-  private static int id = 10;
-
-  /**
-   * Returns a new Atomix instance.
-   *
-   * @return a new Atomix instance.
-   */
-  protected Atomix atomix() throws Exception {
-    Atomix instance = createAtomix(Node.Type.CLIENT, id++, 1, 2, 3).start().get(10, TimeUnit.SECONDS);
-    instances.add(instance);
-    return instance;
-  }
 
   @BeforeClass
   public static void setupAtomix() throws Exception {
     deleteData();
     messagingServiceFactory = new TestMessagingServiceFactory();
-    endpoints = new HashMap<>();
-    instances = new ArrayList<>();
-    instances.add(createAtomix(Node.Type.DATA, 1, 1, 2, 3));
-    instances.add(createAtomix(Node.Type.DATA, 2, 1, 2, 3));
-    instances.add(createAtomix(Node.Type.DATA, 3, 1, 2, 3));
-    List<CompletableFuture<Atomix>> futures = instances.stream().map(Atomix::start).collect(Collectors.toList());
-    CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(30, TimeUnit.SECONDS);
   }
 
   /**
    * Creates an Atomix instance.
    */
-  private static Atomix createAtomix(Node.Type type, int id, Integer... ids) {
+  protected static Atomix createAtomix(Node.Type type, int id, Integer... ids) {
     Node localNode = Node.builder(String.valueOf(id))
         .withType(type)
-        .withEndpoint(endpoints.computeIfAbsent(id, i -> Endpoint.from("localhost", BASE_PORT + id)))
+        .withEndpoint(Endpoint.from("localhost", BASE_PORT + id))
         .build();
 
     Collection<Node> bootstrapNodes = Stream.of(ids)
         .map(nodeId -> Node.builder(String.valueOf(nodeId))
             .withType(Node.Type.DATA)
-            .withEndpoint(endpoints.computeIfAbsent(nodeId, i -> Endpoint.from("localhost", BASE_PORT + nodeId)))
+            .withEndpoint(Endpoint.from("localhost", BASE_PORT + nodeId))
             .build())
         .collect(Collectors.toList());
 
@@ -112,19 +84,13 @@ public abstract class AbstractAtomixTest {
 
   @AfterClass
   public static void teardownAtomix() throws Exception {
-    List<CompletableFuture<Void>> futures = instances.stream().map(Atomix::stop).collect(Collectors.toList());
-    try {
-      CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
-    } catch (Exception e) {
-      // Do nothing
-    }
     deleteData();
   }
 
   /**
    * Deletes data from the test data directory.
    */
-  private static void deleteData() throws Exception {
+  protected static void deleteData() throws Exception {
     Path directory = Paths.get("target/test-logs/");
     if (Files.exists(directory)) {
       Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {

--- a/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
@@ -45,7 +45,7 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
 
   @BeforeClass
   public static void setupAtomix() throws Exception {
-    deleteData();
+    AbstractAtomixTest.setupAtomix();
     instances = new ArrayList<>();
     instances.add(createAtomix(Node.Type.DATA, 1, 1, 2, 3));
     instances.add(createAtomix(Node.Type.DATA, 2, 1, 2, 3));
@@ -62,6 +62,6 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
     } catch (Exception e) {
       // Do nothing
     }
-    deleteData();
+    AbstractAtomixTest.teardownAtomix();
   }
 }

--- a/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core;
+
+import io.atomix.cluster.Node;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Base Atomix test.
+ */
+public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
+  private static List<Atomix> instances;
+  private static int id = 10;
+
+  /**
+   * Returns a new Atomix instance.
+   *
+   * @return a new Atomix instance.
+   */
+  protected Atomix atomix() throws Exception {
+    Atomix instance = createAtomix(Node.Type.CLIENT, id++, 1, 2, 3).start().get(10, TimeUnit.SECONDS);
+    instances.add(instance);
+    return instance;
+  }
+
+  @BeforeClass
+  public static void setupAtomix() throws Exception {
+    deleteData();
+    instances = new ArrayList<>();
+    instances.add(createAtomix(Node.Type.DATA, 1, 1, 2, 3));
+    instances.add(createAtomix(Node.Type.DATA, 2, 1, 2, 3));
+    instances.add(createAtomix(Node.Type.DATA, 3, 1, 2, 3));
+    List<CompletableFuture<Atomix>> futures = instances.stream().map(Atomix::start).collect(Collectors.toList());
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(30, TimeUnit.SECONDS);
+  }
+
+  @AfterClass
+  public static void teardownAtomix() throws Exception {
+    List<CompletableFuture<Void>> futures = instances.stream().map(Atomix::stop).collect(Collectors.toList());
+    try {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+    } catch (Exception e) {
+      // Do nothing
+    }
+    deleteData();
+  }
+}

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core;
+
+import io.atomix.cluster.Node;
+import io.atomix.utils.concurrent.Futures;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Atomix test.
+ */
+public class AtomixTest extends AbstractAtomixTest {
+  private List<Atomix> instances;
+
+  @Before
+  public void setupInstances() throws Exception {
+    deleteData();
+    instances = new ArrayList<>();
+  }
+
+  @After
+  public void teardownInstances() throws Exception {
+    List<CompletableFuture<Void>> futures = instances.stream().map(Atomix::stop).collect(Collectors.toList());
+    try {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+    } catch (Exception e) {
+      // Do nothing
+    }
+    deleteData();
+  }
+
+  protected CompletableFuture<Atomix> startAtomix(int numPartitions, Node.Type type, int id, Integer... ids) {
+    Atomix atomix = createAtomix(numPartitions, type, id, ids);
+    instances.add(atomix);
+    return atomix.start();
+  }
+
+  /**
+   * Tests scaling up a cluster.
+   */
+  @Test
+  public void testScaleUp() throws Exception {
+    Atomix atomix1 = startAtomix(3, Node.Type.DATA, 1, 1).join();
+    Atomix atomix2 = startAtomix(3, Node.Type.DATA, 2, 1, 2).join();
+    Atomix atomix3 = startAtomix(3, Node.Type.DATA, 3, 1, 2, 3).join();
+  }
+
+  /**
+   * Tests scaling down a cluster.
+   */
+  @Test
+  public void testScaleDown() throws Exception {
+    List<CompletableFuture<Atomix>> futures = new ArrayList<>();
+    futures.add(startAtomix(3, Node.Type.DATA, 1, 1, 2, 3));
+    futures.add(startAtomix(3, Node.Type.DATA, 2, 1, 2, 3));
+    futures.add(startAtomix(3, Node.Type.DATA, 3, 1, 2, 3));
+    Futures.allOf(futures).join();
+    instances.get(0).stop().join();
+    instances.get(1).stop().join();
+    instances.get(2).stop().join();
+  }
+}

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -34,7 +34,7 @@ public class AtomixTest extends AbstractAtomixTest {
 
   @Before
   public void setupInstances() throws Exception {
-    deleteData();
+    AbstractAtomixTest.setupAtomix();
     instances = new ArrayList<>();
   }
 
@@ -46,7 +46,7 @@ public class AtomixTest extends AbstractAtomixTest {
     } catch (Exception e) {
       // Do nothing
     }
-    deleteData();
+    AbstractAtomixTest.teardownAtomix();
   }
 
   protected CompletableFuture<Atomix> startAtomix(int numPartitions, Node.Type type, int id, Integer... ids) {

--- a/core/src/test/java/io/atomix/core/counter/impl/AtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/impl/AtomicCounterTest.java
@@ -15,9 +15,8 @@
  */
 package io.atomix.core.counter.impl;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.counter.AsyncAtomicCounter;
-import io.atomix.core.counter.impl.AtomicCounterProxy;
 
 import org.junit.Test;
 
@@ -28,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link AtomicCounterProxy}.
  */
-public class AtomicCounterTest extends AbstractAtomixTest {
+public class AtomicCounterTest extends AbstractPrimitiveTest {
   @Test
   public void testBasicOperations() throws Throwable {
     AsyncAtomicCounter along = atomix().atomicCounterBuilder("test-counter-basic-operations").build().async();

--- a/core/src/test/java/io/atomix/core/election/impl/LeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/LeaderElectionTest.java
@@ -16,12 +16,11 @@
 package io.atomix.core.election.impl;
 
 import io.atomix.cluster.NodeId;
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.election.AsyncLeaderElection;
 import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEvent;
 import io.atomix.core.election.LeadershipEventListener;
-import io.atomix.core.election.impl.LeaderElectionProxy;
 
 import org.junit.Test;
 
@@ -36,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link LeaderElectionProxy}.
  */
-public class LeaderElectionTest extends AbstractAtomixTest {
+public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   NodeId node1 = NodeId.from("node1");
   NodeId node2 = NodeId.from("node2");

--- a/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
@@ -16,7 +16,7 @@
 package io.atomix.core.election.impl;
 
 import io.atomix.cluster.NodeId;
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.election.AsyncLeaderElector;
 import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEvent;
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Leader elector test.
  */
-public class LeaderElectorTest extends AbstractAtomixTest {
+public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   NodeId node1 = new NodeId("4");
   NodeId node2 = new NodeId("5");

--- a/core/src/test/java/io/atomix/core/generator/impl/IdGeneratorTest.java
+++ b/core/src/test/java/io/atomix/core/generator/impl/IdGeneratorTest.java
@@ -15,9 +15,8 @@
  */
 package io.atomix.core.generator.impl;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.generator.AsyncAtomicIdGenerator;
-import io.atomix.core.generator.impl.DelegatingIdGenerator;
 
 import org.junit.Test;
 
@@ -28,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Unit test for {@code AtomixIdGenerator}.
  */
-public class IdGeneratorTest extends AbstractAtomixTest {
+public class IdGeneratorTest extends AbstractPrimitiveTest {
 
   /**
    * Tests generating IDs.

--- a/core/src/test/java/io/atomix/core/lock/impl/DistributedLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/impl/DistributedLockTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.lock.impl;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.lock.AsyncDistributedLock;
 import io.atomix.utils.time.Version;
 import org.junit.Test;
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertFalse;
 /**
  * Raft lock test.
  */
-public class DistributedLockTest extends AbstractAtomixTest {
+public class DistributedLockTest extends AbstractPrimitiveTest {
 
   /**
    * Tests locking and unlocking a lock.

--- a/core/src/test/java/io/atomix/core/map/impl/AtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/AtomicCounterMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map.impl;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.map.AsyncAtomicCounterMap;
 
 import org.junit.Test;
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit test for {@code AtomixCounterMap}.
  */
-public class AtomicCounterMapTest extends AbstractAtomixTest {
+public class AtomicCounterMapTest extends AbstractPrimitiveTest {
 
   /**
    * Tests basic counter map operations.

--- a/core/src/test/java/io/atomix/core/map/impl/ConsistentMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/ConsistentMapTest.java
@@ -18,7 +18,7 @@ package io.atomix.core.map.impl;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.ConsistentMap;
 import io.atomix.core.map.MapEvent;
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link io.atomix.core.map.ConsistentMap}.
  */
-public class ConsistentMapTest extends AbstractAtomixTest {
+public class ConsistentMapTest extends AbstractPrimitiveTest {
 
   /**
    * Tests null values.

--- a/core/src/test/java/io/atomix/core/map/impl/ConsistentTreeMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/ConsistentTreeMapTest.java
@@ -18,11 +18,10 @@ package io.atomix.core.map.impl;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.map.AsyncConsistentTreeMap;
 import io.atomix.core.map.MapEvent;
 import io.atomix.core.map.MapEventListener;
-import io.atomix.core.map.impl.ConsistentTreeMapProxy;
 
 import org.junit.Test;
 
@@ -43,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link ConsistentTreeMapProxy}.
  */
-public class ConsistentTreeMapTest extends AbstractAtomixTest {
+public class ConsistentTreeMapTest extends AbstractPrimitiveTest {
   private final String four = "hello";
   private final String three = "goodbye";
   private final String two = "foo";

--- a/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapTest.java
@@ -21,9 +21,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.TreeMultiset;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.multimap.AsyncConsistentMultimap;
-import io.atomix.core.multimap.impl.ConsistentSetMultimapProxy;
 
 import org.junit.Test;
 
@@ -40,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the {@link ConsistentSetMultimapProxy}.
  */
-public class ConsistentSetMultimapTest extends AbstractAtomixTest {
+public class ConsistentSetMultimapTest extends AbstractPrimitiveTest {
   private final String one = "hello";
   private final String two = "goodbye";
   private final String three = "foo";

--- a/core/src/test/java/io/atomix/core/queue/impl/WorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/impl/WorkQueueTest.java
@@ -17,11 +17,10 @@ package io.atomix.core.queue.impl;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.queue.AsyncWorkQueue;
 import io.atomix.core.queue.Task;
 import io.atomix.core.queue.WorkQueueStats;
-import io.atomix.core.queue.impl.WorkQueueProxy;
 
 import org.junit.Test;
 
@@ -40,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link WorkQueueProxy}.
  */
-public class WorkQueueTest extends AbstractAtomixTest {
+public class WorkQueueTest extends AbstractPrimitiveTest {
   private static final Duration DEFAULT_PROCESSING_TIME = Duration.ofMillis(100);
   private static final String DEFAULT_PAYLOAD = "hello world";
 

--- a/core/src/test/java/io/atomix/core/tree/impl/DocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/impl/DocumentTreeTest.java
@@ -18,14 +18,13 @@ package io.atomix.core.tree.impl;
 
 import com.google.common.base.Throwables;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.tree.AsyncDocumentTree;
 import io.atomix.core.tree.DocumentPath;
 import io.atomix.core.tree.DocumentTreeEvent;
 import io.atomix.core.tree.DocumentTreeListener;
 import io.atomix.core.tree.IllegalDocumentModificationException;
 import io.atomix.core.tree.NoSuchDocumentPathException;
-import io.atomix.core.tree.impl.DocumentTreeProxy;
 import io.atomix.primitive.Ordering;
 import io.atomix.utils.time.Versioned;
 import org.junit.Ignore;
@@ -46,7 +45,7 @@ import static org.junit.Assert.fail;
 /**
  * Unit tests for {@link DocumentTreeProxy}.
  */
-public class DocumentTreeTest extends AbstractAtomixTest {
+public class DocumentTreeTest extends AbstractPrimitiveTest {
 
   protected AsyncDocumentTree<String> newTree(String name) throws Exception {
     return newTree(name, null);

--- a/core/src/test/java/io/atomix/core/value/impl/AtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/impl/AtomicValueTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.value.impl;
 
-import io.atomix.core.AbstractAtomixTest;
+import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.value.AsyncAtomicValue;
 
 import org.junit.Test;
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Raft atomic value test.
  */
-public class AtomicValueTest extends AbstractAtomixTest {
+public class AtomicValueTest extends AbstractPrimitiveTest {
   @Test
   public void testValue() throws Exception {
     AsyncAtomicValue<String> value = atomix().<String>atomicValueBuilder("test-value").build().async();

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -144,7 +144,7 @@ public class RaftPartition implements Partition<RaftProtocol> {
     if (server == null && metadata.members().contains(managementService.getClusterService().getLocalNode().id())) {
       server = createServer(managementService);
       return server.join(metadata.members());
-    } else if (server != null && server.isRunning()) {
+    } else if (server != null && !metadata.members().contains(managementService.getClusterService().getLocalNode().id())) {
       return server.leave().thenRun(() -> server = null);
     }
     return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
This PR adds new tests for reconfiguring the Atomix cluster as well as a few bug fixes for cluster reconfiguration.

First, the `ClusterMetadataService` does not properly handle single node clusters due to an issue in the `bootstrap` method. We simply check that there are nodes from which to bootstrap the configuration before bootstrapping it.

Second, a condition in the balancing of `RaftPartition`s on reconfiguration was not correct. This PR fixes that logic to ensure Raft nodes are added to/removed from partitions on metadata changes as necessary.