### PR TITLE
Merge local node with provided configuration in Atomix agent

### DIFF
--- a/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
+++ b/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
@@ -148,20 +148,20 @@ public class AtomixAgentTest {
     config.add("  nodes:");
     config.add("    - id: node1");
     config.add("      type: data");
-    config.add("      address: localhost:5000");
+    config.add("      address: localhost:5001");
     config.add("    - id: node2");
     config.add("      type: data");
-    config.add("      address: localhost:5001");
+    config.add("      address: localhost:5002");
     config.add("    - id: node3");
     config.add("      type: data");
-    config.add("      address: localhost:5002");
+    config.add("      address: localhost:5003");
     config.add("partition-groups:");
     config.add("  - type: multi-primary");
     config.add("    name: data");
 
     Thread thread1 = new Thread(() -> {
       try {
-        AtomixAgent.main(new String[]{"node1@localhost:5000", "-c", Joiner.on('\n').join(config)});
+        AtomixAgent.main(new String[]{"node1", "-c", Joiner.on('\n').join(config), "-p", "6001"});
       } catch (Exception e) {
         e.printStackTrace();
         Thread.currentThread().interrupt();
@@ -170,7 +170,7 @@ public class AtomixAgentTest {
 
     Thread thread2 = new Thread(() -> {
       try {
-        AtomixAgent.main(new String[]{"node2@localhost:5001", "-c", Joiner.on('\n').join(config)});
+        AtomixAgent.main(new String[]{"node2", "-c", Joiner.on('\n').join(config), "-p", "6002"});
       } catch (Exception e) {
         e.printStackTrace();
         Thread.currentThread().interrupt();
@@ -179,7 +179,7 @@ public class AtomixAgentTest {
 
     Thread thread3 = new Thread(() -> {
       try {
-        AtomixAgent.main(new String[]{"node3@localhost:5002", "-c", Joiner.on('\n').join(config)});
+        AtomixAgent.main(new String[]{"node3", "-c", Joiner.on('\n').join(config), "-p", "6003"});
       } catch (Exception e) {
         e.printStackTrace();
         Thread.currentThread().interrupt();

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -132,6 +132,16 @@ public class Atomix implements PrimitivesService, Managed<Atomix> {
     return new Builder(loadConfig(configFile));
   }
 
+  /**
+   * Returns a new Atomix builder.
+   *
+   * @param config the Atomix configuration
+   * @return a new Atomix builder
+   */
+  public static Builder builder(AtomixConfig config) {
+    return new Builder(config);
+  }
+
   protected static final String SYSTEM_GROUP_NAME = "system";
   protected static final String CORE_GROUP_NAME = "core";
   protected static final String DATA_GROUP_NAME = "data";


### PR DESCRIPTION
This PR merges the local node passed as an argument on the command line with the configuration file's `nodes`, allowing e.g.:

`atomix.yaml`

```yaml
cluster:
  nodes:
    - name: node1
      type: core
      address: localhost:5001
    - name: node2
      type: core
      address: localhost:5002
    - name: node3
      type: core
      address: localhost:5003
partition-groups:
  - name: raft
    type: raft
    partitions: 3
    partition-size: 3
    data-directory: data/raft
```

to be run with:

```
bin/atomix-agent node1 -c atomix.yaml
```

The local node `node1` will become `node1@localhost:5001` by merging with the configuration file.