### PR TITLE
Ensure pending commands can be committed on retries after leader change.

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -680,11 +680,8 @@ public final class LeaderRole extends ActiveRole {
     // duplicate requests aren't committed as duplicate entries in the log.
     PendingCommand existingCommand = session.getCommand(sequenceNumber);
     if (existingCommand != null) {
-      if (sequenceNumber == session.nextRequestSequence()) {
-        session.removeCommand(sequenceNumber);
-        commitCommand(existingCommand.request(), existingCommand.future());
-        session.setRequestSequence(sequenceNumber);
-        drainCommands(session);
+      if (sequenceNumber <= session.nextRequestSequence()) {
+        drainCommands(sequenceNumber, session);
       }
       log.trace("Returning pending result for command sequence {}", sequenceNumber);
       return existingCommand.future();
@@ -737,8 +734,18 @@ public final class LeaderRole extends ActiveRole {
    *
    * @param session the session for which to drain commands
    */
-  private void drainCommands(RaftSessionContext session) {
+  private void drainCommands(long sequenceNumber, RaftSessionContext session) {
+    // First we need to drain any commands that exist in the queue *prior* to the next sequence number. This is
+    // possible if commands from the prior term are committed after a leader change.
     long nextSequence = session.nextRequestSequence();
+    for (long i = sequenceNumber; i < nextSequence; i++) {
+      PendingCommand nextCommand = session.removeCommand(i);
+      if (nextCommand != null) {
+        commitCommand(nextCommand.request(), nextCommand.future());
+      }
+    }
+
+    // Finally, drain any commands that are sequenced in the session.
     PendingCommand nextCommand = session.removeCommand(nextSequence);
     while (nextCommand != null) {
       commitCommand(nextCommand.request(), nextCommand.future());


### PR DESCRIPTION
This PR fixes a bug that can create a livelock in a Raft client's session immediately following a leader change.

The bug requires a series of events involving queueing of commands inside Raft servers and retrying commands on clients:
* Client sends command `1` to the leader for term `1`
* The leader for term `1` replicates the command to a majority of the cluster and then crashes
* A new leader is elected for term `2`
* The new leader commits entries from term `1`
* The client retries command `1` on the leader for term `2`
* The leader for term `2` queues the command as a `PendingCommand` since its sequence number does not align (hasn't yet applied entries from the prior term)
* The leader for term `2` then applies command `1`, thus incrementing the client's `requestSequence` beyond that of command `1`
* The client again retries command `1`, and the leader for term `2` again responds with the `PendingCommand` future

The last point is where the livelock is. Because the `requestSequence` number has been incremented beyond that of command `1`, the `PendingCommand` is never committed, nor are any later pending commands for the session. This PR ensures that commands up to `requestSequence` are drained.