### PR TITLE
Limit memory consumption for client retries

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyState.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyState.java
@@ -35,6 +35,7 @@ public final class RaftProxyState {
   private final ServiceType serviceType;
   private final long timeout;
   private volatile RaftProxy.State state = RaftProxy.State.CONNECTED;
+  private volatile Long suspendedTime;
   private volatile long commandRequest;
   private volatile long commandResponse;
   private volatile long responseIndex;
@@ -113,7 +114,18 @@ public final class RaftProxyState {
   public void setState(RaftProxy.State state) {
     if (this.state != state) {
       this.state = state;
+      if (state == RaftProxy.State.SUSPENDED) {
+        if (suspendedTime == null) {
+          suspendedTime = System.currentTimeMillis();
+        }
+      } else {
+        suspendedTime = null;
+      }
       changeListeners.forEach(l -> l.accept(state));
+    } else if (this.state == RaftProxy.State.SUSPENDED) {
+      if (System.currentTimeMillis() - suspendedTime > timeout) {
+        setState(RaftProxy.State.CLOSED);
+      }
     }
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/impl/DefaultServiceContext.java
@@ -32,7 +32,6 @@ import io.atomix.protocols.raft.session.RaftSession;
 import io.atomix.protocols.raft.session.RaftSessions;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.protocols.raft.session.impl.RaftSessionContext;
-import io.atomix.protocols.raft.storage.snapshot.Snapshot;
 import io.atomix.protocols.raft.storage.snapshot.SnapshotReader;
 import io.atomix.protocols.raft.storage.snapshot.SnapshotWriter;
 import io.atomix.storage.buffer.Bytes;
@@ -45,9 +44,7 @@ import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import org.slf4j.Logger;
 
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentSkipListMap;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -64,8 +61,6 @@ public class DefaultServiceContext implements ServiceContext {
   private final RaftContext raft;
   private final DefaultServiceSessions sessions;
   private final ThreadContextFactory threadContextFactory;
-  private final Map<Long, PendingSnapshot> pendingSnapshots = new ConcurrentSkipListMap<>();
-  private long snapshotIndex;
   private long currentIndex;
   private long currentTimestamp;
   private OperationType currentOperation;
@@ -588,24 +583,5 @@ public class DefaultServiceContext implements ServiceContext {
         .add("name", serviceName)
         .add("id", serviceId)
         .toString();
-  }
-
-  /**
-   * Pending snapshot.
-   */
-  private class PendingSnapshot {
-    private volatile Snapshot snapshot;
-    private final CompletableFuture<Long> future = new CompletableFuture<>();
-
-    public PendingSnapshot(Snapshot snapshot) {
-      this.snapshot = snapshot;
-    }
-
-    /**
-     * Persists the snapshot.
-     */
-    void persist() {
-      this.snapshot = snapshot.persist();
-    }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -541,6 +541,7 @@ public class RaftSessionContext implements RaftSession {
     if (currentEventList != null && currentEventList.eventIndex == index) {
       events.add(currentEventList);
       sendEvents(currentEventList);
+      currentEventList = null;
     }
     setLastApplied(index);
   }


### PR DESCRIPTION
This PR attempts to address memory consumption issues when the Raft cluster becomes overloaded. Clients currently retry operations as long as their sessions are open. But when the cluster is overloaded, it's possible a client's session will not be expired since the client can't receive a valid response from the cluster. This can lead to the client's operations consuming more and more memory and CPU. This PR makes minor changes to the client implementation to limit retries to avoid enqueuing requests when the cluster is overloaded.