### PR TITLE
Rename Endpoint class to Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The builder should be configured with the local node configuration:
 ```java
 builder.withLocalNode(Node.builder("server1")
   .withType(Node.Type.DATA)
-  .withAddress(Address.from("localhost", 5000))
+  .withAddress("localhost:5000")
   .build());
 ```
 
@@ -125,15 +125,15 @@ should provide the same set of bootstrap nodes. Bootstrap nodes _must_ be `DATA`
 builder.withBootstrapNodes(
   Node.builder("server1")
     .withType(Node.Type.DATA)
-    .withAddress(Address.from("localhost", 5000))
+    .withAddress("localhost:5000")
     .build(),
   Node.builder("server2")
     .withType(Node.Type.DATA)
-    .withAddress(Address.from("localhost", 5001))
+    .withAddress("localhost:5001")
     .build(),
   Node.builder("server3")
     .withType(Node.Type.DATA)
-    .withAddress(Address.from("localhost", 5002))
+    .withAddress("localhost:5002")
     .build());
 ```
 
@@ -166,20 +166,20 @@ node builder that the node is a `CLIENT`:
 Atomix atomix = Atomix.builder()
   .withLocalNode(Node.builder("client")
     .withType(Node.Type.CLIENT)
-    .withAddress(Address.from("localhost", 5003))
+    .withAddress("localhost:5003")
     .build())
   .withBootstrapNodes(
       Node.builder("server1")
         .withType(Node.Type.DATA)
-        .withAddress(Address.from("localhost", 5000))
+        .withAddress("localhost:5000")
         .build(),
       Node.builder("server2")
         .withType(Node.Type.DATA)
-        .withAddress(Address.from("localhost", 5001))
+        .withAddress("localhost:5001")
         .build(),
       Node.builder("server3")
         .withType(Node.Type.DATA)
-        .withAddress(Address.from("localhost", 5002))
+        .withAddress("localhost:5002")
         .build())
   .build();
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The builder should be configured with the local node configuration:
 ```java
 builder.withLocalNode(Node.builder("server1")
   .withType(Node.Type.DATA)
-  .withEndpoint(Endpoint.from("localhost", 5000))
+  .withAddress(Address.from("localhost", 5000))
   .build());
 ```
 
@@ -125,15 +125,15 @@ should provide the same set of bootstrap nodes. Bootstrap nodes _must_ be `DATA`
 builder.withBootstrapNodes(
   Node.builder("server1")
     .withType(Node.Type.DATA)
-    .withEndpoint(Endpoint.from("localhost", 5000))
+    .withAddress(Address.from("localhost", 5000))
     .build(),
   Node.builder("server2")
     .withType(Node.Type.DATA)
-    .withEndpoint(Endpoint.from("localhost", 5001))
+    .withAddress(Address.from("localhost", 5001))
     .build(),
   Node.builder("server3")
     .withType(Node.Type.DATA)
-    .withEndpoint(Endpoint.from("localhost", 5002))
+    .withAddress(Address.from("localhost", 5002))
     .build());
 ```
 
@@ -166,20 +166,20 @@ node builder that the node is a `CLIENT`:
 Atomix atomix = Atomix.builder()
   .withLocalNode(Node.builder("client")
     .withType(Node.Type.CLIENT)
-    .withEndpoint(Endpoint.from("localhost", 5003))
+    .withAddress(Address.from("localhost", 5003))
     .build())
   .withBootstrapNodes(
       Node.builder("server1")
         .withType(Node.Type.DATA)
-        .withEndpoint(Endpoint.from("localhost", 5000))
+        .withAddress(Address.from("localhost", 5000))
         .build(),
       Node.builder("server2")
         .withType(Node.Type.DATA)
-        .withEndpoint(Endpoint.from("localhost", 5001))
+        .withAddress(Address.from("localhost", 5001))
         .build(),
       Node.builder("server3")
         .withType(Node.Type.DATA)
-        .withEndpoint(Endpoint.from("localhost", 5002))
+        .withAddress(Address.from("localhost", 5002))
         .build())
   .build();
 

--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -18,7 +18,7 @@ package io.atomix.agent;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeId;
 import io.atomix.core.Atomix;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.impl.NettyMessagingService;
 import io.atomix.rest.ManagedRestService;
 import io.atomix.rest.RestService;
@@ -45,10 +45,10 @@ public class AtomixAgent {
 
   public static void main(String[] args) throws Exception {
     ArgumentType<Node> nodeArgumentType = (ArgumentParser argumentParser, Argument argument, String value) -> {
-      String[] address = parseAddress(value);
+      String[] address = parseInfo(value);
       return Node.builder(parseNodeId(address))
           .withType(Node.Type.CORE)
-          .withEndpoint(parseEndpoint(address))
+          .withAddress(parseAddress(address))
           .build();
     };
 
@@ -64,7 +64,7 @@ public class AtomixAgent {
         .metavar("NAME:HOST:PORT")
         .setDefault(Node.builder("local")
             .withType(Node.Type.CORE)
-            .withEndpoint(new Endpoint(InetAddress.getByName("127.0.0.1"), NettyMessagingService.DEFAULT_PORT))
+            .withAddress(new Address(InetAddress.getByName("127.0.0.1"), NettyMessagingService.DEFAULT_PORT))
             .build())
         .help("The local node info");
     parser.addArgument("--type", "-t")
@@ -116,7 +116,7 @@ public class AtomixAgent {
     Node.Type type = namespace.get("type");
     localNode = Node.builder(localNode.id())
         .withType(type)
-        .withEndpoint(localNode.endpoint())
+        .withAddress(localNode.address())
         .build();
 
     List<Node> bootstrap = namespace.getList("bootstrap");
@@ -147,16 +147,16 @@ public class AtomixAgent {
 
     atomix.start().join();
 
-    LOGGER.info("Atomix listening at {}:{}", localNode.endpoint().host().getHostAddress(), localNode.endpoint().port());
+    LOGGER.info("Atomix listening at {}:{}", localNode.address().ip().getHostAddress(), localNode.address().port());
 
     ManagedRestService rest = RestService.builder()
         .withAtomix(atomix)
-        .withEndpoint(Endpoint.from(localNode.endpoint().host().getHostAddress(), httpPort))
+        .withAddress(Address.from(localNode.address().ip().getHostAddress(), httpPort))
         .build();
 
     rest.start().join();
 
-    LOGGER.info("HTTP server listening at {}:{}", localNode.endpoint().host().getHostAddress(), httpPort);
+    LOGGER.info("HTTP server listening at {}:{}", localNode.address().ip().getHostAddress(), httpPort);
 
     synchronized (Atomix.class) {
       while (atomix.isRunning()) {
@@ -165,7 +165,7 @@ public class AtomixAgent {
     }
   }
 
-  static String[] parseAddress(String address) {
+  static String[] parseInfo(String address) {
     String[] parsed = address.split(":");
     if (parsed.length > 3) {
       throw new IllegalArgumentException("Malformed address " + address);
@@ -182,18 +182,18 @@ public class AtomixAgent {
       } catch (UnknownHostException e) {
         return NodeId.from(address[0]);
       }
-      return NodeId.from(parseEndpoint(address).host().getHostName());
+      return NodeId.from(parseAddress(address).ip().getHostName());
     } else {
       try {
         InetAddress.getByName(address[0]);
-        return NodeId.from(parseEndpoint(address).host().getHostName());
+        return NodeId.from(parseAddress(address).ip().getHostName());
       } catch (UnknownHostException e) {
         return NodeId.from(address[0]);
       }
     }
   }
 
-  static Endpoint parseEndpoint(String[] address) {
+  static Address parseAddress(String[] address) {
     String host;
     int port;
     if (address.length == 3) {
@@ -218,7 +218,7 @@ public class AtomixAgent {
     }
 
     try {
-      return new Endpoint(InetAddress.getByName(host), port);
+      return new Address(InetAddress.getByName(host), port);
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("Failed to resolve host", e);
     }

--- a/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
+++ b/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
@@ -30,11 +30,11 @@ import static org.junit.Assert.fail;
 public class AtomixAgentTest {
 
   @Test
-  public void testParseAddress() throws Exception {
-    String[] address = AtomixAgent.parseAddress("a:b:c");
-    assertEquals(3, address.length);
+  public void testParseInfo() throws Exception {
+    String[] info = AtomixAgent.parseInfo("a:b:c");
+    assertEquals(3, info.length);
     try {
-      AtomixAgent.parseAddress("a:b:c:d");
+      AtomixAgent.parseInfo("a:b:c:d");
       fail();
     } catch (IllegalArgumentException e) {
     }
@@ -50,12 +50,12 @@ public class AtomixAgentTest {
   }
 
   @Test
-  public void testParseEndpoint() throws Exception {
-    assertEquals(String.format("0.0.0.0:%d", NettyMessagingService.DEFAULT_PORT), AtomixAgent.parseEndpoint(new String[]{"foo"}).toString());
-    assertEquals(String.format("127.0.0.1:%d", NettyMessagingService.DEFAULT_PORT), AtomixAgent.parseEndpoint(new String[]{"127.0.0.1"}).toString());
-    assertEquals(String.format("127.0.0.1:%d", NettyMessagingService.DEFAULT_PORT), AtomixAgent.parseEndpoint(new String[]{"foo", "127.0.0.1"}).toString());
-    assertEquals("127.0.0.1:1234", AtomixAgent.parseEndpoint(new String[]{"127.0.0.1", "1234"}).toString());
-    assertEquals("127.0.0.1:1234", AtomixAgent.parseEndpoint(new String[]{"foo", "127.0.0.1", "1234"}).toString());
+  public void testParseAddress() throws Exception {
+    assertEquals(String.format("0.0.0.0:%d", NettyMessagingService.DEFAULT_PORT), AtomixAgent.parseAddress(new String[]{"foo"}).toString());
+    assertEquals(String.format("127.0.0.1:%d", NettyMessagingService.DEFAULT_PORT), AtomixAgent.parseAddress(new String[]{"127.0.0.1"}).toString());
+    assertEquals(String.format("127.0.0.1:%d", NettyMessagingService.DEFAULT_PORT), AtomixAgent.parseAddress(new String[]{"foo", "127.0.0.1"}).toString());
+    assertEquals("127.0.0.1:1234", AtomixAgent.parseAddress(new String[]{"127.0.0.1", "1234"}).toString());
+    assertEquals("127.0.0.1:1234", AtomixAgent.parseAddress(new String[]{"foo", "127.0.0.1", "1234"}).toString());
   }
 
 }

--- a/cluster/src/main/java/io/atomix/cluster/Node.java
+++ b/cluster/src/main/java/io/atomix/cluster/Node.java
@@ -281,6 +281,40 @@ public class Node {
     /**
      * Sets the node address.
      *
+     * @param address a host:port tuple
+     * @return the node builder
+     * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+     */
+    public Builder withAddress(String address) {
+      return withAddress(Address.from(address));
+    }
+
+    /**
+     * Sets the node host/port.
+     *
+     * @param host the host name
+     * @param port the port number
+     * @return the node builder
+     * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+     */
+    public Builder withAddress(String host, int port) {
+      return withAddress(Address.from(host, port));
+    }
+
+    /**
+     * Sets the node address using local host.
+     *
+     * @param port the port number
+     * @return the node builder
+     * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+     */
+    public Builder withAddress(int port) {
+      return withAddress(Address.from(port));
+    }
+
+    /**
+     * Sets the node address.
+     *
      * @param address the node address
      * @return the node builder
      */
@@ -325,7 +359,7 @@ public class Node {
     @Override
     public Node build() {
       if (id == null) {
-        id = NodeId.from(address.ip().getHostName());
+        id = NodeId.from(address.address().getHostName());
       }
       return new Node(id, type, address, zone, rack, host);
     }

--- a/cluster/src/main/java/io/atomix/cluster/Node.java
+++ b/cluster/src/main/java/io/atomix/cluster/Node.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.cluster;
 
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 
 import java.util.Objects;
 
@@ -62,13 +62,13 @@ public class Node {
    * Returns a new core node.
    *
    * @param nodeId   the core node ID
-   * @param endpoint the core node endpoint
+   * @param address the core node address
    * @return a new core node
    */
-  public static Node core(NodeId nodeId, Endpoint endpoint) {
+  public static Node core(NodeId nodeId, Address address) {
     return builder(nodeId)
         .withType(Type.CORE)
-        .withEndpoint(endpoint)
+        .withAddress(address)
         .build();
   }
 
@@ -76,13 +76,13 @@ public class Node {
    * Returns a new data node.
    *
    * @param nodeId   the data node ID
-   * @param endpoint the data node endpoint
+   * @param address the data node address
    * @return a new data node
    */
-  public static Node data(NodeId nodeId, Endpoint endpoint) {
+  public static Node data(NodeId nodeId, Address address) {
     return builder(nodeId)
         .withType(Type.DATA)
-        .withEndpoint(endpoint)
+        .withAddress(address)
         .build();
   }
 
@@ -90,13 +90,13 @@ public class Node {
    * Returns a new client node.
    *
    * @param nodeId   the client node ID
-   * @param endpoint the client node endpoint
+   * @param address the client node address
    * @return a new client node
    */
-  public static Node client(NodeId nodeId, Endpoint endpoint) {
+  public static Node client(NodeId nodeId, Address address) {
     return builder(nodeId)
         .withType(Type.CLIENT)
-        .withEndpoint(endpoint)
+        .withAddress(address)
         .build();
   }
 
@@ -140,15 +140,15 @@ public class Node {
 
   private final NodeId id;
   private final Type type;
-  private final Endpoint endpoint;
+  private final Address address;
   private final String zone;
   private final String rack;
   private final String host;
 
-  protected Node(NodeId id, Type type, Endpoint endpoint, String zone, String rack, String host) {
+  protected Node(NodeId id, Type type, Address address, String zone, String rack, String host) {
     this.id = checkNotNull(id, "id cannot be null");
     this.type = checkNotNull(type, "type cannot be null");
-    this.endpoint = checkNotNull(endpoint, "endpoint cannot be null");
+    this.address = checkNotNull(address, "address cannot be null");
     this.zone = zone;
     this.rack = rack;
     this.host = host;
@@ -173,12 +173,12 @@ public class Node {
   }
 
   /**
-   * Returns the node endpoint.
+   * Returns the node address.
    *
-   * @return the node endpoint
+   * @return the node address
    */
-  public Endpoint endpoint() {
-    return endpoint;
+  public Address address() {
+    return address;
   }
 
   /**
@@ -232,7 +232,7 @@ public class Node {
     return toStringHelper(this)
         .add("id", id)
         .add("type", type)
-        .add("endpoint", endpoint)
+        .add("address", address)
         .add("zone", zone)
         .add("rack", rack)
         .add("host", host)
@@ -246,7 +246,7 @@ public class Node {
   public static class Builder implements io.atomix.utils.Builder<Node> {
     protected NodeId id;
     protected Type type;
-    protected Endpoint endpoint;
+    protected Address address;
     protected String zone;
     protected String rack;
     protected String host;
@@ -279,13 +279,13 @@ public class Node {
     }
 
     /**
-     * Sets the node endpoint.
+     * Sets the node address.
      *
-     * @param endpoint the node endpoint
+     * @param address the node address
      * @return the node builder
      */
-    public Builder withEndpoint(Endpoint endpoint) {
-      this.endpoint = checkNotNull(endpoint, "endpoint cannot be null");
+    public Builder withAddress(Address address) {
+      this.address = checkNotNull(address, "address cannot be null");
       return this;
     }
 
@@ -325,9 +325,9 @@ public class Node {
     @Override
     public Node build() {
       if (id == null) {
-        id = NodeId.from(endpoint.host().getHostName());
+        id = NodeId.from(address.ip().getHostName());
       }
-      return new Node(id, type, endpoint, zone, rack, host);
+      return new Node(id, type, address, zone, rack, host);
     }
   }
 }

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMetadataService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMetadataService.java
@@ -379,7 +379,7 @@ public class DefaultClusterMetadataService
   static class AddressSerializer extends com.esotericsoftware.kryo.Serializer<Address> {
     @Override
     public void write(Kryo kryo, Output output, Address address) {
-      output.writeString(address.ip().getHostAddress());
+      output.writeString(address.address().getHostAddress());
       output.writeInt(address.port());
     }
 

--- a/cluster/src/main/java/io/atomix/cluster/impl/ReplicatedNode.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/ReplicatedNode.java
@@ -17,7 +17,7 @@ package io.atomix.cluster.impl;
 
 import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeId;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.utils.time.LogicalTimestamp;
 import io.atomix.utils.time.Timestamp;
 
@@ -33,13 +33,13 @@ public class ReplicatedNode extends Node {
   public ReplicatedNode(
       NodeId id,
       Type type,
-      Endpoint endpoint,
+      Address address,
       String zone,
       String rack,
       String host,
       LogicalTimestamp timestamp,
       boolean tombstone) {
-    super(id, type, endpoint, zone, rack, host);
+    super(id, type, address, zone, rack, host);
     this.timestamp = checkNotNull(timestamp, "timestamp cannot be null");
     this.tombstone = tombstone;
   }

--- a/cluster/src/main/java/io/atomix/cluster/impl/StatefulNode.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/StatefulNode.java
@@ -17,7 +17,7 @@ package io.atomix.cluster.impl;
 
 import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeId;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 
 /**
  * Default cluster node.
@@ -28,11 +28,11 @@ public class StatefulNode extends Node {
   public StatefulNode(
       NodeId id,
       Type type,
-      Endpoint endpoint,
+      Address address,
       String zone,
       String rack,
       String host) {
-    super(id, type, endpoint, zone, rack, host);
+    super(id, type, address, zone, rack, host);
   }
 
   /**

--- a/cluster/src/main/java/io/atomix/cluster/messaging/ClusterMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/ClusterMessagingService.java
@@ -16,7 +16,7 @@
 package io.atomix.cluster.messaging;
 
 import io.atomix.cluster.NodeId;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -253,7 +253,7 @@ public interface ClusterMessagingService {
    */
   default <M> CompletableFuture<Void> subscribe(
           String subject,
-          BiConsumer<Endpoint, M> handler,
+          BiConsumer<Address, M> handler,
           Executor executor) {
     return subscribe(subject, BASIC::decode, handler, executor);
   }
@@ -287,7 +287,7 @@ public interface ClusterMessagingService {
   <M> CompletableFuture<Void> subscribe(
           String subject,
           Function<byte[], M> decoder,
-          BiConsumer<Endpoint, M> handler,
+          BiConsumer<Address, M> handler,
           Executor executor);
 
   /**

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
@@ -23,7 +23,7 @@ import io.atomix.cluster.ClusterMetadataService;
 import io.atomix.cluster.ManagedClusterMetadataService;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.utils.concurrent.Futures;
 import org.junit.Test;
 
@@ -59,7 +59,7 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode1 = buildNode(1, Node.Type.CORE);
     ManagedClusterMetadataService metadataService1 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.address()).start().join());
 
     metadataService1.start().join();
 
@@ -67,7 +67,7 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode2 = buildNode(2, Node.Type.CORE);
     ManagedClusterMetadataService metadataService2 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.address()).start().join());
     metadataService2.start().join();
     metadataService2.addNode(localNode2);
 
@@ -82,15 +82,15 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode1 = buildNode(1, Node.Type.CORE);
     ManagedClusterMetadataService metadataService1 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode1.address()).start().join());
 
     Node localNode2 = buildNode(2, Node.Type.CORE);
     ManagedClusterMetadataService metadataService2 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode2.address()).start().join());
 
     Node localNode3 = buildNode(3, Node.Type.CORE);
     ManagedClusterMetadataService metadataService3 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode3.endpoint()).start().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode3.address()).start().join());
 
     List<CompletableFuture<ClusterMetadataService>> futures = new ArrayList<>();
     futures.add(metadataService1.start());
@@ -104,7 +104,7 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode4 = buildNode(4, Node.Type.CORE);
     ManagedClusterMetadataService metadataService4 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode4.endpoint()).start().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode4.address()).start().join());
     metadataService4.start().join();
 
     assertEquals(3, metadataService4.getMetadata().bootstrapNodes().size());
@@ -134,7 +134,7 @@ public class DefaultClusterMetadataServiceTest {
 
     Node localNode5 = buildNode(5, Node.Type.CORE);
     ManagedClusterMetadataService metadataService5 = new DefaultClusterMetadataService(
-        clusterMetadata, messagingServiceFactory.newMessagingService(localNode5.endpoint()).start().join());
+        clusterMetadata, messagingServiceFactory.newMessagingService(localNode5.address()).start().join());
     metadataService5.start().join();
     assertEquals(4, metadataService5.getMetadata().bootstrapNodes().size());
   }
@@ -142,7 +142,7 @@ public class DefaultClusterMetadataServiceTest {
   private Node buildNode(int nodeId, Node.Type type) {
     return Node.builder(String.valueOf(nodeId))
         .withType(type)
-        .withEndpoint(new Endpoint(localhost, nodeId))
+        .withAddress(new Address(localhost, nodeId))
         .build();
   }
 
@@ -151,7 +151,7 @@ public class DefaultClusterMetadataServiceTest {
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
           .withType(Node.Type.CORE)
-          .withEndpoint(new Endpoint(localhost, bootstrapNode))
+          .withAddress(new Address(localhost, bootstrapNode))
           .build());
     }
     return ClusterMetadata.builder().withBootstrapNodes(bootstrap).build();

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMetadataServiceTest.java
@@ -23,12 +23,9 @@ import io.atomix.cluster.ClusterMetadataService;
 import io.atomix.cluster.ManagedClusterMetadataService;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
-import io.atomix.utils.net.Address;
 import io.atomix.utils.concurrent.Futures;
 import org.junit.Test;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -41,15 +38,6 @@ import static org.junit.Assert.assertEquals;
  * Default cluster metadata service test.
  */
 public class DefaultClusterMetadataServiceTest {
-  private final InetAddress localhost;
-
-  public DefaultClusterMetadataServiceTest() {
-    try {
-      localhost = InetAddress.getByName("127.0.0.1");
-    } catch (UnknownHostException e) {
-      throw new AssertionError();
-    }
-  }
 
   @Test
   public void testSingleNodeBootstrap() throws Exception {
@@ -142,7 +130,7 @@ public class DefaultClusterMetadataServiceTest {
   private Node buildNode(int nodeId, Node.Type type) {
     return Node.builder(String.valueOf(nodeId))
         .withType(type)
-        .withAddress(new Address(localhost, nodeId))
+        .withAddress(nodeId)
         .build();
   }
 
@@ -151,7 +139,7 @@ public class DefaultClusterMetadataServiceTest {
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
           .withType(Node.Type.CORE)
-          .withAddress(new Address(localhost, bootstrapNode))
+          .withAddress(bootstrapNode)
           .build());
     }
     return ClusterMetadata.builder().withBootstrapNodes(bootstrap).build();

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterServiceTest.java
@@ -22,11 +22,8 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.Node.State;
 import io.atomix.cluster.NodeId;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
-import io.atomix.utils.net.Address;
 import org.junit.Test;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -38,20 +35,11 @@ import static org.junit.Assert.assertNull;
  * Default cluster service test.
  */
 public class DefaultClusterServiceTest {
-  private final InetAddress localhost;
-
-  public DefaultClusterServiceTest() {
-    try {
-      localhost = InetAddress.getByName("127.0.0.1");
-    } catch (UnknownHostException e) {
-      throw new AssertionError();
-    }
-  }
 
   private Node buildNode(int nodeId, Node.Type type) {
     return Node.builder(String.valueOf(nodeId))
         .withType(type)
-        .withAddress(new Address(localhost, nodeId))
+        .withAddress(nodeId)
         .build();
   }
 
@@ -60,7 +48,7 @@ public class DefaultClusterServiceTest {
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
           .withType(Node.Type.CORE)
-          .withAddress(new Address(localhost, bootstrapNode))
+          .withAddress(bootstrapNode)
           .build());
     }
     return ClusterMetadata.builder().withBootstrapNodes(bootstrap).build();

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterServiceTest.java
@@ -22,7 +22,7 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.Node.State;
 import io.atomix.cluster.NodeId;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -51,7 +51,7 @@ public class DefaultClusterServiceTest {
   private Node buildNode(int nodeId, Node.Type type) {
     return Node.builder(String.valueOf(nodeId))
         .withType(type)
-        .withEndpoint(new Endpoint(localhost, nodeId))
+        .withAddress(new Address(localhost, nodeId))
         .build();
   }
 
@@ -60,7 +60,7 @@ public class DefaultClusterServiceTest {
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
           .withType(Node.Type.CORE)
-          .withEndpoint(new Endpoint(localhost, bootstrapNode))
+          .withAddress(new Address(localhost, bootstrapNode))
           .build());
     }
     return ClusterMetadata.builder().withBootstrapNodes(bootstrap).build();
@@ -76,19 +76,19 @@ public class DefaultClusterServiceTest {
     ManagedClusterService clusterService1 = new DefaultClusterService(
         localNode1,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(localNode1.endpoint()).start().join());
+        messagingServiceFactory.newMessagingService(localNode1.address()).start().join());
 
     Node localNode2 = buildNode(2, Node.Type.CORE);
     ManagedClusterService clusterService2 = new DefaultClusterService(
         localNode2,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(localNode2.endpoint()).start().join());
+        messagingServiceFactory.newMessagingService(localNode2.address()).start().join());
 
     Node localNode3 = buildNode(3, Node.Type.CORE);
     ManagedClusterService clusterService3 = new DefaultClusterService(
         localNode3,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(localNode3.endpoint()).start().join());
+        messagingServiceFactory.newMessagingService(localNode3.address()).start().join());
 
     assertNull(clusterService1.getNode(NodeId.from("1")));
     assertNull(clusterService1.getNode(NodeId.from("2")));
@@ -122,7 +122,7 @@ public class DefaultClusterServiceTest {
     ManagedClusterService dataClusterService = new DefaultClusterService(
         dataNode,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(dataNode.endpoint()).start().join());
+        messagingServiceFactory.newMessagingService(dataNode.address()).start().join());
 
     assertEquals(State.INACTIVE, dataClusterService.getLocalNode().getState());
 
@@ -146,7 +146,7 @@ public class DefaultClusterServiceTest {
     ManagedClusterService clientClusterService = new DefaultClusterService(
         clientNode,
         new TestClusterMetadataService(clusterMetadata),
-        messagingServiceFactory.newMessagingService(clientNode.endpoint()).start().join());
+        messagingServiceFactory.newMessagingService(clientNode.address()).start().join());
 
     assertEquals(State.INACTIVE, clientClusterService.getLocalNode().getState());
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventingServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventingServiceTest.java
@@ -22,14 +22,11 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.impl.DefaultClusterService;
 import io.atomix.cluster.impl.TestClusterMetadataService;
 import io.atomix.cluster.messaging.ClusterEventingService;
-import io.atomix.utils.net.Address;
 import io.atomix.messaging.MessagingService;
 import io.atomix.utils.serializer.KryoNamespaces;
 import io.atomix.utils.serializer.Serializer;
 import org.junit.Test;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -43,20 +40,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class DefaultClusterEventingServiceTest {
   private static final Serializer SERIALIZER = Serializer.using(KryoNamespaces.BASIC);
-  private final InetAddress localhost;
-
-  public DefaultClusterEventingServiceTest() {
-    try {
-      localhost = InetAddress.getByName("127.0.0.1");
-    } catch (UnknownHostException e) {
-      throw new AssertionError();
-    }
-  }
 
   private Node buildNode(int nodeId, Node.Type type) {
     return Node.builder(String.valueOf(nodeId))
         .withType(type)
-        .withAddress(new Address(localhost, nodeId))
+        .withAddress(nodeId)
         .build();
   }
 
@@ -65,7 +53,7 @@ public class DefaultClusterEventingServiceTest {
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
           .withType(Node.Type.CORE)
-          .withAddress(new Address(localhost, bootstrapNode))
+          .withAddress(bootstrapNode)
           .build());
     }
     return ClusterMetadata.builder().withBootstrapNodes(bootstrap).build();

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventingServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventingServiceTest.java
@@ -22,7 +22,7 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.impl.DefaultClusterService;
 import io.atomix.cluster.impl.TestClusterMetadataService;
 import io.atomix.cluster.messaging.ClusterEventingService;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.MessagingService;
 import io.atomix.utils.serializer.KryoNamespaces;
 import io.atomix.utils.serializer.Serializer;
@@ -56,7 +56,7 @@ public class DefaultClusterEventingServiceTest {
   private Node buildNode(int nodeId, Node.Type type) {
     return Node.builder(String.valueOf(nodeId))
         .withType(type)
-        .withEndpoint(new Endpoint(localhost, nodeId))
+        .withAddress(new Address(localhost, nodeId))
         .build();
   }
 
@@ -65,7 +65,7 @@ public class DefaultClusterEventingServiceTest {
     for (int bootstrapNode : bootstrapNodes) {
       bootstrap.add(Node.builder(String.valueOf(bootstrapNode))
           .withType(Node.Type.CORE)
-          .withEndpoint(new Endpoint(localhost, bootstrapNode))
+          .withAddress(new Address(localhost, bootstrapNode))
           .build());
     }
     return ClusterMetadata.builder().withBootstrapNodes(bootstrap).build();
@@ -78,17 +78,17 @@ public class DefaultClusterEventingServiceTest {
     ClusterMetadata clusterMetadata = buildClusterMetadata(1, 1, 2, 3);
 
     Node localNode1 = buildNode(1, Node.Type.CORE);
-    MessagingService messagingService1 = factory.newMessagingService(localNode1.endpoint()).start().join();
+    MessagingService messagingService1 = factory.newMessagingService(localNode1.address()).start().join();
     ClusterService clusterService1 = new DefaultClusterService(localNode1, new TestClusterMetadataService(clusterMetadata), messagingService1).start().join();
     ClusterEventingService eventService1 = new DefaultClusterEventingService(clusterService1, messagingService1).start().join();
 
     Node localNode2 = buildNode(2, Node.Type.CORE);
-    MessagingService messagingService2 = factory.newMessagingService(localNode2.endpoint()).start().join();
+    MessagingService messagingService2 = factory.newMessagingService(localNode2.address()).start().join();
     ClusterService clusterService2 = new DefaultClusterService(localNode2, new TestClusterMetadataService(clusterMetadata), messagingService2).start().join();
     ClusterEventingService eventService2 = new DefaultClusterEventingService(clusterService2, messagingService2).start().join();
 
     Node localNode3 = buildNode(3, Node.Type.CORE);
-    MessagingService messagingService3 = factory.newMessagingService(localNode3.endpoint()).start().join();
+    MessagingService messagingService3 = factory.newMessagingService(localNode3.address()).start().join();
     ClusterService clusterService3 = new DefaultClusterService(localNode3, new TestClusterMetadataService(clusterMetadata), messagingService3).start().join();
     ClusterEventingService eventService3 = new DefaultClusterEventingService(clusterService3, messagingService3).start().join();
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.cluster.messaging.impl;
 
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.ManagedMessagingService;
 import io.atomix.messaging.MessagingException.NoRemoteHandler;
 import io.atomix.messaging.MessagingService;
@@ -37,33 +37,33 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Test messaging service.
  */
 public class TestMessagingService implements ManagedMessagingService {
-  private final Endpoint endpoint;
-  private final Map<Endpoint, TestMessagingService> services;
-  private final Map<String, BiFunction<Endpoint, byte[], CompletableFuture<byte[]>>> handlers = new ConcurrentHashMap<>();
+  private final Address address;
+  private final Map<Address, TestMessagingService> services;
+  private final Map<String, BiFunction<Address, byte[], CompletableFuture<byte[]>>> handlers = new ConcurrentHashMap<>();
   private final AtomicBoolean started = new AtomicBoolean();
 
-  public TestMessagingService(Endpoint endpoint, Map<Endpoint, TestMessagingService> services) {
-    this.endpoint = endpoint;
+  public TestMessagingService(Address address, Map<Address, TestMessagingService> services) {
+    this.address = address;
     this.services = services;
   }
 
   /**
-   * Returns the test service for the given endpoint or {@code null} if none has been created.
+   * Returns the test service for the given address or {@code null} if none has been created.
    */
-  private TestMessagingService getService(Endpoint endpoint) {
-    checkNotNull(endpoint);
-    return services.get(endpoint);
+  private TestMessagingService getService(Address address) {
+    checkNotNull(address);
+    return services.get(address);
   }
 
   /**
-   * Returns the given handler for the given endpoint.
+   * Returns the given handler for the given address.
    */
-  private BiFunction<Endpoint, byte[], CompletableFuture<byte[]>> getHandler(Endpoint endpoint, String type) {
-    TestMessagingService service = getService(endpoint);
+  private BiFunction<Address, byte[], CompletableFuture<byte[]>> getHandler(Address address, String type) {
+    TestMessagingService service = getService(address);
     if (service == null) {
       return (e, p) -> Futures.exceptionalFuture(new NoRemoteHandler());
     }
-    BiFunction<Endpoint, byte[], CompletableFuture<byte[]>> handler = service.handlers.get(checkNotNull(type));
+    BiFunction<Address, byte[], CompletableFuture<byte[]>> handler = service.handlers.get(checkNotNull(type));
     if (handler == null) {
       return (e, p) -> Futures.exceptionalFuture(new NoRemoteHandler());
     }
@@ -71,29 +71,29 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public Endpoint endpoint() {
-    return endpoint;
+  public Address address() {
+    return address;
   }
 
   @Override
-  public CompletableFuture<Void> sendAsync(Endpoint ep, String type, byte[] payload) {
-    return getHandler(ep, type).apply(endpoint, payload).thenApply(v -> null);
+  public CompletableFuture<Void> sendAsync(Address ep, String type, byte[] payload) {
+    return getHandler(ep, type).apply(address, payload).thenApply(v -> null);
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Endpoint ep, String type, byte[] payload) {
-    return getHandler(ep, type).apply(endpoint, payload);
+  public CompletableFuture<byte[]> sendAndReceive(Address ep, String type, byte[] payload) {
+    return getHandler(ep, type).apply(address, payload);
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Endpoint ep, String type, byte[] payload, Executor executor) {
+  public CompletableFuture<byte[]> sendAndReceive(Address ep, String type, byte[] payload, Executor executor) {
     ComposableFuture<byte[]> future = new ComposableFuture<>();
     sendAndReceive(ep, type, payload).whenCompleteAsync(future, executor);
     return future;
   }
 
   @Override
-  public void registerHandler(String type, BiConsumer<Endpoint, byte[]> handler, Executor executor) {
+  public void registerHandler(String type, BiConsumer<Address, byte[]> handler, Executor executor) {
     checkNotNull(type);
     checkNotNull(handler);
     handlers.put(type, (e, p) -> {
@@ -107,7 +107,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public void registerHandler(String type, BiFunction<Endpoint, byte[], byte[]> handler, Executor executor) {
+  public void registerHandler(String type, BiFunction<Address, byte[], byte[]> handler, Executor executor) {
     checkNotNull(type);
     checkNotNull(handler);
     handlers.put(type, (e, p) -> {
@@ -122,7 +122,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public void registerHandler(String type, BiFunction<Endpoint, byte[], CompletableFuture<byte[]>> handler) {
+  public void registerHandler(String type, BiFunction<Address, byte[], CompletableFuture<byte[]>> handler) {
     checkNotNull(type);
     checkNotNull(handler);
     handlers.put(type, handler);
@@ -135,7 +135,7 @@ public class TestMessagingService implements ManagedMessagingService {
 
   @Override
   public CompletableFuture<MessagingService> start() {
-    services.put(endpoint, this);
+    services.put(address, this);
     started.set(true);
     return CompletableFuture.completedFuture(this);
   }
@@ -147,7 +147,7 @@ public class TestMessagingService implements ManagedMessagingService {
 
   @Override
   public CompletableFuture<Void> stop() {
-    services.remove(endpoint);
+    services.remove(address);
     started.set(false);
     return CompletableFuture.completedFuture(null);
   }

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingServiceFactory.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingServiceFactory.java
@@ -16,7 +16,7 @@
 package io.atomix.cluster.messaging.impl;
 
 import com.google.common.collect.Maps;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.ManagedMessagingService;
 
 import java.util.Map;
@@ -25,15 +25,15 @@ import java.util.Map;
  * Test messaging service factory.
  */
 public class TestMessagingServiceFactory {
-  private final Map<Endpoint, TestMessagingService> services = Maps.newConcurrentMap();
+  private final Map<Address, TestMessagingService> services = Maps.newConcurrentMap();
 
   /**
-   * Returns a new test messaging service for the given endpoint.
+   * Returns a new test messaging service for the given address.
    *
-   * @param endpoint the endpoint for which to return a messaging service
-   * @return the messaging service for the given endpoint
+   * @param address the address for which to return a messaging service
+   * @return the messaging service for the given address
    */
-  public ManagedMessagingService newMessagingService(Endpoint endpoint) {
-    return new TestMessagingService(endpoint, services);
+  public ManagedMessagingService newMessagingService(Address address) {
+    return new TestMessagingService(address, services);
   }
 }

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -494,15 +494,11 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
     public Atomix build() {
       // If the local node has not be configured, create a default node.
       if (localNode == null) {
-        try {
-          InetAddress address = getLocalAddress();
-          localNode = Node.builder(address.getHostName())
-              .withType(Node.Type.CORE)
-              .withAddress(new Address(address, NettyMessagingService.DEFAULT_PORT))
-              .build();
-        } catch (UnknownHostException e) {
-          throw new ConfigurationException("Cannot configure local node", e);
-        }
+        Address address = Address.from(NettyMessagingService.DEFAULT_PORT);
+        localNode = Node.builder(address.toString())
+            .withType(Node.Type.CORE)
+            .withAddress(address)
+            .build();
       }
 
       // If the bootstrap nodes have not been configured, default to the local node if possible.

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -32,7 +32,7 @@ import io.atomix.cluster.messaging.impl.DefaultClusterMessagingService;
 import io.atomix.core.generator.impl.IdGeneratorSessionIdService;
 import io.atomix.core.impl.CorePrimitivesService;
 import io.atomix.core.transaction.TransactionBuilder;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.ManagedMessagingService;
 import io.atomix.messaging.MessagingService;
 import io.atomix.messaging.impl.NettyMessagingService;
@@ -498,7 +498,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
           InetAddress address = getLocalAddress();
           localNode = Node.builder(address.getHostName())
               .withType(Node.Type.CORE)
-              .withEndpoint(new Endpoint(address, NettyMessagingService.DEFAULT_PORT))
+              .withAddress(new Address(address, NettyMessagingService.DEFAULT_PORT))
               .build();
         } catch (UnknownHostException e) {
           throw new ConfigurationException("Cannot configure local node", e);
@@ -547,7 +547,7 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
     protected ManagedMessagingService buildMessagingService() {
       return NettyMessagingService.builder()
           .withName(name)
-          .withEndpoint(localNode.endpoint())
+          .withAddress(localNode.address())
           .build();
     }
 

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -20,7 +20,7 @@ import io.atomix.cluster.ManagedClusterService;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.messaging.ManagedClusterEventingService;
 import io.atomix.cluster.messaging.ManagedClusterMessagingService;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.ManagedMessagingService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
@@ -64,13 +64,13 @@ public abstract class AbstractAtomixTest {
   protected static Atomix createAtomix(Node.Type type, int id, Integer... ids) {
     Node localNode = Node.builder(String.valueOf(id))
         .withType(type)
-        .withEndpoint(Endpoint.from("localhost", BASE_PORT + id))
+        .withAddress(Address.from("localhost", BASE_PORT + id))
         .build();
 
     Collection<Node> bootstrapNodes = Stream.of(ids)
         .map(nodeId -> Node.builder(String.valueOf(nodeId))
             .withType(Node.Type.CORE)
-            .withEndpoint(Endpoint.from("localhost", BASE_PORT + nodeId))
+            .withAddress(Address.from("localhost", BASE_PORT + nodeId))
             .build())
         .collect(Collectors.toList());
 
@@ -122,7 +122,7 @@ public abstract class AbstractAtomixTest {
     static class Builder extends Atomix.Builder {
       @Override
       protected ManagedMessagingService buildMessagingService() {
-        return messagingServiceFactory.newMessagingService(localNode.endpoint());
+        return messagingServiceFactory.newMessagingService(localNode.address());
       }
 
       @Override

--- a/core/src/test/java/io/atomix/core/TestMessagingServiceFactory.java
+++ b/core/src/test/java/io/atomix/core/TestMessagingServiceFactory.java
@@ -16,7 +16,7 @@
 package io.atomix.core;
 
 import com.google.common.collect.Maps;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.ManagedMessagingService;
 
 import java.util.Map;
@@ -25,15 +25,15 @@ import java.util.Map;
  * Test messaging service factory.
  */
 public class TestMessagingServiceFactory {
-  private final Map<Endpoint, TestMessagingService> services = Maps.newConcurrentMap();
+  private final Map<Address, TestMessagingService> services = Maps.newConcurrentMap();
 
   /**
-   * Returns a new test messaging service for the given endpoint.
+   * Returns a new test messaging service for the given address.
    *
-   * @param endpoint the endpoint for which to return a messaging service
-   * @return the messaging service for the given endpoint
+   * @param address the address for which to return a messaging service
+   * @return the messaging service for the given address
    */
-  public ManagedMessagingService newMessagingService(Endpoint endpoint) {
-    return new TestMessagingService(endpoint, services);
+  public ManagedMessagingService newMessagingService(Address address) {
+    return new TestMessagingService(address, services);
   }
 }

--- a/messaging/src/main/java/io/atomix/messaging/MessagingService.java
+++ b/messaging/src/main/java/io/atomix/messaging/MessagingService.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.messaging;
 
+import io.atomix.utils.net.Address;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
@@ -26,43 +28,43 @@ import java.util.function.BiFunction;
 public interface MessagingService {
 
   /**
-   * Returns the local messaging service endpoint.
+   * Returns the local messaging service address.
    *
-   * @return the local endpoint
+   * @return the local address
    */
-  Endpoint endpoint();
+  Address address();
 
   /**
-   * Sends a message asynchronously to the specified communication end point.
+   * Sends a message asynchronously to the specified communication address.
    * The message is specified using the type and payload.
    *
-   * @param ep      end point to send the message to.
+   * @param address address to send the message to.
    * @param type    type of message.
    * @param payload message payload bytes.
    * @return future that is completed when the message is sent
    */
-  CompletableFuture<Void> sendAsync(Endpoint ep, String type, byte[] payload);
+  CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload);
 
   /**
    * Sends a message asynchronously and expects a response.
    *
-   * @param ep      end point to send the message to.
+   * @param address address to send the message to.
    * @param type    type of message.
    * @param payload message payload.
    * @return a response future
    */
-  CompletableFuture<byte[]> sendAndReceive(Endpoint ep, String type, byte[] payload);
+  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload);
 
   /**
    * Sends a message synchronously and expects a response.
    *
-   * @param ep       end point to send the message to.
+   * @param address  address to send the message to.
    * @param type     type of message.
    * @param payload  message payload.
    * @param executor executor over which any follow up actions after completion will be executed.
    * @return a response future
    */
-  CompletableFuture<byte[]> sendAndReceive(Endpoint ep, String type, byte[] payload, Executor executor);
+  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Executor executor);
 
   /**
    * Registers a new message handler for message type.
@@ -71,7 +73,7 @@ public interface MessagingService {
    * @param handler  message handler
    * @param executor executor to use for running message handler logic.
    */
-  void registerHandler(String type, BiConsumer<Endpoint, byte[]> handler, Executor executor);
+  void registerHandler(String type, BiConsumer<Address, byte[]> handler, Executor executor);
 
   /**
    * Registers a new message handler for message type.
@@ -80,7 +82,7 @@ public interface MessagingService {
    * @param handler  message handler
    * @param executor executor to use for running message handler logic.
    */
-  void registerHandler(String type, BiFunction<Endpoint, byte[], byte[]> handler, Executor executor);
+  void registerHandler(String type, BiFunction<Address, byte[], byte[]> handler, Executor executor);
 
   /**
    * Registers a new message handler for message type.
@@ -88,7 +90,7 @@ public interface MessagingService {
    * @param type    message type.
    * @param handler message handler
    */
-  void registerHandler(String type, BiFunction<Endpoint, byte[], CompletableFuture<byte[]>> handler);
+  void registerHandler(String type, BiFunction<Address, byte[], CompletableFuture<byte[]>> handler);
 
   /**
    * Unregister current handler, if one exists for message type.

--- a/messaging/src/main/java/io/atomix/messaging/impl/InternalRequest.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/InternalRequest.java
@@ -16,20 +16,20 @@
 package io.atomix.messaging.impl;
 
 import com.google.common.base.MoreObjects;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.utils.ArraySizeHashPrinter;
 
 /**
  * Internal request message.
  */
 public final class InternalRequest extends InternalMessage {
-    private final Endpoint sender;
+    private final Address sender;
     private final String subject;
 
     public InternalRequest(
         int preamble,
         long id,
-        Endpoint sender,
+        Address sender,
         String subject,
         byte[] payload) {
         super(preamble, id, payload);
@@ -46,7 +46,7 @@ public final class InternalRequest extends InternalMessage {
         return subject;
     }
 
-    public Endpoint sender() {
+    public Address sender() {
         return sender;
     }
 

--- a/messaging/src/main/java/io/atomix/messaging/impl/MessageDecoder.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/MessageDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.messaging.impl;
 
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -152,7 +152,7 @@ public class MessageDecoder extends ByteToMessageDecoder {
             InternalRequest message = new InternalRequest(
                 preamble,
                 messageId,
-                new Endpoint(senderIp, senderPort),
+                new Address(senderIp, senderPort),
                 subject,
                 content);
             out.add(message);

--- a/messaging/src/main/java/io/atomix/messaging/impl/MessageDecoder.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/MessageDecoder.java
@@ -47,6 +47,7 @@ public class MessageDecoder extends ByteToMessageDecoder {
 
   private InetAddress senderIp;
   private int senderPort;
+  private Address address;
 
   private InternalMessage.Type type;
   private int preamble;
@@ -83,6 +84,7 @@ public class MessageDecoder extends ByteToMessageDecoder {
           return;
         }
         senderPort = buffer.readInt();
+        address = new Address(senderIp.getHostName(), senderPort, senderIp);
         currentState = DecoderState.READ_TYPE;
       case READ_TYPE:
         if (buffer.readableBytes() < BYTE_SIZE) {
@@ -152,7 +154,7 @@ public class MessageDecoder extends ByteToMessageDecoder {
             InternalRequest message = new InternalRequest(
                 preamble,
                 messageId,
-                new Address(senderIp, senderPort),
+                address,
                 subject,
                 content);
             out.add(message);

--- a/messaging/src/main/java/io/atomix/messaging/impl/MessageEncoder.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/MessageEncoder.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.messaging.impl;
 
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
@@ -35,13 +35,13 @@ public class MessageEncoder extends MessageToByteEncoder<Object> {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private final Endpoint endpoint;
+  private final Address address;
   private final int preamble;
-  private boolean endpointWritten;
+  private boolean addressWritten;
 
-  public MessageEncoder(Endpoint endpoint, int preamble) {
+  public MessageEncoder(Address address, int preamble) {
     super();
-    this.endpoint = endpoint;
+    this.address = address;
     this.preamble = preamble;
   }
 
@@ -58,17 +58,17 @@ public class MessageEncoder extends MessageToByteEncoder<Object> {
   }
 
   private void encodeMessage(InternalMessage message, ByteBuf out) {
-    // If the endpoint hasn't been written to the channel, write it.
-    if (!endpointWritten) {
-      final InetAddress senderIp = endpoint.host();
+    // If the address hasn't been written to the channel, write it.
+    if (!addressWritten) {
+      final InetAddress senderIp = address.ip();
       final byte[] senderIpBytes = senderIp.getAddress();
       out.writeByte(senderIpBytes.length);
       out.writeBytes(senderIpBytes);
 
       // write sender port
-      out.writeInt(endpoint.port());
+      out.writeInt(address.port());
 
-      endpointWritten = true;
+      addressWritten = true;
     }
 
     out.writeByte(message.type().id());

--- a/messaging/src/main/java/io/atomix/messaging/impl/MessageEncoder.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/MessageEncoder.java
@@ -60,7 +60,7 @@ public class MessageEncoder extends MessageToByteEncoder<Object> {
   private void encodeMessage(InternalMessage message, ByteBuf out) {
     // If the address hasn't been written to the channel, write it.
     if (!addressWritten) {
-      final InetAddress senderIp = address.ip();
+      final InetAddress senderIp = address.address();
       final byte[] senderIpBytes = senderIp.getAddress();
       out.writeByte(senderIpBytes.length);
       out.writeBytes(senderIpBytes);

--- a/messaging/src/test/java/io/atomix/messaging/impl/NettyMessagingServiceTest.java
+++ b/messaging/src/test/java/io/atomix/messaging/impl/NettyMessagingServiceTest.java
@@ -17,8 +17,8 @@ package io.atomix.messaging.impl;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
-import io.atomix.utils.net.Address;
 import io.atomix.messaging.ManagedMessagingService;
+import io.atomix.utils.net.Address;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -62,21 +62,21 @@ public class NettyMessagingServiceTest {
 
   @Before
   public void setUp() throws Exception {
-    ep1 = new Address(InetAddress.getByName("127.0.0.1"), findAvailablePort(5001));
+    ep1 = Address.from(findAvailablePort(5001));
     netty1 = (ManagedMessagingService) NettyMessagingService.builder()
         .withAddress(ep1)
         .build()
         .start()
         .join();
 
-    ep2 = new Address(InetAddress.getByName("127.0.0.1"), findAvailablePort(5003));
+    ep2 = Address.from(findAvailablePort(5003));
     netty2 = (ManagedMessagingService) NettyMessagingService.builder()
         .withAddress(ep2)
         .build()
         .start()
         .join();
 
-    invalidAddress = new Address(InetAddress.getByName(IP_STRING), 5003);
+    invalidAddress = Address.from(IP_STRING, 5003);
   }
 
   /**

--- a/protocols/primary-backup/src/test/java/io/atomix/cluster/TestClusterService.java
+++ b/protocols/primary-backup/src/test/java/io/atomix/cluster/TestClusterService.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.cluster;
 
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 
 import java.util.Collection;
 import java.util.Set;
@@ -37,7 +37,7 @@ public class TestClusterService implements ClusterService {
   public Node getLocalNode() {
     return Node.builder(localNode)
         .withType(Node.Type.CORE)
-        .withEndpoint(Endpoint.from("localhost", localNode.hashCode()))
+        .withAddress(Address.from("localhost", localNode.hashCode()))
         .build();
   }
 
@@ -46,7 +46,7 @@ public class TestClusterService implements ClusterService {
     return nodes.stream()
         .map(node -> Node.builder(node)
             .withType(Node.Type.CORE)
-            .withEndpoint(Endpoint.from("localhost", node.hashCode()))
+            .withAddress(Address.from("localhost", node.hashCode()))
             .build())
         .collect(Collectors.toSet());
   }

--- a/rest/src/main/java/io/atomix/rest/RestService.java
+++ b/rest/src/main/java/io/atomix/rest/RestService.java
@@ -16,7 +16,7 @@
 package io.atomix.rest;
 
 import io.atomix.core.Atomix;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.rest.impl.VertxRestService;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -39,18 +39,18 @@ public interface RestService {
    * REST service builder.
    */
   abstract class Builder implements io.atomix.utils.Builder<ManagedRestService> {
-    protected Endpoint endpoint;
+    protected Address address;
     protected Atomix atomix;
 
     /**
-     * Sets the REST service endpoint.
+     * Sets the REST service address.
      *
-     * @param endpoint the REST service endpoint
+     * @param address the REST service address
      * @return the REST service builder
-     * @throws NullPointerException if the endpoint is null
+     * @throws NullPointerException if the address is null
      */
-    public Builder withEndpoint(Endpoint endpoint) {
-      this.endpoint = checkNotNull(endpoint, "endpoint cannot be null");
+    public Builder withAddress(Address address) {
+      this.address = checkNotNull(address, "address cannot be null");
       return this;
     }
 

--- a/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
+++ b/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
@@ -20,7 +20,7 @@ import io.atomix.cluster.messaging.ClusterMessagingService;
 import io.atomix.core.Atomix;
 import io.atomix.core.PrimitivesService;
 import io.atomix.cluster.messaging.ClusterEventingService;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.rest.ManagedRestService;
 import io.atomix.rest.RestService;
 import io.atomix.rest.resources.ClusterResource;
@@ -50,15 +50,15 @@ public class VertxRestService implements ManagedRestService {
   private static final int PRIMITIVE_CACHE_SIZE = 1000;
 
   private final Atomix atomix;
-  private final Endpoint endpoint;
+  private final Address address;
   private final Vertx vertx;
   private HttpServer server;
   private VertxResteasyDeployment deployment;
   private final AtomicBoolean open = new AtomicBoolean();
 
-  public VertxRestService(Atomix atomix, Endpoint endpoint) {
+  public VertxRestService(Atomix atomix, Address address) {
     this.atomix = checkNotNull(atomix, "atomix cannot be null");
-    this.endpoint = checkNotNull(endpoint, "endpoint cannot be null");
+    this.address = checkNotNull(address, "address cannot be null");
     this.vertx = Vertx.vertx();
   }
 
@@ -90,7 +90,7 @@ public class VertxRestService implements ManagedRestService {
     server.requestHandler(new VertxRequestHandler(vertx, deployment));
 
     CompletableFuture<RestService> future = new CompletableFuture<>();
-    server.listen(endpoint.port(), endpoint.host().getHostAddress(), result -> {
+    server.listen(address.port(), address.ip().getHostAddress(), result -> {
       if (result.succeeded()) {
         open.set(true);
         LOGGER.info("Started");
@@ -131,10 +131,10 @@ public class VertxRestService implements ManagedRestService {
 
     @Override
     public ManagedRestService build() {
-      if (endpoint == null) {
-        endpoint = Endpoint.from(DEFAULT_HOST, DEFAULT_PORT);
+      if (address == null) {
+        address = Address.from(DEFAULT_HOST, DEFAULT_PORT);
       }
-      return new VertxRestService(atomix, endpoint);
+      return new VertxRestService(atomix, address);
     }
   }
 }

--- a/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
+++ b/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
@@ -90,7 +90,7 @@ public class VertxRestService implements ManagedRestService {
     server.requestHandler(new VertxRequestHandler(vertx, deployment));
 
     CompletableFuture<RestService> future = new CompletableFuture<>();
-    server.listen(address.port(), address.ip().getHostAddress(), result -> {
+    server.listen(address.port(), address.address().getHostAddress(), result -> {
       if (result.succeeded()) {
         open.set(true);
         LOGGER.info("Started");

--- a/rest/src/main/java/io/atomix/rest/resources/ClusterResource.java
+++ b/rest/src/main/java/io/atomix/rest/resources/ClusterResource.java
@@ -220,7 +220,7 @@ public class ClusterResource extends AbstractRestResource {
     }
 
     public String getHost() {
-      return node.address().ip().getHostAddress();
+      return node.address().address().getHostAddress();
     }
 
     public int getPort() {

--- a/rest/src/main/java/io/atomix/rest/resources/ClusterResource.java
+++ b/rest/src/main/java/io/atomix/rest/resources/ClusterResource.java
@@ -220,11 +220,11 @@ public class ClusterResource extends AbstractRestResource {
     }
 
     public String getHost() {
-      return node.endpoint().host().getHostAddress();
+      return node.address().ip().getHostAddress();
     }
 
     public int getPort() {
-      return node.endpoint().port();
+      return node.address().port();
     }
 
     public Node.Type getType() {

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftFuzzTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftFuzzTest.java
@@ -17,7 +17,7 @@ package io.atomix.protocols.raft;
 
 import com.google.common.collect.Maps;
 import io.atomix.cluster.NodeId;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.MessagingService;
 import io.atomix.messaging.impl.NettyMessagingService;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
@@ -239,7 +239,7 @@ public class RaftFuzzTest implements Runnable {
   private Map<Integer, Scheduled> restartTimers = new ConcurrentHashMap<>();
   private LocalRaftProtocolFactory protocolFactory;
   private List<MessagingService> messagingServices = new ArrayList<>();
-  private Map<NodeId, Endpoint> endpointMap = new ConcurrentHashMap<>();
+  private Map<NodeId, Address> addressMap = new ConcurrentHashMap<>();
   private static final String[] KEYS = new String[1024];
   private final Random random = new Random();
 
@@ -559,11 +559,11 @@ public class RaftFuzzTest implements Runnable {
     RaftServerProtocol protocol;
     if (USE_NETTY) {
       try {
-        Endpoint endpoint = new Endpoint(InetAddress.getLocalHost(), ++port);
-        MessagingService messagingManager = NettyMessagingService.builder().withEndpoint(endpoint).build().start().join();
+        Address address = new Address(InetAddress.getLocalHost(), ++port);
+        MessagingService messagingManager = NettyMessagingService.builder().withAddress(address).build().start().join();
         messagingServices.add(messagingManager);
-        endpointMap.put(member.nodeId(), endpoint);
-        protocol = new RaftServerMessagingProtocol(messagingManager, protocolSerializer, endpointMap::get);
+        addressMap.put(member.nodeId(), address);
+        protocol = new RaftServerMessagingProtocol(messagingManager, protocolSerializer, addressMap::get);
       } catch (UnknownHostException e) {
         throw new RuntimeException(e);
       }
@@ -594,10 +594,10 @@ public class RaftFuzzTest implements Runnable {
 
     RaftClientProtocol protocol;
     if (USE_NETTY) {
-      Endpoint endpoint = new Endpoint(InetAddress.getLocalHost(), ++port);
-      MessagingService messagingManager = NettyMessagingService.builder().withEndpoint(endpoint).build().start().join();
-      endpointMap.put(nodeId, endpoint);
-      protocol = new RaftClientMessagingProtocol(messagingManager, protocolSerializer, endpointMap::get);
+      Address address = new Address(InetAddress.getLocalHost(), ++port);
+      MessagingService messagingManager = NettyMessagingService.builder().withAddress(address).build().start().join();
+      addressMap.put(nodeId, address);
+      protocol = new RaftClientMessagingProtocol(messagingManager, protocolSerializer, addressMap::get);
     } else {
       protocol = protocolFactory.newClientProtocol(nodeId);
     }

--- a/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftClientMessagingProtocol.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftClientMessagingProtocol.java
@@ -16,7 +16,7 @@
 package io.atomix.protocols.raft.protocol;
 
 import io.atomix.cluster.NodeId;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.MessagingService;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.Serializer;
@@ -31,8 +31,8 @@ import java.util.function.Function;
  * Raft client messaging service protocol.
  */
 public class RaftClientMessagingProtocol extends RaftMessagingProtocol implements RaftClientProtocol {
-  public RaftClientMessagingProtocol(MessagingService messagingService, Serializer serializer, Function<NodeId, Endpoint> endpointProvider) {
-    super(messagingService, serializer, endpointProvider);
+  public RaftClientMessagingProtocol(MessagingService messagingService, Serializer serializer, Function<NodeId, Address> addressProvider) {
+    super(messagingService, serializer, addressProvider);
   }
 
   @Override

--- a/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftServerMessagingProtocol.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/protocol/RaftServerMessagingProtocol.java
@@ -16,7 +16,7 @@
 package io.atomix.protocols.raft.protocol;
 
 import io.atomix.cluster.NodeId;
-import io.atomix.messaging.Endpoint;
+import io.atomix.utils.net.Address;
 import io.atomix.messaging.MessagingService;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.Serializer;
@@ -30,8 +30,8 @@ import java.util.function.Function;
  * Raft server messaging protocol.
  */
 public class RaftServerMessagingProtocol extends RaftMessagingProtocol implements RaftServerProtocol {
-  public RaftServerMessagingProtocol(MessagingService messagingService, Serializer serializer, Function<NodeId, Endpoint> endpointProvider) {
-    super(messagingService, serializer, endpointProvider);
+  public RaftServerMessagingProtocol(MessagingService messagingService, Serializer serializer, Function<NodeId, Address> addressProvider) {
+    super(messagingService, serializer, addressProvider);
   }
 
   @Override

--- a/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.messaging;
+package io.atomix.utils.net;
 
 import com.google.common.base.Preconditions;
 
@@ -22,28 +22,34 @@ import java.net.UnknownHostException;
 import java.util.Objects;
 
 /**
- * Representation of a TCP/UDP communication end point.
+ * Representation of a network address.
  */
-public final class Endpoint {
+public final class Address {
 
   /**
-   * Returns an endpoint for the given host/port.
+   * Returns an address for the given host/port.
    *
    * @param host the host
    * @param port the port
-   * @return a new endpoint
+   * @return a new address
    */
-  public static Endpoint from(String host, int port) {
+  public static Address from(String host, int port) {
     try {
-      return new Endpoint(InetAddress.getByName(host), port);
+      return new Address(InetAddress.getByName(host), port);
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("Failed to locate host", e);
     }
   }
 
-  public static Endpoint from(int port) {
+  /**
+   * Returns an address for the local host and the given port.
+   *
+   * @param port the port
+   * @return a new address
+   */
+  public static Address from(int port) {
     try {
-      return new Endpoint(getLocalAddress(), port);
+      return new Address(getLocalAddress(), port);
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("Failed to locate host", e);
     }
@@ -52,7 +58,7 @@ public final class Endpoint {
   private final int port;
   private final InetAddress ip;
 
-  public Endpoint(InetAddress host, int port) {
+  public Address(InetAddress host, int port) {
     this.ip = Preconditions.checkNotNull(host);
     this.port = port;
   }
@@ -66,17 +72,27 @@ public final class Endpoint {
     return InetAddress.getByName(null);
   }
 
-  public InetAddress host() {
+  /**
+   * Returns the IP address.
+   *
+   * @return the IP address
+   */
+  public InetAddress ip() {
     return ip;
   }
 
+  /**
+   * Returns the port.
+   *
+   * @return the port
+   */
   public int port() {
     return port;
   }
 
   @Override
   public String toString() {
-    return String.format("%s:%d", host().getHostAddress(), port);
+    return String.format("%s:%d", ip().getHostAddress(), port);
   }
 
   @Override
@@ -95,7 +111,7 @@ public final class Endpoint {
     if (getClass() != obj.getClass()) {
       return false;
     }
-    Endpoint that = (Endpoint) obj;
+    Address that = (Address) obj;
     return this.port == that.port &&
         Objects.equals(this.ip, that.ip);
   }

--- a/utils/src/main/java/io/atomix/utils/net/MalformedAddressException.java
+++ b/utils/src/main/java/io/atomix/utils/net/MalformedAddressException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.net;
+
+import io.atomix.utils.AtomixRuntimeException;
+
+/**
+ * Malformed address exception.
+ */
+public class MalformedAddressException extends AtomixRuntimeException {
+  public MalformedAddressException(String message) {
+    super(message);
+  }
+
+  public MalformedAddressException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/utils/src/test/java/io/atomix/utils/net/AddressTest.java
+++ b/utils/src/test/java/io/atomix/utils/net/AddressTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.net;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Address test.
+ */
+public class AddressTest {
+  @Test
+  public void testIPv4Address() throws Exception {
+    Address address = Address.from("127.0.0.1:5000");
+    assertEquals("127.0.0.1", address.host());
+    assertEquals(5000, address.port());
+    assertEquals("127.0.0.1:5000", address.toString());
+  }
+
+  @Test
+  public void testIPv6Address() throws Exception {
+    Address address = Address.from("[FE80:CD00:0000:0CDE:1257:0000:211E:729C]:5000");
+    assertEquals("FE80:CD00:0000:0CDE:1257:0000:211E:729C", address.host());
+    assertEquals(5000, address.port());
+    assertEquals("[FE80:CD00:0000:0CDE:1257:0000:211E:729C]:5000", address.toString());
+  }
+}


### PR DESCRIPTION
Renames the `Endpoint` class to `Address` as it will now be used to represent more than just endpoints.