### PR TITLE
Improve efficiency of resolving Raft log conflicts

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/AppendResponse.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/AppendResponse.java
@@ -39,12 +39,14 @@ public class AppendResponse extends AbstractRaftResponse {
   private final long term;
   private final boolean succeeded;
   private final long lastLogIndex;
+  private final long lastLogTerm;
 
-  public AppendResponse(Status status, RaftError error, long term, boolean succeeded, long lastLogIndex) {
+  public AppendResponse(Status status, RaftError error, long term, boolean succeeded, long lastLogIndex, long lastLogTerm) {
     super(status, error);
     this.term = term;
     this.succeeded = succeeded;
     this.lastLogIndex = lastLogIndex;
+    this.lastLogTerm = lastLogTerm;
   }
 
   /**
@@ -74,9 +76,18 @@ public class AppendResponse extends AbstractRaftResponse {
     return lastLogIndex;
   }
 
+  /**
+   * Returns the last term of the replica's log.
+   *
+   * @return The last term of the responding replica's log.
+   */
+  public long lastLogTerm() {
+    return lastLogTerm;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), status, term, succeeded, lastLogIndex);
+    return Objects.hash(getClass(), status, term, succeeded, lastLogIndex, lastLogTerm);
   }
 
   @Override
@@ -86,7 +97,8 @@ public class AppendResponse extends AbstractRaftResponse {
       return response.status == status
           && response.term == term
           && response.succeeded == succeeded
-          && response.lastLogIndex == lastLogIndex;
+          && response.lastLogIndex == lastLogIndex
+          && response.lastLogTerm == lastLogTerm;
     }
     return false;
   }
@@ -99,6 +111,7 @@ public class AppendResponse extends AbstractRaftResponse {
           .add("term", term)
           .add("succeeded", succeeded)
           .add("lastLogIndex", lastLogIndex)
+          .add("lastLogTerm", lastLogTerm)
           .toString();
     } else {
       return toStringHelper(this)
@@ -115,6 +128,7 @@ public class AppendResponse extends AbstractRaftResponse {
     private long term;
     private boolean succeeded;
     private long lastLogIndex;
+    private long lastLogTerm;
 
     /**
      * Sets the response term.
@@ -153,12 +167,26 @@ public class AppendResponse extends AbstractRaftResponse {
       return this;
     }
 
+    /**
+     * Sets the last term of the replica's log.
+     *
+     * @param lastLogTerm The last index of the replica's log.
+     * @return The append response builder.
+     * @throws IllegalArgumentException if {@code index} is negative
+     */
+    public Builder withLastLogTerm(long lastLogTerm) {
+      checkArgument(lastLogTerm >= 0, "lastLogTerm must be positive");
+      this.lastLogTerm = lastLogTerm;
+      return this;
+    }
+
     @Override
     protected void validate() {
       super.validate();
       if (status == Status.OK) {
         checkArgument(term > 0, "term must be positive");
         checkArgument(lastLogIndex >= 0, "lastLogIndex must be positive");
+        checkArgument(lastLogTerm >= 0, "lastLogTerm must be positive");
       }
     }
 
@@ -168,7 +196,7 @@ public class AppendResponse extends AbstractRaftResponse {
     @Override
     public AppendResponse build() {
       validate();
-      return new AppendResponse(status, error, term, succeeded, lastLogIndex);
+      return new AppendResponse(status, error, term, succeeded, lastLogIndex, lastLogTerm);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -29,7 +29,6 @@ import io.atomix.protocols.raft.protocol.RaftRequest;
 import io.atomix.protocols.raft.storage.snapshot.Snapshot;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -394,8 +393,7 @@ final class LeaderAppender extends AbstractAppender {
     // us converge on the matchIndex faster than by simply decrementing nextIndex one index at a time.
     else {
       member.appendFailed();
-      resetMatchIndex(member, response);
-      resetNextIndex(member, response);
+      resetIndexes(member, request, response);
 
       // If there are more entries to send then attempt to send another commit.
       if (hasMoreEntries(member)) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -16,6 +16,7 @@
 package io.atomix.protocols.raft.storage.log;
 
 import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.protocols.raft.storage.log.index.RaftTermIndex;
 import io.atomix.serializer.Serializer;
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.DelegatingJournal;
@@ -45,6 +46,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
   private final SegmentedJournal<RaftLogEntry> journal;
   private final boolean flushOnCommit;
   private final RaftLogWriter writer;
+  private final RaftTermIndex termIndex = new RaftTermIndex();
   private volatile long commitIndex;
 
   protected RaftLog(SegmentedJournal<RaftLogEntry> journal, boolean flushOnCommit) {
@@ -103,6 +105,13 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
   }
 
   /**
+   * Returns the log term index.
+   */
+  RaftTermIndex getTermIndex() {
+    return termIndex;
+  }
+
+  /**
    * Returns a boolean indicating whether a segment can be removed from the journal prior to the given index.
    *
    * @param index the index from which to remove segments
@@ -131,6 +140,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
    */
   public void compact(long index) {
     journal.compact(index);
+    termIndex.compact(index);
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLogReader.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLogReader.java
@@ -60,6 +60,16 @@ public class RaftLogReader extends DelegatingJournalReader<RaftLogEntry> {
     return reader.getFirstIndex();
   }
 
+  /**
+   * Returns the first index with the given term.
+   *
+   * @param term the term for which to return the first index
+   * @return the first index for the given term
+   */
+  public long getFirstIndex(long term) {
+    return log.getTermIndex().lookup(term);
+  }
+
   @Override
   public boolean hasNext() {
     if (mode == Mode.ALL) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/index/RaftTermIndex.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/index/RaftTermIndex.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.storage.log.index;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Raft log term index.
+ *
+ * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
+ */
+public final class RaftTermIndex {
+  private final TreeMap<Long, Long> terms = new TreeMap<>();
+
+  /**
+   * Indexes the given index with the given term.
+   *
+   * @param term  The term to index.
+   * @param index the starting index of the given term
+   */
+  public void index(long term, long index) {
+    terms.put(term, index);
+  }
+
+  /**
+   * Looks up the index for the given term.
+   *
+   * @param term The term for which to look up the index.
+   * @return The first index for the given term.
+   */
+  public long lookup(long term) {
+    return terms.getOrDefault(term, 0L);
+  }
+
+  /**
+   * Truncates the index to the given index.
+   *
+   * @param index The entry index to which to truncate the index.
+   */
+  public void truncate(long index) {
+    terms.entrySet().removeIf(entry -> entry.getValue() > index);
+  }
+
+  /**
+   * Compacts the head of the index to the given index.
+   *
+   * @param index the entry index to which to compact the index
+   */
+  public void compact(long index) {
+    Iterator<Map.Entry<Long, Long>> iterator = terms.entrySet().iterator();
+    Map.Entry<Long, Long> lastEntry = null;
+    while (iterator.hasNext()) {
+      Map.Entry<Long, Long> entry = iterator.next();
+      if (entry.getValue() < index) {
+        iterator.remove();
+        lastEntry = entry;
+      } else {
+        break;
+      }
+    }
+
+    if (lastEntry != null) {
+      Map.Entry<Long, Long> firstEntry = terms.firstEntry();
+      if (firstEntry == null || firstEntry.getValue() > index) {
+        terms.put(lastEntry.getKey(), index);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName();
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/index/RaftTermIndexTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/index/RaftTermIndexTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.storage.log.index;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Raft term index test.
+ */
+public class RaftTermIndexTest {
+  @Test
+  public void testTermIndex() {
+    RaftTermIndex index = new RaftTermIndex();
+    assertEquals(0, index.lookup(1));
+    index.index(1, 1);
+    assertEquals(1, index.lookup(1));
+    index.index(2, 10);
+    index.index(3, 99);
+    assertEquals(10, index.lookup(2));
+    assertEquals(99, index.lookup(3));
+    index.truncate(100);
+    assertEquals(99, index.lookup(3));
+    index.truncate(99);
+    assertEquals(99, index.lookup(3));
+    index.truncate(80);
+    assertEquals(0, index.lookup(3));
+    assertEquals(10, index.lookup(2));
+    index.compact(1);
+    assertEquals(1, index.lookup(1));
+    index.compact(3);
+    assertEquals(3, index.lookup(1));
+    index.compact(10);
+    assertEquals(0, index.lookup(1));
+    assertEquals(10, index.lookup(2));
+    index.compact(15);
+    assertEquals(15, index.lookup(2));
+  }
+}


### PR DESCRIPTION
This PR improves the efficiency of resolving differences between a Raft leader's and follower's logs by providing additional information in rejected `AppendResponse`s. This is done by tracking the indexes at which each term starts in the Raft log and returning the first index of the rejected term to the leader. This information is then used by the leader to skip conflicting entries in that term, thus significantly reducing the amount of time it takes to find the consistent portion of the follower's logs.