### PR TITLE
Implement support for time-to-live for map keys

### DIFF
--- a/core/src/main/java/io/atomix/core/map/AsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/AsyncConsistentMap.java
@@ -17,7 +17,6 @@
 package io.atomix.core.map;
 
 import com.google.common.util.concurrent.MoreExecutors;
-
 import io.atomix.core.PrimitiveTypes;
 import io.atomix.core.map.impl.MapUpdate;
 import io.atomix.core.transaction.Transactional;
@@ -213,7 +212,22 @@ public interface AsyncConsistentMap<K, V> extends AsyncPrimitive, Transactional<
    * @return the previous value (and version) associated with key, or null if there was
    * no mapping for key.
    */
-  CompletableFuture<Versioned<V>> put(K key, V value);
+  default CompletableFuture<Versioned<V>> put(K key, V value) {
+    return put(key, value, Duration.ZERO);
+  }
+
+  /**
+   * Associates the specified value with the specified key in this map (optional operation).
+   * If the map previously contained a mapping for the key, the old value is replaced by the
+   * specified value.
+   *
+   * @param key   key with which the specified value is to be associated
+   * @param value value to be associated with the specified key
+   * @param ttl   the time to live after which to remove the value
+   * @return the previous value (and version) associated with key, or null if there was
+   * no mapping for key.
+   */
+  CompletableFuture<Versioned<V>> put(K key, V value, Duration ttl);
 
   /**
    * Associates the specified value with the specified key in this map (optional operation).
@@ -224,7 +238,21 @@ public interface AsyncConsistentMap<K, V> extends AsyncPrimitive, Transactional<
    * @param value value to be associated with the specified key
    * @return new value.
    */
-  CompletableFuture<Versioned<V>> putAndGet(K key, V value);
+  default CompletableFuture<Versioned<V>> putAndGet(K key, V value) {
+    return putAndGet(key, value, Duration.ZERO);
+  }
+
+  /**
+   * Associates the specified value with the specified key in this map (optional operation).
+   * If the map previously contained a mapping for the key, the old value is replaced by the
+   * specified value.
+   *
+   * @param key   key with which the specified value is to be associated
+   * @param value value to be associated with the specified key
+   * @param ttl   the time to live after which to remove the value
+   * @return new value.
+   */
+  CompletableFuture<Versioned<V>> putAndGet(K key, V value, Duration ttl);
 
   /**
    * Removes the mapping for a key from this map if it is present (optional operation).
@@ -286,7 +314,22 @@ public interface AsyncConsistentMap<K, V> extends AsyncPrimitive, Transactional<
    * @return the previous value associated with the specified key or null
    * if key does not already mapped to a value.
    */
-  CompletableFuture<Versioned<V>> putIfAbsent(K key, V value);
+  default CompletableFuture<Versioned<V>> putIfAbsent(K key, V value) {
+    return putIfAbsent(key, value, Duration.ZERO);
+  }
+
+  /**
+   * If the specified key is not already associated with a value associates
+   * it with the given value and returns null, else behaves as a get
+   * returning the existing mapping without making any changes.
+   *
+   * @param key   key with which the specified value is to be associated
+   * @param value value to be associated with the specified key
+   * @param ttl   the time to live after which to remove the value
+   * @return the previous value associated with the specified key or null
+   * if key does not already mapped to a value.
+   */
+  CompletableFuture<Versioned<V>> putIfAbsent(K key, V value, Duration ttl);
 
   /**
    * Removes the entry for the specified key only if it is currently

--- a/core/src/main/java/io/atomix/core/map/ConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentMap.java
@@ -23,6 +23,7 @@ import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.SyncPrimitive;
 import io.atomix.utils.time.Versioned;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -167,7 +168,22 @@ public interface ConsistentMap<K, V> extends SyncPrimitive {
    * @return the previous value (and version) associated with key, or null if there was
    * no mapping for key.
    */
-  Versioned<V> put(K key, V value);
+  default Versioned<V> put(K key, V value) {
+    return put(key, value, Duration.ZERO);
+  }
+
+  /**
+   * Associates the specified value with the specified key in this map (optional operation).
+   * If the map previously contained a mapping for the key, the old value is replaced by the
+   * specified value.
+   *
+   * @param key   key with which the specified value is to be associated
+   * @param value value to be associated with the specified key
+   * @param ttl   the time to live after which to remove the value
+   * @return the previous value (and version) associated with key, or null if there was
+   * no mapping for key.
+   */
+  Versioned<V> put(K key, V value, Duration ttl);
 
   /**
    * Associates the specified value with the specified key in this map (optional operation).
@@ -178,7 +194,21 @@ public interface ConsistentMap<K, V> extends SyncPrimitive {
    * @param value value to be associated with the specified key
    * @return new value.
    */
-  Versioned<V> putAndGet(K key, V value);
+  default Versioned<V> putAndGet(K key, V value) {
+    return putAndGet(key, value, Duration.ZERO);
+  }
+
+  /**
+   * Associates the specified value with the specified key in this map (optional operation).
+   * If the map previously contained a mapping for the key, the old value is replaced by the
+   * specified value.
+   *
+   * @param key   key with which the specified value is to be associated
+   * @param value value to be associated with the specified key
+   * @param ttl   the time to live after which to remove the value
+   * @return new value.
+   */
+  Versioned<V> putAndGet(K key, V value, Duration ttl);
 
   /**
    * Removes the mapping for a key from this map if it is present (optional operation).
@@ -237,7 +267,21 @@ public interface ConsistentMap<K, V> extends SyncPrimitive {
    * @return the previous value associated with the specified key or null
    * if key does not already mapped to a value.
    */
-  Versioned<V> putIfAbsent(K key, V value);
+  default Versioned<V> putIfAbsent(K key, V value) {
+    return putIfAbsent(key, value, Duration.ZERO);
+  }
+
+  /**
+   * If the specified key is not already associated with a value
+   * associates it with the given value and returns null, else returns the current value.
+   *
+   * @param key   key with which the specified value is to be associated
+   * @param value value to be associated with the specified key
+   * @param ttl   the time to live after which to remove the value
+   * @return the previous value associated with the specified key or null
+   * if key does not already mapped to a value.
+   */
+  Versioned<V> putIfAbsent(K key, V value, Duration ttl);
 
   /**
    * Removes the entry for the specified key only if it is currently

--- a/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentMap.java
@@ -16,7 +16,6 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.base.Throwables;
-
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.ConsistentMap;
 import io.atomix.core.map.ConsistentMapBackedJavaMap;
@@ -26,6 +25,7 @@ import io.atomix.primitive.Synchronous;
 import io.atomix.utils.concurrent.Retries;
 import io.atomix.utils.time.Versioned;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
@@ -118,13 +118,13 @@ public class BlockingConsistentMap<K, V> extends Synchronous<AsyncConsistentMap<
   }
 
   @Override
-  public Versioned<V> put(K key, V value) {
-    return complete(asyncMap.put(key, value));
+  public Versioned<V> put(K key, V value, Duration ttl) {
+    return complete(asyncMap.put(key, value, ttl));
   }
 
   @Override
-  public Versioned<V> putAndGet(K key, V value) {
-    return complete(asyncMap.putAndGet(key, value));
+  public Versioned<V> putAndGet(K key, V value, Duration ttl) {
+    return complete(asyncMap.putAndGet(key, value, ttl));
   }
 
   @Override
@@ -153,8 +153,8 @@ public class BlockingConsistentMap<K, V> extends Synchronous<AsyncConsistentMap<
   }
 
   @Override
-  public Versioned<V> putIfAbsent(K key, V value) {
-    return complete(asyncMap.putIfAbsent(key, value));
+  public Versioned<V> putIfAbsent(K key, V value, Duration ttl) {
+    return complete(asyncMap.putIfAbsent(key, value, ttl));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentTreeMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentTreeMap.java
@@ -17,7 +17,6 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.base.Throwables;
-
 import io.atomix.core.map.AsyncConsistentTreeMap;
 import io.atomix.core.map.ConsistentMapBackedJavaMap;
 import io.atomix.core.map.ConsistentMapException;
@@ -26,6 +25,7 @@ import io.atomix.core.map.MapEventListener;
 import io.atomix.primitive.Synchronous;
 import io.atomix.utils.time.Versioned;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -198,13 +198,13 @@ public class BlockingConsistentTreeMap<V>
   }
 
   @Override
-  public Versioned<V> put(String key, V value) {
-    return complete(treeMap.put(key, value));
+  public Versioned<V> put(String key, V value, Duration ttl) {
+    return complete(treeMap.put(key, value, ttl));
   }
 
   @Override
-  public Versioned<V> putAndGet(String key, V value) {
-    return complete(treeMap.putAndGet(key, value));
+  public Versioned<V> putAndGet(String key, V value, Duration ttl) {
+    return complete(treeMap.putAndGet(key, value, ttl));
   }
 
   @Override
@@ -233,8 +233,8 @@ public class BlockingConsistentTreeMap<V>
   }
 
   @Override
-  public Versioned<V> putIfAbsent(String key, V value) {
-    return complete(treeMap.putIfAbsent(key, value));
+  public Versioned<V> putIfAbsent(String key, V value, Duration ttl) {
+    return complete(treeMap.putIfAbsent(key, value, ttl));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapOperations.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapOperations.java
@@ -282,11 +282,18 @@ public enum ConsistentMapOperations implements OperationId {
    * Map put operation.
    */
   public static class Put extends KeyValueOperation {
+    private long ttl;
+
     public Put() {
     }
 
-    public Put(String key, byte[] value) {
+    public Put(String key, byte[] value, long ttl) {
       super(key, value);
+      this.ttl = ttl;
+    }
+
+    public long ttl() {
+      return ttl;
     }
   }
 

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxy.java
@@ -182,11 +182,11 @@ public class ConsistentMapProxy extends AbstractAsyncPrimitive implements AsyncC
 
   @Override
   @SuppressWarnings("unchecked")
-  public CompletableFuture<Versioned<byte[]>> put(String key, byte[] value) {
+  public CompletableFuture<Versioned<byte[]>> put(String key, byte[] value, Duration ttl) {
     return proxy.<Put, MapEntryUpdateResult<String, byte[]>>invoke(
         PUT,
         serializer()::encode,
-        new Put(key, value),
+        new Put(key, value, ttl.toMillis()),
         serializer()::decode)
         .whenComplete((r, e) -> throwIfLocked(r))
         .thenApply(v -> v.result());
@@ -194,11 +194,11 @@ public class ConsistentMapProxy extends AbstractAsyncPrimitive implements AsyncC
 
   @Override
   @SuppressWarnings("unchecked")
-  public CompletableFuture<Versioned<byte[]>> putAndGet(String key, byte[] value) {
+  public CompletableFuture<Versioned<byte[]>> putAndGet(String key, byte[] value, Duration ttl) {
     return proxy.<Put, MapEntryUpdateResult<String, byte[]>>invoke(
         PUT_AND_GET,
         serializer()::encode,
-        new Put(key, value),
+        new Put(key, value, ttl.toMillis()),
         serializer()::decode)
         .whenComplete((r, e) -> throwIfLocked(r))
         .thenApply(v -> v.result());
@@ -206,11 +206,11 @@ public class ConsistentMapProxy extends AbstractAsyncPrimitive implements AsyncC
 
   @Override
   @SuppressWarnings("unchecked")
-  public CompletableFuture<Versioned<byte[]>> putIfAbsent(String key, byte[] value) {
+  public CompletableFuture<Versioned<byte[]>> putIfAbsent(String key, byte[] value, Duration ttl) {
     return proxy.<Put, MapEntryUpdateResult<String, byte[]>>invoke(
         PUT_IF_ABSENT,
         serializer()::encode,
-        new Put(key, value),
+        new Put(key, value, ttl.toMillis()),
         serializer()::decode)
         .whenComplete((r, e) -> throwIfLocked(r))
         .thenApply(v -> v.result());
@@ -322,7 +322,7 @@ public class ConsistentMapProxy extends AbstractAsyncPrimitive implements AsyncC
         return proxy.<Put, MapEntryUpdateResult<String, byte[]>>invoke(
             PUT_IF_ABSENT,
             serializer()::encode,
-            new Put(key, computedValue),
+            new Put(key, computedValue, 0),
             serializer()::decode)
             .whenComplete((r, e) -> throwIfLocked(r))
             .thenCompose(r -> checkLocked(r))

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentMap.java
@@ -92,13 +92,13 @@ public class DelegatingAsyncConsistentMap<K, V>
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> put(K key, V value) {
-    return delegateMap.put(key, value);
+  public CompletableFuture<Versioned<V>> put(K key, V value, Duration ttl) {
+    return delegateMap.put(key, value, ttl);
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putAndGet(K key, V value) {
-    return delegateMap.putAndGet(key, value);
+  public CompletableFuture<Versioned<V>> putAndGet(K key, V value, Duration ttl) {
+    return delegateMap.putAndGet(key, value, ttl);
   }
 
   @Override
@@ -127,8 +127,8 @@ public class DelegatingAsyncConsistentMap<K, V>
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putIfAbsent(K key, V value) {
-    return delegateMap.putIfAbsent(key, value);
+  public CompletableFuture<Versioned<V>> putIfAbsent(K key, V value, Duration ttl) {
+    return delegateMap.putIfAbsent(key, value, ttl);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentTreeMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentTreeMap.java
@@ -178,13 +178,13 @@ public class DelegatingAsyncConsistentTreeMap<V>
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> put(String key, V value) {
-    return delegateMap.put(key, value);
+  public CompletableFuture<Versioned<V>> put(String key, V value, Duration ttl) {
+    return delegateMap.put(key, value, ttl);
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putAndGet(String key, V value) {
-    return delegateMap.putAndGet(key, value);
+  public CompletableFuture<Versioned<V>> putAndGet(String key, V value, Duration ttl) {
+    return delegateMap.putAndGet(key, value, ttl);
   }
 
   @Override
@@ -213,8 +213,8 @@ public class DelegatingAsyncConsistentTreeMap<V>
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putIfAbsent(String key, V value) {
-    return delegateMap.putIfAbsent(key, value);
+  public CompletableFuture<Versioned<V>> putIfAbsent(String key, V value, Duration ttl) {
+    return delegateMap.putIfAbsent(key, value, ttl);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/PartitionedAsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/PartitionedAsyncConsistentMap.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.ConsistentMap;
 import io.atomix.core.map.MapEventListener;
@@ -129,13 +128,13 @@ public class PartitionedAsyncConsistentMap<K, V> implements AsyncConsistentMap<K
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> put(K key, V value) {
-    return getMap(key).put(key, value);
+  public CompletableFuture<Versioned<V>> put(K key, V value, Duration ttl) {
+    return getMap(key).put(key, value, ttl);
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putAndGet(K key, V value) {
-    return getMap(key).putAndGet(key, value);
+  public CompletableFuture<Versioned<V>> putAndGet(K key, V value, Duration ttl) {
+    return getMap(key).putAndGet(key, value, ttl);
   }
 
   @Override
@@ -172,8 +171,8 @@ public class PartitionedAsyncConsistentMap<K, V> implements AsyncConsistentMap<K
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putIfAbsent(K key, V value) {
-    return getMap(key).putIfAbsent(key, value);
+  public CompletableFuture<Versioned<V>> putIfAbsent(K key, V value, Duration ttl) {
+    return getMap(key).putIfAbsent(key, value, ttl);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentMap.java
@@ -154,9 +154,9 @@ public class TranscodingAsyncConsistentMap<K1, V1, K2, V2> implements AsyncConsi
   }
 
   @Override
-  public CompletableFuture<Versioned<V1>> put(K1 key, V1 value) {
+  public CompletableFuture<Versioned<V1>> put(K1 key, V1 value, Duration ttl) {
     try {
-      return backingMap.put(keyEncoder.apply(key), valueEncoder.apply(value))
+      return backingMap.put(keyEncoder.apply(key), valueEncoder.apply(value), ttl)
           .thenApply(versionedValueTransform);
     } catch (Exception e) {
       return Futures.exceptionalFuture(e);
@@ -164,9 +164,9 @@ public class TranscodingAsyncConsistentMap<K1, V1, K2, V2> implements AsyncConsi
   }
 
   @Override
-  public CompletableFuture<Versioned<V1>> putAndGet(K1 key, V1 value) {
+  public CompletableFuture<Versioned<V1>> putAndGet(K1 key, V1 value, Duration ttl) {
     try {
-      return backingMap.putAndGet(keyEncoder.apply(key), valueEncoder.apply(value))
+      return backingMap.putAndGet(keyEncoder.apply(key), valueEncoder.apply(value), ttl)
           .thenApply(versionedValueTransform);
     } catch (Exception e) {
       return Futures.exceptionalFuture(e);
@@ -209,9 +209,9 @@ public class TranscodingAsyncConsistentMap<K1, V1, K2, V2> implements AsyncConsi
   }
 
   @Override
-  public CompletableFuture<Versioned<V1>> putIfAbsent(K1 key, V1 value) {
+  public CompletableFuture<Versioned<V1>> putIfAbsent(K1 key, V1 value, Duration ttl) {
     try {
-      return backingMap.putIfAbsent(keyEncoder.apply(key), valueEncoder.apply(value))
+      return backingMap.putIfAbsent(keyEncoder.apply(key), valueEncoder.apply(value), ttl)
           .thenApply(versionedValueTransform);
     } catch (Exception e) {
       return Futures.exceptionalFuture(e);

--- a/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentTreeMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentTreeMap.java
@@ -17,7 +17,6 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.collect.Maps;
-
 import io.atomix.core.map.AsyncConsistentTreeMap;
 import io.atomix.core.map.ConsistentTreeMap;
 import io.atomix.core.map.MapEvent;
@@ -207,14 +206,14 @@ public class TranscodingAsyncConsistentTreeMap<V1, V2> implements AsyncConsisten
   }
 
   @Override
-  public CompletableFuture<Versioned<V1>> put(String key, V1 value) {
-    return backingMap.put(key, valueEncoder.apply(value))
+  public CompletableFuture<Versioned<V1>> put(String key, V1 value, Duration ttl) {
+    return backingMap.put(key, valueEncoder.apply(value), ttl)
         .thenApply(versionedValueTransform);
   }
 
   @Override
-  public CompletableFuture<Versioned<V1>> putAndGet(String key, V1 value) {
-    return backingMap.putAndGet(key, valueEncoder.apply(value))
+  public CompletableFuture<Versioned<V1>> putAndGet(String key, V1 value, Duration ttl) {
+    return backingMap.putAndGet(key, valueEncoder.apply(value), ttl)
         .thenApply(versionedValueTransform);
   }
 
@@ -250,8 +249,8 @@ public class TranscodingAsyncConsistentTreeMap<V1, V2> implements AsyncConsisten
   }
 
   @Override
-  public CompletableFuture<Versioned<V1>> putIfAbsent(String key, V1 value) {
-    return backingMap.putIfAbsent(key, valueEncoder.apply(value))
+  public CompletableFuture<Versioned<V1>> putIfAbsent(String key, V1 value, Duration ttl) {
+    return backingMap.putIfAbsent(key, valueEncoder.apply(value), ttl)
         .thenApply(versionedValueTransform);
   }
 

--- a/core/src/test/java/io/atomix/core/map/impl/ConsistentMapServiceTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/ConsistentMapServiceTest.java
@@ -15,15 +15,19 @@
  */
 package io.atomix.core.map.impl;
 
-import io.atomix.core.map.impl.ConsistentMapService;
 import io.atomix.core.map.impl.ConsistentMapOperations.Get;
 import io.atomix.core.map.impl.ConsistentMapOperations.Put;
 import io.atomix.primitive.service.impl.DefaultCommit;
 import io.atomix.primitive.session.Session;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.Scheduler;
 import io.atomix.utils.time.Versioned;
+import io.atomix.utils.time.WallClock;
 import org.junit.Test;
+
+import java.time.Duration;
 
 import static io.atomix.core.map.impl.ConsistentMapOperations.GET;
 import static io.atomix.core.map.impl.ConsistentMapOperations.PUT;
@@ -35,21 +39,23 @@ import static org.mockito.Mockito.mock;
  * Consistent map service test.
  */
 public class ConsistentMapServiceTest {
+
   @Test
   @SuppressWarnings("unchecked")
   public void testSnapshot() throws Exception {
-    ConsistentMapService service = new ConsistentMapService();
+    ConsistentMapService service = new TestConsistentMapService();
+
     service.put(new DefaultCommit<>(
         2,
         PUT,
-        new Put("foo", "Hello world!".getBytes()),
+        new Put("foo", "Hello world!".getBytes(), 1000),
         mock(Session.class),
         System.currentTimeMillis()));
 
     Buffer buffer = HeapBuffer.allocate();
     service.backup(buffer);
 
-    service = new ConsistentMapService();
+    service = new TestConsistentMapService();
     service.restore(buffer.flip());
 
     Versioned<byte[]> value = service.get(new DefaultCommit<>(
@@ -60,5 +66,29 @@ public class ConsistentMapServiceTest {
         System.currentTimeMillis()));
     assertNotNull(value);
     assertArrayEquals("Hello world!".getBytes(), value.value());
+
+    assertNotNull(service.entries().get("foo").timer);
+  }
+
+  private static class TestConsistentMapService extends ConsistentMapService {
+    @Override
+    protected Scheduler scheduler() {
+      return new Scheduler() {
+        @Override
+        public Scheduled schedule(Duration delay, Runnable callback) {
+          return mock(Scheduled.class);
+        }
+
+        @Override
+        public Scheduled schedule(Duration initialDelay, Duration interval, Runnable callback) {
+          return mock(Scheduled.class);
+        }
+      };
+    }
+
+    @Override
+    protected WallClock wallClock() {
+      return new WallClock();
+    }
   }
 }


### PR DESCRIPTION
This PR implements support for time-to-live durations for map keys, e.g.

```java
ConsistentMap<String, String> map = atomix.consistentMapBuilder("foo").build();
map.put("foo", "bar", Duration.ofSeconds(1));
Thread.sleep(2);
assert map.get("foo") == null;
```