### PR TITLE
Default the number of Raft partitions to 7

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -286,7 +286,11 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    */
   public static class Builder implements io.atomix.utils.Builder<Atomix> {
     protected static final String DEFAULT_CLUSTER_NAME = "atomix";
+    // Default to 7 Raft partitions to allow a leader per node in 7 node clusters
+    protected static final int DEFAULT_COORDINATION_PARTITIONS = 7;
+    // Default to 3-node partitions for the best latency/throughput per Raft partition
     protected static final int DEFAULT_COORDINATION_PARTITION_SIZE = 3;
+    // Default to 71 primary-backup partitions - a prime number that creates about 10 partitions per node in a 7-node cluster
     protected static final int DEFAULT_DATA_PARTITIONS = 71;
     protected static final String COORDINATION_GROUP_NAME = "coordination";
     protected static final String DATA_GROUP_NAME = "data";
@@ -295,7 +299,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
     protected Node localNode;
     protected Collection<Node> bootstrapNodes;
     protected File dataDirectory = new File(System.getProperty("user.dir"), "data");
-    protected int numCoordinationPartitions;
+    protected int numCoordinationPartitions = DEFAULT_COORDINATION_PARTITIONS;
     protected int coordinationPartitionSize = DEFAULT_COORDINATION_PARTITION_SIZE;
     protected int numDataPartitions = DEFAULT_DATA_PARTITIONS;
     protected Collection<ManagedPartitionGroup> partitionGroups = new ArrayList<>();
@@ -572,7 +576,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
       if (partitionGroups.isEmpty()) {
         partitionGroups.add(RaftPartitionGroup.builder(COORDINATION_GROUP_NAME)
             .withDataDirectory(new File(dataDirectory, COORDINATION_GROUP_NAME))
-            .withNumPartitions(numCoordinationPartitions > 0 ? numCoordinationPartitions : bootstrapNodes.size())
+            .withNumPartitions(numCoordinationPartitions)
             .withPartitionSize(coordinationPartitionSize)
             .build());
         partitionGroups.add(PrimaryBackupPartitionGroup.builder(DATA_GROUP_NAME)

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -61,13 +61,6 @@ public abstract class AbstractAtomixTest {
    * Creates an Atomix instance.
    */
   protected static Atomix createAtomix(Node.Type type, int id, Integer... ids) {
-    return createAtomix(ids.length, type, id, ids);
-  }
-
-  /**
-   * Creates an Atomix instance.
-   */
-  protected static Atomix createAtomix(int numPartitions, Node.Type type, int id, Integer... ids) {
     Node localNode = Node.builder(String.valueOf(id))
         .withType(type)
         .withEndpoint(Endpoint.from("localhost", BASE_PORT + id))
@@ -85,7 +78,7 @@ public abstract class AbstractAtomixTest {
         .withDataDirectory(new File("target/test-logs/" + id))
         .withLocalNode(localNode)
         .withBootstrapNodes(bootstrapNodes)
-        .withCoordinationPartitions(numPartitions)
+        .withCoordinationPartitions(3)
         .withDataPartitions(3) // Lower number of partitions for faster testing
         .build();
   }

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -49,8 +49,11 @@ public class AtomixTest extends AbstractAtomixTest {
     AbstractAtomixTest.teardownAtomix();
   }
 
-  protected CompletableFuture<Atomix> startAtomix(int numPartitions, Node.Type type, int id, Integer... ids) {
-    Atomix atomix = createAtomix(numPartitions, type, id, ids);
+  /**
+   * Creates and starts a new test Atomix instance.
+   */
+  protected CompletableFuture<Atomix> startAtomix(Node.Type type, int id, Integer... ids) {
+    Atomix atomix = createAtomix(type, id, ids);
     instances.add(atomix);
     return atomix.start();
   }
@@ -60,9 +63,9 @@ public class AtomixTest extends AbstractAtomixTest {
    */
   @Test
   public void testScaleUp() throws Exception {
-    Atomix atomix1 = startAtomix(3, Node.Type.DATA, 1, 1).join();
-    Atomix atomix2 = startAtomix(3, Node.Type.DATA, 2, 1, 2).join();
-    Atomix atomix3 = startAtomix(3, Node.Type.DATA, 3, 1, 2, 3).join();
+    Atomix atomix1 = startAtomix(Node.Type.DATA, 1, 1).join();
+    Atomix atomix2 = startAtomix(Node.Type.DATA, 2, 1, 2).join();
+    Atomix atomix3 = startAtomix(Node.Type.DATA, 3, 1, 2, 3).join();
   }
 
   /**
@@ -71,9 +74,9 @@ public class AtomixTest extends AbstractAtomixTest {
   @Test
   public void testScaleDown() throws Exception {
     List<CompletableFuture<Atomix>> futures = new ArrayList<>();
-    futures.add(startAtomix(3, Node.Type.DATA, 1, 1, 2, 3));
-    futures.add(startAtomix(3, Node.Type.DATA, 2, 1, 2, 3));
-    futures.add(startAtomix(3, Node.Type.DATA, 3, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.DATA, 1, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.DATA, 2, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.DATA, 3, 1, 2, 3));
     Futures.allOf(futures).join();
     instances.get(0).stop().join();
     instances.get(1).stop().join();


### PR DESCRIPTION
This PR sets a default number of Raft partitions. This approach is being used here to simplify the configuration of Atomix clusters without introducing new complexity to the management of cluster metadata. We could compute and replicate the number of Raft partitions. But that will always be fraught with the same risks as manually configured clusters, and using a static default configuration allows for a practical number of partitions to be created for all clusters by default while still preserving the option to customize the number of Raft partitions. Because the primary-backup protocol uses a similar approach, this simplifies the configuration of clusters that will be modified by adding/removing nodes.