### PR TITLE
Ensure map TTLs are correctly computed when initializing and restoring from snapshots

### DIFF
--- a/core/src/test/java/io/atomix/core/map/impl/ConsistentMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/ConsistentMapTest.java
@@ -17,7 +17,6 @@ package io.atomix.core.map.impl;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
-
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.ConsistentMap;
@@ -224,9 +223,11 @@ public class ConsistentMapTest extends AbstractPrimitiveTest {
       assertTrue(result == 0);
     }).join();
 
-    map.put("foo", "Hello foo!", Duration.ofSeconds(1)).thenAccept(result -> {
+    map.put("foo", "Hello foo!", Duration.ofSeconds(3)).thenAccept(result -> {
       assertNull(result);
     }).join();
+
+    Thread.sleep(1000);
 
     map.get("foo").thenAccept(result -> {
       assertEquals("Hello foo!", result.value());


### PR DESCRIPTION
Fixes #382 

The problem was that there was an odd computation being used to schedule the value expiration. I suspect the reads in tests were just being performed before the next tick of the scheduler. Additionally, this PR ensures the elapsed time is properly calculated into the TTL when restoring from a snapshot.