### PR TITLE
Add sparse index to Raft log

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -68,7 +68,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
    * Opens a new Raft log reader with the given reader mode.
    *
    * @param index The index from which to begin reading entries.
-   * @param mode The mode in which to read entries.
+   * @param mode  The mode in which to read entries.
    * @return The Raft log reader.
    */
   public RaftLogReader openReader(long index, RaftLogReader.Mode mode) {
@@ -242,6 +242,21 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
      */
     public Builder withMaxEntriesPerSegment(int maxEntriesPerSegment) {
       journalBuilder.withMaxEntriesPerSegment(maxEntriesPerSegment);
+      return this;
+    }
+
+    /**
+     * Sets the journal index density.
+     * <p>
+     * The index density is the frequency at which the position of entries written to the journal will be recorded in
+     * an in-memory index for faster seeking.
+     *
+     * @param indexDensity the index density
+     * @return the journal builder
+     * @throws IllegalArgumentException if the density is not between 0 and 1
+     */
+    public Builder withIndexDensity(double indexDensity) {
+      journalBuilder.withIndexDensity(indexDensity);
       return this;
     }
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -93,6 +93,7 @@ public abstract class AbstractLogTest {
         .withStorageLevel(storageLevel())
         .withMaxEntriesPerSegment(MAX_ENTRIES_PER_SEGMENT)
         .withMaxSegmentSize(MAX_SEGMENT_SIZE)
+        .withIndexDensity(.2)
         .build();
   }
 

--- a/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegment.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegment.java
@@ -16,6 +16,7 @@
 package io.atomix.storage.journal;
 
 import io.atomix.serializer.Serializer;
+import io.atomix.storage.journal.index.JournalIndex;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
@@ -28,15 +29,17 @@ import static com.google.common.base.Preconditions.checkState;
 public class JournalSegment<E> implements AutoCloseable {
   protected final JournalSegmentFile file;
   protected final JournalSegmentDescriptor descriptor;
+  protected final JournalIndex index;
   protected final Serializer serializer;
   private final JournalSegmentWriter<E> writer;
   private boolean open = true;
 
-  public JournalSegment(JournalSegmentFile file, JournalSegmentDescriptor descriptor, Serializer serializer) {
+  public JournalSegment(JournalSegmentFile file, JournalSegmentDescriptor descriptor, JournalIndex index, Serializer serializer) {
     this.file = file;
     this.descriptor = descriptor;
+    this.index = index;
     this.serializer = serializer;
-    this.writer = new JournalSegmentWriter<>(descriptor, serializer);
+    this.writer = new JournalSegmentWriter<>(descriptor, index, serializer);
   }
 
   /**
@@ -146,7 +149,7 @@ public class JournalSegment<E> implements AutoCloseable {
    */
   JournalSegmentReader<E> createReader() {
     checkOpen();
-    return new JournalSegmentReader<>(descriptor, serializer);
+    return new JournalSegmentReader<>(descriptor, index, serializer);
   }
 
   /**

--- a/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
@@ -18,6 +18,8 @@ package io.atomix.storage.journal;
 import io.atomix.serializer.Serializer;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.storage.journal.index.JournalIndex;
+import io.atomix.storage.journal.index.Position;
 
 import java.nio.BufferUnderflowException;
 import java.util.NoSuchElementException;
@@ -31,14 +33,16 @@ import java.util.zip.Checksum;
  */
 public class JournalSegmentReader<E> implements JournalReader<E> {
   private final Buffer buffer;
+  private final JournalIndex index;
   private final Serializer serializer;
   private final HeapBuffer memory = HeapBuffer.allocate();
   private final long firstIndex;
   private Indexed<E> currentEntry;
   private Indexed<E> nextEntry;
 
-  public JournalSegmentReader(JournalSegmentDescriptor descriptor, Serializer serializer) {
+  public JournalSegmentReader(JournalSegmentDescriptor descriptor, JournalIndex index, Serializer serializer) {
     this.buffer = descriptor.buffer().slice().duplicate();
+    this.index = index;
     this.serializer = serializer;
     this.firstIndex = descriptor.index();
     readNext();
@@ -62,6 +66,12 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
   @Override
   public void reset(long index) {
     reset();
+    Position position = this.index.lookup(index - 1);
+    if (position != null) {
+      currentEntry = new Indexed<>(position.index() - 1, null, 0);
+      buffer.position(position.position());
+      readNext();
+    }
     while (getNextIndex() < index && hasNext()) {
       next();
     }

--- a/storage/journal/src/main/java/io/atomix/storage/journal/index/JournalIndex.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/index/JournalIndex.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.storage.journal.index;
+
+/**
+ * Journal index.
+ */
+public interface JournalIndex {
+
+  /**
+   * Adds an entry for the given index at the given position.
+   *
+   * @param index the index for which to add the entry
+   * @param position the position of the given index
+   */
+  void index(long index, int position);
+
+  /**
+   * Looks up the position of the given index.
+   *
+   * @param index the index to lookup
+   * @return the position of the given index or a lesser index
+   */
+  Position lookup(long index);
+
+  /**
+   * Truncates the index to the given index.
+   *
+   * @param index the index to which to truncate the index
+   */
+  void truncate(long index);
+
+}

--- a/storage/journal/src/main/java/io/atomix/storage/journal/index/Position.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/index/Position.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.storage.journal.index;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * Journal index position.
+ */
+public class Position {
+  private final long index;
+  private final int position;
+
+  public Position(long index, int position) {
+    this.index = index;
+    this.position = position;
+  }
+
+  public long index() {
+    return index;
+  }
+
+  public int position() {
+    return position;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("index", index)
+        .add("position", position)
+        .toString();
+  }
+}

--- a/storage/journal/src/main/java/io/atomix/storage/journal/index/SparseJournalIndex.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/index/SparseJournalIndex.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.storage.journal.index;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Sparse index.
+ */
+public class SparseJournalIndex implements JournalIndex {
+  private static final int MIN_DENSITY = 1000;
+  private final int density;
+  private final TreeMap<Long, Integer> positions = new TreeMap<>();
+
+  public SparseJournalIndex(double density) {
+    this.density = (int) Math.ceil(MIN_DENSITY / (density * MIN_DENSITY));
+  }
+
+  @Override
+  public void index(long index, int position) {
+    if (index % density == 0) {
+      positions.put(index, position);
+    }
+  }
+
+  @Override
+  public Position lookup(long index) {
+    Map.Entry<Long, Integer> entry = positions.floorEntry(index);
+    return entry != null ? new Position(entry.getKey(), entry.getValue()) : null;
+  }
+
+  @Override
+  public void truncate(long index) {
+    positions.tailMap(index, false).clear();
+  }
+}

--- a/storage/journal/src/test/java/io/atomix/storage/journal/index/SparseJournalIndexTest.java
+++ b/storage/journal/src/test/java/io/atomix/storage/journal/index/SparseJournalIndexTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.storage.journal.index;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Sparse journal index test.
+ */
+public class SparseJournalIndexTest {
+  @Test
+  public void testSparseJournalIndex() throws Exception {
+    JournalIndex index = new SparseJournalIndex(.2);
+    assertNull(index.lookup(1));
+    index.index(1, 2);
+    assertNull(index.lookup(1));
+    index.index(2, 4);
+    index.index(3, 6);
+    index.index(4, 8);
+    index.index(5, 10);
+    assertEquals(5, index.lookup(5).index());
+    assertEquals(10, index.lookup(5).position());
+    index.index(6, 12);
+    index.index(7, 14);
+    index.index(8, 16);
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+    index.index(9, 18);
+    index.index(10, 20);
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+    index.truncate(8);
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+    assertEquals(5, index.lookup(10).index());
+    assertEquals(10, index.lookup(10).position());
+    index.truncate(4);
+    assertNull(index.lookup(4));
+    assertNull(index.lookup(8));
+
+    index = new SparseJournalIndex(.2);
+    assertNull(index.lookup(100));
+    index.index(101, 2);
+    assertNull(index.lookup(1));
+    index.index(102, 4);
+    index.index(103, 6);
+    index.index(104, 8);
+    index.index(105, 10);
+    assertEquals(105, index.lookup(105).index());
+    assertEquals(10, index.lookup(105).position());
+    index.index(106, 12);
+    index.index(107, 14);
+    index.index(108, 16);
+    assertEquals(105, index.lookup(108).index());
+    assertEquals(10, index.lookup(108).position());
+    index.index(109, 18);
+    index.index(110, 20);
+    assertEquals(110, index.lookup(110).index());
+    assertEquals(20, index.lookup(110).position());
+    index.truncate(108);
+    assertEquals(105, index.lookup(108).index());
+    assertEquals(10, index.lookup(108).position());
+    assertEquals(105, index.lookup(110).index());
+    assertEquals(10, index.lookup(110).position());
+    index.truncate(104);
+    assertNull(index.lookup(104));
+    assertNull(index.lookup(108));
+  }
+}


### PR DESCRIPTION
This PR adds a sparse index to the Raft log to allow it to more quickly truncate/reset reader indexes. Slow seeking through large segments has caused significant blocking in Raft server threads, and using a sparse index allows us to much more efficiently navigate to specific portions of the Raft log without much overhead. The index is not thread safe because the Raft log is not thread safe. By default, the index stores .5% of entries.