### PR TITLE
Ensure sequential queries account for received events

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
@@ -128,7 +128,7 @@ final class RaftProxyInvoker {
         .withSession(state.getSessionId().id())
         .withSequence(state.getCommandRequest())
         .withOperation(operation)
-        .withIndex(state.getResponseIndex())
+        .withIndex(Math.max(state.getResponseIndex(), state.getEventIndex()))
         .build();
     invokeQuery(request, future);
   }


### PR DESCRIPTION
`SEQUENTIAL` queries from Raft clients currently break the sequential consistency model with regard to events. When a client receives an event at index `i`, its next query must occur at index `>= i`. This PR simply uses `max(highestResponseIndex, highestEventIndex)` when sending queries to the cluster.