### PR TITLE
Use ClusterService for leader/session failure detection in RaftServer

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -238,12 +238,10 @@ public class DefaultRaftServer implements RaftServer {
         storage = RaftStorage.builder().build();
       }
 
-      RaftContext raft = new RaftContext(name, localNodeId, protocol, storage, primitiveTypes, threadModel, threadPoolSize);
+      RaftContext raft = new RaftContext(name, localNodeId, clusterService, protocol, storage, primitiveTypes, threadModel, threadPoolSize);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
-      raft.setElectionThreshold(electionThreshold);
       raft.setSessionTimeout(sessionTimeout);
-      raft.setSessionFailureThreshold(sessionFailureThreshold);
 
       return new DefaultRaftServer(raft);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -178,6 +178,7 @@ public class RaftPartition implements Partition<RaftProtocol> {
     return new RaftPartitionServer(
         this,
         managementService.getClusterService().getLocalNode().id(),
+        managementService.getClusterService(),
         managementService.getCommunicationService(),
         managementService.getPrimitiveTypes());
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft.partition.impl;
 
+import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.NodeId;
 import io.atomix.cluster.messaging.ClusterMessagingService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
@@ -51,6 +52,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
 
   private final NodeId localNodeId;
   private final RaftPartition partition;
+  private final ClusterService clusterService;
   private final ClusterMessagingService clusterCommunicator;
   private final PrimitiveTypeRegistry primitiveTypes;
   private RaftServer server;
@@ -58,10 +60,12 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   public RaftPartitionServer(
       RaftPartition partition,
       NodeId localNodeId,
+      ClusterService clusterService,
       ClusterMessagingService clusterCommunicator,
       PrimitiveTypeRegistry primitiveTypes) {
     this.partition = partition;
     this.localNodeId = localNodeId;
+    this.clusterService = clusterService;
     this.clusterCommunicator = clusterCommunicator;
     this.primitiveTypes = primitiveTypes;
   }
@@ -130,6 +134,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   private RaftServer buildServer() {
     return RaftServer.builder(localNodeId)
         .withName(partition.name())
+        .withClusterService(clusterService)
         .withProtocol(new RaftServerCommunicator(
             partition.name(),
             Serializer.using(RaftNamespaces.RAFT_PROTOCOL),

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
@@ -117,11 +117,6 @@ public abstract class AbstractRole implements RaftRole {
       raft.getCluster().reset();
       return true;
     }
-
-    // If the leader is non-null, update the last heartbeat time.
-    if (leader != null) {
-      raft.setLastHeartbeatTime();
-    }
     return false;
   }
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft;
 
+import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.NodeId;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
@@ -82,6 +83,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 /**
  * Raft test.
@@ -1209,6 +1211,7 @@ public class RaftTest extends ConcurrentTestCase {
    */
   private RaftServer createServer(NodeId nodeId) {
     RaftServer.Builder builder = RaftServer.builder(nodeId)
+        .withClusterService(mock(ClusterService.class))
         .withProtocol(protocolFactory.newServerProtocol(nodeId))
         .withStorage(RaftStorage.builder()
             .withStorageLevel(StorageLevel.DISK)


### PR DESCRIPTION
This PR modifies the `RaftServer` to use the `ClusterService` for failure detection. The Raft implementation in the past has used a separate `PhiAccrualFailureDetector` to detect client failures and expire sessions. However, since it now has access to the `ClusterService` and its general failure detection, we should use the existing failure detector rather than unnecessarily adding additional network overhead for Raft failure detection.