### PR TITLE
Support interpolating environment variables and system properties in config

### DIFF
--- a/config/src/main/java/io/atomix/core/config/jackson/JacksonConfigProvider.java
+++ b/config/src/main/java/io/atomix/core/config/jackson/JacksonConfigProvider.java
@@ -16,6 +16,9 @@
 package io.atomix.core.config.jackson;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.io.IOContext;
+import com.fasterxml.jackson.core.util.BufferRecycler;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -25,6 +28,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
 import io.atomix.core.config.ConfigProvider;
 import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveProtocolConfig;
@@ -38,9 +42,13 @@ import io.atomix.utils.ConfigurationException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Jackson configuration provider.
@@ -75,7 +83,7 @@ public class JacksonConfigProvider implements ConfigProvider {
   }
 
   private <C extends Config> C loadYaml(File file, Class<C> type) {
-    ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    ObjectMapper mapper = new ObjectMapper(new InterpolatingYamlFactory());
     setupObjectMapper(mapper);
     try {
       return mapper.readValue(file, type);
@@ -177,6 +185,56 @@ public class JacksonConfigProvider implements ConfigProvider {
     @SuppressWarnings("unchecked")
     public PrimitiveConfigDeserializer() {
       super(PrimitiveConfig.class, type -> PrimitiveTypes.getPrimitiveType(type).configClass());
+    }
+  }
+
+  private static class InterpolatingYamlFactory extends YAMLFactory {
+    @Override
+    protected YAMLParser _createParser(InputStream in, IOContext ctxt) throws IOException {
+      return new InterpolatingYamlParser(ctxt, _getBufferRecycler(), _parserFeatures, _yamlParserFeatures, _objectCodec, _createReader(in, null, ctxt));
+    }
+  }
+
+  private static class InterpolatingYamlParser extends YAMLParser {
+    private final Pattern sysPattern = Pattern.compile("\\$\\{sys:([A-Za-z0-9-_.]+)\\}");
+    private final Pattern envPattern = Pattern.compile("\\$\\{env:([A-Za-z0-9_]+)\\}");
+
+    InterpolatingYamlParser(IOContext ctxt, BufferRecycler br, int parserFeatures, int formatFeatures, ObjectCodec codec, Reader reader) {
+      super(ctxt, br, parserFeatures, formatFeatures, codec, reader);
+    }
+
+    @Override
+    public String getText() throws IOException {
+      String value = super.getText();
+      return value != null ? interpolateString(value) : null;
+    }
+
+    @Override
+    public String getValueAsString() throws IOException {
+      return getValueAsString(null);
+    }
+
+    @Override
+    public String getValueAsString(String defaultValue) throws IOException {
+      String value = super.getValueAsString(defaultValue);
+      return value != null ? interpolateString(value) : null;
+    }
+
+    private String interpolateString(String value) {
+      value = interpolate(value, sysPattern, name -> System.getProperty(name, ""));
+      value = interpolate(value, envPattern, name -> System.getenv(name));
+      return value;
+    }
+
+    private String interpolate(String value, Pattern pattern, Function<String, String> supplier) {
+      Matcher matcher = pattern.matcher(value);
+      while (matcher.find()) {
+        String name = matcher.group(1);
+        String replace = supplier.apply(name);
+        Pattern subPattern = Pattern.compile(Pattern.quote(matcher.group(0)));
+        value = subPattern.matcher(value).replaceAll(replace);
+      }
+      return value;
     }
   }
 }

--- a/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
+++ b/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
@@ -17,6 +17,7 @@ package io.atomix.core.config.jackson;
 
 import io.atomix.core.AtomixConfig;
 import io.atomix.core.config.ConfigProvider;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -46,5 +47,25 @@ public class JacksonConfigProviderTest {
     AtomixConfig config = provider.load(file, AtomixConfig.class);
     assertEquals("test", config.getClusterConfig().getName());
     assertEquals(1, config.getPrimitives().get("foo").getSerializerConfig().getTypes().size());
+  }
+
+  @Test
+  @Ignore
+  public void testEnv() throws Exception {
+    ConfigProvider provider = new JacksonConfigProvider();
+    File file = new File(getClass().getClassLoader().getResource("env.yaml").getFile());
+    assertTrue(provider.isConfigFile(file));
+    AtomixConfig config = provider.load(file, AtomixConfig.class);
+    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
+  }
+
+  @Test
+  @Ignore
+  public void testSystemProperty() throws Exception {
+    ConfigProvider provider = new JacksonConfigProvider();
+    File file = new File(getClass().getClassLoader().getResource("sys.yaml").getFile());
+    assertTrue(provider.isConfigFile(file));
+    AtomixConfig config = provider.load(file, AtomixConfig.class);
+    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
   }
 }

--- a/config/src/test/resources/config.json
+++ b/config/src/test/resources/config.json
@@ -7,6 +7,7 @@
   ],
   "primitives": {
     "foo": {
+      "type": "consistent-map",
       "serializer": {
         "types": [
           {

--- a/config/src/test/resources/config.yaml
+++ b/config/src/test/resources/config.yaml
@@ -4,6 +4,7 @@ primitive-types:
   - io.atomix.core.map.ConsistentMapType
 primitives:
   foo:
+    type: consistent-map
     serializer:
       types:
         - type: io.atomix.cluster.NodeId

--- a/config/src/test/resources/env.yaml
+++ b/config/src/test/resources/env.yaml
@@ -1,0 +1,7 @@
+cluster:
+  name: test
+primitive-types:
+  - io.atomix.core.map.ConsistentMapType
+partition-groups:
+  - name: ${env:GROUP_NAME}
+    type: raft

--- a/config/src/test/resources/sys.yaml
+++ b/config/src/test/resources/sys.yaml
@@ -1,0 +1,7 @@
+cluster:
+  name: test
+primitive-types:
+  - io.atomix.core.map.ConsistentMapType
+partition-groups:
+  - name: ${sys:group.name}
+    type: raft


### PR DESCRIPTION
This PR adds support for interpolating environment variables and system properties in YAML configuration files, e.g.:

```yaml
partition-groups:
  - name: test
     type: raft
     partitions: ${NUM_RAFT_PARTITIONS}
     partition-size: ${raft.partition.size}
```