### PR TITLE
Skip empty keep-alives when resetting indexes

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
@@ -244,6 +244,11 @@ public class RaftProxyManager {
   private synchronized void resetAllIndexes() {
     Collection<RaftProxyState> sessions = Lists.newArrayList(this.sessions.values());
 
+    // If no sessions are open, skip the keep-alive.
+    if (sessions.isEmpty()) {
+      return;
+    }
+
     // Allocate session IDs, command response sequence numbers, and event index arrays.
     long[] sessionIds = new long[sessions.size()];
     long[] commandResponses = new long[sessions.size()];


### PR DESCRIPTION
Ensures empty keep-alives are not sent to Raft clusters.