### PR TITLE
Do not add reply time of zero to samples.

### DIFF
--- a/messaging/src/main/java/io/atomix/messaging/impl/NettyMessagingService.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/NettyMessagingService.java
@@ -1020,6 +1020,7 @@ public class NettyMessagingService implements ManagedMessagingService {
    * Request-reply timeout history tracker.
    */
   private static final class RequestMonitor {
+    private static final int MIN_REPLY_TIME = 1;
     private final DescriptiveStatistics samples = new SynchronizedDescriptiveStatistics(WINDOW_SIZE);
 
     /**
@@ -1028,7 +1029,9 @@ public class NettyMessagingService implements ManagedMessagingService {
      * @param replyTime the reply time to add to the history
      */
     void addReplyTime(long replyTime) {
-      samples.addValue(replyTime);
+      if (replyTime > MIN_REPLY_TIME) {
+        samples.addValue(replyTime);
+      }
     }
 
     /**


### PR DESCRIPTION
By excluding reply time of zero in samples the custom PHI failure detector in NettyMessagingService did not report any false positives with my previous stress test and test with artificial random delays.

Fixes https://github.com/atomix/atomix/issues/366