### PR TITLE
Fix keep on restoring.

### DIFF
--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/roles/BackupRole.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/roles/BackupRole.java
@@ -94,6 +94,9 @@ public class BackupRole extends PrimaryBackupRole {
             applyClose((CloseOperation) operation);
             break;
         }
+
+      } else if (operation.index() < i) {
+        continue;
       } else {
         requestRestore(context.primary());
         break;

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
@@ -299,7 +299,6 @@ public class PrimaryBackupServiceContext implements ServiceContext {
     currentOperation = OperationType.COMMAND;
     operationIndex = index;
     currentIndex = index;
-    commitIndex = index;
     currentTimestamp = timestamp;
     service.tick(new WallClockTimestamp(currentTimestamp));
   }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
@@ -288,6 +288,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
     currentOperation = OperationType.COMMAND;
     operationIndex = index;
     currentIndex = index;
+    commitIndex = index;
     currentTimestamp = timestamp;
   }
 

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
@@ -300,6 +300,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
     operationIndex = index;
     currentIndex = index;
     currentTimestamp = timestamp;
+    setCommitIndex(index);
     service.tick(new WallClockTimestamp(currentTimestamp));
   }
 

--- a/utils/src/main/java/io/atomix/utils/concurrent/OrderedFuture.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/OrderedFuture.java
@@ -80,6 +80,7 @@ public class OrderedFuture<T> extends CompletableFuture<T> {
           future.completeExceptionally(error);
         }
       }
+      orderedFutures.clear();
     }
   }
 

--- a/utils/src/main/java/io/atomix/utils/concurrent/OrderedFuture.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/OrderedFuture.java
@@ -33,9 +33,9 @@ import java.util.function.Function;
  */
 public class OrderedFuture<T> extends CompletableFuture<T> {
   private final Queue<CompletableFuture<T>> orderedFutures = new LinkedList<>();
-  private boolean complete;
-  private T result;
-  private Throwable error;
+  private volatile boolean complete;
+  private volatile T result;
+  private volatile Throwable error;
 
   public OrderedFuture() {
     super.whenComplete(this::complete);
@@ -45,18 +45,21 @@ public class OrderedFuture<T> extends CompletableFuture<T> {
    * Adds a new ordered future.
    */
   private CompletableFuture<T> orderedFuture() {
-    synchronized (orderedFutures) {
-      if (complete) {
-        if (error == null) {
-          return CompletableFuture.completedFuture(result);
-        } else {
-          return Futures.exceptionalFuture(error);
+    if (!complete) {
+      synchronized (orderedFutures) {
+        if (!complete) {
+          CompletableFuture<T> future = new CompletableFuture<>();
+          orderedFutures.add(future);
+          return future;
         }
-      } else {
-        CompletableFuture<T> future = new CompletableFuture<>();
-        orderedFutures.add(future);
-        return future;
       }
+    }
+
+    // Completed
+    if (error == null) {
+      return CompletableFuture.completedFuture(result);
+    } else {
+      return Futures.exceptionalFuture(error);
     }
   }
 
@@ -65,9 +68,9 @@ public class OrderedFuture<T> extends CompletableFuture<T> {
    */
   private void complete(T result, Throwable error) {
     synchronized (orderedFutures) {
-      this.complete = true;
       this.result = result;
       this.error = error;
+      this.complete = true;
       if (error == null) {
         for (CompletableFuture<T> future : orderedFutures) {
           future.complete(result);


### PR DESCRIPTION
1. backup index out of order  
```context.protocol().backup(nodeId, request);```
PrimaryRole send backup index 1 ~ 100 and 101 ~ 200 without interval, BackupRole may receive 101 ~ 200 and 1 ~ 100, then request restore.

2. keep on restoring
   PrimaryRole send RestoreResponse at 2300, but in the AsynchronousReplicator queue, there may be operations whose index is less than 2300 waiting to be sent. 
  then RestoreRequest again. 

join backupResponse to fix 1.
clear operations whose index is less than restore index to fix 2.
