### PR TITLE
Remove protocol dependencies from Atomix core

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -39,6 +39,16 @@
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>
+      <artifactId>atomix-raft</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix-primary-backup</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
       <artifactId>atomix-rest</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -33,6 +33,18 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix-raft</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix-primary-backup</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>

--- a/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
+++ b/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
@@ -17,7 +17,6 @@ package io.atomix.core.config.jackson;
 
 import io.atomix.core.AtomixConfig;
 import io.atomix.core.config.ConfigProvider;
-import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
 import org.apache.commons.io.IOUtils;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -69,7 +68,7 @@ public class JacksonConfigProviderTest {
     File file = new File(getClass().getClassLoader().getResource("env.yaml").getFile());
     AtomixConfig config = provider.load(IOUtils.toString(file.toURI(), StandardCharsets.UTF_8), AtomixConfig.class);
     assertEquals("test", config.getPartitionGroups().iterator().next().getName());
-    assertEquals(3, ((RaftPartitionGroupConfig) config.getPartitionGroups().iterator().next()).getPartitions());
+    assertEquals(3, config.getPartitionGroups().iterator().next().getPartitions());
   }
 
   @Test

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,13 +34,20 @@
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>
+      <artifactId>atomix-primitive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
       <artifactId>atomix-raft</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>
       <artifactId>atomix-primary-backup</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupConfig.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupConfig.java
@@ -22,6 +22,7 @@ import io.atomix.utils.Config;
  */
 public abstract class PartitionGroupConfig<C extends PartitionGroupConfig<C>> implements Config {
   private String name;
+  private int partitions = getDefaultPartitions();
 
   /**
    * Returns the partition group name.
@@ -41,5 +42,37 @@ public abstract class PartitionGroupConfig<C extends PartitionGroupConfig<C>> im
   public C setName(String name) {
     this.name = name;
     return (C) this;
+  }
+
+  /**
+   * Returns the number of partitions in the group.
+   *
+   * @return the number of partitions in the group.
+   */
+  public int getPartitions() {
+    return partitions;
+  }
+
+  /**
+   * Sets the number of partitions in the group.
+   *
+   * @param partitions the number of partitions in the group
+   * @return the partition group configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setPartitions(int partitions) {
+    this.partitions = partitions;
+    return (C) this;
+  }
+
+  /**
+   * Returns the default number of partitions.
+   * <p>
+   * Partition group configurations should override this method to provide a default number of partitions.
+   *
+   * @return the default number of partitions
+   */
+  protected int getDefaultPartitions() {
+    return 1;
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupFactory.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupFactory.java
@@ -18,6 +18,8 @@ package io.atomix.primitive.partition;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.Generics;
 
+import java.io.File;
+
 /**
  * Partition group factory.
  */
@@ -56,6 +58,15 @@ public interface PartitionGroupFactory<C extends PartitionGroupConfig<C>, P exte
    * @param config the partition group configuration
    * @return the partition group
    */
-  P create(C config);
+  P createGroup(C config);
+
+  /**
+   * Creates a system group.
+   *
+   * @param size the group size
+   * @param dataDirectory the default group data directory
+   * @return a system group
+   */
+  P createSystemGroup(int size, File dataDirectory);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroups.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroups.java
@@ -22,6 +22,8 @@ import io.atomix.utils.Services;
  * Partition groups.
  */
 public class PartitionGroups {
+  private static final String RAFT = "raft";
+  private static final String PRIMARY_BACKUP = "multi-primary";
 
   /**
    * Creates a new protocol instance from the given configuration.
@@ -33,7 +35,7 @@ public class PartitionGroups {
   public static ManagedPartitionGroup createGroup(PartitionGroupConfig config) {
     for (PartitionGroupFactory factory : Services.loadAll(PartitionGroupFactory.class)) {
       if (factory.configClass().isAssignableFrom(config.getClass())) {
-        return factory.create(config);
+        return factory.createGroup(config);
       }
     }
     throw new ConfigurationException("Unknown partition group configuration type: " + config.getClass().getSimpleName());
@@ -52,6 +54,26 @@ public class PartitionGroups {
       }
     }
     throw new ConfigurationException("Unknown partition group type: " + type);
+  }
+
+  /**
+   * Returns the Raft partition group factory if it's available on the class path.
+   *
+   * @return the Raft partition group factory
+   * @throws ConfigurationException if the Raft partition group factory is not on the classpath
+   */
+  public static PartitionGroupFactory getRaftGroupFactory() {
+    return getGroupFactory(RAFT);
+  }
+
+  /**
+   * Returns the primary-backup partition group factory if it's available on the class path.
+   *
+   * @return the primary-backup partition group factory
+   * @throws ConfigurationException if the primary-backup partition group factory is not on the classpath
+   */
+  public static PartitionGroupFactory getPrimaryBackupGroupFactory() {
+    return getGroupFactory(PRIMARY_BACKUP);
   }
 
   private PartitionGroups() {

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
@@ -17,8 +17,6 @@ package io.atomix.protocols.backup.partition;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.PrimitiveProtocol.Type;
 import io.atomix.primitive.Recovery;
 import io.atomix.primitive.Replication;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
@@ -29,6 +27,8 @@ import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.PrimitiveProtocol.Type;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.concurrent.ThreadPoolContextFactory;
@@ -218,7 +218,7 @@ public class PrimaryBackupPartitionGroup implements ManagedPartitionGroup {
     }
 
     @Override
-    public ManagedPartitionGroup build() {
+    public PrimaryBackupPartitionGroup build() {
       return new PrimaryBackupPartitionGroup(config);
     }
   }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroupConfig.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroupConfig.java
@@ -23,27 +23,13 @@ import io.atomix.primitive.partition.PartitionGroupConfig;
  * Primary-backup partition group configuration.
  */
 public class PrimaryBackupPartitionGroupConfig extends PartitionGroupConfig<PrimaryBackupPartitionGroupConfig> {
-  private int partitions;
+  private static final int DEFAULT_PARTITIONS = 71;
+
   private MemberGroupProvider memberGroupProvider = MemberGroupStrategy.NODE_AWARE;
 
-  /**
-   * Returns the number of partitions in the group.
-   *
-   * @return the number of partitions in the group.
-   */
-  public int getPartitions() {
-    return partitions;
-  }
-
-  /**
-   * Sets the number of partitions in the group.
-   *
-   * @param partitions the number of partitions in the group
-   * @return the partition group configuration
-   */
-  public PrimaryBackupPartitionGroupConfig setPartitions(int partitions) {
-    this.partitions = partitions;
-    return this;
+  @Override
+  protected int getDefaultPartitions() {
+    return DEFAULT_PARTITIONS;
   }
 
   /**

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroupFactory.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroupFactory.java
@@ -19,17 +19,28 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.partition.PartitionGroupFactory;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
+import java.io.File;
+
 /**
  * Primary-backup partition group factory.
  */
 public class PrimaryBackupPartitionGroupFactory implements PartitionGroupFactory<PrimaryBackupPartitionGroupConfig, PrimaryBackupPartitionGroup> {
+  private static final String SYSTEM_GROUP_NAME = "system";
+
   @Override
   public PrimitiveProtocol.Type type() {
     return MultiPrimaryProtocol.TYPE;
   }
 
   @Override
-  public PrimaryBackupPartitionGroup create(PrimaryBackupPartitionGroupConfig config) {
+  public PrimaryBackupPartitionGroup createGroup(PrimaryBackupPartitionGroupConfig config) {
     return new PrimaryBackupPartitionGroup(config);
+  }
+
+  @Override
+  public PrimaryBackupPartitionGroup createSystemGroup(int size, File dataDirectory) {
+    return PrimaryBackupPartitionGroup.builder(SYSTEM_GROUP_NAME)
+        .withNumPartitions(1)
+        .build();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
@@ -23,8 +23,6 @@ import io.atomix.cluster.ClusterEventListener;
 import io.atomix.cluster.ClusterService;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeId;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.PrimitiveProtocol.Type;
 import io.atomix.primitive.Recovery;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.Partition;
@@ -32,6 +30,8 @@ import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.PrimitiveProtocol.Type;
 import io.atomix.protocols.raft.RaftProtocol;
 import io.atomix.storage.StorageLevel;
 import io.atomix.utils.concurrent.Futures;
@@ -267,7 +267,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     @Override
-    public ManagedPartitionGroup build() {
+    public RaftPartitionGroup build() {
       return new RaftPartitionGroup(config);
     }
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
@@ -24,29 +24,15 @@ import java.io.File;
  * Raft partition group configuration.
  */
 public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartitionGroupConfig> {
-  private int partitions;
+  private static final int DEFAULT_PARTITIONS = 7;
+
   private int partitionSize;
   private StorageLevel storageLevel = StorageLevel.MAPPED;
   private File dataDirectory = new File(System.getProperty("user.dir"), "data");
 
-  /**
-   * Returns the number of partitions in the group.
-   *
-   * @return the number of partitions in the group
-   */
-  public int getPartitions() {
-    return partitions;
-  }
-
-  /**
-   * Sets the number of partitions in the group.
-   *
-   * @param partitions the number of partitions in the group
-   * @return the Raft partition group configuration
-   */
-  public RaftPartitionGroupConfig setPartitions(int partitions) {
-    this.partitions = partitions;
-    return this;
+  @Override
+  protected int getDefaultPartitions() {
+    return DEFAULT_PARTITIONS;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupFactory.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupFactory.java
@@ -15,21 +15,36 @@
  */
 package io.atomix.protocols.raft.partition;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.partition.PartitionGroupFactory;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.protocols.raft.RaftProtocol;
+import io.atomix.storage.StorageLevel;
+
+import java.io.File;
 
 /**
  * Raft partition group factory.
  */
 public class RaftPartitionGroupFactory implements PartitionGroupFactory<RaftPartitionGroupConfig, RaftPartitionGroup> {
+  private static final String SYSTEM_GROUP_NAME = "system";
+
   @Override
   public PrimitiveProtocol.Type type() {
     return RaftProtocol.TYPE;
   }
 
   @Override
-  public RaftPartitionGroup create(RaftPartitionGroupConfig config) {
+  public RaftPartitionGroup createGroup(RaftPartitionGroupConfig config) {
     return new RaftPartitionGroup(config);
+  }
+
+  @Override
+  public RaftPartitionGroup createSystemGroup(int size, File dataDirectory) {
+    return RaftPartitionGroup.builder(SYSTEM_GROUP_NAME)
+        .withNumPartitions(1)
+        .withPartitionSize(size)
+        .withDataDirectory(new File(dataDirectory, SYSTEM_GROUP_NAME))
+        .withStorageLevel(StorageLevel.DISK)
+        .build();
   }
 }

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -38,6 +38,18 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix-raft</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix-primary-backup</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
       <version>${vertx.version}</version>


### PR DESCRIPTION
This PR removes the `atomix-raft` and `atomix-primary-backup` protocol dependencies from Atomix core. Users can now include protocols depending on their desired cluster configuration.