### PR TITLE
Separate consensus nodes from primary-backup nodes

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/ClusterMetadata.java
+++ b/cluster/src/main/java/io/atomix/cluster/ClusterMetadata.java
@@ -42,7 +42,7 @@ public class ClusterMetadata {
 
   public ClusterMetadata(Collection<Node> bootstrapNodes) {
     this.bootstrapNodes = bootstrapNodes.stream()
-        .filter(node -> node.type() == Type.DATA)
+        .filter(node -> node.type() == Type.CORE)
         .collect(Collectors.toSet());
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/Node.java
+++ b/cluster/src/main/java/io/atomix/cluster/Node.java
@@ -59,6 +59,20 @@ public class Node {
   }
 
   /**
+   * Returns a new core node.
+   *
+   * @param nodeId   the core node ID
+   * @param endpoint the core node endpoint
+   * @return a new core node
+   */
+  public static Node core(NodeId nodeId, Endpoint endpoint) {
+    return builder(nodeId)
+        .withType(Type.CORE)
+        .withEndpoint(endpoint)
+        .build();
+  }
+
+  /**
    * Returns a new data node.
    *
    * @param nodeId   the data node ID
@@ -90,6 +104,11 @@ public class Node {
    * Node type.
    */
   public enum Type {
+
+    /**
+     * Represents a core node.
+     */
+    CORE,
 
     /**
      * Represents a data node.

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterService.java
@@ -111,14 +111,14 @@ public class DefaultClusterService
   public Set<Node> getNodes() {
     return ImmutableSet.copyOf(nodes.values()
         .stream()
-        .filter(node -> node.type() == Node.Type.DATA || node.getState() == State.ACTIVE)
+        .filter(node -> node.type() == Node.Type.CORE || node.getState() == State.ACTIVE)
         .collect(Collectors.toList()));
   }
 
   @Override
   public Node getNode(NodeId nodeId) {
     Node node = nodes.get(nodeId);
-    return node != null && (node.type() == Node.Type.DATA || node.getState() == State.ACTIVE) ? node : null;
+    return node != null && (node.type() == Node.Type.CORE || node.getState() == State.ACTIVE) ? node : null;
   }
 
   /**
@@ -211,9 +211,10 @@ public class DefaultClusterService
     if (existingNode != null && existingNode.getState() == State.ACTIVE) {
       existingNode.setState(State.INACTIVE);
       switch (existingNode.type()) {
-        case DATA:
+        case CORE:
           post(new ClusterEvent(ClusterEvent.Type.NODE_DEACTIVATED, existingNode));
           break;
+        case DATA:
         case CLIENT:
           post(new ClusterEvent(ClusterEvent.Type.NODE_DEACTIVATED, existingNode));
           post(new ClusterEvent(ClusterEvent.Type.NODE_REMOVED, existingNode));
@@ -243,7 +244,7 @@ public class DefaultClusterService
 
     // Filter the set of data node IDs from the local node information.
     Set<NodeId> dataNodes = nodes.entrySet().stream()
-        .filter(entry -> entry.getValue().type() == Node.Type.DATA)
+        .filter(entry -> entry.getValue().type() == Node.Type.CORE)
         .map(entry -> entry.getKey())
         .collect(Collectors.toSet());
 

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/DefaultClusterMessagingService.java
@@ -38,7 +38,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
@@ -57,7 +57,7 @@ public class DefaultClusterMetadataServiceTest {
 
     ClusterMetadata clusterMetadata = buildClusterMetadata(1);
 
-    Node localNode1 = buildNode(1, Node.Type.DATA);
+    Node localNode1 = buildNode(1, Node.Type.CORE);
     ManagedClusterMetadataService metadataService1 = new DefaultClusterMetadataService(
         clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
 
@@ -65,7 +65,7 @@ public class DefaultClusterMetadataServiceTest {
 
     assertEquals(1, metadataService1.getMetadata().bootstrapNodes().size());
 
-    Node localNode2 = buildNode(2, Node.Type.DATA);
+    Node localNode2 = buildNode(2, Node.Type.CORE);
     ManagedClusterMetadataService metadataService2 = new DefaultClusterMetadataService(
         clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
     metadataService2.start().join();
@@ -80,15 +80,15 @@ public class DefaultClusterMetadataServiceTest {
 
     ClusterMetadata clusterMetadata = buildClusterMetadata(1, 2, 3);
 
-    Node localNode1 = buildNode(1, Node.Type.DATA);
+    Node localNode1 = buildNode(1, Node.Type.CORE);
     ManagedClusterMetadataService metadataService1 = new DefaultClusterMetadataService(
         clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
 
-    Node localNode2 = buildNode(2, Node.Type.DATA);
+    Node localNode2 = buildNode(2, Node.Type.CORE);
     ManagedClusterMetadataService metadataService2 = new DefaultClusterMetadataService(
         clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
 
-    Node localNode3 = buildNode(3, Node.Type.DATA);
+    Node localNode3 = buildNode(3, Node.Type.CORE);
     ManagedClusterMetadataService metadataService3 = new DefaultClusterMetadataService(
         clusterMetadata, messagingServiceFactory.newMessagingService(localNode3.endpoint()).start().join());
 
@@ -102,7 +102,7 @@ public class DefaultClusterMetadataServiceTest {
     assertEquals(3, metadataService2.getMetadata().bootstrapNodes().size());
     assertEquals(3, metadataService3.getMetadata().bootstrapNodes().size());
 
-    Node localNode4 = buildNode(4, Node.Type.DATA);
+    Node localNode4 = buildNode(4, Node.Type.CORE);
     ManagedClusterMetadataService metadataService4 = new DefaultClusterMetadataService(
         clusterMetadata, messagingServiceFactory.newMessagingService(localNode4.endpoint()).start().join());
     metadataService4.start().join();
@@ -132,7 +132,7 @@ public class DefaultClusterMetadataServiceTest {
     assertEquals(4, remoteEventListener3.event().subject().bootstrapNodes().size());
     assertEquals(4, metadataService3.getMetadata().bootstrapNodes().size());
 
-    Node localNode5 = buildNode(5, Node.Type.DATA);
+    Node localNode5 = buildNode(5, Node.Type.CORE);
     ManagedClusterMetadataService metadataService5 = new DefaultClusterMetadataService(
         clusterMetadata, messagingServiceFactory.newMessagingService(localNode5.endpoint()).start().join());
     metadataService5.start().join();
@@ -150,7 +150,7 @@ public class DefaultClusterMetadataServiceTest {
     List<Node> bootstrap = new ArrayList<>();
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
-          .withType(Node.Type.DATA)
+          .withType(Node.Type.CORE)
           .withEndpoint(new Endpoint(localhost, bootstrapNode))
           .build());
     }

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventingServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventingServiceTest.java
@@ -64,7 +64,7 @@ public class DefaultClusterEventingServiceTest {
     List<Node> bootstrap = new ArrayList<>();
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
-          .withType(Node.Type.DATA)
+          .withType(Node.Type.CORE)
           .withEndpoint(new Endpoint(localhost, bootstrapNode))
           .build());
     }
@@ -77,17 +77,17 @@ public class DefaultClusterEventingServiceTest {
 
     ClusterMetadata clusterMetadata = buildClusterMetadata(1, 1, 2, 3);
 
-    Node localNode1 = buildNode(1, Node.Type.DATA);
+    Node localNode1 = buildNode(1, Node.Type.CORE);
     MessagingService messagingService1 = factory.newMessagingService(localNode1.endpoint()).start().join();
     ClusterService clusterService1 = new DefaultClusterService(localNode1, new TestClusterMetadataService(clusterMetadata), messagingService1).start().join();
     ClusterEventingService eventService1 = new DefaultClusterEventingService(clusterService1, messagingService1).start().join();
 
-    Node localNode2 = buildNode(2, Node.Type.DATA);
+    Node localNode2 = buildNode(2, Node.Type.CORE);
     MessagingService messagingService2 = factory.newMessagingService(localNode2.endpoint()).start().join();
     ClusterService clusterService2 = new DefaultClusterService(localNode2, new TestClusterMetadataService(clusterMetadata), messagingService2).start().join();
     ClusterEventingService eventService2 = new DefaultClusterEventingService(clusterService2, messagingService2).start().join();
 
-    Node localNode3 = buildNode(3, Node.Type.DATA);
+    Node localNode3 = buildNode(3, Node.Type.CORE);
     MessagingService messagingService3 = factory.newMessagingService(localNode3.endpoint()).start().join();
     ClusterService clusterService3 = new DefaultClusterService(localNode3, new TestClusterMetadataService(clusterMetadata), messagingService3).start().join();
     ClusterEventingService eventService3 = new DefaultClusterEventingService(clusterService3, messagingService3).start().join();

--- a/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
@@ -47,9 +47,9 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
   public static void setupAtomix() throws Exception {
     AbstractAtomixTest.setupAtomix();
     instances = new ArrayList<>();
-    instances.add(createAtomix(Node.Type.DATA, 1, 1, 2, 3));
-    instances.add(createAtomix(Node.Type.DATA, 2, 1, 2, 3));
-    instances.add(createAtomix(Node.Type.DATA, 3, 1, 2, 3));
+    instances.add(createAtomix(Node.Type.CORE, 1, 1, 2, 3));
+    instances.add(createAtomix(Node.Type.CORE, 2, 1, 2, 3));
+    instances.add(createAtomix(Node.Type.CORE, 3, 1, 2, 3));
     List<CompletableFuture<Atomix>> futures = instances.stream().map(Atomix::start).collect(Collectors.toList());
     CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(30, TimeUnit.SECONDS);
   }

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -72,14 +72,14 @@ public class AtomixTest extends AbstractAtomixTest {
    */
   @Test
   public void testScaleUp() throws Exception {
-    Atomix atomix1 = startAtomix(Node.Type.DATA, 1, 1).join();
-    Atomix atomix2 = startAtomix(Node.Type.DATA, 2, 1, 2).join();
-    Atomix atomix3 = startAtomix(Node.Type.DATA, 3, 1, 2, 3).join();
+    Atomix atomix1 = startAtomix(Node.Type.CORE, 1, 1).join();
+    Atomix atomix2 = startAtomix(Node.Type.CORE, 2, 1, 2).join();
+    Atomix atomix3 = startAtomix(Node.Type.CORE, 3, 1, 2, 3).join();
   }
 
   @Test
   public void testStopStart() throws Exception {
-    Atomix atomix1 = startAtomix(Node.Type.DATA, 1, 1).join();
+    Atomix atomix1 = startAtomix(Node.Type.CORE, 1, 1).join();
     atomix1.stop().join();
     try {
       atomix1.start().join();
@@ -96,9 +96,9 @@ public class AtomixTest extends AbstractAtomixTest {
   @Test
   public void testScaleDown() throws Exception {
     List<CompletableFuture<Atomix>> futures = new ArrayList<>();
-    futures.add(startAtomix(Node.Type.DATA, 1, 1, 2, 3));
-    futures.add(startAtomix(Node.Type.DATA, 2, 1, 2, 3));
-    futures.add(startAtomix(Node.Type.DATA, 3, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.CORE, 1, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.CORE, 2, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.CORE, 3, 1, 2, 3));
     Futures.allOf(futures).join();
     instances.get(0).stop().join();
     instances.get(1).stop().join();
@@ -111,9 +111,9 @@ public class AtomixTest extends AbstractAtomixTest {
   @Test
   public void testClientJoinLeave() throws Exception {
     List<CompletableFuture<Atomix>> futures = new ArrayList<>();
-    futures.add(startAtomix(Node.Type.DATA, 1, 1, 2, 3));
-    futures.add(startAtomix(Node.Type.DATA, 2, 1, 2, 3));
-    futures.add(startAtomix(Node.Type.DATA, 3, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.CORE, 1, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.CORE, 2, 1, 2, 3));
+    futures.add(startAtomix(Node.Type.CORE, 3, 1, 2, 3));
     Futures.allOf(futures).join();
 
     TestClusterEventListener dataListener = new TestClusterEventListener();

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionServer.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionServer.java
@@ -51,7 +51,8 @@ public class PrimaryBackupPartitionServer implements Managed<PrimaryBackupPartit
 
   @Override
   public CompletableFuture<PrimaryBackupPartitionServer> start() {
-    if (managementService.getClusterService().getLocalNode().type() == Node.Type.DATA) {
+    Node.Type localNodeType = managementService.getClusterService().getLocalNode().type();
+    if (localNodeType == Node.Type.CORE || localNodeType == Node.Type.DATA) {
       synchronized (this) {
         server = buildServer();
       }

--- a/protocols/primary-backup/src/test/java/io/atomix/cluster/TestClusterService.java
+++ b/protocols/primary-backup/src/test/java/io/atomix/cluster/TestClusterService.java
@@ -36,7 +36,7 @@ public class TestClusterService implements ClusterService {
   @Override
   public Node getLocalNode() {
     return Node.builder(localNode)
-        .withType(Node.Type.DATA)
+        .withType(Node.Type.CORE)
         .withEndpoint(Endpoint.from("localhost", localNode.hashCode()))
         .build();
   }
@@ -45,7 +45,7 @@ public class TestClusterService implements ClusterService {
   public Set<Node> getNodes() {
     return nodes.stream()
         .map(node -> Node.builder(node)
-            .withType(Node.Type.DATA)
+            .withType(Node.Type.CORE)
             .withEndpoint(Endpoint.from("localhost", node.hashCode()))
             .build())
         .collect(Collectors.toSet());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
@@ -131,7 +131,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   }
 
   private synchronized void handleClusterEvent(ClusterEvent event) {
-    if (event.type() == ClusterEvent.Type.NODE_ADDED && event.subject().type() == Node.Type.DATA) {
+    if (event.type() == ClusterEvent.Type.NODE_ADDED && event.subject().type() == Node.Type.CORE) {
       metadataChangeFuture = metadataChangeFuture.thenCompose(v -> {
         Collection<PartitionMetadata> partitions = buildPartitions(managementService.getClusterService());
         if (!this.metadata.equals(partitions)) {
@@ -153,7 +153,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     List<NodeId> sorted = new ArrayList<>(clusterService.getNodes().stream()
-        .filter(node -> node.type() == Node.Type.DATA)
+        .filter(node -> node.type() == Node.Type.CORE)
         .map(Node::id)
         .collect(Collectors.toSet()));
     Collections.sort(sorted);

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
@@ -441,7 +441,7 @@ public class RaftPerformanceTest implements Runnable {
     List<RaftServer> servers = new ArrayList<>();
 
     for (int i = 0; i < nodes; i++) {
-      members.add(nextNode(Node.Type.DATA));
+      members.add(nextNode(Node.Type.CORE));
     }
 
     CountDownLatch latch = new CountDownLatch(nodes);


### PR DESCRIPTION
This PR adds a third node type to Atomix. Currently, node types are `DATA` and `CLIENT`, and `DATA` nodes store both Raft and primary-backup partitions. This change adds a `CONSENSUS` node type which stores persistent Raft partitions, and keeps `DATA` for storing in-memory primary-backup partitions.

We will be using this in ONOS to move Raft partitions into a separate cluster and keep primary-backup partitions in the ONOS processes for local reads. In the future, we may want to be able to configure which node types a partition group can be replicated on and perhaps even allow arbitrary classification of nodes and partition groups. 