### PR TITLE
Fix improper lock override on tryLock()

### DIFF
--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockService.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockService.java
@@ -109,7 +109,7 @@ public class DistributedLockService extends AbstractPrimitiveService {
     } else if (commit.value().timeout() == 0) {
       commit.session().publish(DistributedLockEvents.FAIL, SERIALIZER::encode, new LockEvent(commit.value().id(), commit.index()));
     } else if (commit.value().timeout() > 0) {
-      LockHolder holder = lock = new LockHolder(
+      LockHolder holder = new LockHolder(
           commit.value().id(),
           commit.index(),
           commit.session().sessionId().id(),


### PR DESCRIPTION
This PR fixes bugs in the `DistributedLock` primitive state machine. When `tryLock` is used, an existing lock can be improperly overwritten by the new lock.