### PR TITLE
Return ConnectException when peer is unavailable

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterService.java
@@ -118,7 +118,7 @@ public class DefaultClusterService
   @Override
   public Node getNode(NodeId nodeId) {
     Node node = nodes.get(nodeId);
-    return node != null ? node.type() == Node.Type.DATA || node.getState() == State.ACTIVE ? node : null : null;
+    return node != null && (node.type() == Node.Type.DATA || node.getState() == State.ACTIVE) ? node : null;
   }
 
   /**


### PR DESCRIPTION
The `DefaultCLusterMessagingService` looks up nodes via the `ClusterService` and throws an `IllegalArgumentException` if a message is sent to an unknown node. Instead, it should return `ConnectException` to ensure Raft clients - which are designed to handle connection issues - properly handle the error and look for another node to connect to. This is the cause of #430.