### PR TITLE
Set leader to null in Raft client when leader is not a member of the cluster

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/MemberSelector.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/MemberSelector.java
@@ -138,7 +138,7 @@ public final class MemberSelector implements Iterator<NodeId>, AutoCloseable {
    */
   public MemberSelector reset(NodeId leader, Collection<NodeId> members) {
     if (changed(leader, members)) {
-      this.leader = leader;
+      this.leader = leader != null && members.contains(leader) ? leader : null;
       this.members = Sets.newLinkedHashSet(members);
       this.selections = strategy.selectConnections(leader, Lists.newLinkedList(members));
       this.selectionsIterator = null;
@@ -152,8 +152,8 @@ public final class MemberSelector implements Iterator<NodeId>, AutoCloseable {
   private boolean changed(NodeId leader, Collection<NodeId> members) {
     checkNotNull(members, "members");
     checkArgument(!members.isEmpty(), "members cannot be empty");
-    if (leader != null) {
-      checkArgument(members.contains(leader), "leader must be present in members list");
+    if (leader != null && !members.contains(leader)) {
+      leader = null;
     }
     if (!Objects.equals(this.leader, leader)) {
       return true;

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/MemberSelectorTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/MemberSelectorTest.java
@@ -141,6 +141,10 @@ public class MemberSelectorTest {
     selectorManager.resetAll(null, Arrays.asList(NodeId.from("a"), NodeId.from("b"), NodeId.from("c")));
     assertNull(selector.leader());
     assertTrue(selector.hasNext());
+
+    selectorManager.resetAll(NodeId.from("a"), Arrays.asList(NodeId.from("b"), NodeId.from("c")));
+    assertNull(selector.leader());
+    assertTrue(selector.hasNext());
   }
 
 }


### PR DESCRIPTION
This PR fixes an exception that can occur while Raft clusters are being reconfigured. When a leader reconfigures the cluster to remove itself, client responses can indicate that a leader is not a member of the cluster. In that case, clients should simply unset the leader rather than throwing an exception.