### PR TITLE
Transform Raft exceptions into PrimitiveException on client

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveException.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveException.java
@@ -38,6 +38,12 @@ public class PrimitiveException extends AtomixRuntimeException {
    * Store is temporarily unavailable.
    */
   public static class Unavailable extends PrimitiveException {
+    public Unavailable() {
+    }
+
+    public Unavailable(String message) {
+      super(message);
+    }
   }
 
   /**
@@ -62,35 +68,83 @@ public class PrimitiveException extends AtomixRuntimeException {
    * Primitive service exception.
    */
   public static class ServiceException extends PrimitiveException {
+    public ServiceException() {
+    }
+
+    public ServiceException(String message) {
+      super(message);
+    }
   }
 
   /**
    * Command failure exception.
    */
   public static class CommandFailure extends PrimitiveException {
+    public CommandFailure() {
+    }
+
+    public CommandFailure(String message) {
+      super(message);
+    }
   }
 
   /**
    * Query failure exception.
    */
   public static class QueryFailure extends PrimitiveException {
+    public QueryFailure() {
+    }
+
+    public QueryFailure(String message) {
+      super(message);
+    }
   }
 
   /**
    * Unknown client exception.
    */
   public static class UnknownClient extends PrimitiveException {
+    public UnknownClient() {
+    }
+
+    public UnknownClient(String message) {
+      super(message);
+    }
   }
 
   /**
    * Unknown session exception.
    */
   public static class UnknownSession extends PrimitiveException {
+    public UnknownSession() {
+    }
+
+    public UnknownSession(String message) {
+      super(message);
+    }
+  }
+
+  /**
+   * Unknown service exception.
+   */
+  public static class UnknownService extends PrimitiveException {
+    public UnknownService() {
+    }
+
+    public UnknownService(String message) {
+      super(message);
+    }
   }
 
   /**
    * Closed session exception.
    */
   public static class ClosedSession extends PrimitiveException {
+    public ClosedSession() {
+    }
+
+    public ClosedSession(String message) {
+      super(message);
+    }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftError.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftError.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.protocols.raft;
 
+import io.atomix.primitive.PrimitiveException;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -56,7 +58,7 @@ public class RaftError {
    *
    * @return The error exception.
    */
-  public RaftException createException() {
+  public PrimitiveException createException() {
     return type.createException(message);
   }
 
@@ -78,13 +80,13 @@ public class RaftError {
      */
     NO_LEADER {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Failed to locate leader");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.NoLeader(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.Unavailable(message) : createException();
       }
     },
 
@@ -93,13 +95,13 @@ public class RaftError {
      */
     QUERY_FAILURE {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Failed to obtain read quorum");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.QueryFailure(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.QueryFailure(message) : createException();
       }
     },
 
@@ -108,13 +110,13 @@ public class RaftError {
      */
     COMMAND_FAILURE {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Failed to obtain write quorum");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.CommandFailure(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.CommandFailure(message) : createException();
       }
     },
 
@@ -123,13 +125,13 @@ public class RaftError {
      */
     APPLICATION_ERROR {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("An application error occurred");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.ApplicationException(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.ServiceException(message) : createException();
       }
     },
 
@@ -138,13 +140,13 @@ public class RaftError {
      */
     ILLEGAL_MEMBER_STATE {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Illegal member state");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.IllegalMemberState(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.Unavailable(message) : createException();
       }
     },
 
@@ -153,13 +155,13 @@ public class RaftError {
      */
     UNKNOWN_CLIENT {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Unknown client");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.UnknownClient(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.UnknownClient(message) : createException();
       }
     },
 
@@ -168,13 +170,13 @@ public class RaftError {
      */
     UNKNOWN_SESSION {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Unknown member session");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.UnknownSession(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.UnknownSession(message) : createException();
       }
     },
 
@@ -183,13 +185,13 @@ public class RaftError {
      */
     UNKNOWN_SERVICE {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Unknown state machine");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.UnknownService(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.UnknownService(message) : createException();
       }
     },
 
@@ -198,13 +200,13 @@ public class RaftError {
      */
     CLOSED_SESSION {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Closed session");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.ClosedSession(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.ClosedSession(message) : createException();
       }
     },
 
@@ -213,13 +215,13 @@ public class RaftError {
      */
     PROTOCOL_ERROR {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Failed to reach consensus");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.ProtocolException(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.Unavailable(message) : createException();
       }
     },
 
@@ -228,13 +230,13 @@ public class RaftError {
      */
     CONFIGURATION_ERROR {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Configuration failed");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.ConfigurationException(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.Unavailable(message) : createException();
       }
     },
 
@@ -243,13 +245,13 @@ public class RaftError {
      */
     UNAVAILABLE {
       @Override
-      RaftException createException() {
+      PrimitiveException createException() {
         return createException("Service is unavailable");
       }
 
       @Override
-      RaftException createException(String message) {
-        return message != null ? new RaftException.Unavailable(message) : createException();
+      PrimitiveException createException(String message) {
+        return message != null ? new PrimitiveException.Unavailable(message) : createException();
       }
     };
 
@@ -258,7 +260,7 @@ public class RaftError {
      *
      * @return the exception
      */
-    abstract RaftException createException();
+    abstract PrimitiveException createException();
 
     /**
      * Creates an exception with the given message.
@@ -266,6 +268,6 @@ public class RaftError {
      * @param message the exception message
      * @return the exception
      */
-    abstract RaftException createException(String message);
+    abstract PrimitiveException createException(String message);
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft.proxy.impl;
 
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.proxy.PrimitiveProxy;
 import io.atomix.protocols.raft.RaftError;
@@ -85,7 +86,7 @@ final class RaftProxyInvoker {
   /**
    * Submits a operation to the cluster.
    *
-   * @param operation   The operation to submit.
+   * @param operation The operation to submit.
    * @return A completable future to be completed once the command has been submitted.
    */
   public CompletableFuture<byte[]> invoke(PrimitiveOperation operation) {
@@ -329,7 +330,7 @@ final class RaftProxyInvoker {
 
     @Override
     protected Throwable defaultException() {
-      return new RaftException.CommandFailure("failed to complete command");
+      return new PrimitiveException.CommandFailure("failed to complete command");
     }
 
     @Override
@@ -404,7 +405,7 @@ final class RaftProxyInvoker {
 
     @Override
     protected Throwable defaultException() {
-      return new RaftException.QueryFailure("failed to complete query");
+      return new PrimitiveException.QueryFailure("failed to complete query");
     }
 
     @Override


### PR DESCRIPTION
This PR transforms Raft exceptions into `PrimitiveException` on clients to ensure `RetryingPrimitiveProxy` properly handles exceptions.