### PR TITLE
Check for closeFuture when start is invoked.

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -51,6 +51,7 @@ import io.atomix.primitive.session.ManagedSessionIdService;
 import io.atomix.protocols.backup.partition.PrimaryBackupPartitionGroup;
 import io.atomix.protocols.raft.partition.RaftPartitionGroup;
 import io.atomix.utils.Managed;
+import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
 import org.slf4j.Logger;
@@ -217,6 +218,10 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
    */
   @Override
   public synchronized CompletableFuture<Atomix> start() {
+    if (closeFuture != null) {
+      return Futures.exceptionalFuture(new IllegalStateException("Atomix instance " +
+              (closeFuture.isDone() ? "shutdown" : "shutting down")));
+    }
     if (openFuture != null) {
       return openFuture;
     }

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core;
 
-import com.google.common.base.Throwables;
 import io.atomix.cluster.ClusterEvent;
 import io.atomix.cluster.ClusterEventListener;
 import io.atomix.cluster.Node;
@@ -29,9 +28,12 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Atomix test.
@@ -73,6 +75,19 @@ public class AtomixTest extends AbstractAtomixTest {
     Atomix atomix1 = startAtomix(Node.Type.DATA, 1, 1).join();
     Atomix atomix2 = startAtomix(Node.Type.DATA, 2, 1, 2).join();
     Atomix atomix3 = startAtomix(Node.Type.DATA, 3, 1, 2, 3).join();
+  }
+
+  @Test
+  public void testStopStart() throws Exception {
+    Atomix atomix1 = startAtomix(Node.Type.DATA, 1, 1).join();
+    atomix1.stop().join();
+    try {
+      atomix1.start().join();
+      fail("Expected CompletionException");
+    } catch (CompletionException ex) {
+      assertTrue(ex.getCause() instanceof IllegalStateException);
+      assertEquals("Atomix instance shutdown", ex.getCause().getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
Simple check to avoid confusion when invoking start after stop (not supported).