### PR TITLE
Do not apply configuration change on replication failure

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -341,7 +341,9 @@ public final class LeaderRole extends ActiveRole {
 
           return appender.appendEntries(entry.index()).whenComplete((commitIndex, commitError) -> {
             raft.checkThread();
-            raft.getStateMachine().<OperationResult>apply(entry.index());
+            if (isRunning() && commitError == null) {
+              raft.getStateMachine().<OperationResult>apply(entry.index());
+            }
             configuring = 0;
           });
         }, raft.getThreadContext());


### PR DESCRIPTION
This PR fixes a missing error check that causes #343 