### PR TITLE
Replace primitive configurations with PrimitiveProtocol requirement

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -44,6 +44,7 @@ import io.atomix.primitive.Recovery;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.ManagedPrimaryElectionService;
+import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.partition.impl.DefaultPartitionManagementService;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
@@ -245,7 +246,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
               .thenComposeAsync(v2 -> sessionIdService.start(), context)
               .thenApply(v2 -> new DefaultPartitionManagementService(metadataService, clusterService, clusterMessagingService, primitiveTypes, electionService, sessionIdService));
         }, context)
-        .thenComposeAsync(partitionManagementService -> partitions.open(partitionManagementService), context)
+        .thenComposeAsync(partitionManagementService -> partitions.open((PartitionManagementService) partitionManagementService), context)
         .thenComposeAsync(v -> primitives.start(), context)
         .thenApplyAsync(v -> {
           metadataService.addNode(clusterService.getLocalNode());

--- a/core/src/main/java/io/atomix/core/PrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/PrimitivesService.java
@@ -31,6 +31,7 @@ import io.atomix.core.tree.DocumentTreeBuilder;
 import io.atomix.core.value.AtomicValueBuilder;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
+import io.atomix.primitive.PrimitiveProtocol;
 import io.atomix.primitive.PrimitiveType;
 
 import java.util.Set;
@@ -43,6 +44,7 @@ public interface PrimitivesService {
   /**
    * Creates a new ConsistentMapBuilder.
    *
+   * @param name the primitive name
    * @param <K> key type
    * @param <V> value type
    * @return builder for a consistent map
@@ -54,6 +56,20 @@ public interface PrimitivesService {
   /**
    * Creates a new ConsistentMapBuilder.
    *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <K> key type
+   * @param <V> value type
+   * @return builder for a consistent map
+   */
+  default <K, V> ConsistentMapBuilder<K, V> consistentMapBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.map(), protocol);
+  }
+
+  /**
+   * Creates a new ConsistentMapBuilder.
+   *
+   * @param name the primitive name
    * @param <V> value type
    * @return builder for a consistent map
    */
@@ -62,9 +78,21 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new ConsistentMapBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <V> value type
+   * @return builder for a consistent map
+   */
+  default <V> DocumentTreeBuilder<V> documentTreeBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.tree(), protocol);
+  }
+
+  /**
    * Creates a new {@code AsyncConsistentTreeMapBuilder}.
    *
-   * @param <K> key type
+   * @param name the primitive name
    * @param <V> value type
    * @return builder for a async consistent tree map
    */
@@ -73,8 +101,21 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new {@code AsyncConsistentTreeMapBuilder}.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <V> value type
+   * @return builder for a async consistent tree map
+   */
+  default <V> ConsistentTreeMapBuilder<V> consistentTreeMapBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.treeMap(), protocol);
+  }
+
+  /**
    * Creates a new {@code AsyncConsistentSetMultimapBuilder}.
    *
+   * @param name the primitive name
    * @param <K> key type
    * @param <V> value type
    * @return builder for a set based async consistent multimap
@@ -84,8 +125,22 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new {@code AsyncConsistentSetMultimapBuilder}.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <K> key type
+   * @param <V> value type
+   * @return builder for a set based async consistent multimap
+   */
+  default <K, V> ConsistentMultimapBuilder<K, V> consistentMultimapBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.multimap(), protocol);
+  }
+
+  /**
    * Creates a new {@code AtomicCounterMapBuilder}.
    *
+   * @param name the primitive name
    * @param <K> key type
    * @return builder for an atomic counter map
    */
@@ -94,8 +149,21 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new {@code AtomicCounterMapBuilder}.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <K> key type
+   * @return builder for an atomic counter map
+   */
+  default <K> AtomicCounterMapBuilder<K> atomicCounterMapBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.counterMap(), protocol);
+  }
+
+  /**
    * Creates a new DistributedSetBuilder.
    *
+   * @param name the primitive name
    * @param <E> set element type
    * @return builder for an distributed set
    */
@@ -104,8 +172,21 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new DistributedSetBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <E> set element type
+   * @return builder for an distributed set
+   */
+  default <E> DistributedSetBuilder<E> setBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.set(), protocol);
+  }
+
+  /**
    * Creates a new AtomicCounterBuilder.
    *
+   * @param name the primitive name
    * @return atomic counter builder
    */
   default AtomicCounterBuilder atomicCounterBuilder(String name) {
@@ -113,8 +194,20 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new AtomicCounterBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @return atomic counter builder
+   */
+  default AtomicCounterBuilder atomicCounterBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.counter(), protocol);
+  }
+
+  /**
    * Creates a new AtomicIdGeneratorBuilder.
    *
+   * @param name the primitive name
    * @return atomic ID generator builder
    */
   default AtomicIdGeneratorBuilder atomicIdGeneratorBuilder(String name) {
@@ -122,8 +215,20 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new AtomicIdGeneratorBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @return atomic ID generator builder
+   */
+  default AtomicIdGeneratorBuilder atomicIdGeneratorBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.idGenerator(), protocol);
+  }
+
+  /**
    * Creates a new AtomicValueBuilder.
    *
+   * @param name the primitive name
    * @param <V> atomic value type
    * @return atomic value builder
    */
@@ -132,8 +237,21 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new AtomicValueBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <V> atomic value type
+   * @return atomic value builder
+   */
+  default <V> AtomicValueBuilder<V> atomicValueBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.value(), protocol);
+  }
+
+  /**
    * Creates a new LeaderElectionBuilder.
    *
+   * @param name the primitive name
    * @return leader election builder
    */
   default <T> LeaderElectionBuilder<T> leaderElectionBuilder(String name) {
@@ -141,8 +259,20 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new LeaderElectionBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @return leader election builder
+   */
+  default <T> LeaderElectionBuilder<T> leaderElectionBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.leaderElection(), protocol);
+  }
+
+  /**
    * Creates a new LeaderElectorBuilder.
    *
+   * @param name the primitive name
    * @return leader elector builder
    */
   default <T> LeaderElectorBuilder<T> leaderElectorBuilder(String name) {
@@ -150,8 +280,20 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new LeaderElectorBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @return leader elector builder
+   */
+  default <T> LeaderElectorBuilder<T> leaderElectorBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.leaderElector(), protocol);
+  }
+
+  /**
    * Creates a new DistributedLockBuilder.
    *
+   * @param name the primitive name
    * @return distributed lock builder
    */
   default DistributedLockBuilder lockBuilder(String name) {
@@ -159,13 +301,37 @@ public interface PrimitivesService {
   }
 
   /**
+   * Creates a new DistributedLockBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @return distributed lock builder
+   */
+  default DistributedLockBuilder lockBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.lock(), protocol);
+  }
+
+  /**
    * Creates a new WorkQueueBuilder.
    *
+   * @param name the primitive name
    * @param <E> work queue element type
    * @return work queue builder
    */
   default <E> WorkQueueBuilder<E> workQueueBuilder(String name) {
     return primitiveBuilder(name, PrimitiveTypes.workQueue());
+  }
+
+  /**
+   * Creates a new WorkQueueBuilder.
+   *
+   * @param name the primitive name
+   * @param protocol the primitive protocol
+   * @param <E> work queue element type
+   * @return work queue builder
+   */
+  default <E> WorkQueueBuilder<E> workQueueBuilder(String name, PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, PrimitiveTypes.workQueue(), protocol);
   }
 
   /**
@@ -195,7 +361,25 @@ public interface PrimitivesService {
    * @return the primitive builder
    */
   <B extends DistributedPrimitiveBuilder<B, P>, P extends DistributedPrimitive> B primitiveBuilder(
-      String name, PrimitiveType<B, P> primitiveType);
+      String name,
+      PrimitiveType<B, P> primitiveType);
+
+  /**
+   * Returns a primitive builder of the given type.
+   *
+   * @param name the primitive name
+   * @param primitiveType the primitive type
+   * @param protocol the primitive protocol
+   * @param <B> the primitive builder type
+   * @param <P> the primitive type
+   * @return the primitive builder
+   */
+  default <B extends DistributedPrimitiveBuilder<B, P>, P extends DistributedPrimitive> B primitiveBuilder(
+      String name,
+      PrimitiveType<B, P> primitiveType,
+      PrimitiveProtocol protocol) {
+    return primitiveBuilder(name, primitiveType).withProtocol(protocol);
+  }
 
   /**
    * Returns a list of map names.

--- a/core/src/main/java/io/atomix/core/election/LeaderElectionBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectionBuilder.java
@@ -17,15 +17,8 @@ package io.atomix.core.election;
 
 import io.atomix.cluster.NodeId;
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.KryoNamespaces;
 import io.atomix.utils.serializer.Serializer;
@@ -104,43 +97,5 @@ public abstract class LeaderElectionBuilder<T>
           .build());
     }
     return serializer;
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-    return newRaftProtocol(consistency());
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(electionTimeout)
-        .withMaxTimeout(Duration.ofSeconds(5))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
@@ -17,15 +17,8 @@ package io.atomix.core.election;
 
 import io.atomix.cluster.NodeId;
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.KryoNamespaces;
 import io.atomix.utils.serializer.Serializer;
@@ -104,43 +97,5 @@ public abstract class LeaderElectorBuilder<T>
           .build());
     }
     return serializer;
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-    return newRaftProtocol(consistency());
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(electionTimeout)
-        .withMaxTimeout(Duration.ofSeconds(5))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxyBuilder.java
@@ -56,7 +56,7 @@ public class LeaderElectorProxyBuilder<T> extends LeaderElectorBuilder<T> {
   @SuppressWarnings("unchecked")
   public CompletableFuture<LeaderElector<T>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
-    PartitionGroup partitions = managementService.getPartitionService().getPartitionGroup(protocol);
+    PartitionGroup<?> partitions = managementService.getPartitionService().getPartitionGroup(protocol);
 
     Map<PartitionId, CompletableFuture<AsyncLeaderElector<T>>> electors = Maps.newConcurrentMap();
     for (Partition partition : partitions.getPartitions()) {

--- a/core/src/main/java/io/atomix/core/generator/AtomicIdGeneratorBuilder.java
+++ b/core/src/main/java/io/atomix/core/generator/AtomicIdGeneratorBuilder.java
@@ -16,17 +16,7 @@
 package io.atomix.core.generator;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * Builder for AtomicIdGenerator.
@@ -35,77 +25,5 @@ public abstract class AtomicIdGeneratorBuilder
     extends DistributedPrimitiveBuilder<AtomicIdGeneratorBuilder, AtomicIdGenerator> {
   protected AtomicIdGeneratorBuilder(String name) {
     super(PrimitiveTypes.idGenerator(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, Replication.SYNCHRONOUS);
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, Replication.SYNCHRONOUS);
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -17,15 +17,14 @@ package io.atomix.core.impl;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-
 import io.atomix.cluster.ClusterService;
+import io.atomix.cluster.messaging.ClusterEventingService;
 import io.atomix.cluster.messaging.ClusterMessagingService;
 import io.atomix.core.ManagedPrimitivesService;
 import io.atomix.core.PrimitivesService;
 import io.atomix.core.transaction.ManagedTransactionService;
 import io.atomix.core.transaction.TransactionBuilder;
 import io.atomix.core.transaction.impl.DefaultTransactionBuilder;
-import io.atomix.cluster.messaging.ClusterEventingService;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
@@ -66,7 +65,9 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
   }
 
   @Override
-  public <B extends DistributedPrimitiveBuilder<B, P>, P extends DistributedPrimitive> B primitiveBuilder(String name, PrimitiveType<B, P> primitiveType) {
+  public <B extends DistributedPrimitiveBuilder<B, P>, P extends DistributedPrimitive> B primitiveBuilder(
+      String name,
+      PrimitiveType<B, P> primitiveType) {
     return primitiveType.newPrimitiveBuilder(name, managementService);
   }
 

--- a/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
@@ -99,6 +99,7 @@ public class CoreTransactionService implements ManagedTransactionService {
   public CompletableFuture<TransactionService> start() {
     return ConsistentMapType.<TransactionId, TransactionState>instance()
         .newPrimitiveBuilder("atomix-transactions", managementService)
+        .withProtocol(managementService.getPartitionService().getDefaultPartitionGroup().newProtocol())
         .withSerializer(SERIALIZER)
         .buildAsync()
         .thenApply(transactions -> {

--- a/core/src/main/java/io/atomix/core/lock/DistributedLockBuilder.java
+++ b/core/src/main/java/io/atomix/core/lock/DistributedLockBuilder.java
@@ -16,15 +16,8 @@
 package io.atomix.core.lock;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -82,43 +75,5 @@ public abstract class DistributedLockBuilder
    */
   public Duration lockTimeout() {
     return lockTimeout;
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-    return newRaftProtocol(consistency());
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(lockTimeout)
-        .withMaxTimeout(Duration.ofSeconds(5))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/map/AtomicCounterMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicCounterMapBuilder.java
@@ -16,17 +16,7 @@
 package io.atomix.core.map;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * Builder for AtomicCounterMap.
@@ -35,77 +25,5 @@ public abstract class AtomicCounterMapBuilder<K>
     extends DistributedPrimitiveBuilder<AtomicCounterMapBuilder<K>, AtomicCounterMap<K>> {
   public AtomicCounterMapBuilder(String name) {
     super(PrimitiveTypes.counterMap(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.SEQUENTIAL;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.EPHEMERAL;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, replication());
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, replication());
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE_LEASE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/map/ConsistentMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentMapBuilder.java
@@ -16,17 +16,7 @@
 package io.atomix.core.map;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * Builder for {@link ConsistentMap} instances.
@@ -41,21 +31,6 @@ public abstract class ConsistentMapBuilder<K, V>
 
   public ConsistentMapBuilder(String name) {
     super(PrimitiveTypes.map(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.SEQUENTIAL;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.EPHEMERAL;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
   }
 
   /**
@@ -75,62 +50,5 @@ public abstract class ConsistentMapBuilder<K, V>
    */
   public boolean nullValues() {
     return nullValues;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, replication());
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, replication());
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE_LEASE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/map/ConsistentTreeMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentTreeMapBuilder.java
@@ -17,97 +17,14 @@
 package io.atomix.core.map;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * Builder for {@link ConsistentTreeMap}.
  */
 public abstract class ConsistentTreeMapBuilder<V>
     extends DistributedPrimitiveBuilder<ConsistentTreeMapBuilder<V>, ConsistentTreeMap<V>> {
-
   public ConsistentTreeMapBuilder(String name) {
     super(PrimitiveTypes.treeMap(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.SEQUENTIAL;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.EPHEMERAL;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, replication());
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, replication());
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE_LEASE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxyBuilder.java
@@ -57,7 +57,7 @@ public class ConsistentMapProxyBuilder<K, V> extends ConsistentMapBuilder<K, V> 
   @SuppressWarnings("unchecked")
   public CompletableFuture<ConsistentMap<K, V>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
-    PartitionGroup partitions = managementService.getPartitionService().getPartitionGroup(protocol);
+    PartitionGroup<?> partitions = managementService.getPartitionService().getPartitionGroup(protocol);
 
     Map<PartitionId, CompletableFuture<AsyncConsistentMap<byte[], byte[]>>> maps = Maps.newConcurrentMap();
     for (Partition partition : partitions.getPartitions()) {

--- a/core/src/main/java/io/atomix/core/multimap/ConsistentMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/ConsistentMultimapBuilder.java
@@ -17,97 +17,14 @@
 package io.atomix.core.multimap;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * A builder class for {@code AsyncConsistentMultimap}.
  */
 public abstract class ConsistentMultimapBuilder<K, V>
     extends DistributedPrimitiveBuilder<ConsistentMultimapBuilder<K, V>, ConsistentMultimap<K, V>> {
-
   public ConsistentMultimapBuilder(String name) {
     super(PrimitiveTypes.multimap(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.SEQUENTIAL;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.EPHEMERAL;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, replication());
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, replication());
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE_LEASE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/queue/WorkQueueBuilder.java
+++ b/core/src/main/java/io/atomix/core/queue/WorkQueueBuilder.java
@@ -16,96 +16,13 @@
 package io.atomix.core.queue;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * Work queue builder.
  */
 public abstract class WorkQueueBuilder<E> extends DistributedPrimitiveBuilder<WorkQueueBuilder<E>, WorkQueue<E>> {
-
   public WorkQueueBuilder(String name) {
     super(PrimitiveTypes.workQueue(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.SEQUENTIAL;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.EPHEMERAL;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, replication());
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, replication());
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE_LEASE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/set/DistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSetBuilder.java
@@ -16,10 +16,7 @@
 package io.atomix.core.set;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.Replication;
 
 /**
  * Builder for distributed set.
@@ -29,20 +26,5 @@ import io.atomix.primitive.Replication;
 public abstract class DistributedSetBuilder<E> extends DistributedPrimitiveBuilder<DistributedSetBuilder<E>, DistributedSet<E>> {
   public DistributedSetBuilder(String name) {
     super(PrimitiveTypes.set(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.SEQUENTIAL;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.EPHEMERAL;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
   }
 }

--- a/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
@@ -18,13 +18,9 @@ package io.atomix.core.set.impl;
 import io.atomix.core.map.ConsistentMapBuilder;
 import io.atomix.core.set.DistributedSet;
 import io.atomix.core.set.DistributedSetBuilder;
-import io.atomix.primitive.Consistency;
-import io.atomix.primitive.Persistence;
 import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
 import io.atomix.utils.serializer.Serializer;
 
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -65,42 +61,6 @@ public class DelegatingDistributedSetBuilder<E> extends DistributedSetBuilder<E>
   }
 
   @Override
-  public DistributedSetBuilder<E> withConsistency(Consistency consistency) {
-    mapBuilder.withConsistency(consistency);
-    return this;
-  }
-
-  @Override
-  public DistributedSetBuilder<E> withPersistence(Persistence persistence) {
-    mapBuilder.withPersistence(persistence);
-    return this;
-  }
-
-  @Override
-  public DistributedSetBuilder<E> withReplication(Replication replication) {
-    mapBuilder.withReplication(replication);
-    return this;
-  }
-
-  @Override
-  public DistributedSetBuilder<E> withBackups(int numBackups) {
-    mapBuilder.withBackups(numBackups);
-    return this;
-  }
-
-  @Override
-  public DistributedSetBuilder<E> withMaxRetries(int maxRetries) {
-    mapBuilder.withMaxRetries(maxRetries);
-    return this;
-  }
-
-  @Override
-  public DistributedSetBuilder<E> withRetryDelay(Duration retryDelay) {
-    mapBuilder.withRetryDelay(retryDelay);
-    return this;
-  }
-
-  @Override
   public boolean readOnly() {
     return mapBuilder.readOnly();
   }
@@ -123,36 +83,6 @@ public class DelegatingDistributedSetBuilder<E> extends DistributedSetBuilder<E>
   @Override
   public PrimitiveProtocol protocol() {
     return mapBuilder.protocol();
-  }
-
-  @Override
-  public Consistency consistency() {
-    return mapBuilder.consistency();
-  }
-
-  @Override
-  public Persistence persistence() {
-    return mapBuilder.persistence();
-  }
-
-  @Override
-  public Replication replication() {
-    return mapBuilder.replication();
-  }
-
-  @Override
-  public int backups() {
-    return mapBuilder.backups();
-  }
-
-  @Override
-  public int maxRetries() {
-    return mapBuilder.maxRetries();
-  }
-
-  @Override
-  public Duration retryDelay() {
-    return mapBuilder.retryDelay();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/AsyncTransaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/AsyncTransaction.java
@@ -17,6 +17,7 @@ package io.atomix.core.transaction;
 
 import io.atomix.primitive.AsyncPrimitive;
 import io.atomix.primitive.DistributedPrimitive;
+import io.atomix.primitive.PrimitiveProtocol;
 import io.atomix.primitive.PrimitiveType;
 
 import java.time.Duration;
@@ -79,20 +80,45 @@ public interface AsyncTransaction extends AsyncPrimitive {
    * Returns a new transactional map builder.
    *
    * @param name the map name
-   * @param <K> the key type
-   * @param <V> the value type
+   * @param <K>  the key type
+   * @param <V>  the value type
    * @return the transactional map builder
    */
   <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name);
 
   /**
+   * Returns a new transactional map builder.
+   *
+   * @param name the map name
+   * @param protocol the map protocol
+   * @param <K>  the key type
+   * @param <V>  the value type
+   * @return the transactional map builder
+   */
+  default <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name, PrimitiveProtocol protocol) {
+    return this.<K, V>mapBuilder(name).withProtocol(protocol);
+  }
+
+  /**
    * Returns a new transactional set builder.
    *
    * @param name the set name
-   * @param <E> the set element type
+   * @param <E>  the set element type
    * @return the transactional set builder
    */
   <E> TransactionalSetBuilder<E> setBuilder(String name);
+
+  /**
+   * Returns a new transactional set builder.
+   *
+   * @param name the set name
+   * @param protocol the map protocol
+   * @param <E>  the set element type
+   * @return the transactional set builder
+   */
+  default <E> TransactionalSetBuilder<E> setBuilder(String name, PrimitiveProtocol protocol) {
+    return this.<E>setBuilder(name).withProtocol(protocol);
+  }
 
   @Override
   default Transaction sync() {

--- a/core/src/main/java/io/atomix/core/transaction/Transaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/Transaction.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.transaction;
 
+import io.atomix.primitive.PrimitiveProtocol;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.SyncPrimitive;
 
@@ -71,20 +72,45 @@ public interface Transaction extends SyncPrimitive {
    * Returns a new transactional map builder.
    *
    * @param name the map name
-   * @param <K> the key type
-   * @param <V> the value type
+   * @param <K>  the key type
+   * @param <V>  the value type
    * @return the transactional map builder
    */
   <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name);
 
   /**
+   * Returns a new transactional map builder.
+   *
+   * @param name     the map name
+   * @param protocol the primitive protocol
+   * @param <K>      the key type
+   * @param <V>      the value type
+   * @return the transactional map builder
+   */
+  default <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name, PrimitiveProtocol protocol) {
+    return this.<K, V>mapBuilder(name).withProtocol(protocol);
+  }
+
+  /**
    * Returns a new transactional set builder.
    *
    * @param name the set name
-   * @param <E> the set element type
+   * @param <E>  the set element type
    * @return the transactional set builder
    */
   <E> TransactionalSetBuilder<E> setBuilder(String name);
+
+  /**
+   * Returns a new transactional set builder.
+   *
+   * @param name     the set name
+   * @param protocol the primitive protocol
+   * @param <E>      the set element type
+   * @return the transactional set builder
+   */
+  default <E> TransactionalSetBuilder<E> setBuilder(String name, PrimitiveProtocol protocol) {
+    return this.<E>setBuilder(name).withProtocol(protocol);
+  }
 
   @Override
   AsyncTransaction async();

--- a/core/src/main/java/io/atomix/core/transaction/TransactionBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionBuilder.java
@@ -15,10 +15,7 @@
  */
 package io.atomix.core.transaction;
 
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.Replication;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -30,21 +27,6 @@ public abstract class TransactionBuilder extends DistributedPrimitiveBuilder<Tra
 
   protected TransactionBuilder(String name) {
     super(TransactionType.instance(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
   }
 
   /**

--- a/core/src/main/java/io/atomix/core/transaction/TransactionalMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionalMapBuilder.java
@@ -16,10 +16,7 @@
 package io.atomix.core.transaction;
 
 import io.atomix.core.map.ConsistentMapType;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.Replication;
 
 /**
  * Transactional map builder.
@@ -28,20 +25,5 @@ public abstract class TransactionalMapBuilder<K, V>
     extends DistributedPrimitiveBuilder<TransactionalMapBuilder<K, V>, TransactionalMap<K, V>> {
   protected TransactionalMapBuilder(String name) {
     super(ConsistentMapType.instance(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
   }
 }

--- a/core/src/main/java/io/atomix/core/transaction/TransactionalSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionalSetBuilder.java
@@ -16,10 +16,7 @@
 package io.atomix.core.transaction;
 
 import io.atomix.core.set.DistributedSetType;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.Replication;
 
 /**
  * Transactional set builder.
@@ -28,20 +25,5 @@ public abstract class TransactionalSetBuilder<E>
     extends DistributedPrimitiveBuilder<TransactionalSetBuilder<E>, TransactionalSet<E>> {
   protected TransactionalSetBuilder(String name) {
     super(DistributedSetType.instance(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
   }
 }

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.map.ConsistentMapType;
 import io.atomix.core.transaction.TransactionalMap;
 import io.atomix.core.transaction.TransactionalMapBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.PrimitiveProtocol;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -34,6 +35,12 @@ public class DefaultTransactionalMapBuilder<K, V> extends TransactionalMapBuilde
     super(name);
     this.mapBuilder = ConsistentMapType.<K, V>instance().newPrimitiveBuilder(name, managementService);
     this.transaction = transaction;
+  }
+
+  @Override
+  public TransactionalMapBuilder<K, V> withProtocol(PrimitiveProtocol protocol) {
+    mapBuilder.withProtocol(protocol);
+    return this;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
@@ -19,6 +19,7 @@ import io.atomix.core.transaction.TransactionalMapBuilder;
 import io.atomix.core.transaction.TransactionalSet;
 import io.atomix.core.transaction.TransactionalSetBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.PrimitiveProtocol;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -31,6 +32,12 @@ public class DefaultTransactionalSetBuilder<E> extends TransactionalSetBuilder<E
   public DefaultTransactionalSetBuilder(String name, PrimitiveManagementService managementService, DefaultTransaction transaction) {
     super(name);
     this.mapBuilder = new DefaultTransactionalMapBuilder<>(name, managementService, transaction);
+  }
+
+  @Override
+  public TransactionalSetBuilder<E> withProtocol(PrimitiveProtocol protocol) {
+    mapBuilder.withProtocol(protocol);
+    return this;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/DocumentTreeBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/DocumentTreeBuilder.java
@@ -17,19 +17,9 @@
 package io.atomix.core.tree;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
 import io.atomix.primitive.Ordering;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * Builder for {@link DocumentTree}.
@@ -70,83 +60,11 @@ public abstract class DocumentTreeBuilder<V>
   }
 
   @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.SEQUENTIAL;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.EPHEMERAL;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
   public PrimitiveType primitiveType() {
     if (ordering == null) {
       return DocumentTreeType.instance();
     } else {
       return DocumentTreeType.ordered(ordering);
     }
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, replication());
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, replication());
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE_LEASE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeProxyBuilder.java
@@ -55,7 +55,7 @@ public class DocumentTreeProxyBuilder<V> extends DocumentTreeBuilder<V> {
   @SuppressWarnings("unchecked")
   public CompletableFuture<DocumentTree<V>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
-    PartitionGroup partitions = managementService.getPartitionService().getPartitionGroup(protocol);
+    PartitionGroup<?> partitions = managementService.getPartitionService().getPartitionGroup(protocol);
 
     Map<PartitionId, CompletableFuture<AsyncDocumentTree<V>>> trees = Maps.newConcurrentMap();
     for (Partition partition : partitions.getPartitions()) {

--- a/core/src/main/java/io/atomix/core/value/AtomicValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/AtomicValueBuilder.java
@@ -16,17 +16,7 @@
 package io.atomix.core.value;
 
 import io.atomix.core.PrimitiveTypes;
-import io.atomix.primitive.Consistency;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.Persistence;
-import io.atomix.primitive.PrimitiveProtocol;
-import io.atomix.primitive.Replication;
-import io.atomix.protocols.backup.MultiPrimaryProtocol;
-import io.atomix.protocols.raft.RaftProtocol;
-import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-
-import java.time.Duration;
 
 /**
  * Builder for constructing new AtomicValue instances.
@@ -35,80 +25,7 @@ import java.time.Duration;
  */
 public abstract class AtomicValueBuilder<V>
     extends DistributedPrimitiveBuilder<AtomicValueBuilder<V>, AtomicValue<V>> {
-
   public AtomicValueBuilder(String name) {
     super(PrimitiveTypes.value(), name);
-  }
-
-  @Override
-  protected Consistency defaultConsistency() {
-    return Consistency.LINEARIZABLE;
-  }
-
-  @Override
-  protected Persistence defaultPersistence() {
-    return Persistence.PERSISTENT;
-  }
-
-  @Override
-  protected Replication defaultReplication() {
-    return Replication.SYNCHRONOUS;
-  }
-
-  @Override
-  public PrimitiveProtocol protocol() {
-    PrimitiveProtocol protocol = super.protocol();
-    if (protocol != null) {
-      return protocol;
-    }
-
-    switch (consistency()) {
-      case LINEARIZABLE:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.LINEARIZABLE);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.LINEARIZABLE, Replication.SYNCHRONOUS);
-        }
-      case SEQUENTIAL:
-      case EVENTUAL:
-        switch (persistence()) {
-          case PERSISTENT:
-            return newRaftProtocol(Consistency.SEQUENTIAL);
-          case EPHEMERAL:
-            return newMultiPrimaryProtocol(Consistency.SEQUENTIAL, Replication.SYNCHRONOUS);
-          default:
-            throw new AssertionError();
-        }
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  private PrimitiveProtocol newRaftProtocol(Consistency readConsistency) {
-    return RaftProtocol.builder()
-        .withMinTimeout(Duration.ofSeconds(5))
-        .withMaxTimeout(Duration.ofSeconds(30))
-        .withReadConsistency(readConsistency == Consistency.LINEARIZABLE
-            ? ReadConsistency.LINEARIZABLE_LEASE
-            : ReadConsistency.SEQUENTIAL)
-        .withCommunicationStrategy(readConsistency == Consistency.SEQUENTIAL
-            ? CommunicationStrategy.FOLLOWERS
-            : CommunicationStrategy.LEADER)
-        .withRecoveryStrategy(recovery())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
-  }
-
-  private PrimitiveProtocol newMultiPrimaryProtocol(Consistency consistency, Replication replication) {
-    return MultiPrimaryProtocol.builder()
-        .withConsistency(consistency)
-        .withReplication(replication)
-        .withRecovery(recovery())
-        .withBackups(backups())
-        .withMaxRetries(maxRetries())
-        .withRetryDelay(retryDelay())
-        .build();
   }
 }

--- a/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
@@ -16,6 +16,7 @@
 package io.atomix.core;
 
 import io.atomix.cluster.Node;
+import io.atomix.primitive.PrimitiveProtocol;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -31,6 +32,13 @@ import java.util.stream.Collectors;
 public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
   private static List<Atomix> instances;
   private static int id = 10;
+
+  /**
+   * Returns the primitive protocol with which to test.
+   *
+   * @return the protocol with which to test
+   */
+  protected abstract PrimitiveProtocol protocol();
 
   /**
    * Returns a new Atomix instance.

--- a/core/src/test/java/io/atomix/core/counter/impl/AtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/impl/AtomicCounterTest.java
@@ -27,10 +27,10 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link AtomicCounterProxy}.
  */
-public class AtomicCounterTest extends AbstractPrimitiveTest {
+public abstract class AtomicCounterTest extends AbstractPrimitiveTest {
   @Test
   public void testBasicOperations() throws Throwable {
-    AsyncAtomicCounter along = atomix().atomicCounterBuilder("test-counter-basic-operations").build().async();
+    AsyncAtomicCounter along = atomix().atomicCounterBuilder("test-counter-basic-operations", protocol()).build().async();
     assertEquals(0, along.get().join().longValue());
     assertEquals(1, along.incrementAndGet().join().longValue());
     along.set(100).join();

--- a/core/src/test/java/io/atomix/core/counter/impl/PrimaryBackupAtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/impl/PrimaryBackupAtomicCounterTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.counter.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup atomic counter test.
+ */
+public class PrimaryBackupAtomicCounterTest extends AtomicCounterTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/counter/impl/RaftAtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/impl/RaftAtomicCounterTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.counter.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft atomic counter test.
+ */
+public class RaftAtomicCounterTest extends AtomicCounterTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/election/impl/LeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/LeaderElectionTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link LeaderElectionProxy}.
  */
-public class LeaderElectionTest extends AbstractPrimitiveTest {
+public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   NodeId node1 = NodeId.from("node1");
   NodeId node2 = NodeId.from("node2");
@@ -43,7 +43,7 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testRun() throws Throwable {
-    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-run").build().async();
+    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-run", protocol()).build().async();
     election1.run(node1).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -51,7 +51,7 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
       assertEquals(node1, result.candidates().get(0));
     }).join();
 
-    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-run").build().async();
+    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-run", protocol()).build().async();
     election2.run(node2).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -63,9 +63,9 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testWithdraw() throws Throwable {
-    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-withdraw").build().async();
+    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-withdraw", protocol()).build().async();
     election1.run(node1).join();
-    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-withdraw").build().async();
+    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-withdraw", protocol()).build().async();
     election2.run(node2).join();
 
     LeaderEventListener listener1 = new LeaderEventListener();
@@ -101,9 +101,9 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testAnoint() throws Throwable {
-    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-anoint").build().async();
-    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-anoint").build().async();
-    AsyncLeaderElection<NodeId> election3 = atomix().<NodeId>leaderElectionBuilder("test-election-anoint").build().async();
+    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-anoint", protocol()).build().async();
+    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-anoint", protocol()).build().async();
+    AsyncLeaderElection<NodeId> election3 = atomix().<NodeId>leaderElectionBuilder("test-election-anoint", protocol()).build().async();
     election1.run(node1).join();
     election2.run(node2).join();
 
@@ -147,9 +147,9 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testPromote() throws Throwable {
-    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-promote").build().async();
-    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-promote").build().async();
-    AsyncLeaderElection<NodeId> election3 = atomix().<NodeId>leaderElectionBuilder("test-election-promote").build().async();
+    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-promote", protocol()).build().async();
+    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-promote", protocol()).build().async();
+    AsyncLeaderElection<NodeId> election3 = atomix().<NodeId>leaderElectionBuilder("test-election-promote", protocol()).build().async();
     election1.run(node1).join();
     election2.run(node2).join();
 
@@ -197,9 +197,9 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testLeaderSessionClose() throws Throwable {
-    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-leader-session-close").build().async();
+    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-leader-session-close", protocol()).build().async();
     election1.run(node1).join();
-    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-leader-session-close").build().async();
+    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-leader-session-close", protocol()).build().async();
     LeaderEventListener listener = new LeaderEventListener();
     election2.run(node2).join();
     election2.addListener(listener).join();
@@ -213,9 +213,9 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testNonLeaderSessionClose() throws Throwable {
-    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-non-leader-session-close").build().async();
+    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-non-leader-session-close", protocol()).build().async();
     election1.run(node1).join();
-    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-non-leader-session-close").build().async();
+    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-non-leader-session-close", protocol()).build().async();
     LeaderEventListener listener = new LeaderEventListener();
     election2.run(node2).join();
     election1.addListener(listener).join();
@@ -229,8 +229,8 @@ public class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testQueries() throws Throwable {
-    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-query").build().async();
-    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-query").build().async();
+    AsyncLeaderElection<NodeId> election1 = atomix().<NodeId>leaderElectionBuilder("test-election-query", protocol()).build().async();
+    AsyncLeaderElection<NodeId> election2 = atomix().<NodeId>leaderElectionBuilder("test-election-query", protocol()).build().async();
     election1.run(node1).join();
     election2.run(node2).join();
     election2.run(node2).join();

--- a/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Leader elector test.
  */
-public class LeaderElectorTest extends AbstractPrimitiveTest {
+public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   NodeId node1 = new NodeId("4");
   NodeId node2 = new NodeId("5");
@@ -43,7 +43,7 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testRun() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-run").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-run", protocol()).build().async();
     elector1.run("foo", node1).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -58,7 +58,7 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
       assertEquals(node1, result.candidates().get(0));
     }).join();
 
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-run").build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-run", protocol()).build().async();
     elector2.run("bar", node2).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -70,9 +70,9 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testWithdraw() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-withdraw").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-withdraw", protocol()).build().async();
     elector1.run("foo", node1).join();
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-withdraw").build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-withdraw", protocol()).build().async();
     elector2.run("foo", node2).join();
 
     LeaderEventListener listener1 = new LeaderEventListener();
@@ -114,9 +114,9 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testAnoint() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-anoint").build().async();
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-anoint").build().async();
-    AsyncLeaderElector<NodeId> elector3 = atomix().<NodeId>leaderElectorBuilder("test-elector-anoint").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-anoint", protocol()).build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-anoint", protocol()).build().async();
+    AsyncLeaderElector<NodeId> elector3 = atomix().<NodeId>leaderElectorBuilder("test-elector-anoint", protocol()).build().async();
     elector1.run("foo", node1).join();
     elector2.run("foo", node2).join();
 
@@ -160,9 +160,9 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testPromote() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-promote").build().async();
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-promote").build().async();
-    AsyncLeaderElector<NodeId> elector3 = atomix().<NodeId>leaderElectorBuilder("test-elector-promote").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-promote", protocol()).build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-promote", protocol()).build().async();
+    AsyncLeaderElector<NodeId> elector3 = atomix().<NodeId>leaderElectorBuilder("test-elector-promote", protocol()).build().async();
     elector1.run("foo", node1).join();
     elector2.run("foo", node2).join();
 
@@ -210,9 +210,9 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testLeaderSessionClose() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-session-close").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-session-close", protocol()).build().async();
     elector1.run("foo", node1).join();
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-session-close").build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-session-close", protocol()).build().async();
     LeaderEventListener listener = new LeaderEventListener();
     elector2.run("foo", node2).join();
     elector2.addListener("foo", listener).join();
@@ -226,9 +226,9 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testNonLeaderSessionClose() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-non-leader-session-close").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-non-leader-session-close", protocol()).build().async();
     elector1.run("foo", node1).join();
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-non-leader-session-close").build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-non-leader-session-close", protocol()).build().async();
     LeaderEventListener listener = new LeaderEventListener();
     elector2.run("foo", node2).join();
     elector1.addListener("foo", listener).join();
@@ -243,17 +243,17 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
   @Test
   @Ignore // Leader balancing is currently not deterministic in this test
   public void testLeaderBalance() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-balance").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-balance", protocol()).build().async();
     elector1.run("foo", node1).join();
     elector1.run("bar", node1).join();
     elector1.run("baz", node1).join();
 
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-balance").build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-balance", protocol()).build().async();
     elector2.run("foo", node2).join();
     elector2.run("bar", node2).join();
     elector2.run("baz", node2).join();
 
-    AsyncLeaderElector<NodeId> elector3 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-balance").build().async();
+    AsyncLeaderElector<NodeId> elector3 = atomix().<NodeId>leaderElectorBuilder("test-elector-leader-balance", protocol()).build().async();
     elector3.run("foo", node3).join();
     elector3.run("bar", node3).join();
     elector3.run("baz", node3).join();
@@ -287,8 +287,8 @@ public class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testQueries() throws Throwable {
-    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-query").build().async();
-    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-query").build().async();
+    AsyncLeaderElector<NodeId> elector1 = atomix().<NodeId>leaderElectorBuilder("test-elector-query", protocol()).build().async();
+    AsyncLeaderElector<NodeId> elector2 = atomix().<NodeId>leaderElectorBuilder("test-elector-query", protocol()).build().async();
     elector1.run("foo", node1).join();
     elector2.run("foo", node2).join();
     elector2.run("bar", node2).join();

--- a/core/src/test/java/io/atomix/core/election/impl/PrimaryBackupLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/PrimaryBackupLeaderElectionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.election.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup leader election test.
+ */
+public class PrimaryBackupLeaderElectionTest extends LeaderElectionTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/election/impl/PrimaryBackupLeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/PrimaryBackupLeaderElectorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.election.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup leader elector test.
+ */
+public class PrimaryBackupLeaderElectorTest extends LeaderElectorTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/election/impl/RaftLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/RaftLeaderElectionTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.election.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft leader election test.
+ */
+public class RaftLeaderElectionTest extends LeaderElectionTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/election/impl/RaftLeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/RaftLeaderElectorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.election.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft leader elector test.
+ */
+public class RaftLeaderElectorTest extends LeaderElectorTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/generator/impl/IdGeneratorTest.java
+++ b/core/src/test/java/io/atomix/core/generator/impl/IdGeneratorTest.java
@@ -27,15 +27,15 @@ import static org.junit.Assert.assertEquals;
 /**
  * Unit test for {@code AtomixIdGenerator}.
  */
-public class IdGeneratorTest extends AbstractPrimitiveTest {
+public abstract class IdGeneratorTest extends AbstractPrimitiveTest {
 
   /**
    * Tests generating IDs.
    */
   @Test
   public void testNextId() throws Throwable {
-    AsyncAtomicIdGenerator idGenerator1 = atomix().atomicIdGeneratorBuilder("testNextId").build().async();
-    AsyncAtomicIdGenerator idGenerator2 = atomix().atomicIdGeneratorBuilder("testNextId").build().async();
+    AsyncAtomicIdGenerator idGenerator1 = atomix().atomicIdGeneratorBuilder("testNextId", protocol()).build().async();
+    AsyncAtomicIdGenerator idGenerator2 = atomix().atomicIdGeneratorBuilder("testNextId", protocol()).build().async();
 
     CompletableFuture<Long> future11 = idGenerator1.nextId();
     CompletableFuture<Long> future12 = idGenerator1.nextId();
@@ -65,9 +65,9 @@ public class IdGeneratorTest extends AbstractPrimitiveTest {
   @Test
   public void testNextIdBatchRollover() throws Throwable {
     DelegatingAtomicIdGenerator idGenerator1 = new DelegatingAtomicIdGenerator(
-        atomix().atomicCounterBuilder("testNextIdBatchRollover").build().async(), 2);
+        atomix().atomicCounterBuilder("testNextIdBatchRollover", protocol()).build().async(), 2);
     DelegatingAtomicIdGenerator idGenerator2 = new DelegatingAtomicIdGenerator(
-        atomix().atomicCounterBuilder("testNextIdBatchRollover").build().async(), 2);
+        atomix().atomicCounterBuilder("testNextIdBatchRollover", protocol()).build().async(), 2);
 
     CompletableFuture<Long> future11 = idGenerator1.nextId();
     CompletableFuture<Long> future12 = idGenerator1.nextId();

--- a/core/src/test/java/io/atomix/core/generator/impl/PrimaryBackupIdGeneratorTest.java
+++ b/core/src/test/java/io/atomix/core/generator/impl/PrimaryBackupIdGeneratorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.generator.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup ID generator test.
+ */
+public class PrimaryBackupIdGeneratorTest extends IdGeneratorTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/generator/impl/RaftIdGeneratorTest.java
+++ b/core/src/test/java/io/atomix/core/generator/impl/RaftIdGeneratorTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.generator.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft ID generator test.
+ */
+public class RaftIdGeneratorTest extends IdGeneratorTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/lock/impl/DistributedLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/impl/DistributedLockTest.java
@@ -30,14 +30,14 @@ import static org.junit.Assert.assertTrue;
 /**
  * Raft lock test.
  */
-public class DistributedLockTest extends AbstractPrimitiveTest {
+public abstract class DistributedLockTest extends AbstractPrimitiveTest {
 
   /**
    * Tests locking and unlocking a lock.
    */
   @Test
   public void testLockUnlock() throws Throwable {
-    AsyncDistributedLock lock = atomix().lockBuilder("test-lock-unlock").build().async();
+    AsyncDistributedLock lock = atomix().lockBuilder("test-lock-unlock", protocol()).build().async();
     lock.lock().join();
     lock.unlock().join();
   }
@@ -47,8 +47,8 @@ public class DistributedLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testReleaseOnClose() throws Throwable {
-    AsyncDistributedLock lock1 = atomix().lockBuilder("test-lock-on-close").build().async();
-    AsyncDistributedLock lock2 = atomix().lockBuilder("test-lock-on-close").build().async();
+    AsyncDistributedLock lock1 = atomix().lockBuilder("test-lock-on-close", protocol()).build().async();
+    AsyncDistributedLock lock2 = atomix().lockBuilder("test-lock-on-close", protocol()).build().async();
     lock1.lock().join();
     CompletableFuture<Version> future = lock2.lock();
     lock1.close();
@@ -60,8 +60,8 @@ public class DistributedLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockFail() throws Throwable {
-    AsyncDistributedLock lock1 = atomix().lockBuilder("test-try-lock-fail").build().async();
-    AsyncDistributedLock lock2 = atomix().lockBuilder("test-try-lock-fail").build().async();
+    AsyncDistributedLock lock1 = atomix().lockBuilder("test-try-lock-fail", protocol()).build().async();
+    AsyncDistributedLock lock2 = atomix().lockBuilder("test-try-lock-fail", protocol()).build().async();
 
     lock1.lock().join();
 
@@ -73,7 +73,7 @@ public class DistributedLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockSucceed() throws Throwable {
-    AsyncDistributedLock lock = atomix().lockBuilder("test-try-lock-succeed").build().async();
+    AsyncDistributedLock lock = atomix().lockBuilder("test-try-lock-succeed", protocol()).build().async();
     assertTrue(lock.tryLock().join().isPresent());
   }
 
@@ -82,8 +82,8 @@ public class DistributedLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockFailWithTimeout() throws Throwable {
-    AsyncDistributedLock lock1 = atomix().lockBuilder("test-try-lock-fail-with-timeout").build().async();
-    AsyncDistributedLock lock2 = atomix().lockBuilder("test-try-lock-fail-with-timeout").build().async();
+    AsyncDistributedLock lock1 = atomix().lockBuilder("test-try-lock-fail-with-timeout", protocol()).build().async();
+    AsyncDistributedLock lock2 = atomix().lockBuilder("test-try-lock-fail-with-timeout", protocol()).build().async();
 
     lock1.lock().join();
 
@@ -95,8 +95,8 @@ public class DistributedLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockSucceedWithTimeout() throws Throwable {
-    AsyncDistributedLock lock1 = atomix().lockBuilder("test-try-lock-succeed-with-timeout").build().async();
-    AsyncDistributedLock lock2 = atomix().lockBuilder("test-try-lock-succeed-with-timeout").build().async();
+    AsyncDistributedLock lock1 = atomix().lockBuilder("test-try-lock-succeed-with-timeout", protocol()).build().async();
+    AsyncDistributedLock lock2 = atomix().lockBuilder("test-try-lock-succeed-with-timeout", protocol()).build().async();
 
     lock1.lock().join();
 
@@ -110,8 +110,8 @@ public class DistributedLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testBlockingUnlock() throws Throwable {
-    AsyncDistributedLock lock1 = atomix().lockBuilder("test-blocking-unlock").build().async();
-    AsyncDistributedLock lock2 = atomix().lockBuilder("test-blocking-unlock").build().async();
+    AsyncDistributedLock lock1 = atomix().lockBuilder("test-blocking-unlock", protocol()).build().async();
+    AsyncDistributedLock lock2 = atomix().lockBuilder("test-blocking-unlock", protocol()).build().async();
 
     lock1.lock().thenRun(() -> {
       lock1.unlock().join();

--- a/core/src/test/java/io/atomix/core/lock/impl/PrimaryBackupDistributedLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/impl/PrimaryBackupDistributedLockTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.lock.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup distributed lock test.
+ */
+public class PrimaryBackupDistributedLockTest extends DistributedLockTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/lock/impl/RaftDistributedLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/impl/RaftDistributedLockTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.lock.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft distributed lock test.
+ */
+public class RaftDistributedLockTest extends DistributedLockTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/map/impl/AtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/AtomicCounterMapTest.java
@@ -26,14 +26,14 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit test for {@code AtomixCounterMap}.
  */
-public class AtomicCounterMapTest extends AbstractPrimitiveTest {
+public abstract class AtomicCounterMapTest extends AbstractPrimitiveTest {
 
   /**
    * Tests basic counter map operations.
    */
   @Test
   public void testBasicCounterMapOperations() throws Throwable {
-    AsyncAtomicCounterMap<String> map = atomix().<String>atomicCounterMapBuilder("testBasicCounterMapOperationMap").build().async();
+    AsyncAtomicCounterMap<String> map = atomix().<String>atomicCounterMapBuilder("testBasicCounterMapOperationMap", protocol()).build().async();
 
     map.isEmpty().thenAccept(isEmpty -> {
       assertTrue(isEmpty);

--- a/core/src/test/java/io/atomix/core/map/impl/ConsistentMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/ConsistentMapTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link io.atomix.core.map.ConsistentMap}.
  */
-public class ConsistentMapTest extends AbstractPrimitiveTest {
+public abstract class ConsistentMapTest extends AbstractPrimitiveTest {
 
   /**
    * Tests null values.
@@ -59,7 +59,7 @@ public class ConsistentMapTest extends AbstractPrimitiveTest {
     final String barValue = "Hello bar!";
 
     AsyncConsistentMap<String, String> map = atomix()
-        .<String, String>consistentMapBuilder("testNullValues")
+        .<String, String>consistentMapBuilder("testNullValues", protocol())
         .withNullValues()
         .build().async();
 
@@ -96,7 +96,7 @@ public class ConsistentMapTest extends AbstractPrimitiveTest {
     final String fooValue = "Hello foo!";
     final String barValue = "Hello bar!";
 
-    AsyncConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("testBasicMapOperationMap").build().async();
+    AsyncConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("testBasicMapOperationMap", protocol()).build().async();
 
     map.isEmpty().thenAccept(result -> {
       assertTrue(result);
@@ -280,7 +280,7 @@ public class ConsistentMapTest extends AbstractPrimitiveTest {
     final String value2 = "value2";
     final String value3 = "value3";
 
-    AsyncConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("testMapComputeOperationsMap").build().async();
+    AsyncConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("testMapComputeOperationsMap", protocol()).build().async();
 
     map.computeIfAbsent("foo", k -> value1).thenAccept(result -> {
       assertEquals(Versioned.valueOrElse(result, null), value1);
@@ -317,7 +317,7 @@ public class ConsistentMapTest extends AbstractPrimitiveTest {
     final String value2 = "value2";
     final String value3 = "value3";
 
-    AsyncConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("testMapListenerMap").build().async();
+    AsyncConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("testMapListenerMap", protocol()).build().async();
     TestMapEventListener listener = new TestMapEventListener();
 
     // add listener; insert new value into map and verify an INSERT event is received.
@@ -388,13 +388,13 @@ public class ConsistentMapTest extends AbstractPrimitiveTest {
         .withIsolation(Isolation.READ_COMMITTED)
         .build();
     transaction1.begin();
-    TransactionalMap<String, String> map1 = transaction1.<String, String>mapBuilder("test-transactional-map").build();
+    TransactionalMap<String, String> map1 = transaction1.<String, String>mapBuilder("test-transactional-map", protocol()).build();
 
     Transaction transaction2 = atomix().transactionBuilder()
         .withIsolation(Isolation.REPEATABLE_READS)
         .build();
     transaction2.begin();
-    TransactionalMap<String, String> map2 = transaction2.<String, String>mapBuilder("test-transactional-map").build();
+    TransactionalMap<String, String> map2 = transaction2.<String, String>mapBuilder("test-transactional-map", protocol()).build();
 
     assertNull(map1.get("foo"));
     assertFalse(map1.containsKey("foo"));
@@ -419,13 +419,13 @@ public class ConsistentMapTest extends AbstractPrimitiveTest {
         .withIsolation(Isolation.REPEATABLE_READS)
         .build();
     transaction3.begin();
-    TransactionalMap<String, String> map3 = transaction3.<String, String>mapBuilder("test-transactional-map").build();
+    TransactionalMap<String, String> map3 = transaction3.<String, String>mapBuilder("test-transactional-map", protocol()).build();
     assertEquals(map3.get("foo"), "bar");
     map3.put("foo", "baz");
     assertEquals(map3.get("foo"), "baz");
     assertEquals(transaction3.commit(), CommitStatus.SUCCESS);
 
-    ConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("test-transactional-map").build();
+    ConsistentMap<String, String> map = atomix().<String, String>consistentMapBuilder("test-transactional-map", protocol()).build();
     assertEquals(map.get("foo").value(), "baz");
     assertEquals(map.get("bar").value(), "baz");
 

--- a/core/src/test/java/io/atomix/core/map/impl/ConsistentTreeMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/ConsistentTreeMapTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link ConsistentTreeMapProxy}.
  */
-public class ConsistentTreeMapTest extends AbstractPrimitiveTest {
+public abstract class ConsistentTreeMapTest extends AbstractPrimitiveTest {
   private final String four = "hello";
   private final String three = "goodbye";
   private final String two = "foo";
@@ -458,7 +458,7 @@ public class ConsistentTreeMapTest extends AbstractPrimitiveTest {
 
   private AsyncConsistentTreeMap<String> createResource(String mapName) {
     try {
-      return atomix().<String>consistentTreeMapBuilder(mapName).build().async();
+      return atomix().<String>consistentTreeMapBuilder(mapName, protocol()).build().async();
     } catch (Throwable e) {
       throw new RuntimeException(e.toString());
     }

--- a/core/src/test/java/io/atomix/core/map/impl/PrimaryBackupAtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/PrimaryBackupAtomicCounterMapTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup atomic counter map test.
+ */
+public class PrimaryBackupAtomicCounterMapTest extends AtomicCounterMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/map/impl/PrimaryBackupConsistentMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/PrimaryBackupConsistentMapTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup consistent map test.
+ */
+public class PrimaryBackupConsistentMapTest extends ConsistentMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/map/impl/PrimaryBackupConsistentTreeMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/PrimaryBackupConsistentTreeMapTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup consistent tree map test.
+ */
+public class PrimaryBackupConsistentTreeMapTest extends ConsistentTreeMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/map/impl/RaftAtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/RaftAtomicCounterMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft atomic counter map test.
+ */
+public class RaftAtomicCounterMapTest extends AtomicCounterMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/map/impl/RaftConsistentMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/RaftConsistentMapTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+import java.time.Duration;
+
+/**
+ * Raft consistent map test.
+ */
+public class RaftConsistentMapTest extends ConsistentMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxTimeout(Duration.ofSeconds(1))
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/map/impl/RaftConsistentTreeMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/RaftConsistentTreeMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft consistent tree map test.
+ */
+public class RaftConsistentTreeMapTest extends ConsistentTreeMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the {@link ConsistentSetMultimapProxy}.
  */
-public class ConsistentSetMultimapTest extends AbstractPrimitiveTest {
+public abstract class ConsistentSetMultimapTest extends AbstractPrimitiveTest {
   private final String one = "hello";
   private final String two = "goodbye";
   private final String three = "foo";
@@ -373,7 +373,7 @@ public class ConsistentSetMultimapTest extends AbstractPrimitiveTest {
 
   private AsyncConsistentMultimap<String, String> createResource(String mapName) {
     try {
-      return atomix().<String, String>consistentMultimapBuilder(mapName).build().async();
+      return atomix().<String, String>consistentMultimapBuilder(mapName, protocol()).build().async();
     } catch (Throwable e) {
       throw new RuntimeException(e.toString());
     }

--- a/core/src/test/java/io/atomix/core/multimap/impl/PrimaryBackupConsistentSetMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/impl/PrimaryBackupConsistentSetMultimapTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.multimap.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Raft multimap test.
+ */
+public class PrimaryBackupConsistentSetMultimapTest extends ConsistentSetMultimapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/multimap/impl/RaftConsistentSetMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/impl/RaftConsistentSetMultimapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.multimap.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft multimap test.
+ */
+public class RaftConsistentSetMultimapTest extends ConsistentSetMultimapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/queue/impl/PrimaryBackupWorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/impl/PrimaryBackupWorkQueueTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.queue.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup work queue test.
+ */
+public class PrimaryBackupWorkQueueTest extends WorkQueueTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/queue/impl/RaftWorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/impl/RaftWorkQueueTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.queue.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft work queue test.
+ */
+public class RaftWorkQueueTest extends WorkQueueTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/queue/impl/WorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/impl/WorkQueueTest.java
@@ -39,18 +39,18 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link WorkQueueProxy}.
  */
-public class WorkQueueTest extends AbstractPrimitiveTest {
+public abstract class WorkQueueTest extends AbstractPrimitiveTest {
   private static final Duration DEFAULT_PROCESSING_TIME = Duration.ofMillis(100);
   private static final String DEFAULT_PAYLOAD = "hello world";
 
   @Test
   public void testAdd() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String item = DEFAULT_PAYLOAD;
     queue1.addOne(item).join();
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String task2 = DEFAULT_PAYLOAD;
     queue2.addOne(task2).join();
 
@@ -63,7 +63,7 @@ public class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testAddMultiple() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String item1 = DEFAULT_PAYLOAD;
     String item2 = DEFAULT_PAYLOAD;
     queue1.addMultiple(Arrays.asList(item1, item2)).join();
@@ -77,11 +77,11 @@ public class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testTakeAndComplete() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String item1 = DEFAULT_PAYLOAD;
     queue1.addOne(item1).join();
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     Task<String> removedTask = queue2.take().join();
 
     WorkQueueStats stats = queue2.stats().join();
@@ -104,11 +104,11 @@ public class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testUnexpectedClientClose() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String item1 = DEFAULT_PAYLOAD;
     queue1.addOne(item1).join();
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     queue2.take().join();
 
     WorkQueueStats stats = queue1.stats().join();
@@ -127,13 +127,13 @@ public class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testAutomaticTaskProcessing() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     Executor executor = Executors.newSingleThreadExecutor();
 
     CountDownLatch latch1 = new CountDownLatch(1);
     queue1.registerTaskProcessor(s -> latch1.countDown(), 2, executor);
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String item1 = DEFAULT_PAYLOAD;
     queue2.addOne(item1).join();
 
@@ -161,11 +161,11 @@ public class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testDestroy() throws Exception {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String item = DEFAULT_PAYLOAD;
     queue1.addOne(item).join();
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String task2 = DEFAULT_PAYLOAD;
     queue2.addOne(task2).join();
 
@@ -185,7 +185,7 @@ public class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testCompleteAttemptWithIncorrectSession() throws Exception {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
     String item = DEFAULT_PAYLOAD;
     queue1.addOne(item).join();
 
@@ -193,7 +193,7 @@ public class WorkQueueTest extends AbstractPrimitiveTest {
     String taskId = task.taskId();
 
     // Create another client and get a handle to the same queue.
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
 
     // Attempt completing the task with new client and verify task is not completed
     queue2.complete(taskId).join();

--- a/core/src/test/java/io/atomix/core/tree/impl/DocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/impl/DocumentTreeTest.java
@@ -45,16 +45,15 @@ import static org.junit.Assert.fail;
 /**
  * Unit tests for {@link DocumentTreeProxy}.
  */
-public class DocumentTreeTest extends AbstractPrimitiveTest {
+public abstract class DocumentTreeTest extends AbstractPrimitiveTest {
 
   protected AsyncDocumentTree<String> newTree(String name) throws Exception {
     return newTree(name, null);
   }
 
   protected AsyncDocumentTree<String> newTree(String name, Ordering ordering) throws Exception {
-    return atomix().<String>documentTreeBuilder(name)
+    return atomix().<String>documentTreeBuilder(name, protocol())
         .withOrdering(ordering)
-        .withMaxRetries(5)
         .build()
         .async();
   }

--- a/core/src/test/java/io/atomix/core/tree/impl/PrimaryBackupDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/impl/PrimaryBackupDocumentTreeTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.tree.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Document tree test using the primary-backup protocol.
+ */
+public class PrimaryBackupDocumentTreeTest extends DocumentTreeTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/tree/impl/RaftDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/impl/RaftDocumentTreeTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.tree.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Document tree test using the Raft protocol.
+ */
+public class RaftDocumentTreeTest extends DocumentTreeTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/value/impl/AtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/impl/AtomicValueTest.java
@@ -28,10 +28,10 @@ import static org.junit.Assert.assertTrue;
 /**
  * Raft atomic value test.
  */
-public class AtomicValueTest extends AbstractPrimitiveTest {
+public abstract class AtomicValueTest extends AbstractPrimitiveTest {
   @Test
   public void testValue() throws Exception {
-    AsyncAtomicValue<String> value = atomix().<String>atomicValueBuilder("test-value").build().async();
+    AsyncAtomicValue<String> value = atomix().<String>atomicValueBuilder("test-value", protocol()).build().async();
     assertNull(value.get().join());
     value.set("a").join();
     assertEquals("a", value.get().join());

--- a/core/src/test/java/io/atomix/core/value/impl/PrimaryBackupAtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/impl/PrimaryBackupAtomicValueTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.value.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup atomic value test.
+ */
+public class PrimaryBackupAtomicValueTest extends AtomicValueTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/value/impl/RaftAtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/impl/RaftAtomicValueTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.value.impl;
+
+import io.atomix.primitive.PrimitiveProtocol;
+import io.atomix.protocols.raft.RaftProtocol;
+
+/**
+ * Raft atomix value test.
+ */
+public class RaftAtomicValueTest extends AtomicValueTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return RaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/DistributedPrimitiveBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/DistributedPrimitiveBuilder.java
@@ -22,7 +22,6 @@ import io.atomix.utils.serializer.Serializer;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -38,10 +37,6 @@ public abstract class DistributedPrimitiveBuilder<B extends DistributedPrimitive
   private boolean readOnly = false;
   private boolean relaxedReadConsistency = false;
   private PrimitiveProtocol protocol;
-  private Persistence persistence = defaultPersistence();
-  private Consistency consistency = defaultConsistency();
-  private Replication replication = defaultReplication();
-  private Recovery recovery = defaultRecovery();
   private int numBackups = 2;
   private int maxRetries;
   private Duration retryDelay = Duration.ofMillis(100);
@@ -94,97 +89,6 @@ public abstract class DistributedPrimitiveBuilder<B extends DistributedPrimitive
   @SuppressWarnings("unchecked")
   public B withProtocol(PrimitiveProtocol protocol) {
     this.protocol = checkNotNull(protocol, "protocol cannot be null");
-    return (B) this;
-  }
-
-  /**
-   * Sets the primitive consistency model.
-   *
-   * @param consistency the primitive consistency model
-   * @return the primitive builder
-   * @throws NullPointerException if the consistency model is null
-   */
-  @SuppressWarnings("unchecked")
-  public B withConsistency(Consistency consistency) {
-    this.consistency = checkNotNull(consistency, "consistency cannot be null");
-    return (B) this;
-  }
-
-  /**
-   * Sets the primitive persistence level.
-   *
-   * @param persistence the primitive persistence level
-   * @return the primitive builder
-   * @throws NullPointerException if the persistence level is null
-   */
-  @SuppressWarnings("unchecked")
-  public B withPersistence(Persistence persistence) {
-    this.persistence = checkNotNull(persistence, "persistence cannot be null");
-    return (B) this;
-  }
-
-  /**
-   * Sets the primitive replication strategy.
-   *
-   * @param replication the primitive replication strategy
-   * @return the primitive builder
-   * @throws NullPointerException if the replication strategy is null
-   */
-  @SuppressWarnings("unchecked")
-  public B withReplication(Replication replication) {
-    this.replication = checkNotNull(replication, "replication cannot be null");
-    return (B) this;
-  }
-
-  /**
-   * Sets the primitive recovery strategy.
-   *
-   * @param recovery the primitive recovery strategy
-   * @return the primitive builder
-   * @throws NullPointerException if the recovery strategy is null
-   */
-  @SuppressWarnings("unchecked")
-  public B withRecovery(Recovery recovery) {
-    this.recovery = checkNotNull(recovery, "recovery cannot be null");
-    return (B) this;
-  }
-
-  /**
-   * Sets the number of backups.
-   *
-   * @param numBackups the number of backups
-   * @return the primitive builder
-   * @throws IllegalArgumentException if the number of backups is not positive or {@code -1}
-   */
-  @SuppressWarnings("unchecked")
-  public B withBackups(int numBackups) {
-    checkArgument(numBackups >= 0, "numBackups must be positive");
-    this.numBackups = numBackups;
-    return (B) this;
-  }
-
-  /**
-   * Sets the maximum number of operation retries.
-   *
-   * @param maxRetries the maximum number of allowed operation retries
-   * @return this builder
-   */
-  @SuppressWarnings("unchecked")
-  public B withMaxRetries(int maxRetries) {
-    checkArgument(maxRetries >= 0, "maxRetries must be positive");
-    this.maxRetries = maxRetries;
-    return (B) this;
-  }
-
-  /**
-   * Sets the retry delay.
-   *
-   * @param retryDelay the retry delay
-   * @return this builder
-   */
-  @SuppressWarnings("unchecked")
-  public B withRetryDelay(Duration retryDelay) {
-    this.retryDelay = checkNotNull(retryDelay, "retryDelay cannot be null");
     return (B) this;
   }
 
@@ -244,99 +148,6 @@ public abstract class DistributedPrimitiveBuilder<B extends DistributedPrimitive
   public PrimitiveProtocol protocol() {
     return protocol;
   }
-
-  /**
-   * Returns the primitive consistency model.
-   *
-   * @return the primitive consistency model
-   */
-  public Consistency consistency() {
-    return consistency;
-  }
-
-  /**
-   * Returns the default consistency model.
-   *
-   * @return the default consistency model
-   */
-  protected abstract Consistency defaultConsistency();
-
-  /**
-   * Returns the primitive persistence level.
-   *
-   * @return the primitive persistence level
-   */
-  public Persistence persistence() {
-    return persistence;
-  }
-
-  /**
-   * Returns the default persistence level.
-   *
-   * @return the default persistence level
-   */
-  protected abstract Persistence defaultPersistence();
-
-  /**
-   * Returns the replication strategy.
-   *
-   * @return the replication strategy
-   */
-  public Replication replication() {
-    return replication;
-  }
-
-  /**
-   * Returns the recovery strategy.
-   *
-   * @return the recovery strategy
-   */
-  public Recovery recovery() {
-    return recovery;
-  }
-
-  /**
-   * Returns the default recovery strategy.
-   *
-   * @return the default recovery strategy
-   */
-  protected Recovery defaultRecovery() {
-    return Recovery.RECOVER;
-  }
-
-  /**
-   * Returns the number of backups for the primitive.
-   *
-   * @return the number of backups for the primitive
-   */
-  public int backups() {
-    return numBackups;
-  }
-
-  /**
-   * Returns the maximum number of allowed retries.
-   *
-   * @return the maximum number of allowed retries
-   */
-  public int maxRetries() {
-    return maxRetries;
-  }
-
-  /**
-   * Returns the retry delay.
-   *
-   * @return the retry delay
-   */
-  public Duration retryDelay() {
-    return retryDelay;
-  }
-
-  /**
-   * Returns the default replication strategy.
-   *
-   * @return the default replication strategy
-   */
-  protected abstract Replication defaultReplication();
 
   /**
    * Constructs an instance of the distributed primitive.

--- a/primitive/src/main/java/io/atomix/primitive/partition/ManagedPartitionGroup.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/ManagedPartitionGroup.java
@@ -15,12 +15,14 @@
  */
 package io.atomix.primitive.partition;
 
+import io.atomix.primitive.PrimitiveProtocol;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Managed partition group.
  */
-public interface ManagedPartitionGroup extends PartitionGroup {
+public interface ManagedPartitionGroup<P extends PrimitiveProtocol> extends PartitionGroup<P> {
 
   /**
    * Initializes the partition group.
@@ -28,7 +30,7 @@ public interface ManagedPartitionGroup extends PartitionGroup {
    * @param managementService the partition management service
    * @return a future to be completed once the partition group has been initialized
    */
-  CompletableFuture<ManagedPartitionGroup> open(PartitionManagementService managementService);
+  CompletableFuture<ManagedPartitionGroup<P>> open(PartitionManagementService managementService);
 
   /**
    * Closes the partition group.

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * Primitive partition group.
  */
-public interface PartitionGroup {
+public interface PartitionGroup<P extends PrimitiveProtocol> {
 
   /**
    * Returns the partition group name.
@@ -40,6 +40,13 @@ public interface PartitionGroup {
    * @return the primitive protocol type supported by the partition group
    */
   PrimitiveProtocol.Type type();
+
+  /**
+   * Returns a new primitive protocol.
+   *
+   * @return a new primitive protocol
+   */
+  P newProtocol();
 
   /**
    * Returns a partition by ID.
@@ -66,7 +73,7 @@ public interface PartitionGroup {
    *
    * @return a collection of all partitions
    */
-  Collection<Partition> getPartitions();
+  Collection<Partition<P>> getPartitions();
 
   /**
    * Returns a sorted list of partition IDs.

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
@@ -74,6 +74,6 @@ public interface PartitionService {
    *
    * @return a collection of all partition groups
    */
-  Collection<PartitionGroup> getPartitionGroups();
+  Collection<PartitionGroup<?>> getPartitionGroups();
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 public class DefaultPartitionService implements ManagedPartitionService {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPartitionService.class);
 
-  private final Map<String, ManagedPartitionGroup> groups = Maps.newConcurrentMap();
+  private final Map<String, ManagedPartitionGroup<?>> groups = Maps.newConcurrentMap();
 
   public DefaultPartitionService(Collection<ManagedPartitionGroup> groups) {
     groups.forEach(g -> this.groups.put(g.name(), g));
@@ -49,13 +49,14 @@ public class DefaultPartitionService implements ManagedPartitionService {
 
   @Override
   @SuppressWarnings("unchecked")
-  public Collection<PartitionGroup> getPartitionGroups() {
+  public Collection<PartitionGroup<?>> getPartitionGroups() {
     return (Collection) groups.values();
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public CompletableFuture<PartitionService> open(PartitionManagementService managementService) {
-    List<CompletableFuture<ManagedPartitionGroup>> futures = groups.values().stream()
+    List<CompletableFuture> futures = groups.values().stream()
         .map(g -> g.open(managementService))
         .collect(Collectors.toList());
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).thenApply(v -> {

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPrimaryElectionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPrimaryElectionService.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Sets;
 import io.atomix.primitive.PrimitiveProtocol;
 import io.atomix.primitive.partition.ManagedPrimaryElection;
 import io.atomix.primitive.partition.ManagedPrimaryElectionService;
+import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PrimaryElection;
@@ -85,7 +86,7 @@ public class DefaultPrimaryElectionService implements ManagedPrimaryElectionServ
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<PrimaryElectionService> start() {
-    return partitions.getPartitions().iterator().next().getPrimitiveClient()
+    return ((Partition) partitions.getPartitions().iterator().next()).getPrimitiveClient()
         .newProxy(PRIMITIVE_NAME, PrimaryElectorType.instance(), protocol)
         .connect()
         .thenAccept(proxy -> {

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
@@ -17,7 +17,10 @@ package io.atomix.protocols.backup.partition;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import io.atomix.primitive.PrimitiveProtocol;
 import io.atomix.primitive.PrimitiveProtocol.Type;
+import io.atomix.primitive.Recovery;
+import io.atomix.primitive.Replication;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.MemberGroup;
 import io.atomix.primitive.partition.MemberGroupProvider;
@@ -84,6 +87,15 @@ public class PrimaryBackupPartitionGroup implements ManagedPartitionGroup {
   @Override
   public Type type() {
     return MultiPrimaryProtocol.TYPE;
+  }
+
+  @Override
+  public PrimitiveProtocol newProtocol() {
+    return MultiPrimaryProtocol.builder(name)
+        .withRecovery(Recovery.RECOVER)
+        .withBackups(2)
+        .withReplication(Replication.SYNCHRONOUS)
+        .build();
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
@@ -23,7 +23,9 @@ import io.atomix.cluster.ClusterEventListener;
 import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeId;
+import io.atomix.primitive.PrimitiveProtocol;
 import io.atomix.primitive.PrimitiveProtocol.Type;
+import io.atomix.primitive.Recovery;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionGroup;
@@ -95,6 +97,14 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   @Override
   public Type type() {
     return RaftProtocol.TYPE;
+  }
+
+  @Override
+  public PrimitiveProtocol newProtocol() {
+    return RaftProtocol.builder(name)
+        .withRecoveryStrategy(Recovery.RECOVER)
+        .withMaxRetries(5)
+        .build();
   }
 
   @Override


### PR DESCRIPTION
This PR removes confusing `Replication`/`Consistency`/etc configurations from primitive builders and replaces them only with protocol configurations.