### PR TITLE
Deadlock due to network latency 

### DIFF
--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxy.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxy.java
@@ -18,9 +18,9 @@ package io.atomix.core.lock.impl;
 import com.google.common.collect.Maps;
 import io.atomix.core.lock.AsyncDistributedLock;
 import io.atomix.core.lock.DistributedLock;
+import io.atomix.primitive.AbstractAsyncPrimitiveProxy;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveRegistry;
-import io.atomix.primitive.AbstractAsyncPrimitiveProxy;
 import io.atomix.primitive.proxy.PrimitiveProxy;
 import io.atomix.primitive.proxy.Proxy;
 import io.atomix.utils.concurrent.OrderedExecutor;
@@ -74,6 +74,8 @@ public class DistributedLockProxy
     LockAttempt attempt = attempts.remove(id);
     if (attempt != null) {
       attempt.complete(new Version(version));
+    } else {
+      acceptBy(getPartitionKey(), service -> service.unlock(id));
     }
   }
 


### PR DESCRIPTION

Time | Session1 | Session2 | Server
:--: | :--: | :--: | :--:
0 ms | lock|  |
10 ms |  |  |lock commited<br>locked
20 ms |  | tryLock(100 ms)<br>and client-side timer start<br>timeout at 120ms|
50 ms |  | |lock commited<br>enqueue<br>and timer start<br>timeout at 150ms
120 ms |  | timeout<br>invoke UNLOCK |
125 ms |  | | unlock commited<br>but lockholder is not Session2<br>ignored
130 ms | unlock | |
135 ms |  | | unlock commited<br>unlocked<br>poll the queue<br>publish LOCKED to Session2
140 ms |  | can't find LockAttempt<br>ignore this event |  

then deadlock until session2  disconnected. 
traverse the queue is not the best choice, but in most cases, the queue length will not be very long, so this is not very expensive.
