### PR TITLE
Support string configurations

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -73,8 +73,7 @@ public class AtomixAgent {
         .setDefault(Node.Type.CORE)
         .help("Indicates the local node type");
     parser.addArgument("--config", "-c")
-        .type(fileArgumentType)
-        .metavar("FILE")
+        .metavar("FILE|JSON|YAML")
         .required(false)
         .help("The Atomix configuration file");
     parser.addArgument("--core-nodes", "-n")
@@ -110,9 +109,14 @@ public class AtomixAgent {
     }
 
     AtomixConfig config;
-    File configFile = namespace.get("config");
-    if (configFile != null) {
-      config = new DefaultConfigService().load(configFile, AtomixConfig.class);
+    String configString = namespace.get("config");
+    if (configString != null) {
+      File configFile = new File(configString);
+      if (configFile.exists()) {
+        config = new DefaultConfigService().load(configFile, AtomixConfig.class);
+      } else {
+        config = new DefaultConfigService().load(configString, AtomixConfig.class);
+      }
     } else {
       config = new AtomixConfig();
     }

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -47,6 +47,12 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
+++ b/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
@@ -17,10 +17,13 @@ package io.atomix.core.config.jackson;
 
 import io.atomix.core.AtomixConfig;
 import io.atomix.core.config.ConfigProvider;
+import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
+import org.apache.commons.io.IOUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -51,7 +54,7 @@ public class JacksonConfigProviderTest {
 
   @Test
   @Ignore
-  public void testEnv() throws Exception {
+  public void testEnvFile() throws Exception {
     ConfigProvider provider = new JacksonConfigProvider();
     File file = new File(getClass().getClassLoader().getResource("env.yaml").getFile());
     assertTrue(provider.isConfigFile(file));
@@ -61,11 +64,31 @@ public class JacksonConfigProviderTest {
 
   @Test
   @Ignore
-  public void testSystemProperty() throws Exception {
+  public void testEnvString() throws Exception {
+    ConfigProvider provider = new JacksonConfigProvider();
+    File file = new File(getClass().getClassLoader().getResource("env.yaml").getFile());
+    AtomixConfig config = provider.load(IOUtils.toString(file.toURI(), StandardCharsets.UTF_8), AtomixConfig.class);
+    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
+    assertEquals(3, ((RaftPartitionGroupConfig) config.getPartitionGroups().iterator().next()).getPartitions());
+  }
+
+  @Test
+  @Ignore
+  public void testSystemPropertyFile() throws Exception {
     ConfigProvider provider = new JacksonConfigProvider();
     File file = new File(getClass().getClassLoader().getResource("sys.yaml").getFile());
     assertTrue(provider.isConfigFile(file));
     AtomixConfig config = provider.load(file, AtomixConfig.class);
+    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
+  }
+
+  @Test
+  @Ignore
+  public void testSystemPropertyString() throws Exception {
+    ConfigProvider provider = new JacksonConfigProvider();
+    File file = new File(getClass().getClassLoader().getResource("sys.yaml").getFile());
+    assertTrue(provider.isConfigFile(file));
+    AtomixConfig config = provider.load(IOUtils.toString(file.toURI(), StandardCharsets.UTF_8), AtomixConfig.class);
     assertEquals("test", config.getPartitionGroups().iterator().next().getName());
   }
 }

--- a/config/src/test/resources/env.yaml
+++ b/config/src/test/resources/env.yaml
@@ -5,3 +5,4 @@ primitive-types:
 partition-groups:
   - name: ${env:GROUP_NAME}
     type: raft
+    partitions: ${env:NUM_PARTITIONS}

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -115,11 +115,11 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
   /**
    * Returns a new Atomix builder.
    *
-   * @param configFile the configuration file with which to initialize the builder
+   * @param config the Atomix configuration
    * @return a new Atomix builder
    */
-  public static Builder builder(String configFile) {
-    return new Builder(loadConfig(new File(System.getProperty("user.dir"), configFile)));
+  public static Builder builder(String config) {
+    return new Builder(loadConfig(config));
   }
 
   /**
@@ -433,8 +433,27 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
   /**
    * Loads a context from the given configuration file.
    */
+  private static Context loadContext(String config) {
+    return buildContext(loadConfig(config));
+  }
+
+  /**
+   * Loads a context from the given configuration file.
+   */
   private static Context loadContext(File config) {
     return buildContext(loadConfig(config));
+  }
+
+  /**
+   * Loads a configuration from the given file.
+   */
+  private static AtomixConfig loadConfig(String config) {
+    File configFile = new File(config);
+    if (configFile.exists()) {
+      return new DefaultConfigService().load(configFile, AtomixConfig.class);
+    } else {
+      return new DefaultConfigService().load(config, AtomixConfig.class);
+    }
   }
 
   /**

--- a/core/src/main/java/io/atomix/core/config/ConfigProvider.java
+++ b/core/src/main/java/io/atomix/core/config/ConfigProvider.java
@@ -42,4 +42,14 @@ public interface ConfigProvider {
    */
   <C extends Config> C load(File file, Class<C> type);
 
+  /**
+   * Loads the given configuration file using the given configuration type.
+   *
+   * @param config the configuration string
+   * @param type the type with which to load the configuration
+   * @param <C> the configuration type
+   * @return the configuration instance
+   */
+  <C extends Config> C load(String config, Class<C> type);
+
 }

--- a/core/src/main/java/io/atomix/core/config/ConfigService.java
+++ b/core/src/main/java/io/atomix/core/config/ConfigService.java
@@ -25,6 +25,16 @@ import java.io.File;
 public interface ConfigService {
 
   /**
+   * Loads the given configuration string using the given configuration type.
+   *
+   * @param config the configurations string
+   * @param type the type with which to load the configuration
+   * @param <C> the configuration type
+   * @return the configuration instance
+   */
+  <C extends Config> C load(String config, Class<C> type);
+
+  /**
    * Loads the given configuration file using the given configuration type.
    *
    * @param file the file to load

--- a/core/src/main/java/io/atomix/core/config/impl/DefaultConfigService.java
+++ b/core/src/main/java/io/atomix/core/config/impl/DefaultConfigService.java
@@ -28,6 +28,19 @@ import java.io.File;
  */
 public class DefaultConfigService implements ConfigService {
   @Override
+  public <C extends Config> C load(String config, Class<C> type) {
+    Exception error = null;
+    for (ConfigProvider provider : Services.loadAll(ConfigProvider.class)) {
+      try {
+        return provider.load(config, type);
+      } catch (Exception e) {
+        error = e;
+      }
+    }
+    throw new ConfigurationException("Unknown configuration format", error);
+  }
+
+  @Override
   public <C extends Config> C load(File file, Class<C> type) {
     for (ConfigProvider provider : Services.loadAll(ConfigProvider.class)) {
       if (provider.isConfigFile(file)) {


### PR DESCRIPTION
This PR adds support for string configurations provided to the Atomix agent, e.g.:

```
java -jar atomix-agent.jar test:localhost:1234 -c '{"cluster": {"name": "foo"}}'
```