### PR TITLE
Fix DistributedLockService NPE when releaseSession

### DIFF
--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockService.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockService.java
@@ -160,7 +160,7 @@ public class DistributedLockService extends AbstractPrimitiveService {
   }
 
   private void releaseSession(Session session) {
-    if (lock.session == session.sessionId().id()) {
+    if (lock != null && lock.session == session.sessionId().id()) {
       lock = queue.poll();
       while (lock != null) {
         if (lock.session == session.sessionId().id()) {


### PR DESCRIPTION
```java
DistributedLock lock = atomix.lockBuilder("test").withLockTimeout(6000).build();
lock.lock();
lock.unlock(); 

atomix.stop();
```  

```
[raft-server-coordination-partition-4-3] ERROR io.atomix.utils.concurrent.ThreadPoolContext - An uncaught exception occurred
java.lang.NullPointerException
	at io.atomix.core.lock.impl.DistributedLockService$LockHolder.access$200(DistributedLockService.java:186)
	at io.atomix.core.lock.impl.DistributedLockService.releaseSession(DistributedLockService.java:163)
	at io.atomix.core.lock.impl.DistributedLockService.onExpire(DistributedLockService.java:90)
	at io.atomix.protocols.raft.service.RaftSessions.lambda$expireSession$1(RaftSessions.java:73)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at java.base/java.util.Collections$SetFromMap.forEach(Collections.java:5511)
	at io.atomix.protocols.raft.service.RaftSessions.expireSession(RaftSessions.java:73)
	at io.atomix.protocols.raft.service.RaftServiceContext.lambda$closeSession$9(RaftServiceContext.java:578)
	at io.atomix.utils.concurrent.ThreadPoolContext.lambda$new$0(ThreadPoolContext.java:81)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:514)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:299)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.base/java.lang.Thread.run(Thread.java:844)
```