### PR TITLE
Pooled IO objects.

### DIFF
--- a/utils/src/main/java/io/atomix/utils/serializer/BufferAwareByteArrayOutputStream.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/BufferAwareByteArrayOutputStream.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * Exposes protected byte array length in {@link ByteArrayOutputStream}.
+ */
+final class BufferAwareByteArrayOutputStream extends ByteArrayOutputStream {
+
+    BufferAwareByteArrayOutputStream(int size) {
+        super(size);
+    }
+
+    int getBufferSize() {
+        return buf.length;
+    }
+}

--- a/utils/src/main/java/io/atomix/utils/serializer/ByteArrayOutput.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/ByteArrayOutput.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Convenience class to avoid extra object allocation and casting.
+ */
+final class ByteArrayOutput extends Output {
+
+    private final BufferAwareByteArrayOutputStream stream;
+
+    ByteArrayOutput(final int bufferSize, final int maxBufferSize, final BufferAwareByteArrayOutputStream stream) {
+        super(bufferSize, maxBufferSize);
+        super.setOutputStream(stream);
+        this.stream = stream;
+    }
+
+    BufferAwareByteArrayOutputStream getByteArrayOutputStream() {
+        return stream;
+    }
+}

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoIOPool.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoIOPool.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import java.lang.ref.SoftReference;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+
+abstract class KryoIOPool<T> {
+
+    private final Queue<SoftReference<T>> queue = new ConcurrentLinkedQueue<>();
+
+    private T borrow(final int bufferSize) {
+        T element;
+        SoftReference<T> reference;
+        while ((reference = queue.poll()) != null) {
+            if ((element = reference.get()) != null) {
+                return element;
+            }
+        }
+        return create(bufferSize);
+    }
+
+    protected abstract T create(final int bufferSize);
+
+    protected abstract boolean recycle(final T element);
+
+    <R> R run(final Function<T, R> function, final int bufferSize) {
+        final T element = borrow(bufferSize);
+        try {
+            return function.apply(element);
+        } finally {
+            if (recycle(element)) {
+                queue.offer(new SoftReference<>(element));
+            }
+        }
+    }
+}

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoInputPool.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoInputPool.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import com.esotericsoftware.kryo.io.Input;
+
+class KryoInputPool extends KryoIOPool<Input> {
+
+    static final int MAX_POOLED_BUFFER_SIZE = 512 * 1024;
+
+    @Override
+    protected Input create(int bufferSize) {
+        return new Input(bufferSize);
+    }
+
+    @Override
+    protected boolean recycle(Input input) {
+        if (input.getBuffer().length < MAX_POOLED_BUFFER_SIZE) {
+            input.setInputStream(null);
+            return true;
+        }
+        return false; // discard
+    }
+}

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoNamespace.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoNamespace.java
@@ -20,7 +20,6 @@ import com.esotericsoftware.kryo.Registration;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.ByteBufferInput;
 import com.esotericsoftware.kryo.io.ByteBufferOutput;
-import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.pool.KryoCallback;
 import com.esotericsoftware.kryo.pool.KryoFactory;
 import com.esotericsoftware.kryo.pool.KryoPool;
@@ -299,7 +298,8 @@ public final class KryoNamespace implements Namespace, KryoFactory, KryoPool {
     return kryoOutputPool.run(output -> {
       return kryoPool.run(kryo -> {
         kryo.writeClassAndObject(output, obj);
-        return output.toBytes();
+        output.flush();
+        return output.getByteArrayOutputStream().toByteArray();
       });
     }, bufferSize);
   }

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoOutputPool.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoOutputPool.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import com.esotericsoftware.kryo.io.Output;
+
+class KryoOutputPool extends KryoIOPool<Output> {
+
+    private static final int MAX_BUFFER_SIZE = 768 * 1024;
+    static final int MAX_POOLED_BUFFER_SIZE = 512 * 1024;
+
+    @Override
+    protected Output create(int bufferSize) {
+        return new Output(bufferSize, MAX_BUFFER_SIZE);
+    }
+
+    @Override
+    protected boolean recycle(Output output) {
+        if (output.getBuffer().length < MAX_POOLED_BUFFER_SIZE) {
+            output.clear();
+            return true;
+        }
+        return false; // discard
+    }
+}

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoOutputPool.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoOutputPool.java
@@ -15,21 +15,20 @@
  */
 package io.atomix.utils.serializer;
 
-import com.esotericsoftware.kryo.io.Output;
-
-class KryoOutputPool extends KryoIOPool<Output> {
+class KryoOutputPool extends KryoIOPool<ByteArrayOutput> {
 
     private static final int MAX_BUFFER_SIZE = 768 * 1024;
     static final int MAX_POOLED_BUFFER_SIZE = 512 * 1024;
 
     @Override
-    protected Output create(int bufferSize) {
-        return new Output(bufferSize, MAX_BUFFER_SIZE);
+    protected ByteArrayOutput create(int bufferSize) {
+        return new ByteArrayOutput(bufferSize, MAX_BUFFER_SIZE, new BufferAwareByteArrayOutputStream(bufferSize));
     }
 
     @Override
-    protected boolean recycle(Output output) {
-        if (output.getBuffer().length < MAX_POOLED_BUFFER_SIZE) {
+    protected boolean recycle(ByteArrayOutput output) {
+        if (output.getByteArrayOutputStream().getBufferSize() < MAX_POOLED_BUFFER_SIZE) {
+            output.getByteArrayOutputStream().reset();
             output.clear();
             return true;
         }

--- a/utils/src/test/java/io/atomix/utils/serializer/BufferAwareByteArrayOutputStreamTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/BufferAwareByteArrayOutputStreamTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BufferAwareByteArrayOutputStreamTest {
+
+    @Test
+    public void testBufferSize() throws Exception {
+        BufferAwareByteArrayOutputStream outputStream = new BufferAwareByteArrayOutputStream(8);
+        assertEquals(8, outputStream.getBufferSize());
+        outputStream.write(new byte[]{1,2,3,4,5,6,7,8});
+        assertEquals(8, outputStream.getBufferSize());
+        outputStream.write(new byte[]{1,2,3,4,5,6,7,8});
+        assertEquals(16, outputStream.getBufferSize());
+        outputStream.reset();
+        assertEquals(16, outputStream.getBufferSize());
+    }
+}

--- a/utils/src/test/java/io/atomix/utils/serializer/KryoInputPoolTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/KryoInputPoolTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import com.esotericsoftware.kryo.io.Input;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KryoInputPoolTest {
+
+    private KryoInputPool kryoInputPool;
+
+    @Before
+    public void setUp() throws Exception {
+        kryoInputPool = new KryoInputPool();
+    }
+
+    @Test
+    public void discardOutput() {
+        final Input[] result = new Input[2];
+        kryoInputPool.run(new Function<Input, Object>() {
+            public Object apply(Input input) {
+                result[0] = input;
+                return null;
+            }
+        }, KryoInputPool.MAX_POOLED_BUFFER_SIZE + 1);
+        kryoInputPool.run(new Function<Input, Object>() {
+            public Object apply(Input input) {
+                result[1] = input;
+                return null;
+            }
+        }, 0);
+        assertTrue(result[0] != result[1]);
+    }
+
+
+    @Test
+    public void recycleOutput() {
+        final Input[] result = new Input[2];
+        kryoInputPool.run(new Function<Input, Object>() {
+            public Object apply(Input input) {
+                assertEquals(0, input.position());
+                byte[] payload = new byte[] {1,2,3,4};
+                input.setBuffer(payload);
+                assertArrayEquals(payload, input.readBytes(4));
+                result[0] = input;
+                return null;
+            }
+        }, 0);
+        assertEquals(0, result[0].position());
+        kryoInputPool.run(new Function<Input, Object>() {
+            public Object apply(Input input) {
+                result[1] = input;
+                return null;
+            }
+        }, 0);
+        assertTrue(result[0] == result[1]);
+    }
+}

--- a/utils/src/test/java/io/atomix/utils/serializer/KryoInputPoolTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/KryoInputPoolTest.java
@@ -19,10 +19,9 @@ import com.esotericsoftware.kryo.io.Input;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.function.Function;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class KryoInputPoolTest {
@@ -37,17 +36,13 @@ public class KryoInputPoolTest {
     @Test
     public void discardOutput() {
         final Input[] result = new Input[2];
-        kryoInputPool.run(new Function<Input, Object>() {
-            public Object apply(Input input) {
-                result[0] = input;
-                return null;
-            }
+        kryoInputPool.run(input -> {
+            result[0] = input;
+            return null;
         }, KryoInputPool.MAX_POOLED_BUFFER_SIZE + 1);
-        kryoInputPool.run(new Function<Input, Object>() {
-            public Object apply(Input input) {
-                result[1] = input;
-                return null;
-            }
+        kryoInputPool.run(input -> {
+            result[1] = input;
+            return null;
         }, 0);
         assertTrue(result[0] != result[1]);
     }
@@ -56,22 +51,19 @@ public class KryoInputPoolTest {
     @Test
     public void recycleOutput() {
         final Input[] result = new Input[2];
-        kryoInputPool.run(new Function<Input, Object>() {
-            public Object apply(Input input) {
-                assertEquals(0, input.position());
-                byte[] payload = new byte[] {1,2,3,4};
-                input.setBuffer(payload);
-                assertArrayEquals(payload, input.readBytes(4));
-                result[0] = input;
-                return null;
-            }
+        kryoInputPool.run(input -> {
+            assertEquals(0, input.position());
+            byte[] payload = new byte[] {1,2,3,4};
+            input.setBuffer(payload);
+            assertArrayEquals(payload, input.readBytes(4));
+            result[0] = input;
+            return null;
         }, 0);
+        assertNull(result[0].getInputStream());
         assertEquals(0, result[0].position());
-        kryoInputPool.run(new Function<Input, Object>() {
-            public Object apply(Input input) {
-                result[1] = input;
-                return null;
-            }
+        kryoInputPool.run(input -> {
+            result[1] = input;
+            return null;
         }, 0);
         assertTrue(result[0] == result[1]);
     }

--- a/utils/src/test/java/io/atomix/utils/serializer/KryoOutputPoolTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/KryoOutputPoolTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import com.esotericsoftware.kryo.io.Output;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KryoOutputPoolTest {
+
+    private KryoOutputPool kryoOutputPool;
+
+    @Before
+    public void setUp() throws Exception {
+        kryoOutputPool = new KryoOutputPool();
+    }
+
+    @Test
+    public void discardOutput() {
+        final Output[] result = new Output[2];
+        kryoOutputPool.run(output -> {
+            result[0] = output;
+            return null;
+        }, KryoOutputPool.MAX_POOLED_BUFFER_SIZE + 1);
+        kryoOutputPool.run(output -> {
+            result[1] = output;
+            return null;
+        }, 0);
+        assertTrue(result[0] != result[1]);
+    }
+
+    @Test
+    public void recycleOutput() {
+        final Output[] result = new Output[2];
+        kryoOutputPool.run(output -> {
+            output.writeInt(1);
+            assertEquals(Integer.BYTES, output.position());
+            result[0] = output;
+            return null;
+        }, 0);
+        assertEquals(0, result[0].position());
+        kryoOutputPool.run(output -> {
+            assertEquals(0, output.position());
+            result[1] = output;
+            return null;
+        }, 0);
+        assertTrue(result[0] == result[1]);
+    }
+}

--- a/utils/src/test/java/io/atomix/utils/serializer/KryoOutputPoolTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/KryoOutputPoolTest.java
@@ -47,7 +47,7 @@ public class KryoOutputPoolTest {
 
     @Test
     public void recycleOutput() {
-        final Output[] result = new Output[2];
+        final ByteArrayOutput[] result = new ByteArrayOutput[2];
         kryoOutputPool.run(output -> {
             output.writeInt(1);
             assertEquals(Integer.BYTES, output.position());
@@ -55,6 +55,7 @@ public class KryoOutputPoolTest {
             return null;
         }, 0);
         assertEquals(0, result[0].position());
+        assertEquals(0, result[0].getByteArrayOutputStream().size());
         kryoOutputPool.run(output -> {
             assertEquals(0, output.position());
             result[1] = output;


### PR DESCRIPTION
This pull request introduces pooled IO objects which sacrifices memory for speed (increase of 120000 op/s).

```
Atomix (before)

Benchmark                                         Mode  Cnt       Score      Error  Units
SingleNodeBenchmark.requestThroughput            thrpt  100  217284.327 ± 1274.281  ops/s
SingleNodeBenchmark.avgRequestTime_batched        avgt  100       5.976 ±    0.029  us/op
SingleNodeBenchmark.avgRequestTime_singleThread   avgt  100      19.552 ±    0.120  us/op

Atomix (after)

Benchmark                                         Mode  Cnt       Score      Error  Units
SingleNodeBenchmark.requestThroughput            thrpt  100  345203.644 ± 3027.675  ops/s
SingleNodeBenchmark.avgRequestTime_batched        avgt  100       4.729 ±    0.030  us/op
SingleNodeBenchmark.avgRequestTime_singleThread   avgt  100      17.532 ±    0.374  us/op

JGroups

Benchmark                                         Mode  Cnt       Score      Error  Units
SingleNodeBenchmark.requestThroughput            thrpt  100  342470.417 ± 2624.415  ops/s
SingleNodeBenchmark.avgRequestTime_batched        avgt  100       3.340 ±    0.029  us/op
SingleNodeBenchmark.avgRequestTime_singleThread   avgt  100      22.910 ±    0.149  us/op
```

With these changes Atomix is on-par with JGroups throughput (within error margin).