### PR TITLE
Fix the wrong type of ExpireOperation.

### DIFF
--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/protocol/ExpireOperation.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/protocol/ExpireOperation.java
@@ -24,7 +24,7 @@ public class ExpireOperation extends BackupOperation {
   private final long session;
 
   public ExpireOperation(long index, long timestamp, long session) {
-    super(Type.CLOSE, index, timestamp);
+    super(Type.EXPIRE, index, timestamp);
     this.session = session;
   }
 


### PR DESCRIPTION
Exception when stop an atomix client  
```java
ConsistentMap<Integer, String> map = atomix.<Integer, String>consistentMapBuilder("testMap").build();

 map.put(1, String.valueOf(1));
log.info("map {} ", map.get(1));

atomix.stop();
```

```
[atomix-data-0] ERROR io.atomix.utils.concurrent.ThreadPoolContext - An uncaught exception occurred
java.lang.ClassCastException: io.atomix.protocols.backup.protocol.ExpireOperation cannot be cast to io.atomix.protocols.backup.protocol.CloseOperation
	at io.atomix.protocols.backup.roles.BackupRole.applyOperations(BackupRole.java:91)
	at io.atomix.protocols.backup.roles.BackupRole.lambda$backup$0(BackupRole.java:64)
	at io.atomix.utils.concurrent.ThreadPoolContext.lambda$new$0(ThreadPoolContext.java:81)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:299)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.base/java.lang.Thread.run(Thread.java:844)
```