### PR TITLE
Numerous fault tolerance bug fixes

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft.impl;
 
+import com.google.common.collect.Maps;
 import com.google.common.primitives.Longs;
 import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.RaftServer;
@@ -51,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -69,6 +71,7 @@ public class RaftServiceManager implements AutoCloseable {
   private final ThreadContextFactory threadContextFactory;
   private final RaftLog log;
   private final RaftLogReader reader;
+  private final Map<Long, CompletableFuture> futures = Maps.newHashMap();
 
   public RaftServiceManager(RaftContext raft, ThreadContextFactory threadContextFactory) {
     this.raft = checkNotNull(raft, "state cannot be null");
@@ -105,19 +108,40 @@ public class RaftServiceManager implements AutoCloseable {
    * @param index The index to apply.
    * @return A completable future to be completed once the commit has been applied.
    */
+  @SuppressWarnings("unchecked")
   public <T> CompletableFuture<T> apply(long index) {
+    CompletableFuture<T> future = futures.computeIfAbsent(index, i -> new CompletableFuture<T>());
+    applyNext(index);
+    return future;
+  }
+
+  /**
+   * Applies the next entry in the log up to the given index.
+   *
+   * @param index the index up to which to apply the entry
+   */
+  @SuppressWarnings("unchecked")
+  private void applyNext(long index) {
     // Apply entries prior to this entry.
-    while (reader.hasNext()) {
+    if (reader.hasNext()) {
       long nextIndex = reader.getNextIndex();
 
       // Validate that the next entry can be applied.
       long lastApplied = raft.getLastApplied();
       if (nextIndex > lastApplied + 1 && nextIndex != reader.getFirstIndex()) {
         logger.error("Cannot apply non-sequential index {} unless it's the first entry in the log: {}", nextIndex, reader.getFirstIndex());
-        return Futures.exceptionalFuture(new IndexOutOfBoundsException("Cannot apply non-sequential index unless it's the first entry in the log"));
+        CompletableFuture future = futures.remove(nextIndex);
+        if (future != null) {
+          future.completeExceptionally(new IndexOutOfBoundsException("Cannot apply non-sequential index unless it's the first entry in the log"));
+        }
+        return;
       } else if (nextIndex < lastApplied) {
         logger.error("Cannot apply duplicate entry at index {}", nextIndex);
-        return Futures.exceptionalFuture(new IndexOutOfBoundsException("Cannot apply duplicate entry at index " + nextIndex));
+        CompletableFuture future = futures.remove(nextIndex);
+        if (future != null) {
+          future.completeExceptionally(new IndexOutOfBoundsException("Cannot apply duplicate entry at index " + nextIndex));
+        }
+        return;
       }
 
       // If the next index is less than or equal to the given index, read and apply the entry.
@@ -131,6 +155,8 @@ public class RaftServiceManager implements AutoCloseable {
         } finally {
           raft.setLastApplied(nextIndex);
         }
+        raft.getThreadContext().execute(() -> applyNext(index));
+        return;
       }
       // If the next index is equal to the applied index, apply it and return the result.
       else if (nextIndex == index) {
@@ -142,23 +168,40 @@ public class RaftServiceManager implements AutoCloseable {
             throw new IllegalStateException("inconsistent index applying entry " + index + ": " + entry);
           }
           restoreIndex(entry.index() - 1);
-          return apply(entry);
+          CompletableFuture future = futures.remove(nextIndex);
+          apply(entry).whenComplete((r, e) -> {
+            if (future != null) {
+              if (e == null) {
+                future.complete(r);
+              } else {
+                future.completeExceptionally(e);
+              }
+            }
+          });
         } catch (Exception e) {
           logger.error("Failed to apply {}: {}", entry, e);
         } finally {
           raft.setLastApplied(nextIndex);
         }
+        return;
       }
       // If the applied index has been passed, return a null result.
       else {
         logger.warn("Skipped applying index {}", index);
         raft.setLastApplied(nextIndex);
-        return Futures.completedFuture(null);
+        CompletableFuture future = futures.remove(nextIndex);
+        if (future != null) {
+          future.complete(null);
+        }
+        return;
       }
     }
 
-    logger.error("Cannot commit index " + index);
-    return Futures.exceptionalFuture(new IndexOutOfBoundsException("Cannot commit index " + index));
+    CompletableFuture future = futures.remove(index);
+    if (future != null) {
+      logger.error("Cannot commit index " + index);
+      future.completeExceptionally(new IndexOutOfBoundsException("Cannot commit index " + index));
+    }
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
@@ -242,7 +242,6 @@ abstract class AbstractAppender implements AutoCloseable {
     // If the response failed, the follower should have provided the correct last index in their log. This helps
     // us converge on the matchIndex faster than by simply decrementing nextIndex one index at a time.
     else {
-      resetMatchIndex(member, response);
       resetNextIndex(member);
 
       // If there are more entries to send then attempt to send another commit.
@@ -297,14 +296,6 @@ abstract class AbstractAppender implements AutoCloseable {
   protected void updateMatchIndex(RaftMemberContext member, AppendResponse response) {
     // If the replica returned a valid match index then update the existing match index.
     member.setMatchIndex(response.lastLogIndex());
-  }
-
-  /**
-   * Resets the match index when a response fails.
-   */
-  protected void resetMatchIndex(RaftMemberContext member, AppendResponse response) {
-    member.setMatchIndex(response.lastLogIndex());
-    log.trace("Reset match index for {} to {}", member, member.getMatchIndex());
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
@@ -313,8 +313,11 @@ abstract class AbstractAppender implements AutoCloseable {
    * Resets the next index when a response fails.
    */
   protected void resetNextIndex(RaftMemberContext member, AppendResponse response) {
-    member.getLogReader().reset(response.lastLogIndex() + 1);
-    log.trace("Reset next index for {} to {} + 1", member, response.lastLogIndex());
+    long nextIndex = response.lastLogIndex() + 1;
+    if (member.getLogReader().getNextIndex() != nextIndex) {
+      member.getLogReader().reset(nextIndex);
+      log.trace("Reset next index for {} to {}", member, nextIndex);
+    }
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/InactiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/InactiveRole.java
@@ -88,6 +88,7 @@ public class InactiveRole extends AbstractRole {
       raft.getCluster().commit();
     }
 
+    raft.setLastHeartbeatTime();
     return CompletableFuture.completedFuture(logResponse(ConfigureResponse.newBuilder()
         .withStatus(RaftResponse.Status.OK)
         .build()));

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -408,7 +408,6 @@ final class LeaderAppender extends AbstractAppender {
     // us converge on the matchIndex faster than by simply decrementing nextIndex one index at a time.
     else {
       member.appendFailed();
-      resetMatchIndex(member, response);
       resetNextIndex(member);
 
       // If there are more entries to send then attempt to send another commit.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -183,9 +183,12 @@ final class LeaderAppender extends AbstractAppender {
     // member state in a set of configuring members.
     // Once the configuration is complete sendAppendRequest will be called recursively.
     else if (member.getConfigTerm() < raft.getTerm()
-        || member.getConfigIndex() < raft.getCluster().getConfiguration().index()
-        && member.canConfigure()) {
-      sendConfigureRequest(member, buildConfigureRequest(member));
+        || member.getConfigIndex() < raft.getCluster().getConfiguration().index()) {
+      if (member.canConfigure()) {
+        sendConfigureRequest(member, buildConfigureRequest(member));
+      } else if (member.canHeartbeat()) {
+        sendAppendRequest(member, buildAppendEmptyRequest(member));
+      }
     }
     // If there's a snapshot at the member's nextIndex, replicate the snapshot.
     else if (member.getMember().getType() == RaftMember.Type.ACTIVE

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -182,10 +182,10 @@ final class LeaderAppender extends AbstractAppender {
     // Ensure that only one configuration attempt per member is attempted at any given time by storing the
     // member state in a set of configuring members.
     // Once the configuration is complete sendAppendRequest will be called recursively.
-    else if (member.getConfigTerm() < raft.getTerm() || member.getConfigIndex() < raft.getCluster().getConfiguration().index()) {
-      if (member.canConfigure()) {
-        sendConfigureRequest(member, buildConfigureRequest(member));
-      }
+    else if (member.getConfigTerm() < raft.getTerm()
+        || member.getConfigIndex() < raft.getCluster().getConfiguration().index()
+        && member.canConfigure()) {
+      sendConfigureRequest(member, buildConfigureRequest(member));
     }
     // If there's a snapshot at the member's nextIndex, replicate the snapshot.
     else if (member.getMember().getType() == RaftMember.Type.ACTIVE

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -373,9 +373,8 @@ final class LeaderAppender extends AbstractAppender {
 
   @Override
   protected void handleAppendResponse(RaftMemberContext member, AppendRequest request, AppendResponse response, long timestamp) {
-    // Record a successful heartbeat to the member.
-    recordHeartbeat(member, timestamp);
     super.handleAppendResponse(member, request, response, timestamp);
+    recordHeartbeat(member, timestamp);
   }
 
   @Override
@@ -452,16 +451,14 @@ final class LeaderAppender extends AbstractAppender {
 
   @Override
   protected void handleConfigureResponse(RaftMemberContext member, ConfigureRequest request, ConfigureResponse response, long timestamp) {
-    // Record a successful heartbeat to the member.
-    recordHeartbeat(member, timestamp);
     super.handleConfigureResponse(member, request, response, timestamp);
+    recordHeartbeat(member, timestamp);
   }
 
   @Override
   protected void handleInstallResponse(RaftMemberContext member, InstallRequest request, InstallResponse response, long timestamp) {
-    // Record a successful heartbeat to the member.
-    recordHeartbeat(member, timestamp);
     super.handleInstallResponse(member, request, response, timestamp);
+    recordHeartbeat(member, timestamp);
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -408,7 +408,8 @@ final class LeaderAppender extends AbstractAppender {
     // us converge on the matchIndex faster than by simply decrementing nextIndex one index at a time.
     else {
       member.appendFailed();
-      resetNextIndex(member);
+      resetMatchIndex(member, response);
+      resetNextIndex(member, response);
 
       // If there are more entries to send then attempt to send another commit.
       if (hasMoreEntries(member)) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -198,6 +198,7 @@ final class LeaderAppender extends AbstractAppender {
           return;
         }
 
+        log.debug("Replicating {} snapshots to {}", snapshots.size(), member.getMember().memberId());
         Snapshot nextSnapshot = null;
         for (Snapshot snapshot : snapshots) {
           if (snapshot.serviceId().id() > member.getSnapshotId()) {
@@ -209,7 +210,9 @@ final class LeaderAppender extends AbstractAppender {
         if (nextSnapshot != null) {
           sendInstallRequest(member, buildInstallRequest(member, nextSnapshot));
         } else if (member.canAppend()) {
+          log.debug("Completed replicating {} snapshots to {}", snapshots.size(), member.getMember().memberId());
           member.setSnapshotIndex(currentIndex);
+          member.setSnapshotId(0);
           sendAppendRequest(member, buildAppendRequest(member, -1));
         }
       } else if (member.canAppend()) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -105,7 +105,7 @@ public class PassiveRole extends InactiveRole {
     raft.checkThread();
     logRequest(request);
     updateTermAndLeader(request.term(), request.leader());
-    return handleAppend(request);
+    return handleAppend(request).whenComplete((r, e) -> raft.setLastHeartbeatTime());
   }
 
   /**
@@ -372,7 +372,7 @@ public class PassiveRole extends InactiveRole {
     // If this server has not yet applied entries up to the client's session ID, forward the
     // query to the leader. This ensures that a follower does not tell the client its session
     // doesn't exist if the follower hasn't had a chance to see the session's registration entry.
-    if (raft.getLastApplied() < request.session()) {
+    if (raft.getState() != RaftContext.State.READY || raft.getLastApplied() < request.session()) {
       log.trace("State out of sync, forwarding query to leader");
       return queryForward(request);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -169,7 +169,9 @@ public class PassiveRole extends InactiveRole {
         // If the previous log index is less than the last written entry index, look up the entry.
         if (request.prevLogIndex() < lastEntry.index()) {
           // Reset the reader to the previous log index.
-          reader.reset(request.prevLogIndex());
+          if (reader.getNextIndex() != request.prevLogIndex()) {
+            reader.reset(request.prevLogIndex());
+          }
 
           // The previous entry should exist in the log if we've gotten this far.
           if (!reader.hasNext()) {
@@ -236,7 +238,9 @@ public class PassiveRole extends InactiveRole {
           // we need to validate that the entry that's already in the log matches this entry.
           if (lastEntry.index() > index) {
             // Reset the reader to the current entry index.
-            reader.reset(index);
+            if (reader.getNextIndex() != index) {
+              reader.reset(index);
+            }
 
             // If the reader does not have any next entry, that indicates an inconsistency between the reader and writer.
             if (!reader.hasNext()) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -608,7 +608,7 @@ public class RaftSessionContext implements RaftSession {
         PublishRequest request = PublishRequest.newBuilder()
             .withSession(sessionId().id())
             .withEventIndex(event.eventIndex)
-            .withPreviousIndex(Math.max(event.previousIndex, completeIndex))
+            .withPreviousIndex(event.previousIndex)
             .withEvents(event.events)
             .build();
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/compactor/RaftLogCompactor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/compactor/RaftLogCompactor.java
@@ -309,7 +309,7 @@ public class RaftLogCompactor {
       this.compactFuture.complete(null);
       this.compactFuture = null;
       // Immediately attempt to take new snapshots since compaction is already run after a time interval.
-      compact();
+      snapshotServices(false, false);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotWriter.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotWriter.java
@@ -202,6 +202,7 @@ public class SnapshotWriter implements BufferOutput<SnapshotWriter> {
 
   @Override
   public void close() {
+    buffer.flush();
     snapshot.closeWriter(this);
     buffer.close();
   }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -925,7 +925,6 @@ public class RaftTest extends ConcurrentTestCase {
    * Tests submitting sequential events.
    */
   @Test
-  @Ignore // Ignored due to lack of timeouts/retries in test protocol
   public void testThreeNodesEventsAfterFollowerKill() throws Throwable {
     testEventsAfterFollowerKill(3);
   }
@@ -934,7 +933,6 @@ public class RaftTest extends ConcurrentTestCase {
    * Tests submitting sequential events.
    */
   @Test
-  @Ignore // Ignored due to lack of timeouts/retries in test protocol
   public void testFiveNodesEventsAfterFollowerKill() throws Throwable {
     testEventsAfterFollowerKill(5);
   }
@@ -976,7 +974,6 @@ public class RaftTest extends ConcurrentTestCase {
    * Tests submitting events.
    */
   @Test
-  @Ignore // Ignored due to lack of timeouts/retries in test protocol
   public void testFiveNodesEventsAfterLeaderKill() throws Throwable {
     testEventsAfterLeaderKill(5);
   }

--- a/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -621,6 +621,7 @@ public class SegmentedJournal<E> implements Journal<E> {
           segment.delete();
         }
         compactSegments.clear();
+        resetHead(segmentEntry.getValue().index());
       }
     }
   }


### PR DESCRIPTION
• A race condition resulting from the order in which snapshots are applied to state machines and the ordering of the snapshot replication protocol can lead to a replicated snapshot being skipped rather than installed. This sometimes results in Raft sessions not being properly restored after a node is down for a long time before being restarted. Nodes now ensure they apply the latest snapshot before applying the following index rather than applying the next snapshot after the prior index to ensure snapshots replicated between the two indexes are installed when the next index is applied.
• Servers send ordering information to clients with each event, and clients use that information to ensure events and responses are handled in the correct order. But currently, servers send the last completed event index to clients with server events rather than the previous event index if the last completed index exceeds the previous event index. Because snapshots are always completed after all events are received, this logic can lead servers to send a non-event index to clients after a snapshot is installed and thus cause clients to wait for an event that will never arrive, ultimately resulting in a livelock and timeouts. The event protocol now always uses the previous event index when sending events to clients.
• After snapshots are taken of the system’s state and early segments are removed from the log, log readers’ indexes may not be properly reset to the head of the log. This can lead to leaders’ log readers for unavailable followers attempting to read closed/deleted segments once those followers recover, and prevents log segments indexes from aligning properly. Log readers’ heads are now properly reset after compaction.
• After a leader replicates a set of snapshots to a follower, the last replicated snapshot ID is not correctly reset. This prevents a leader from replicating more than one set of snapshots to the same follower. Leaders now properly reset snapshot IDs after the snapshot replication protocol is complete.
• Leaders currently allow the matchIndex for a follower to be incorrectly *increased* on a failed AppendResponse. The rationale for modifying the matchIndex on a failed AppendResponse is to account for missing entries after restarting a follower that uses MEMORY logs or doesn’t flush commits to disk. But matchIndex should only be allowed to be *decreased* by a failed AppendResponse.
• When a follower is recovering from a large log (e.g. hundreds of thousands of commands), it can still begin an election and get elected leader. This can lead to blocked commands while the log was replayed, causing timeouts on clients. Followers no longer attempt to get elected while sill replaying logs.
• When a follower is recovering from a large log (e.g. hundreds of thousands of commands), it accepts and queues SEQUENTIAL queries. This can also lead to query timeouts while logs were being replayed. Followers no longer accept queries while logs are being replayed.
• When a leader is pipelining entries to a follower with an inconsistent log (that needs to be truncated), failed AppendResponses in some cases do not cause the leader to correctly reset the follower’s log reader before the next request because of the order in which the leader handles the response and sends the next AppendRequest. If linearizable queries are pending on the leader, it may send the next AppendRequest before handling the response and resetting the follower’s log reader. Pipelining of AppendRequests can then cause a loop between the leader and follower wherein the follower’s log is never properly resolved with the leader’s, ultimately leading to an additional leader change and timeouts on clients. Leaders will now always handle responses before attempting to send any further entries to ensure log readers are properly managed based on response context.
• The expensive cost of resetting log readers’ indexes (seeking through potentially large log segments) on followers after a new leader is elected can lead to AppendRequest timeouts when large log segments are used. Log readers’ indexes are now checked before being reset on followers to avoid resetting a log reader to the same index.
• While replaying log entries at startup, a node’s request thread can be blocked, leading to leader election timeouts and unnecessary leader changes. Log entry application is now done asynchronously via a queue to avoid blocking.