### PR TITLE
Implement timeouts in Raft test protocol client/server

### DIFF
--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -49,6 +49,8 @@ import io.atomix.protocols.raft.storage.system.Configuration;
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.buffer.BufferInput;
 import io.atomix.storage.buffer.BufferOutput;
+import io.atomix.utils.concurrent.SingleThreadContext;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.Serializer;
 import net.jodah.concurrentunit.ConcurrentTestCase;
@@ -120,6 +122,7 @@ public class RaftTest extends ConcurrentTestCase {
   protected volatile List<RaftClient> clients = new ArrayList<>();
   protected volatile List<RaftServer> servers = new ArrayList<>();
   protected volatile TestRaftProtocolFactory protocolFactory;
+  protected volatile ThreadContext context;
 
   /**
    * Tests getting session metadata.
@@ -1295,11 +1298,16 @@ public class RaftTest extends ConcurrentTestCase {
       });
     }
 
+    if (context != null) {
+      context.close();
+    }
+
     members = new ArrayList<>();
     nextId = 0;
     clients = new ArrayList<>();
     servers = new ArrayList<>();
-    protocolFactory = new TestRaftProtocolFactory();
+    context = new SingleThreadContext("raft-test-messaging-%d");
+    protocolFactory = new TestRaftProtocolFactory(context);
   }
 
   private static final OperationId WRITE = OperationId.command("write");

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftClientProtocol.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftClientProtocol.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import io.atomix.cluster.NodeId;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.concurrent.ThreadContext;
 
 import java.net.ConnectException;
 import java.util.Map;
@@ -35,8 +36,12 @@ public class TestRaftClientProtocol extends TestRaftProtocol implements RaftClie
   private Function<HeartbeatRequest, CompletableFuture<HeartbeatResponse>> heartbeatHandler;
   private final Map<Long, Consumer<PublishRequest>> publishListeners = Maps.newConcurrentMap();
 
-  public TestRaftClientProtocol(NodeId memberId, Map<NodeId, TestRaftServerProtocol> servers, Map<NodeId, TestRaftClientProtocol> clients) {
-    super(servers, clients);
+  public TestRaftClientProtocol(
+      NodeId memberId,
+      Map<NodeId, TestRaftServerProtocol> servers,
+      Map<NodeId, TestRaftClientProtocol> clients,
+      ThreadContext context) {
+    super(servers, clients, context);
     clients.put(memberId, this);
   }
 
@@ -69,32 +74,32 @@ public class TestRaftClientProtocol extends TestRaftProtocol implements RaftClie
 
   @Override
   public CompletableFuture<OpenSessionResponse> openSession(NodeId memberId, OpenSessionRequest request) {
-    return getServer(memberId).thenCompose(protocol -> protocol.openSession(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(protocol -> protocol.openSession(request)));
   }
 
   @Override
   public CompletableFuture<CloseSessionResponse> closeSession(NodeId memberId, CloseSessionRequest request) {
-    return getServer(memberId).thenCompose(protocol -> protocol.closeSession(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(protocol -> protocol.closeSession(request)));
   }
 
   @Override
   public CompletableFuture<KeepAliveResponse> keepAlive(NodeId memberId, KeepAliveRequest request) {
-    return getServer(memberId).thenCompose(protocol -> protocol.keepAlive(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(protocol -> protocol.keepAlive(request)));
   }
 
   @Override
   public CompletableFuture<QueryResponse> query(NodeId memberId, QueryRequest request) {
-    return getServer(memberId).thenCompose(protocol -> protocol.query(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(protocol -> protocol.query(request)));
   }
 
   @Override
   public CompletableFuture<CommandResponse> command(NodeId memberId, CommandRequest request) {
-    return getServer(memberId).thenCompose(protocol -> protocol.command(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(protocol -> protocol.command(request)));
   }
 
   @Override
   public CompletableFuture<MetadataResponse> metadata(NodeId memberId, MetadataRequest request) {
-    return getServer(memberId).thenCompose(protocol -> protocol.metadata(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(protocol -> protocol.metadata(request)));
   }
 
   @Override

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftProtocolFactory.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftProtocolFactory.java
@@ -17,6 +17,7 @@ package io.atomix.protocols.raft.protocol;
 
 import com.google.common.collect.Maps;
 import io.atomix.cluster.NodeId;
+import io.atomix.utils.concurrent.ThreadContext;
 
 import java.util.Map;
 
@@ -26,6 +27,11 @@ import java.util.Map;
 public class TestRaftProtocolFactory {
   private final Map<NodeId, TestRaftServerProtocol> servers = Maps.newConcurrentMap();
   private final Map<NodeId, TestRaftClientProtocol> clients = Maps.newConcurrentMap();
+  private final ThreadContext context;
+
+  public TestRaftProtocolFactory(ThreadContext context) {
+    this.context = context;
+  }
 
   /**
    * Returns a new test client protocol.
@@ -34,7 +40,7 @@ public class TestRaftProtocolFactory {
    * @return a new test client protocol
    */
   public RaftClientProtocol newClientProtocol(NodeId memberId) {
-    return new TestRaftClientProtocol(memberId, servers, clients);
+    return new TestRaftClientProtocol(memberId, servers, clients, context);
   }
 
   /**
@@ -44,6 +50,6 @@ public class TestRaftProtocolFactory {
    * @return a new test server protocol
    */
   public RaftServerProtocol newServerProtocol(NodeId memberId) {
-    return new TestRaftServerProtocol(memberId, servers, clients);
+    return new TestRaftServerProtocol(memberId, servers, clients, context);
   }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftServerProtocol.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftServerProtocol.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import io.atomix.cluster.NodeId;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.concurrent.ThreadContext;
 
 import java.net.ConnectException;
 import java.util.Map;
@@ -48,8 +49,12 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   private Function<AppendRequest, CompletableFuture<AppendResponse>> appendHandler;
   private final Map<Long, Consumer<ResetRequest>> resetListeners = Maps.newConcurrentMap();
 
-  public TestRaftServerProtocol(NodeId memberId, Map<NodeId, TestRaftServerProtocol> servers, Map<NodeId, TestRaftClientProtocol> clients) {
-    super(servers, clients);
+  public TestRaftServerProtocol(
+      NodeId memberId,
+      Map<NodeId, TestRaftServerProtocol> servers,
+      Map<NodeId, TestRaftClientProtocol> clients,
+      ThreadContext context) {
+    super(servers, clients, context);
     servers.put(memberId, this);
   }
 
@@ -73,77 +78,77 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
 
   @Override
   public CompletableFuture<OpenSessionResponse> openSession(NodeId memberId, OpenSessionRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.openSession(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.openSession(request)));
   }
 
   @Override
   public CompletableFuture<CloseSessionResponse> closeSession(NodeId memberId, CloseSessionRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.closeSession(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.closeSession(request)));
   }
 
   @Override
   public CompletableFuture<KeepAliveResponse> keepAlive(NodeId memberId, KeepAliveRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.keepAlive(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.keepAlive(request)));
   }
 
   @Override
   public CompletableFuture<QueryResponse> query(NodeId memberId, QueryRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.query(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.query(request)));
   }
 
   @Override
   public CompletableFuture<CommandResponse> command(NodeId memberId, CommandRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.command(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.command(request)));
   }
 
   @Override
   public CompletableFuture<MetadataResponse> metadata(NodeId memberId, MetadataRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.metadata(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.metadata(request)));
   }
 
   @Override
   public CompletableFuture<JoinResponse> join(NodeId memberId, JoinRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.join(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.join(request)));
   }
 
   @Override
   public CompletableFuture<LeaveResponse> leave(NodeId memberId, LeaveRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.leave(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.leave(request)));
   }
 
   @Override
   public CompletableFuture<ConfigureResponse> configure(NodeId memberId, ConfigureRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.configure(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.configure(request)));
   }
 
   @Override
   public CompletableFuture<ReconfigureResponse> reconfigure(NodeId memberId, ReconfigureRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.reconfigure(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.reconfigure(request)));
   }
 
   @Override
   public CompletableFuture<InstallResponse> install(NodeId memberId, InstallRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.install(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.install(request)));
   }
 
   @Override
   public CompletableFuture<TransferResponse> transfer(NodeId memberId, TransferRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.transfer(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.transfer(request)));
   }
 
   @Override
   public CompletableFuture<PollResponse> poll(NodeId memberId, PollRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.poll(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.poll(request)));
   }
 
   @Override
   public CompletableFuture<VoteResponse> vote(NodeId memberId, VoteRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.vote(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.vote(request)));
   }
 
   @Override
   public CompletableFuture<AppendResponse> append(NodeId memberId, AppendRequest request) {
-    return getServer(memberId).thenCompose(listener -> listener.append(request));
+    return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.append(request)));
   }
 
   @Override
@@ -153,7 +158,7 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
 
   @Override
   public CompletableFuture<HeartbeatResponse> heartbeat(NodeId memberId, HeartbeatRequest request) {
-    return getClient(memberId).thenCompose(protocol -> protocol.heartbeat(request));
+    return scheduleTimeout(getClient(memberId).thenCompose(protocol -> protocol.heartbeat(request)));
   }
 
   CompletableFuture<OpenSessionResponse> openSession(OpenSessionRequest request) {


### PR DESCRIPTION
This PR fixes the cause of frequent Raft test failures. The test failures are not due to any bug in the Raft implementation, but rather in an inconsistency between the implementation of the test protocol and the messaging service implementation. This PR adds timeouts to the Raft test protocol client and server to mimic the behavior of the messaging service that's used during normal operation.