### PR TITLE
Support revisions in Raft state machines

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftError.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftError.java
@@ -251,6 +251,21 @@ public class RaftError {
       RaftException createException(String message) {
         return message != null ? new RaftException.Unavailable(message) : createException();
       }
+    },
+
+    /**
+     * Read-only service error.
+     */
+    READ_ONLY {
+      @Override
+      RaftException createException() {
+        return createException("Service is read-only");
+      }
+
+      @Override
+      RaftException createException(String message) {
+        return message != null ? new RaftException.ReadOnly(message) : createException();
+      }
     };
 
     /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftException.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftException.java
@@ -139,4 +139,10 @@ public abstract class RaftException extends RuntimeException {
       super(RaftError.Type.UNAVAILABLE, cause);
     }
   }
+
+  public static class ReadOnly extends RaftException {
+    public ReadOnly(String message, Object... args) {
+      super(RaftError.Type.READ_ONLY, message, args);
+    }
+  }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -427,7 +427,7 @@ public class RaftServiceManager implements AutoCloseable {
    *
    * @param index the index for which to take snapshots
    */
-  private Snapshot snapshot(long index) {
+  Snapshot snapshot(long index) {
     Snapshot snapshot = raft.getSnapshotStore().newTemporarySnapshot(index, new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       for (DefaultServiceContext service : raft.getServices()) {
@@ -464,7 +464,7 @@ public class RaftServiceManager implements AutoCloseable {
    *
    * @param index the index for which to install snapshots
    */
-  private void install(long index) {
+  void install(long index) {
     Snapshot snapshot = raft.getSnapshotStore().getSnapshot(index - 1);
 
     // If snapshots exist for the prior index, iterate through snapshots and populate services/sessions.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceRegistry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceRegistry.java
@@ -15,19 +15,22 @@
  */
 package io.atomix.protocols.raft.impl;
 
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.impl.DefaultServiceContext;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * Raft service registry.
  */
 public class RaftServiceRegistry implements Iterable<DefaultServiceContext> {
-  private final Map<String, DefaultServiceContext> services = new ConcurrentHashMap<>();
+  private final Map<String, SortedMap<Integer, DefaultServiceContext>> services = new ConcurrentHashMap<>();
 
   /**
    * Registers a new service.
@@ -35,30 +38,56 @@ public class RaftServiceRegistry implements Iterable<DefaultServiceContext> {
    * @param service the service to register
    */
   public void registerService(DefaultServiceContext service) {
-    services.put(service.serviceName(), service);
+    services.computeIfAbsent(service.serviceName(), name -> new ConcurrentSkipListMap<>())
+        .put(service.revision().revision(), service);
   }
 
   /**
-   * Gets a registered service by name.
+   * Gets a registered service by revision.
    *
    * @param name the service name
+   * @param revision the service revision
    * @return the registered service
    */
-  public DefaultServiceContext getService(String name) {
-    return services.get(name);
+  public DefaultServiceContext getRevision(String name, ServiceRevision revision) {
+    Map<Integer, DefaultServiceContext> revisions = services.get(name);
+    return revisions != null ? revisions.get(revision.revision()) : null;
+  }
+
+  /**
+   * Gets the current revision for a registered service.
+   *
+   * @param name the service name
+   * @return the current revision for the given service
+   */
+  public DefaultServiceContext getCurrentRevision(String name) {
+    SortedMap<Integer, DefaultServiceContext> revisions = services.get(name);
+    if (revisions == null) {
+      return null;
+    }
+
+    Integer lastKey = revisions.lastKey();
+    if (lastKey == null) {
+      return null;
+    }
+    return revisions.get(lastKey);
+  }
+
+  /**
+   * Returns all revisions for the given service.
+   *
+   * @param name the service name
+   * @return a collection of revisions for the given service
+   */
+  public Collection<DefaultServiceContext> getRevisions(String name) {
+    SortedMap<Integer, DefaultServiceContext> revisions = services.get(name);
+    return revisions != null ? revisions.values() : Collections.emptyList();
   }
 
   @Override
   public Iterator<DefaultServiceContext> iterator() {
-    return services.values().iterator();
-  }
-
-  /**
-   * Returns a copy of the services registered in the registry.
-   *
-   * @return a copy of the registered services
-   */
-  public Collection<DefaultServiceContext> copyValues() {
-    return new ArrayList<>(services.values());
+    return services.values().stream()
+        .flatMap(s -> s.values().stream())
+        .iterator();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxy.java
@@ -20,6 +20,7 @@ import io.atomix.protocols.raft.event.EventType;
 import io.atomix.protocols.raft.operation.OperationId;
 import io.atomix.protocols.raft.operation.RaftOperation;
 import io.atomix.protocols.raft.service.ServiceType;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.utils.Managed;
 
 import java.time.Duration;
@@ -198,6 +199,8 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
     protected RecoveryStrategy recoveryStrategy = RecoveryStrategy.RECOVER;
     protected Duration minTimeout = Duration.ofMillis(250);
     protected Duration maxTimeout = Duration.ofMillis(0);
+    protected int revision = 0;
+    protected PropagationStrategy propagationStrategy = PropagationStrategy.NONE;
 
     /**
      * Sets the session name.
@@ -396,6 +399,29 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
      */
     public Builder withExecutor(Executor executor) {
       this.executor = checkNotNull(executor, "executor cannot be null");
+      return this;
+    }
+
+    /**
+     * Sets the revision number.
+     *
+     * @param revision the revision number
+     * @return the proxy builder
+     */
+    public Builder withRevision(int revision) {
+      checkArgument(revision >= 0, "revision must be positive");
+      this.revision = revision;
+      return this;
+    }
+
+    /**
+     * Sets the revision propagation strategy.
+     *
+     * @param propagationStrategy the revision propagation strategy
+     * @return the proxy builder
+     */
+    public Builder withPropagationStrategy(PropagationStrategy propagationStrategy) {
+      this.propagationStrategy = checkNotNull(propagationStrategy);
       return this;
     }
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyClient.java
@@ -18,6 +18,7 @@ package io.atomix.protocols.raft.proxy;
 import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.service.ServiceType;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.utils.Managed;
 
 import java.time.Duration;
@@ -48,6 +49,8 @@ public interface RaftProxyClient extends RaftProxyExecutor, Managed<RaftProxyCli
     protected RecoveryStrategy recoveryStrategy = RecoveryStrategy.RECOVER;
     protected Duration minTimeout = Duration.ofMillis(250);
     protected Duration maxTimeout = Duration.ofMillis(0);
+    protected int revision = 0;
+    protected PropagationStrategy propagationStrategy = PropagationStrategy.NONE;
 
     /**
      * Sets the session name.
@@ -234,6 +237,29 @@ public interface RaftProxyClient extends RaftProxyExecutor, Managed<RaftProxyCli
     public Builder withMaxTimeout(Duration timeout) {
       checkArgument(!checkNotNull(timeout).isNegative(), "timeout must be positive");
       this.maxTimeout = timeout;
+      return this;
+    }
+
+    /**
+     * Sets the revision number.
+     *
+     * @param revision the revision number
+     * @return the proxy builder
+     */
+    public Builder withRevision(int revision) {
+      checkArgument(revision >= 0, "revision must be positive");
+      this.revision = revision;
+      return this;
+    }
+
+    /**
+     * Sets the revision propagation strategy.
+     *
+     * @param propagationStrategy the revision propagation strategy
+     * @return the proxy builder
+     */
+    public Builder withPropagationStrategy(PropagationStrategy propagationStrategy) {
+      this.propagationStrategy = checkNotNull(propagationStrategy);
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyExecutor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxyExecutor.java
@@ -18,6 +18,7 @@ package io.atomix.protocols.raft.proxy;
 import io.atomix.protocols.raft.event.RaftEvent;
 import io.atomix.protocols.raft.operation.OperationId;
 import io.atomix.protocols.raft.operation.RaftOperation;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.storage.buffer.HeapBytes;
@@ -50,6 +51,13 @@ public interface RaftProxyExecutor {
    * @return The client proxy type.
    */
   ServiceType serviceType();
+
+  /**
+   * Returns the proxy revision.
+   *
+   * @return the proxy revision
+   */
+  ServiceRevision revision();
 
   /**
    * Returns the session state.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DelegatingRaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DelegatingRaftProxy.java
@@ -21,6 +21,7 @@ import io.atomix.protocols.raft.event.RaftEvent;
 import io.atomix.protocols.raft.operation.RaftOperation;
 import io.atomix.protocols.raft.proxy.RaftProxy;
 import io.atomix.protocols.raft.proxy.RaftProxyClient;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.session.SessionId;
 
@@ -55,6 +56,11 @@ public class DelegatingRaftProxy implements RaftProxy {
   @Override
   public ServiceType serviceType() {
     return client.serviceType();
+  }
+
+  @Override
+  public ServiceRevision revision() {
+    return client.revision();
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DelegatingRaftProxyClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DelegatingRaftProxyClient.java
@@ -19,6 +19,7 @@ import io.atomix.protocols.raft.event.RaftEvent;
 import io.atomix.protocols.raft.operation.RaftOperation;
 import io.atomix.protocols.raft.proxy.RaftProxy;
 import io.atomix.protocols.raft.proxy.RaftProxyClient;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.session.SessionId;
 
@@ -51,6 +52,11 @@ public class DelegatingRaftProxyClient implements RaftProxyClient {
   @Override
   public SessionId sessionId() {
     return delegate.sessionId();
+  }
+
+  @Override
+  public ServiceRevision revision() {
+    return delegate.revision();
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DiscreteRaftProxyClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DiscreteRaftProxyClient.java
@@ -22,6 +22,7 @@ import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 import io.atomix.protocols.raft.proxy.RaftProxy;
 import io.atomix.protocols.raft.proxy.RaftProxyClient;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -130,6 +131,11 @@ public class DiscreteRaftProxyClient implements RaftProxyClient {
   @Override
   public SessionId sessionId() {
     return state.getSessionId();
+  }
+
+  @Override
+  public ServiceRevision revision() {
+    return state.getRevision();
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
@@ -60,7 +60,8 @@ public class RaftProxyConnection {
           || response.error().type() == RaftError.Type.UNKNOWN_CLIENT
           || response.error().type() == RaftError.Type.UNKNOWN_SESSION
           || response.error().type() == RaftError.Type.UNKNOWN_SERVICE
-          || response.error().type() == RaftError.Type.PROTOCOL_ERROR;
+          || response.error().type() == RaftError.Type.PROTOCOL_ERROR
+          || response.error().type() == RaftError.Type.READ_ONLY;
 
   private final Logger log;
   private final RaftClientProtocol protocol;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
@@ -357,7 +357,8 @@ final class RaftProxyInvoker {
         }
         // If a PROTOCOL_ERROR or APPLICATION_ERROR occurred, complete the request exceptionally with the error message.
         else if (response.error().type() == RaftError.Type.PROTOCOL_ERROR
-            || response.error().type() == RaftError.Type.APPLICATION_ERROR) {
+            || response.error().type() == RaftError.Type.APPLICATION_ERROR
+            || response.error().type() == RaftError.Type.READ_ONLY) {
           complete(response.error().createException());
         }
         // If the client is unknown by the cluster, close the session and complete the operation exceptionally.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
@@ -32,6 +32,8 @@ import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 import io.atomix.protocols.raft.proxy.RaftProxy;
 import io.atomix.protocols.raft.proxy.RaftProxyClient;
+import io.atomix.protocols.raft.service.ServiceRevision;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.utils.concurrent.Futures;
@@ -139,7 +141,9 @@ public class RaftProxyManager {
       ReadConsistency readConsistency,
       CommunicationStrategy communicationStrategy,
       Duration minTimeout,
-      Duration maxTimeout) {
+      Duration maxTimeout,
+      int revision,
+      PropagationStrategy propagationStrategy) {
     checkNotNull(serviceName, "serviceName cannot be null");
     checkNotNull(serviceType, "serviceType cannot be null");
     checkNotNull(communicationStrategy, "communicationStrategy cannot be null");
@@ -153,6 +157,8 @@ public class RaftProxyManager {
         .withReadConsistency(readConsistency)
         .withMinTimeout(minTimeout.toMillis())
         .withMaxTimeout(maxTimeout.toMillis())
+        .withRevision(revision)
+        .withPropagationStrategy(propagationStrategy)
         .build();
 
     CompletableFuture<RaftProxyClient> future = new CompletableFuture<>();
@@ -166,6 +172,7 @@ public class RaftProxyManager {
               SessionId.from(response.session()),
               serviceName,
               serviceType,
+              new ServiceRevision(response.revision(), response.propagationStrategy()),
               response.timeout());
           sessions.put(state.getSessionId().id(), state);
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyState.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyState.java
@@ -16,6 +16,7 @@
 package io.atomix.protocols.raft.proxy.impl;
 
 import io.atomix.protocols.raft.proxy.RaftProxy;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.session.SessionId;
 
@@ -33,6 +34,7 @@ public final class RaftProxyState {
   private final SessionId sessionId;
   private final String serviceName;
   private final ServiceType serviceType;
+  private final ServiceRevision revision;
   private final long timeout;
   private volatile RaftProxy.State state = RaftProxy.State.CONNECTED;
   private volatile Long suspendedTime;
@@ -42,11 +44,12 @@ public final class RaftProxyState {
   private volatile long eventIndex;
   private final Set<Consumer<RaftProxy.State>> changeListeners = new CopyOnWriteArraySet<>();
 
-  RaftProxyState(String clientId, SessionId sessionId, String serviceName, ServiceType serviceType, long timeout) {
+  RaftProxyState(String clientId, SessionId sessionId, String serviceName, ServiceType serviceType, ServiceRevision revision, long timeout) {
     this.clientId = clientId;
     this.sessionId = sessionId;
     this.serviceName = serviceName;
     this.serviceType = serviceType;
+    this.revision = revision;
     this.timeout = timeout;
     this.responseIndex = sessionId.id();
     this.eventIndex = sessionId.id();
@@ -86,6 +89,15 @@ public final class RaftProxyState {
    */
   public ServiceType getServiceType() {
     return serviceType;
+  }
+
+  /**
+   * Returns the revision number.
+   *
+   * @return the revision number
+   */
+  public ServiceRevision getRevision() {
+    return revision;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RecoveringRaftProxyClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RecoveringRaftProxyClient.java
@@ -21,6 +21,7 @@ import io.atomix.protocols.raft.event.RaftEvent;
 import io.atomix.protocols.raft.operation.RaftOperation;
 import io.atomix.protocols.raft.proxy.RaftProxy;
 import io.atomix.protocols.raft.proxy.RaftProxyClient;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.utils.concurrent.Futures;
@@ -47,6 +48,7 @@ public class RecoveringRaftProxyClient implements RaftProxyClient {
   private static final SessionId DEFAULT_SESSION_ID = SessionId.from(0);
   private final String name;
   private final ServiceType serviceType;
+  private final ServiceRevision revision;
   private final RaftProxyClient.Builder proxyClientBuilder;
   private final Scheduler scheduler;
   private Logger log;
@@ -58,9 +60,16 @@ public class RecoveringRaftProxyClient implements RaftProxyClient {
   private Scheduled recoverTask;
   private volatile boolean open = false;
 
-  public RecoveringRaftProxyClient(String clientId, String name, ServiceType serviceType, RaftProxyClient.Builder proxyClientBuilder, Scheduler scheduler) {
+  public RecoveringRaftProxyClient(
+      String clientId,
+      String name,
+      ServiceType serviceType,
+      ServiceRevision revision,
+      RaftProxyClient.Builder proxyClientBuilder,
+      Scheduler scheduler) {
     this.name = checkNotNull(name);
     this.serviceType = checkNotNull(serviceType);
+    this.revision = checkNotNull(revision);
     this.proxyClientBuilder = checkNotNull(proxyClientBuilder);
     this.scheduler = checkNotNull(scheduler);
     this.log = ContextualLoggerFactory.getLogger(getClass(), LoggerContext.builder(RaftClient.class)
@@ -82,6 +91,12 @@ public class RecoveringRaftProxyClient implements RaftProxyClient {
   @Override
   public ServiceType serviceType() {
     return serviceType;
+  }
+
+  @Override
+  public ServiceRevision revision() {
+    RaftProxyClient client = this.client;
+    return client != null ? client.revision() : revision;
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/PropagationStrategy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/PropagationStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.service;
+
+/**
+ * Propagation strategy.
+ */
+public enum PropagationStrategy {
+
+  /**
+   * A session that does not propagate state changes across versions.
+   */
+  NONE,
+
+  /**
+   * A session that creates immutable versions.
+   */
+  VERSION,
+
+  /**
+   * A session that propagates older changes to newer versions.
+   */
+  PROPAGATE,
+
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/ServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/ServiceContext.java
@@ -52,6 +52,13 @@ public interface ServiceContext {
   ServiceType serviceType();
 
   /**
+   * Returns the service revision number.
+   *
+   * @return the service revision number
+   */
+  ServiceRevision revision();
+
+  /**
    * Returns the current state machine index.
    * <p>
    * The state index is indicative of the index of the current operation

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/ServiceRevision.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/ServiceRevision.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.service;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * Service revision.
+ */
+public final class ServiceRevision {
+  private final int revision;
+  private final PropagationStrategy propagationStrategy;
+
+  public ServiceRevision(int revision, PropagationStrategy propagationStrategy) {
+    this.revision = revision;
+    this.propagationStrategy = propagationStrategy;
+  }
+
+  /**
+   * Returns the revision number.
+   *
+   * @return the revision number
+   */
+  public int revision() {
+    return revision;
+  }
+
+  /**
+   * Returns the revision propagation strategy.
+   *
+   * @return the revision propagation strategy
+   */
+  public PropagationStrategy propagationStrategy() {
+    return propagationStrategy;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(revision, propagationStrategy);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    return object instanceof ServiceRevision
+        && ((ServiceRevision) object).revision == revision;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("revision", revision)
+        .add("strategy", propagationStrategy)
+        .toString();
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -19,6 +19,7 @@ import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.event.EventType;
 import io.atomix.protocols.raft.event.RaftEvent;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.storage.buffer.HeapBytes;
 
@@ -69,6 +70,13 @@ public interface RaftSession {
    * @return The session's service type.
    */
   ServiceType serviceType();
+
+  /**
+   * Returns the session's service revision.
+   *
+   * @return the session's service revision
+   */
+  ServiceRevision serviceRevision();
 
   /**
    * Returns the member identifier to which the session belongs.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/OpenSessionEntry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/OpenSessionEntry.java
@@ -16,6 +16,7 @@
 package io.atomix.protocols.raft.storage.log.entry;
 
 import io.atomix.protocols.raft.ReadConsistency;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.utils.TimestampPrinter;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -30,8 +31,20 @@ public class OpenSessionEntry extends TimestampedEntry {
   private final ReadConsistency readConsistency;
   private final long minTimeout;
   private final long maxTimeout;
+  private final int revision;
+  private final PropagationStrategy propagationStrategy;
 
-  public OpenSessionEntry(long term, long timestamp, String memberId, String serviceName, String serviceType, ReadConsistency readConsistency, long minTimeout, long maxTimeout) {
+  public OpenSessionEntry(
+      long term,
+      long timestamp,
+      String memberId,
+      String serviceName,
+      String serviceType,
+      ReadConsistency readConsistency,
+      long minTimeout,
+      long maxTimeout,
+      int revision,
+      PropagationStrategy propagationStrategy) {
     super(term, timestamp);
     this.memberId = memberId;
     this.serviceName = serviceName;
@@ -39,6 +52,8 @@ public class OpenSessionEntry extends TimestampedEntry {
     this.readConsistency = readConsistency;
     this.minTimeout = minTimeout;
     this.maxTimeout = maxTimeout;
+    this.revision = revision;
+    this.propagationStrategy = propagationStrategy;
   }
 
   /**
@@ -95,6 +110,24 @@ public class OpenSessionEntry extends TimestampedEntry {
     return maxTimeout;
   }
 
+  /**
+   * Returns the revision number.
+   *
+   * @return the revision number
+   */
+  public int revision() {
+    return revision;
+  }
+
+  /**
+   * Returns the revision propagation strategy.
+   *
+   * @return the revision propagation strategy
+   */
+  public PropagationStrategy propagationStrategy() {
+    return propagationStrategy;
+  }
+
   @Override
   public String toString() {
     return toStringHelper(this)
@@ -106,6 +139,8 @@ public class OpenSessionEntry extends TimestampedEntry {
         .add("readConsistency", readConsistency)
         .add("minTimeout", minTimeout)
         .add("maxTimeout", maxTimeout)
+        .add("revision", revision)
+        .add("synchronizationStrategy", propagationStrategy)
         .toString();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/EphemeralSnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/EphemeralSnapshot.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.storage.snapshot;
+
+import io.atomix.storage.buffer.Buffer;
+import io.atomix.storage.buffer.HeapBuffer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Special snapshot that is not stored in the SnapshotStore.
+ */
+public class EphemeralSnapshot extends Snapshot {
+  private final Buffer buffer;
+
+  public EphemeralSnapshot(SnapshotDescriptor descriptor) {
+    this(HeapBuffer.allocate(), descriptor);
+  }
+
+  public EphemeralSnapshot(Buffer buffer, SnapshotDescriptor descriptor) {
+    super(descriptor);
+    this.buffer = checkNotNull(buffer);
+  }
+
+  @Override
+  public SnapshotWriter openWriter() {
+    return new SnapshotWriter(buffer, this);
+  }
+
+  @Override
+  public SnapshotReader openReader() {
+    return new SnapshotReader(buffer, this);
+  }
+
+  @Override
+  public boolean isPersisted() {
+    return false;
+  }
+
+  @Override
+  public Snapshot complete() {
+    buffer.flip();
+    return this;
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
@@ -31,7 +31,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * File-based snapshot backed by a {@link FileBuffer}.
  */
-final class FileSnapshot extends Snapshot {
+public final class FileSnapshot extends StoredSnapshot {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileSnapshot.class);
   private final SnapshotFile file;
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
@@ -24,7 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * In-memory snapshot backed by a {@link HeapBuffer}.
  */
-final class MemorySnapshot extends Snapshot {
+public final class MemorySnapshot extends StoredSnapshot {
   private final HeapBuffer buffer;
   private final SnapshotDescriptor descriptor;
   private final SnapshotStore store;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
@@ -56,12 +56,10 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public abstract class Snapshot implements AutoCloseable {
   protected final SnapshotDescriptor descriptor;
-  protected final SnapshotStore store;
   private SnapshotWriter writer;
 
-  protected Snapshot(SnapshotDescriptor descriptor, SnapshotStore store) {
+  protected Snapshot(SnapshotDescriptor descriptor) {
     this.descriptor = checkNotNull(descriptor, "descriptor cannot be null");
-    this.store = checkNotNull(store, "store cannot be null");
   }
 
   /**
@@ -160,7 +158,6 @@ public abstract class Snapshot implements AutoCloseable {
    * @return The completed snapshot.
    */
   public Snapshot complete() {
-    store.completeSnapshot(this);
     return this;
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptor.java
@@ -31,6 +31,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public final class SnapshotDescriptor implements AutoCloseable {
   public static final int BYTES = 64;
 
+  private static final int INDEX_OFFSET = 0;
+  private static final int TIMESTAMP_OFFSET = 8;
+  private static final int LOCK_OFFSET = 16;
+
   /**
    * Returns a descriptor builder.
    * <p>
@@ -103,7 +107,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
    */
   public void lock() {
     buffer.flush()
-        .writeBoolean(16, true)
+        .writeBoolean(LOCK_OFFSET, true)
         .flush();
     locked = true;
   }
@@ -152,7 +156,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The snapshot builder.
      */
     public Builder withIndex(long index) {
-      buffer.writeLong(0, index);
+      buffer.writeLong(INDEX_OFFSET, index);
       return this;
     }
 
@@ -163,7 +167,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The snapshot builder.
      */
     public Builder withTimestamp(long timestamp) {
-      buffer.writeLong(8, timestamp);
+      buffer.writeLong(TIMESTAMP_OFFSET, timestamp);
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/StoredSnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/StoredSnapshot.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.storage.snapshot;
+
+/**
+ * Snapshot that's stored in the SnapshotStore.
+ */
+public abstract class StoredSnapshot extends Snapshot {
+  protected final SnapshotStore store;
+
+  public StoredSnapshot(SnapshotDescriptor descriptor, SnapshotStore store) {
+    super(descriptor);
+    this.store = store;
+  }
+
+  @Override
+  public Snapshot complete() {
+    store.completeSnapshot(this);
+    return this;
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.impl;
+
+import io.atomix.protocols.raft.ReadConsistency;
+import io.atomix.protocols.raft.ThreadModel;
+import io.atomix.protocols.raft.cluster.MemberId;
+import io.atomix.protocols.raft.cluster.RaftMember;
+import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.protocols.raft.operation.OperationId;
+import io.atomix.protocols.raft.operation.OperationType;
+import io.atomix.protocols.raft.operation.RaftOperation;
+import io.atomix.protocols.raft.operation.impl.DefaultOperationId;
+import io.atomix.protocols.raft.protocol.RaftServerProtocol;
+import io.atomix.protocols.raft.service.AbstractRaftService;
+import io.atomix.protocols.raft.service.PropagationStrategy;
+import io.atomix.protocols.raft.service.RaftServiceExecutor;
+import io.atomix.protocols.raft.storage.RaftStorage;
+import io.atomix.protocols.raft.storage.log.RaftLogWriter;
+import io.atomix.protocols.raft.storage.log.TestEntry;
+import io.atomix.protocols.raft.storage.log.entry.CloseSessionEntry;
+import io.atomix.protocols.raft.storage.log.entry.CommandEntry;
+import io.atomix.protocols.raft.storage.log.entry.ConfigurationEntry;
+import io.atomix.protocols.raft.storage.log.entry.InitializeEntry;
+import io.atomix.protocols.raft.storage.log.entry.KeepAliveEntry;
+import io.atomix.protocols.raft.storage.log.entry.MetadataEntry;
+import io.atomix.protocols.raft.storage.log.entry.OpenSessionEntry;
+import io.atomix.protocols.raft.storage.log.entry.QueryEntry;
+import io.atomix.protocols.raft.storage.snapshot.Snapshot;
+import io.atomix.protocols.raft.storage.snapshot.SnapshotReader;
+import io.atomix.protocols.raft.storage.snapshot.SnapshotWriter;
+import io.atomix.serializer.Serializer;
+import io.atomix.serializer.kryo.KryoNamespace;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Raft service manager test.
+ */
+public class RaftServiceManagerTest {
+  private static final Path PATH = Paths.get("target/test-logs/");
+
+  private static final Serializer SERIALIZER = Serializer.using(KryoNamespace.newBuilder()
+      .register(CloseSessionEntry.class)
+      .register(CommandEntry.class)
+      .register(ConfigurationEntry.class)
+      .register(InitializeEntry.class)
+      .register(KeepAliveEntry.class)
+      .register(MetadataEntry.class)
+      .register(OpenSessionEntry.class)
+      .register(QueryEntry.class)
+      .register(TestEntry.class)
+      .register(ArrayList.class)
+      .register(HashSet.class)
+      .register(DefaultRaftMember.class)
+      .register(MemberId.class)
+      .register(RaftMember.Type.class)
+      .register(ReadConsistency.class)
+      .register(PropagationStrategy.class)
+      .register(RaftOperation.class)
+      .register(DefaultOperationId.class)
+      .register(OperationType.class)
+      .register(Instant.class)
+      .register(byte[].class)
+      .build());
+
+  private RaftContext raft;
+  private AtomicBoolean snapshotTaken;
+  private AtomicBoolean snapshotInstalled;
+
+  @Test
+  public void testSnapshotTakeInstall() throws Exception {
+    RaftLogWriter writer = raft.getLogWriter();
+    writer.append(new InitializeEntry(1, System.currentTimeMillis()));
+    writer.append(new OpenSessionEntry(
+        1,
+        System.currentTimeMillis(),
+        "test-1",
+        "test",
+        "test",
+        ReadConsistency.LINEARIZABLE,
+        100,
+        1000,
+        1,
+        PropagationStrategy.NONE));
+    writer.commit(2);
+
+    RaftServiceManager manager = raft.getServiceManager();
+
+    manager.apply(2).join();
+
+    assertEquals(1, raft.getServices().getCurrentRevision("test").revision().revision());
+    assertEquals(2, (long) raft.getServices().getCurrentRevision("test").sessions().getSession(2).sessionId().id());
+
+    Snapshot snapshot = manager.snapshot(2);
+    assertEquals(2, snapshot.index());
+    assertTrue(snapshotTaken.get());
+
+    snapshot.persist().complete();
+
+    assertEquals(2, raft.getSnapshotStore().getCurrentSnapshot().index());
+
+    manager.install(3);
+    assertTrue(snapshotInstalled.get());
+  }
+
+  @Test
+  public void testInstallSnapshotOnApply() throws Exception {
+    RaftLogWriter writer = raft.getLogWriter();
+    writer.append(new InitializeEntry(1, System.currentTimeMillis()));
+    writer.append(new OpenSessionEntry(
+        1,
+        System.currentTimeMillis(),
+        "test-1",
+        "test",
+        "test",
+        ReadConsistency.LINEARIZABLE,
+        100,
+        1000,
+        1,
+        PropagationStrategy.NONE));
+    writer.commit(2);
+
+    RaftServiceManager manager = raft.getServiceManager();
+
+    manager.apply(2).join();
+
+    assertEquals(1, raft.getServices().getCurrentRevision("test").revision().revision());
+    assertEquals(2, (long) raft.getServices().getCurrentRevision("test").sessions().getSession(2).sessionId().id());
+
+    Snapshot snapshot = manager.snapshot(2);
+    assertEquals(2, snapshot.index());
+    assertTrue(snapshotTaken.get());
+
+    snapshot.persist().complete();
+
+    assertEquals(2, raft.getSnapshotStore().getCurrentSnapshot().index());
+
+    writer.append(new CommandEntry(1, System.currentTimeMillis(), 2, 1, new RaftOperation(RUN, new byte[0])));
+    writer.commit(3);
+
+    manager.apply(3).join();
+    assertTrue(snapshotInstalled.get());
+  }
+
+  private static final OperationId RUN = OperationId.command("run");
+
+  private class TestService extends AbstractRaftService {
+    @Override
+    protected void configure(RaftServiceExecutor executor) {
+      executor.register(RUN, this::run);
+    }
+
+    @Override
+    public void snapshot(SnapshotWriter writer) {
+      writer.writeLong(10);
+      snapshotTaken.set(true);
+    }
+
+    @Override
+    public void install(SnapshotReader reader) {
+      assertEquals(10, reader.readLong());
+      snapshotInstalled.set(true);
+    }
+
+    private void run() {
+
+    }
+  }
+
+  @Before
+  public void setupContext() throws IOException {
+    deleteStorage();
+
+    RaftStorage storage = RaftStorage.newBuilder()
+        .withPrefix("test")
+        .withDirectory(PATH.toFile())
+        .withSerializer(SERIALIZER)
+        .build();
+    RaftServiceFactoryRegistry registry = new RaftServiceFactoryRegistry();
+    registry.register("test", TestService::new);
+    raft = new RaftContext(
+        "test",
+        MemberId.from("test-1"),
+        mock(RaftServerProtocol.class),
+        storage,
+        registry,
+        ThreadModel.SHARED_THREAD_POOL,
+        1);
+
+    snapshotTaken = new AtomicBoolean();
+    snapshotInstalled = new AtomicBoolean();
+  }
+
+  @After
+  public void teardownContext() throws IOException {
+    raft.close();
+    deleteStorage();
+  }
+
+  private void deleteStorage() throws IOException {
+    if (Files.exists(PATH)) {
+      Files.walkFileTree(PATH, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+          Files.delete(dir);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    }
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceRegistryTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceRegistryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.impl;
+
+import io.atomix.protocols.raft.service.AbstractRaftService;
+import io.atomix.protocols.raft.service.RaftServiceExecutor;
+import io.atomix.protocols.raft.service.ServiceId;
+import io.atomix.protocols.raft.service.ServiceRevision;
+import io.atomix.protocols.raft.service.ServiceType;
+import io.atomix.protocols.raft.service.PropagationStrategy;
+import io.atomix.protocols.raft.service.impl.DefaultServiceContext;
+import io.atomix.protocols.raft.storage.snapshot.SnapshotReader;
+import io.atomix.protocols.raft.storage.snapshot.SnapshotWriter;
+import io.atomix.utils.concurrent.ThreadContextFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Service registry test.
+ */
+public class RaftServiceRegistryTest {
+
+  @Test
+  public void testServiceRegistry() throws Exception {
+    RaftServiceRegistry registry = new RaftServiceRegistry();
+    registry.registerService(createService("foo", 1));
+    assertEquals(1, registry.getCurrentRevision("foo").revision().revision());
+
+    registry.registerService(createService("foo", 2));
+    assertEquals(2, registry.getCurrentRevision("foo").revision().revision());
+    assertEquals(2, registry.getRevisions("foo").size());
+  }
+
+  private DefaultServiceContext createService(String name, int revision) {
+    return new DefaultServiceContext(
+        ServiceId.from(1),
+        name,
+        ServiceType.from("test"),
+        new ServiceRevision(revision, PropagationStrategy.NONE),
+        new AbstractRaftService() {
+          @Override
+          protected void configure(RaftServiceExecutor executor) {
+
+          }
+
+          @Override
+          public void snapshot(SnapshotWriter writer) {
+
+          }
+
+          @Override
+          public void install(SnapshotReader reader) {
+
+          }
+        },
+        mock(RaftContext.class),
+        mock(ThreadContextFactory.class));
+  }
+
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvokerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvokerTest.java
@@ -23,7 +23,9 @@ import io.atomix.protocols.raft.protocol.CommandResponse;
 import io.atomix.protocols.raft.protocol.QueryRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftResponse;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.protocols.raft.session.SessionId;
 import io.atomix.storage.buffer.HeapBytes;
 import io.atomix.utils.concurrent.Scheduled;
@@ -66,7 +68,13 @@ public class RaftProxyInvokerTest {
         .withResult("Hello world!".getBytes())
         .build()));
 
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     RaftProxyManager manager = mock(RaftProxyManager.class);
     ThreadContext threadContext = new TestContext();
 
@@ -90,7 +98,13 @@ public class RaftProxyInvokerTest {
       .thenReturn(future1)
       .thenReturn(future2);
 
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     RaftProxyManager manager = mock(RaftProxyManager.class);
     ThreadContext threadContext = new TestContext();
 
@@ -141,7 +155,13 @@ public class RaftProxyInvokerTest {
         .withResult("Hello world!".getBytes())
         .build()));
 
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     RaftProxyManager manager = mock(RaftProxyManager.class);
     ThreadContext threadContext = new TestContext();
 
@@ -163,7 +183,13 @@ public class RaftProxyInvokerTest {
       .thenReturn(future1)
       .thenReturn(future2);
 
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     RaftProxyManager manager = mock(RaftProxyManager.class);
     ThreadContext threadContext = new TestContext();
 
@@ -210,7 +236,13 @@ public class RaftProxyInvokerTest {
       .thenReturn(future1)
       .thenReturn(future2);
 
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     RaftProxyManager manager = mock(RaftProxyManager.class);
     ThreadContext threadContext = new TestContext();
 
@@ -248,7 +280,13 @@ public class RaftProxyInvokerTest {
     RaftProxyConnection connection = mock(RaftProxyConnection.class);
     Mockito.when(connection.command(any(CommandRequest.class))).thenReturn(future);
 
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     RaftProxyManager manager = mock(RaftProxyManager.class);
     ThreadContext threadContext = new TestContext();
 
@@ -276,7 +314,13 @@ public class RaftProxyInvokerTest {
     Mockito.when(connection.query(any(QueryRequest.class)))
       .thenReturn(future);
 
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     RaftProxyManager manager = mock(RaftProxyManager.class);
     ThreadContext threadContext = new TestContext();
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxySequencerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxySequencerTest.java
@@ -19,7 +19,9 @@ import io.atomix.protocols.raft.protocol.CommandResponse;
 import io.atomix.protocols.raft.protocol.PublishRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftResponse;
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.protocols.raft.session.SessionId;
 import org.junit.Test;
 
@@ -44,7 +46,14 @@ public class RaftProxySequencerTest {
    */
   @Test
   public void testSequenceEventBeforeCommand() throws Throwable {
-    RaftProxySequencer sequencer = new RaftProxySequencer(new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000));
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
+    RaftProxySequencer sequencer = new RaftProxySequencer(state);
     long sequence = sequencer.nextRequest();
 
     PublishRequest request = PublishRequest.newBuilder()
@@ -71,7 +80,14 @@ public class RaftProxySequencerTest {
    */
   @Test
   public void testSequenceEventAfterCommand() throws Throwable {
-    RaftProxySequencer sequencer = new RaftProxySequencer(new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000));
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
+    RaftProxySequencer sequencer = new RaftProxySequencer(state);
     long sequence = sequencer.nextRequest();
 
     PublishRequest request = PublishRequest.newBuilder()
@@ -98,7 +114,14 @@ public class RaftProxySequencerTest {
    */
   @Test
   public void testSequenceEventAtCommand() throws Throwable {
-    RaftProxySequencer sequencer = new RaftProxySequencer(new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000));
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
+    RaftProxySequencer sequencer = new RaftProxySequencer(state);
     long sequence = sequencer.nextRequest();
 
     PublishRequest request = PublishRequest.newBuilder()
@@ -125,7 +148,14 @@ public class RaftProxySequencerTest {
    */
   @Test
   public void testSequenceEventAfterAllCommands() throws Throwable {
-    RaftProxySequencer sequencer = new RaftProxySequencer(new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000));
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
+    RaftProxySequencer sequencer = new RaftProxySequencer(state);
     long sequence = sequencer.nextRequest();
 
     PublishRequest request1 = PublishRequest.newBuilder()
@@ -160,7 +190,14 @@ public class RaftProxySequencerTest {
    */
   @Test
   public void testSequenceEventAbsentCommand() throws Throwable {
-    RaftProxySequencer sequencer = new RaftProxySequencer(new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000));
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
+    RaftProxySequencer sequencer = new RaftProxySequencer(state);
 
     PublishRequest request1 = PublishRequest.newBuilder()
         .withSession(1)
@@ -187,7 +224,14 @@ public class RaftProxySequencerTest {
    */
   @Test
   public void testSequenceResponses() throws Throwable {
-    RaftProxySequencer sequencer = new RaftProxySequencer(new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000));
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
+    RaftProxySequencer sequencer = new RaftProxySequencer(state);
     long sequence1 = sequencer.nextRequest();
     long sequence2 = sequencer.nextRequest();
     assertTrue(sequence2 == sequence1 + 1);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyStateTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyStateTest.java
@@ -41,7 +41,7 @@ public class RaftProxyStateTest {
     RaftProxyState state = new RaftProxyState(
         "test",
         SessionId.from(1),
-        UUID.randomUUID().toString(),
+        sessionName,
         ServiceType.from("test"),
         new ServiceRevision(1, PropagationStrategy.NONE),
         1000);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyStateTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyStateTest.java
@@ -15,7 +15,9 @@
  */
 package io.atomix.protocols.raft.proxy.impl;
 
+import io.atomix.protocols.raft.service.ServiceRevision;
 import io.atomix.protocols.raft.service.ServiceType;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.protocols.raft.session.SessionId;
 import org.junit.Test;
 
@@ -36,7 +38,13 @@ public class RaftProxyStateTest {
   @Test
   public void testSessionStateDefaults() {
     String sessionName = UUID.randomUUID().toString();
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), sessionName, ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     assertEquals(state.getSessionId(), SessionId.from(1));
     assertEquals(state.getServiceName(), sessionName);
     assertEquals(state.getServiceType().id(), "test");
@@ -51,7 +59,13 @@ public class RaftProxyStateTest {
    */
   @Test
   public void testSessionState() {
-    RaftProxyState state = new RaftProxyState("test", SessionId.from(1), UUID.randomUUID().toString(), ServiceType.from("test"), 1000);
+    RaftProxyState state = new RaftProxyState(
+        "test",
+        SessionId.from(1),
+        UUID.randomUUID().toString(),
+        ServiceType.from("test"),
+        new ServiceRevision(1, PropagationStrategy.NONE),
+        1000);
     assertEquals(state.getSessionId(), SessionId.from(1));
     assertEquals(state.getResponseIndex(), 1);
     assertEquals(state.getEventIndex(), 1);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -19,6 +19,7 @@ import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.protocols.raft.storage.log.entry.CloseSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.CommandEntry;
 import io.atomix.protocols.raft.storage.log.entry.ConfigurationEntry;
@@ -107,7 +108,17 @@ public abstract class AbstractLogTest {
     // Append a couple entries.
     Indexed<RaftLogEntry> indexed;
     assertEquals(writer.getNextIndex(), 1);
-    indexed = writer.append(new OpenSessionEntry(1, System.currentTimeMillis(), "client", "test1", "test", ReadConsistency.LINEARIZABLE, 100, 1000));
+    indexed = writer.append(new OpenSessionEntry(
+        1,
+        System.currentTimeMillis(),
+        "client",
+        "test1",
+        "test",
+        ReadConsistency.LINEARIZABLE,
+        100,
+        1000,
+        1,
+        PropagationStrategy.NONE));
     assertEquals(indexed.index(), 1);
 
     assertEquals(writer.getNextIndex(), 2);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -80,6 +80,7 @@ public abstract class AbstractLogTest {
       .register(MemberId.class)
       .register(RaftMember.Type.class)
       .register(ReadConsistency.class)
+      .register(PropagationStrategy.class)
       .register(Instant.class)
       .register(byte[].class)
       .build());

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft.storage.snapshot;
 
+import io.atomix.protocols.raft.service.PropagationStrategy;
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.storage.StorageLevel;
 import io.atomix.time.WallClockTimestamp;

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptorTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptorTest.java
@@ -20,6 +20,8 @@ import io.atomix.storage.buffer.HeapBuffer;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Snapshot descriptor test.
@@ -50,4 +52,14 @@ public class SnapshotDescriptorTest {
     assertEquals(3, descriptor.timestamp());
   }
 
+  @Test
+  public void testLockSnapshotDescriptor() throws Exception {
+    SnapshotDescriptor descriptor = SnapshotDescriptor.newBuilder()
+        .withIndex(2)
+        .withTimestamp(3)
+        .build();
+    assertFalse(descriptor.isLocked());
+    descriptor.lock();
+    assertTrue(descriptor.isLocked());
+  }
 }


### PR DESCRIPTION
This PR implements support for revisions in Raft state machines.

Revisions are essentially versioning for Raft state machines with additional features for optionally propagating some state changes. We use revisions when upgrading ONOS controllers. During rolling upgrades, new primitive revisions can be initialized from the existing primitive state, and changes may or may not be propagated from older revisions to newer revisions based on the requirements of specific applications.

The change supports three `PropagationStrategy`s for revisions:
* `NONE` completely isolates changes to each version
* `VERSION` sets all prior revisions to read-only and supports writes only on the latest revision
* `PROPAGATE` propagates changes on older revisions to newer revisions

When changes are propagated from an older state machine revision to a newer revision, all basic features - including events - continue to operate as normal. The operation behaves just as a normal command on the state machine would.

Revisions are implemented simply by taking temporary snapshots of an existing state machine, creating a new instance of the same state machine, and installing the snapshot on the new state machine.