### PR TITLE
Use enum values for type options in AtomixAgent

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -69,7 +69,7 @@ public class AtomixAgent {
     parser.addArgument("--type", "-t")
         .type(typeArgumentType)
         .metavar("TYPE")
-        .choices("core", "data", "client")
+        .choices(Node.Type.CORE, Node.Type.DATA, Node.Type.CLIENT)
         .setDefault(Node.Type.CORE)
         .help("Indicates the local node type");
     parser.addArgument("--config", "-c")


### PR DESCRIPTION
This PR fixes a bug in the agent when a `--type` argument is provided. Argparse4j requires that the options be enum values if the type is an enum.