### PR TITLE
LeadershipEvent issue

### DIFF
--- a/core/src/main/java/io/atomix/core/election/AsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/AsyncLeaderElector.java
@@ -110,20 +110,22 @@ public interface AsyncLeaderElector<T> extends AsyncPrimitive {
   /**
    * Registers a listener to be notified of Leadership changes for all topics.
    *
+   * @param topic    leadership topic
    * @param listener listener to notify
    * @return CompletableFuture that is completed when the operation completes
    */
-  CompletableFuture<Void> addListener(LeadershipEventListener<T> listener);
+  CompletableFuture<Void> addListener(String topic, LeadershipEventListener<T> listener);
 
   /**
    * Unregisters a previously registered change notification listener.
    * <p>
    * If the specified listener was not previously registered, this operation will be a noop.
    *
+   * @param topic    leadership topic
    * @param listener listener to remove
    * @return CompletableFuture that is completed when the operation completes
    */
-  CompletableFuture<Void> removeListener(LeadershipEventListener<T> listener);
+  CompletableFuture<Void> removeListener(String topic, LeadershipEventListener<T> listener);
 
   @Override
   default LeaderElector<T> sync() {

--- a/core/src/main/java/io/atomix/core/election/LeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElector.java
@@ -98,18 +98,20 @@ public interface LeaderElector<T> extends SyncPrimitive {
   /**
    * Registers a listener to be notified of Leadership changes for all topics.
    *
+   * @param topic    leadership topic
    * @param listener listener to notify
    */
-  void addListener(LeadershipEventListener<T> listener);
+  void addListener(String topic, LeadershipEventListener<T> listener);
 
   /**
    * Unregisters a previously registered change notification listener.
    * <p>
    * If the specified listener was not previously registered, this operation will be a noop.
    *
+   * @param topic    leadership topic
    * @param listener listener to remove
    */
-  void removeListener(LeadershipEventListener<T> listener);
+  void removeListener(String topic, LeadershipEventListener<T> listener);
 
   @Override
   AsyncLeaderElector<T> async();

--- a/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
@@ -81,13 +81,13 @@ public class BlockingLeaderElector<T> extends Synchronous<AsyncLeaderElector<T>>
   }
 
   @Override
-  public void addListener(LeadershipEventListener<T> listener) {
-    complete(asyncElector.addListener(listener));
+  public void addListener(String topic, LeadershipEventListener<T> listener) {
+    complete(asyncElector.addListener(topic, listener));
   }
 
   @Override
-  public void removeListener(LeadershipEventListener<T> listener) {
-    complete(asyncElector.removeListener(listener));
+  public void removeListener(String topic, LeadershipEventListener<T> listener) {
+    complete(asyncElector.removeListener(topic, listener));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorPrimaryElection.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorPrimaryElection.java
@@ -47,7 +47,7 @@ public class LeaderElectorPrimaryElection implements PrimaryElection {
   public LeaderElectorPrimaryElection(PartitionId partitionId, AsyncLeaderElector<NodeId> elector) {
     this.partitionId = checkNotNull(partitionId);
     this.elector = checkNotNull(elector);
-    elector.addListener(eventListener);
+    elector.addListener(partitionId.toString(), eventListener);
   }
 
   @Override
@@ -115,6 +115,6 @@ public class LeaderElectorPrimaryElection implements PrimaryElection {
 
   @Override
   public void close() {
-    elector.removeListener(eventListener);
+    elector.removeListener(partitionId.toString(), eventListener);
   }
 }

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorPrimaryElection.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorPrimaryElection.java
@@ -60,6 +60,11 @@ public class LeaderElectorPrimaryElection implements PrimaryElection {
     return elector.getLeadership(partitionId.toString()).thenApply(this::createTerm);
   }
 
+  @Override
+  public CompletableFuture<Void> open() {
+      return getTerm().thenAccept(term -> this.term = term);
+  }
+
   private PrimaryTerm createTerm(Leadership<NodeId> leadership) {
     NodeId leader = leadership.leader() != null ? leadership.leader().id() : null;
     return new PrimaryTerm(

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorPrimaryElectionService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorPrimaryElectionService.java
@@ -71,6 +71,7 @@ public class LeaderElectorPrimaryElectionService implements ManagedPrimaryElecti
   public PrimaryElection getElectionFor(PartitionId partitionId) {
     return elections.computeIfAbsent(partitionId, id -> {
       PrimaryElection election = new LeaderElectorPrimaryElection(partitionId, elector);
+      election.open().join();
       election.addListener(eventListener);
       return election;
     });

--- a/core/src/main/java/io/atomix/core/election/impl/PartitionedAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/PartitionedAsyncLeaderElector.java
@@ -103,16 +103,16 @@ public class PartitionedAsyncLeaderElector<T> implements AsyncLeaderElector<T> {
   }
 
   @Override
-  public CompletableFuture<Void> addListener(LeadershipEventListener<T> listener) {
+  public CompletableFuture<Void> addListener(String topic, LeadershipEventListener<T> listener) {
     return CompletableFuture.allOf(getLeaderElectors().stream()
-        .map(map -> map.addListener(listener))
+        .map(map -> map.addListener(topic, listener))
         .toArray(CompletableFuture[]::new));
   }
 
   @Override
-  public CompletableFuture<Void> removeListener(LeadershipEventListener<T> listener) {
+  public CompletableFuture<Void> removeListener(String topic, LeadershipEventListener<T> listener) {
     return CompletableFuture.allOf(getLeaderElectors().stream()
-        .map(map -> map.removeListener(listener))
+        .map(map -> map.removeListener(topic, listener))
         .toArray(CompletableFuture[]::new));
   }
 

--- a/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
@@ -90,20 +90,20 @@ public class TranscodingAsyncLeaderElector<V1, V2> implements AsyncLeaderElector
   }
 
   @Override
-  public CompletableFuture<Void> addListener(LeadershipEventListener<V1> listener) {
+  public CompletableFuture<Void> addListener(String topic, LeadershipEventListener<V1> listener) {
     synchronized (listeners) {
       InternalLeadershipEventListener internalListener =
           listeners.computeIfAbsent(listener, k -> new InternalLeadershipEventListener(listener));
-      return backingElector.addListener(internalListener);
+      return backingElector.addListener(topic, internalListener);
     }
   }
 
   @Override
-  public CompletableFuture<Void> removeListener(LeadershipEventListener<V1> listener) {
+  public CompletableFuture<Void> removeListener(String topic, LeadershipEventListener<V1> listener) {
     synchronized (listeners) {
       InternalLeadershipEventListener internalListener = listeners.remove(listener);
       if (internalListener != null) {
-        return backingElector.removeListener(internalListener);
+        return backingElector.removeListener(topic, internalListener);
       } else {
         return CompletableFuture.completedFuture(null);
       }

--- a/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
@@ -21,7 +21,6 @@ import io.atomix.core.election.AsyncLeaderElector;
 import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEvent;
 import io.atomix.core.election.LeadershipEventListener;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -77,10 +76,14 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
     elector2.run("foo", node2).join();
 
     LeaderEventListener listener1 = new LeaderEventListener();
-    elector1.addListener(listener1).join();
+    elector1.addListener("foo", listener1).join();
 
     LeaderEventListener listener2 = new LeaderEventListener();
-    elector2.addListener(listener2).join();
+    elector2.addListener("foo", listener2).join();
+
+    LeaderEventListener listener3 = new LeaderEventListener();
+    elector1.addListener("bar", listener3);
+    elector2.addListener("bar", listener3);
 
     elector1.withdraw("foo", node1).join();
 
@@ -97,6 +100,8 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
       assertEquals(1, result.newLeadership().candidates().size());
       assertEquals(node2, result.newLeadership().candidates().get(0));
     }).join();
+
+    assertFalse(listener3.hasEvent());
 
     Leadership leadership1 = elector1.getLeadership("foo").join();
     assertEquals(node2, leadership1.leader().id());
@@ -116,11 +121,11 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
     elector2.run("foo", node2).join();
 
     LeaderEventListener listener1 = new LeaderEventListener();
-    elector1.addListener(listener1).join();
+    elector1.addListener("foo", listener1).join();
     LeaderEventListener listener2 = new LeaderEventListener();
-    elector2.addListener(listener2);
+    elector2.addListener("foo", listener2);
     LeaderEventListener listener3 = new LeaderEventListener();
-    elector3.addListener(listener3).join();
+    elector3.addListener("foo", listener3).join();
 
     elector3.anoint("foo", node3).thenAccept(result -> {
       assertFalse(result);
@@ -162,11 +167,11 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
     elector2.run("foo", node2).join();
 
     LeaderEventListener listener1 = new LeaderEventListener();
-    elector1.addListener(listener1).join();
+    elector1.addListener("foo", listener1).join();
     LeaderEventListener listener2 = new LeaderEventListener();
-    elector2.addListener(listener2).join();
+    elector2.addListener("foo", listener2).join();
     LeaderEventListener listener3 = new LeaderEventListener();
-    elector3.addListener(listener3).join();
+    elector3.addListener("foo", listener3).join();
 
     elector3.promote("foo", node3).thenAccept(result -> {
       assertFalse(result);
@@ -210,7 +215,7 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
     AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-session-close").build().async();
     LeaderEventListener listener = new LeaderEventListener();
     elector2.run("foo", node2).join();
-    elector2.addListener(listener).join();
+    elector2.addListener("foo", listener).join();
     elector1.close();
     listener.nextEvent().thenAccept(result -> {
       assertEquals(node2, result.newLeadership().leader().id());
@@ -226,7 +231,7 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
     AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-non-leader-session-close").build().async();
     LeaderEventListener listener = new LeaderEventListener();
     elector2.run("foo", node2).join();
-    elector1.addListener(listener).join();
+    elector1.addListener("foo", listener).join();
     elector2.close().join();
     listener.nextEvent().thenAccept(result -> {
       assertEquals(node1, result.newLeadership().leader().id());
@@ -254,7 +259,7 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
     elector3.run("baz", node3).join();
 
     LeaderEventListener listener = new LeaderEventListener();
-    elector2.addListener(listener).join();
+    elector2.addListener("foo", listener).join();
 
     elector1.close();
 

--- a/primitive/src/main/java/io/atomix/primitive/partition/PrimaryElection.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PrimaryElection.java
@@ -41,6 +41,13 @@ public interface PrimaryElection extends ListenerService<PrimaryElectionEvent, P
   CompletableFuture<PrimaryTerm> getTerm();
 
   /**
+   * Opens the primary election.
+   *
+   * @return a future to be completed once the first term has been received
+   */
+  CompletableFuture<Void> open();
+
+  /**
    * Closes the primary election.
    */
   void close();

--- a/protocols/primary-backup/src/test/java/io/atomix/primitive/partition/TestPrimaryElection.java
+++ b/protocols/primary-backup/src/test/java/io/atomix/primitive/partition/TestPrimaryElection.java
@@ -56,6 +56,11 @@ public class TestPrimaryElection implements PrimaryElection {
   }
 
   @Override
+  public CompletableFuture<Void> open() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
   public void addListener(PrimaryElectionEventListener listener) {
     listeners.add(listener);
   }


### PR DESCRIPTION
```JAVA
private final LeadershipEventListener<NodeId> eventListener = event -> updateTerm(event.newLeadership());

public LeaderElectorPrimaryElection(PartitionId partitionId, AsyncLeaderElector<NodeId> elector) {
    this.partitionId = checkNotNull(partitionId);
    this.elector = checkNotNull(elector);
    elector.addListener(eventListener);
}
```  
When the node changes, the elector notifies listeners 71 - partition size times, this will update the local `term` with the last event `term`, which is not necessarily correct, only need the event where event topic is equal to `partitionId.toString()`.   

After fixed the above  
```JAVA
private PrimaryTerm updateTerm(Leadership<NodeId> leadership) {
    PrimaryTerm oldTerm = this.term;
    PrimaryTerm term = createTerm(leadership);

    if (oldTerm != null) {
      PrimaryElectionEvent.Type type = null;
      if (!Objects.equals(oldTerm.primary(), term.primary())) {
        if (!Objects.equals(oldTerm.backups(), term.backups())) {
          type = Type.PRIMARY_AND_BACKUPS_CHANGED;
        } else {
          type = Type.PRIMARY_CHANGED;
        }
      } else if (!Objects.equals(oldTerm.backups(), term.backups())) {
        type = Type.BACKUPS_CHANGED;
      }

      if (type != null) {
        this.term = term;
        PrimaryElectionEvent event = new PrimaryElectionEvent(type, term);
        listeners.forEach(l -> l.onEvent(event));
      }
    } else {
      this.term = term;
    }
    return this.term;
}
```
initial value of term is null, the first event does not notify the listener