### PR TITLE
Use enum names for all primitive operation IDs

### DIFF
--- a/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterOperations.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterOperations.java
@@ -21,30 +21,31 @@ import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.KryoNamespaces;
 
 /**
- * Counter commands.
+ * {@link io.atomix.core.counter.AtomicCounter} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum AtomicCounterOperations implements OperationId {
-  SET("set", OperationType.COMMAND),
-  COMPARE_AND_SET("compareAndSet", OperationType.COMMAND),
-  INCREMENT_AND_GET("incrementAndGet", OperationType.COMMAND),
-  GET_AND_INCREMENT("getAndIncrement", OperationType.COMMAND),
-  DECREMENT_AND_GET("decrementAndGet", OperationType.COMMAND),
-  GET_AND_DECREMENT("getAndDecrement", OperationType.COMMAND),
-  ADD_AND_GET("addAndGet", OperationType.COMMAND),
-  GET_AND_ADD("getAndAdd", OperationType.COMMAND),
-  GET("get", OperationType.QUERY);
+  SET(OperationType.COMMAND),
+  COMPARE_AND_SET(OperationType.COMMAND),
+  INCREMENT_AND_GET(OperationType.COMMAND),
+  GET_AND_INCREMENT(OperationType.COMMAND),
+  DECREMENT_AND_GET(OperationType.COMMAND),
+  GET_AND_DECREMENT(OperationType.COMMAND),
+  ADD_AND_GET(OperationType.COMMAND),
+  GET_AND_ADD(OperationType.COMMAND),
+  GET(OperationType.QUERY);
 
-  private final String id;
   private final OperationType type;
 
-  AtomicCounterOperations(String id, OperationType type) {
-    this.id = id;
+  AtomicCounterOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectionOperations.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectionOperations.java
@@ -16,7 +16,6 @@
 package io.atomix.core.election.impl;
 
 import com.google.common.base.MoreObjects;
-
 import io.atomix.core.election.Leader;
 import io.atomix.core.election.Leadership;
 import io.atomix.primitive.operation.OperationId;
@@ -26,29 +25,30 @@ import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.KryoNamespaces;
 
 /**
- * {@link LeaderElectionProxy} resource state machine operations.
+ * {@link io.atomix.core.election.LeaderElection} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum LeaderElectionOperations implements OperationId {
-  ADD_LISTENER("addListener", OperationType.COMMAND),
-  REMOVE_LISTENER("removeListener", OperationType.COMMAND),
-  RUN("run", OperationType.COMMAND),
-  WITHDRAW("withdraw", OperationType.COMMAND),
-  ANOINT("anoint", OperationType.COMMAND),
-  PROMOTE("promote", OperationType.COMMAND),
-  EVICT("evict", OperationType.COMMAND),
-  GET_LEADERSHIP("getLeadership", OperationType.QUERY);
+  ADD_LISTENER(OperationType.COMMAND),
+  REMOVE_LISTENER(OperationType.COMMAND),
+  RUN(OperationType.COMMAND),
+  WITHDRAW(OperationType.COMMAND),
+  ANOINT(OperationType.COMMAND),
+  PROMOTE(OperationType.COMMAND),
+  EVICT(OperationType.COMMAND),
+  GET_LEADERSHIP(OperationType.QUERY);
 
-  private final String id;
   private final OperationType type;
 
-  LeaderElectionOperations(String id, OperationType type) {
-    this.id = id;
+  LeaderElectionOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorOperations.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorOperations.java
@@ -25,31 +25,32 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * {@link LeaderElectorProxy} resource state machine operations.
+ * {@link io.atomix.core.election.LeaderElector} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum LeaderElectorOperations implements OperationId {
-  ADD_LISTENER("addListener", OperationType.COMMAND),
-  REMOVE_LISTENER("removeListener", OperationType.COMMAND),
-  RUN("run", OperationType.COMMAND),
-  WITHDRAW("withdraw", OperationType.COMMAND),
-  ANOINT("anoint", OperationType.COMMAND),
-  PROMOTE("promote", OperationType.COMMAND),
-  EVICT("evict", OperationType.COMMAND),
-  GET_LEADERSHIP("getLeadership", OperationType.QUERY),
-  GET_ALL_LEADERSHIPS("getAllLeaderships", OperationType.QUERY),
-  GET_ELECTED_TOPICS("getElectedTopics", OperationType.QUERY);
+  ADD_LISTENER(OperationType.COMMAND),
+  REMOVE_LISTENER(OperationType.COMMAND),
+  RUN(OperationType.COMMAND),
+  WITHDRAW(OperationType.COMMAND),
+  ANOINT(OperationType.COMMAND),
+  PROMOTE(OperationType.COMMAND),
+  EVICT(OperationType.COMMAND),
+  GET_LEADERSHIP(OperationType.QUERY),
+  GET_ALL_LEADERSHIPS(OperationType.QUERY),
+  GET_ELECTED_TOPICS(OperationType.QUERY);
 
-  private final String id;
   private final OperationType type;
 
-  LeaderElectorOperations(String id, OperationType type) {
-    this.id = id;
+  LeaderElectorOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockOperations.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockOperations.java
@@ -23,23 +23,24 @@ import io.atomix.utils.serializer.KryoNamespaces;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
- * Counter commands.
+ * {@link io.atomix.core.lock.DistributedLock} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum DistributedLockOperations implements OperationId {
-  LOCK("lock", OperationType.COMMAND),
-  UNLOCK("unlock", OperationType.COMMAND);
+  LOCK(OperationType.COMMAND),
+  UNLOCK(OperationType.COMMAND);
 
-  private final String id;
   private final OperationType type;
 
-  DistributedLockOperations(String id, OperationType type) {
-    this.id = id;
+  DistributedLockOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapOperations.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapOperations.java
@@ -21,36 +21,37 @@ import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.KryoNamespaces;
 
 /**
- * Atomic counter map commands.
+ * {@link io.atomix.core.map.AtomicCounterMap} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum AtomicCounterMapOperations implements OperationId {
-  PUT("put", OperationType.COMMAND),
-  PUT_IF_ABSENT("putIfAbsent", OperationType.COMMAND),
-  GET("get", OperationType.QUERY),
-  REPLACE("replace", OperationType.COMMAND),
-  REMOVE("remove", OperationType.COMMAND),
-  REMOVE_VALUE("removeValue", OperationType.COMMAND),
-  GET_AND_INCREMENT("getAndIncrement", OperationType.COMMAND),
-  GET_AND_DECREMENT("getAndDecrement", OperationType.COMMAND),
-  INCREMENT_AND_GET("incrementAndGet", OperationType.COMMAND),
-  DECREMENT_AND_GET("decrementAndGet", OperationType.COMMAND),
-  ADD_AND_GET("addAndGet", OperationType.COMMAND),
-  GET_AND_ADD("getAndAdd", OperationType.COMMAND),
-  SIZE("size", OperationType.QUERY),
-  IS_EMPTY("isEmpty", OperationType.QUERY),
-  CLEAR("clear", OperationType.COMMAND);
+  PUT(OperationType.COMMAND),
+  PUT_IF_ABSENT(OperationType.COMMAND),
+  GET(OperationType.QUERY),
+  REPLACE(OperationType.COMMAND),
+  REMOVE(OperationType.COMMAND),
+  REMOVE_VALUE(OperationType.COMMAND),
+  GET_AND_INCREMENT(OperationType.COMMAND),
+  GET_AND_DECREMENT(OperationType.COMMAND),
+  INCREMENT_AND_GET(OperationType.COMMAND),
+  DECREMENT_AND_GET(OperationType.COMMAND),
+  ADD_AND_GET(OperationType.COMMAND),
+  GET_AND_ADD(OperationType.COMMAND),
+  SIZE(OperationType.QUERY),
+  IS_EMPTY(OperationType.QUERY),
+  CLEAR(OperationType.COMMAND);
 
-  private final String id;
   private final OperationType type;
 
-  AtomicCounterMapOperations(String id, OperationType type) {
-    this.id = id;
+  AtomicCounterMapOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapOperations.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapOperations.java
@@ -30,48 +30,49 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * {@link ConsistentMapProxy} resource state machine operations.
+ * {@link io.atomix.core.map.ConsistentMap} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum ConsistentMapOperations implements OperationId {
-  IS_EMPTY("isEmpty", OperationType.QUERY),
-  SIZE("size", OperationType.QUERY),
-  CONTAINS_KEY("containsKey", OperationType.QUERY),
-  CONTAINS_VALUE("containsValue", OperationType.QUERY),
-  GET("get", OperationType.QUERY),
-  GET_ALL_PRESENT("getAllPresent", OperationType.QUERY),
-  GET_OR_DEFAULT("getOrDefault", OperationType.QUERY),
-  KEY_SET("keySet", OperationType.QUERY),
-  VALUES("values", OperationType.QUERY),
-  ENTRY_SET("entrySet", OperationType.QUERY),
-  PUT("put", OperationType.COMMAND),
-  PUT_IF_ABSENT("putIfAbsent", OperationType.COMMAND),
-  PUT_AND_GET("putAndGet", OperationType.COMMAND),
-  REMOVE("remove", OperationType.COMMAND),
-  REMOVE_VALUE("removeValue", OperationType.COMMAND),
-  REMOVE_VERSION("removeVersion", OperationType.COMMAND),
-  REPLACE("replace", OperationType.COMMAND),
-  REPLACE_VALUE("replaceValue", OperationType.COMMAND),
-  REPLACE_VERSION("replaceVersion", OperationType.COMMAND),
-  CLEAR("clear", OperationType.COMMAND),
-  ADD_LISTENER("addListener", OperationType.COMMAND),
-  REMOVE_LISTENER("removeListener", OperationType.COMMAND),
-  BEGIN("begin", OperationType.COMMAND),
-  PREPARE("prepare", OperationType.COMMAND),
-  PREPARE_AND_COMMIT("prepareAndCommit", OperationType.COMMAND),
-  COMMIT("commit", OperationType.COMMAND),
-  ROLLBACK("rollback", OperationType.COMMAND);
+  IS_EMPTY(OperationType.QUERY),
+  SIZE(OperationType.QUERY),
+  CONTAINS_KEY(OperationType.QUERY),
+  CONTAINS_VALUE(OperationType.QUERY),
+  GET(OperationType.QUERY),
+  GET_ALL_PRESENT(OperationType.QUERY),
+  GET_OR_DEFAULT(OperationType.QUERY),
+  KEY_SET(OperationType.QUERY),
+  VALUES(OperationType.QUERY),
+  ENTRY_SET(OperationType.QUERY),
+  PUT(OperationType.COMMAND),
+  PUT_IF_ABSENT(OperationType.COMMAND),
+  PUT_AND_GET(OperationType.COMMAND),
+  REMOVE(OperationType.COMMAND),
+  REMOVE_VALUE(OperationType.COMMAND),
+  REMOVE_VERSION(OperationType.COMMAND),
+  REPLACE(OperationType.COMMAND),
+  REPLACE_VALUE(OperationType.COMMAND),
+  REPLACE_VERSION(OperationType.COMMAND),
+  CLEAR(OperationType.COMMAND),
+  ADD_LISTENER(OperationType.COMMAND),
+  REMOVE_LISTENER(OperationType.COMMAND),
+  BEGIN(OperationType.COMMAND),
+  PREPARE(OperationType.COMMAND),
+  PREPARE_AND_COMMIT(OperationType.COMMAND),
+  COMMIT(OperationType.COMMAND),
+  ROLLBACK(OperationType.COMMAND);
 
-  private final String id;
   private final OperationType type;
 
-  ConsistentMapOperations(String id, OperationType type) {
-    this.id = id;
+  ConsistentMapOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override
@@ -571,8 +572,8 @@ public enum ConsistentMapOperations implements OperationId {
     @Override
     public String toString() {
       return toStringHelper(this)
-              .add("keys", keys)
-              .toString();
+          .add("keys", keys)
+          .toString();
     }
   }
 

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentTreeMapOperations.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentTreeMapOperations.java
@@ -30,37 +30,37 @@ import java.util.AbstractMap;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * {@link io.atomix.core.map.AsyncConsistentTreeMap} Resource
- * state machine operations.
+ * {@link io.atomix.core.map.ConsistentTreeMap} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum ConsistentTreeMapOperations implements OperationId {
-  SUB_MAP("subMap", OperationType.QUERY),
-  FIRST_KEY("firstKey", OperationType.QUERY),
-  LAST_KEY("lastKey", OperationType.QUERY),
-  FIRST_ENTRY("firstEntry", OperationType.QUERY),
-  LAST_ENTRY("lastEntry", OperationType.QUERY),
-  POLL_FIRST_ENTRY("pollFirstEntry", OperationType.QUERY),
-  POLL_LAST_ENTRY("pollLastEntry", OperationType.QUERY),
-  LOWER_ENTRY("lowerEntry", OperationType.QUERY),
-  LOWER_KEY("lowerKey", OperationType.QUERY),
-  FLOOR_ENTRY("floorEntry", OperationType.QUERY),
-  FLOOR_KEY("floorKey", OperationType.QUERY),
-  CEILING_ENTRY("ceilingEntry", OperationType.QUERY),
-  CEILING_KEY("ceilingKey", OperationType.QUERY),
-  HIGHER_ENTRY("higherEntry", OperationType.QUERY),
-  HIGHER_KEY("higherKey", OperationType.QUERY);
+  SUB_MAP(OperationType.QUERY),
+  FIRST_KEY(OperationType.QUERY),
+  LAST_KEY(OperationType.QUERY),
+  FIRST_ENTRY(OperationType.QUERY),
+  LAST_ENTRY(OperationType.QUERY),
+  POLL_FIRST_ENTRY(OperationType.QUERY),
+  POLL_LAST_ENTRY(OperationType.QUERY),
+  LOWER_ENTRY(OperationType.QUERY),
+  LOWER_KEY(OperationType.QUERY),
+  FLOOR_ENTRY(OperationType.QUERY),
+  FLOOR_KEY(OperationType.QUERY),
+  CEILING_ENTRY(OperationType.QUERY),
+  CEILING_KEY(OperationType.QUERY),
+  HIGHER_ENTRY(OperationType.QUERY),
+  HIGHER_KEY(OperationType.QUERY);
 
-  private final String id;
   private final OperationType type;
 
-  ConsistentTreeMapOperations(String id, OperationType type) {
-    this.id = id;
+  ConsistentTreeMapOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/ConsistentSetMultimapOperations.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/ConsistentSetMultimapOperations.java
@@ -31,38 +31,39 @@ import java.util.Collection;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * AsyncConsistentMultimap state machine commands.
+ * {@link io.atomix.core.multimap.ConsistentMultimap} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum ConsistentSetMultimapOperations implements OperationId {
-  GET("get", OperationType.QUERY),
-  SIZE("size", OperationType.QUERY),
-  IS_EMPTY("isEmpty", OperationType.QUERY),
-  CONTAINS_KEY("containsKey", OperationType.QUERY),
-  CONTAINS_VALUE("containsValue", OperationType.QUERY),
-  CONTAINS_ENTRY("containsEntry", OperationType.QUERY),
-  KEY_SET("keySet", OperationType.QUERY),
-  KEYS("keys", OperationType.QUERY),
-  VALUES("values", OperationType.QUERY),
-  ENTRIES("entries", OperationType.QUERY),
-  PUT("put", OperationType.COMMAND),
-  REMOVE("remove", OperationType.COMMAND),
-  REMOVE_ALL("removeAll", OperationType.COMMAND),
-  REPLACE("replace", OperationType.COMMAND),
-  CLEAR("clear", OperationType.COMMAND),
-  ADD_LISTENER("addListener", OperationType.COMMAND),
-  REMOVE_LISTENER("removeListener", OperationType.COMMAND);
+  GET(OperationType.QUERY),
+  SIZE(OperationType.QUERY),
+  IS_EMPTY(OperationType.QUERY),
+  CONTAINS_KEY(OperationType.QUERY),
+  CONTAINS_VALUE(OperationType.QUERY),
+  CONTAINS_ENTRY(OperationType.QUERY),
+  KEY_SET(OperationType.QUERY),
+  KEYS(OperationType.QUERY),
+  VALUES(OperationType.QUERY),
+  ENTRIES(OperationType.QUERY),
+  PUT(OperationType.COMMAND),
+  REMOVE(OperationType.COMMAND),
+  REMOVE_ALL(OperationType.COMMAND),
+  REPLACE(OperationType.COMMAND),
+  CLEAR(OperationType.COMMAND),
+  ADD_LISTENER(OperationType.COMMAND),
+  REMOVE_LISTENER(OperationType.COMMAND);
 
-  private final String id;
   private final OperationType type;
 
-  ConsistentSetMultimapOperations(String id, OperationType type) {
-    this.id = id;
+  ConsistentSetMultimapOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/queue/impl/WorkQueueOperations.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/WorkQueueOperations.java
@@ -16,7 +16,6 @@
 package io.atomix.core.queue.impl;
 
 import com.google.common.base.MoreObjects;
-
 import io.atomix.core.queue.Task;
 import io.atomix.core.queue.WorkQueueStats;
 import io.atomix.primitive.operation.OperationId;
@@ -27,28 +26,29 @@ import io.atomix.utils.serializer.KryoNamespaces;
 import java.util.Collection;
 
 /**
- * {@link WorkQueueProxy} resource state machine operations.
+ * {@link io.atomix.core.queue.WorkQueue} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum WorkQueueOperations implements OperationId {
-  STATS("stats", OperationType.QUERY),
-  REGISTER("register", OperationType.COMMAND),
-  UNREGISTER("unregister", OperationType.COMMAND),
-  ADD("add", OperationType.COMMAND),
-  TAKE("take", OperationType.COMMAND),
-  COMPLETE("complete", OperationType.COMMAND),
-  CLEAR("clear", OperationType.COMMAND);
+  STATS(OperationType.QUERY),
+  REGISTER(OperationType.COMMAND),
+  UNREGISTER(OperationType.COMMAND),
+  ADD(OperationType.COMMAND),
+  TAKE(OperationType.COMMAND),
+  COMPLETE(OperationType.COMMAND),
+  CLEAR(OperationType.COMMAND);
 
-  private final String id;
   private final OperationType type;
 
-  WorkQueueOperations(String id, OperationType type) {
-    this.id = id;
+  WorkQueueOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeOperations.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeOperations.java
@@ -17,7 +17,6 @@
 package io.atomix.core.tree.impl;
 
 import com.google.common.base.MoreObjects;
-
 import io.atomix.core.map.impl.CommitResult;
 import io.atomix.core.map.impl.PrepareResult;
 import io.atomix.core.map.impl.RollbackResult;
@@ -35,32 +34,33 @@ import java.util.LinkedHashMap;
 import java.util.Optional;
 
 /**
- * {@link DocumentTreeProxy} resource state machine operations.
+ * {@link io.atomix.core.tree.DocumentTree} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum DocumentTreeOperations implements OperationId {
-  ADD_LISTENER("addListener", OperationType.COMMAND),
-  REMOVE_LISTENER("removeListener", OperationType.COMMAND),
-  GET("get", OperationType.QUERY),
-  GET_CHILDREN("getChildren", OperationType.QUERY),
-  UPDATE("update", OperationType.COMMAND),
-  CLEAR("clear", OperationType.COMMAND),
-  BEGIN("begin", OperationType.COMMAND),
-  PREPARE("prepare", OperationType.COMMAND),
-  PREPARE_AND_COMMIT("prepareAndCommit", OperationType.COMMAND),
-  COMMIT("commit", OperationType.COMMAND),
-  ROLLBACK("rollback", OperationType.COMMAND);
+  ADD_LISTENER(OperationType.COMMAND),
+  REMOVE_LISTENER(OperationType.COMMAND),
+  GET(OperationType.QUERY),
+  GET_CHILDREN(OperationType.QUERY),
+  UPDATE(OperationType.COMMAND),
+  CLEAR(OperationType.COMMAND),
+  BEGIN(OperationType.COMMAND),
+  PREPARE(OperationType.COMMAND),
+  PREPARE_AND_COMMIT(OperationType.COMMAND),
+  COMMIT(OperationType.COMMAND),
+  ROLLBACK(OperationType.COMMAND);
 
-  private final String id;
   private final OperationType type;
 
-  DocumentTreeOperations(String id, OperationType type) {
-    this.id = id;
+  DocumentTreeOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/value/impl/AtomicValueOperations.java
+++ b/core/src/main/java/io/atomix/core/value/impl/AtomicValueOperations.java
@@ -24,27 +24,28 @@ import io.atomix.utils.serializer.KryoNamespaces;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
- * Counter commands.
+ * {@link io.atomix.core.value.AtomicValue} operations.
+ * <p>
+ * WARNING: Do not refactor enum values. Only add to them.
+ * Changing values risk breaking the ability to backup/restore/upgrade clusters.
  */
 public enum AtomicValueOperations implements OperationId {
-  GET("get", OperationType.QUERY),
-  SET("set", OperationType.COMMAND),
-  COMPARE_AND_SET("compareAndSet", OperationType.COMMAND),
-  GET_AND_SET("getAndSet", OperationType.COMMAND),
-  ADD_LISTENER("addListener", OperationType.COMMAND),
-  REMOVE_LISTENER("removeListener", OperationType.COMMAND);
+  GET(OperationType.QUERY),
+  SET(OperationType.COMMAND),
+  COMPARE_AND_SET(OperationType.COMMAND),
+  GET_AND_SET(OperationType.COMMAND),
+  ADD_LISTENER(OperationType.COMMAND),
+  REMOVE_LISTENER(OperationType.COMMAND);
 
-  private final String id;
   private final OperationType type;
 
-  AtomicValueOperations(String id, OperationType type) {
-    this.id = id;
+  AtomicValueOperations(OperationType type) {
     this.type = type;
   }
 
   @Override
   public String id() {
-    return id;
+    return name();
   }
 
   @Override


### PR DESCRIPTION
This PR changes all primitive operations to use the enum `name()` for consistency with [ONOS](http://onosproject.org) primitives. This is needed by ONOS to ensure the on-disk representation of Raft operations does not change across versions for rolling upgrades.