### PR TITLE
Rename builder consistency methods to be more consistent with implementation

### DIFF
--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxyBuilder.java
@@ -92,8 +92,8 @@ public class ConsistentMapProxyBuilder<K, V> extends ConsistentMapBuilder<K, V> 
             map = new NotNullAsyncConsistentMap<>(map);
           }
 
-          if (relaxedReadConsistency()) {
-            map = new CachingAsyncConsistentMap<>(map);
+          if (cacheEnabled()) {
+            map = new CachingAsyncConsistentMap<>(map, cacheSize());
           }
 
           if (readOnly()) {

--- a/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
@@ -43,14 +43,20 @@ public class DelegatingDistributedSetBuilder<E> extends DistributedSetBuilder<E>
   }
 
   @Override
-  public DistributedSetBuilder<E> withUpdatesDisabled() {
-    mapBuilder.withUpdatesDisabled();
+  public DistributedSetBuilder<E> withCacheEnabled(boolean cacheEnabled) {
+    mapBuilder.withCacheEnabled(cacheEnabled);
     return this;
   }
 
   @Override
-  public DistributedSetBuilder<E> withRelaxedReadConsistency() {
-    mapBuilder.withRelaxedReadConsistency();
+  public DistributedSetBuilder<E> withCacheSize(int cacheSize) {
+    mapBuilder.withCacheSize(cacheSize);
+    return this;
+  }
+
+  @Override
+  public DistributedSetBuilder<E> withReadOnly(boolean readOnly) {
+    mapBuilder.withReadOnly(readOnly);
     return this;
   }
 
@@ -61,13 +67,13 @@ public class DelegatingDistributedSetBuilder<E> extends DistributedSetBuilder<E>
   }
 
   @Override
-  public boolean readOnly() {
-    return mapBuilder.readOnly();
+  public String name() {
+    return mapBuilder.name();
   }
 
   @Override
-  public boolean relaxedReadConsistency() {
-    return mapBuilder.relaxedReadConsistency();
+  public PrimitiveProtocol protocol() {
+    return mapBuilder.protocol();
   }
 
   @Override
@@ -76,13 +82,18 @@ public class DelegatingDistributedSetBuilder<E> extends DistributedSetBuilder<E>
   }
 
   @Override
-  public String name() {
-    return mapBuilder.name();
+  public boolean readOnly() {
+    return mapBuilder.readOnly();
   }
 
   @Override
-  public PrimitiveProtocol protocol() {
-    return mapBuilder.protocol();
+  public boolean cacheEnabled() {
+    return mapBuilder.cacheEnabled();
+  }
+
+  @Override
+  public int cacheSize() {
+    return mapBuilder.cacheSize();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeProxyBuilder.java
@@ -82,8 +82,8 @@ public class DocumentTreeProxyBuilder<V> extends DocumentTreeBuilder<V> {
     return Futures.allOf(Lists.newArrayList(trees.values()))
         .thenApply(t -> {
           AsyncDocumentTree<V> tree = new PartitionedAsyncDocumentTree<>(name(), Maps.transformValues(trees, v -> v.getNow(null)), partitioner);
-          if (relaxedReadConsistency()) {
-            tree = new CachingAsyncDocumentTree<>(tree);
+          if (cacheEnabled()) {
+            tree = new CachingAsyncDocumentTree<>(tree, cacheSize());
           }
           return tree.sync();
         });


### PR DESCRIPTION
This PR renames some `DistributedPrimitiveBuilder` methods to ensure they're consistent with the semantics of the implementations. Currently, the builders have a `withRelaxedReadConsistency` method. However, this is actually a cache and can confuse relaxed read consistency in a protocol (e.g. Raft `SEQUENTIAL` reads) with caching. Thus, these methods were renamed to indicate caching.