### PR TITLE
Allow empty partition groups

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -103,11 +103,6 @@ public class AtomixAgent {
         .type(addressArgumentType)
         .metavar("HOST:PORT")
         .help("Sets the multicast discovery address. Defaults to 230.0.0.1:54321");
-    parser.addArgument("--data-dir", "-d")
-        .type(fileArgumentType)
-        .metavar("FILE")
-        .required(false)
-        .help("Sets the global Atomix data directory used for storing system data.");
     parser.addArgument("--http-port", "-p")
         .type(Integer.class)
         .metavar("PORT")
@@ -130,7 +125,6 @@ public class AtomixAgent {
     final List<NodeConfig> bootstrapNodes = namespace.getList("bootstrap_nodes");
     final boolean multicastEnabled = namespace.getBoolean("multicast");
     final Address multicastAddress = namespace.get("multicast_address");
-    final File dataDir = namespace.get("data_dir");
     final Integer httpPort = namespace.getInt("http_port");
 
     // If a configuration was provided, merge the configuration's node information with the provided command line arguments.
@@ -185,10 +179,6 @@ public class AtomixAgent {
       if (multicastAddress != null) {
         builder.withMulticastAddress(multicastAddress);
       }
-    }
-
-    if (dataDir != null) {
-      builder.withDataDirectory(dataDir);
     }
 
     Atomix atomix = builder.build();

--- a/agent/src/test/resources/atomix.yaml
+++ b/agent/src/test/resources/atomix.yaml
@@ -1,17 +1,20 @@
-data-directory: target/test-logs/
 # Cluster configuration
 cluster:
   name: test
   nodes:
     - id: node1
-      type: core
+      type: persistent
       address: localhost:5000
     - id: node2
-      type: core
+      type: persistent
       address: localhost:5001
     - id: node3
-      type: core
+      type: persistent
       address: localhost:5002
+system-partition-group:
+  name: system
+  type: raft
+  data-directory: target/test-logs/system
 # A list of partition groups
 partition-groups:
   - type: raft

--- a/core/src/main/java/io/atomix/core/AtomixConfig.java
+++ b/core/src/main/java/io/atomix/core/AtomixConfig.java
@@ -18,10 +18,10 @@ package io.atomix.core;
 import io.atomix.cluster.ClusterConfig;
 import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.utils.Config;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -34,8 +34,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class AtomixConfig implements Config {
   private ClusterConfig cluster = new ClusterConfig();
-  private File dataDirectory = new File(System.getProperty("user.dir"), "data");
   private boolean enableShutdownHook;
+  private PartitionGroupConfig systemPartitionGroup;
   private Collection<PartitionGroupConfig> partitionGroups = new ArrayList<>();
   private Collection<Class<? extends PrimitiveType>> types = new ArrayList<>();
   private Map<String, PrimitiveConfig> primitives = new HashMap<>();
@@ -61,37 +61,6 @@ public class AtomixConfig implements Config {
   }
 
   /**
-   * Returns the data directory.
-   *
-   * @return the data directory
-   */
-  public File getDataDirectory() {
-    return dataDirectory;
-  }
-
-  /**
-   * Sets the data directory.
-   *
-   * @param dataDirectory the data directory
-   * @return the Atomix configuration
-   */
-  public AtomixConfig setDataDirectory(String dataDirectory) {
-    this.dataDirectory = new File(dataDirectory);
-    return this;
-  }
-
-  /**
-   * Sets the data directory.
-   *
-   * @param dataDirectory the data directory
-   * @return the Atomix configuration
-   */
-  public AtomixConfig setDataDirectory(File dataDirectory) {
-    this.dataDirectory = dataDirectory;
-    return this;
-  }
-
-  /**
    * Returns whether to enable the shutdown hook.
    *
    * @return whether to enable the shutdown hook
@@ -108,6 +77,26 @@ public class AtomixConfig implements Config {
    */
   public AtomixConfig setEnableShutdownHook(boolean enableShutdownHook) {
     this.enableShutdownHook = enableShutdownHook;
+    return this;
+  }
+
+  /**
+   * Returns the system partition group.
+   *
+   * @return the system partition group
+   */
+  public PartitionGroupConfig getSystemPartitionGroup() {
+    return systemPartitionGroup;
+  }
+
+  /**
+   * Sets the system partition group.
+   *
+   * @param systemPartitionGroup the system partition group
+   * @return the Atomix configuration
+   */
+  public AtomixConfig setSystemPartitionGroup(PartitionGroupConfig systemPartitionGroup) {
+    this.systemPartitionGroup = systemPartitionGroup;
     return this;
   }
 

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -74,19 +74,23 @@ public abstract class AbstractAtomixTest {
         .withClusterName("test")
         .withLocalNode(localNode)
         .withNodes(nodes)
-        .withSystemPartitionGroup(RaftPartitionGroup.builder("system")
-            .withPartitionSize(3)
-            .withNumPartitions(1)
-            .withDataDirectory(new File("target/test-logs/" + id + "/system"))
-            .build())
         .addPartitionGroup(PrimaryBackupPartitionGroup.builder("data")
             .withNumPartitions(3)
             .build());
     if (!nodeIds.isEmpty()) {
+      builder.withSystemPartitionGroup(RaftPartitionGroup.builder("system")
+          .withPartitionSize(3)
+          .withNumPartitions(1)
+          .withDataDirectory(new File("target/test-logs/" + id + "/system"))
+          .build());
       builder.addPartitionGroup(RaftPartitionGroup.builder("core")
           .withPartitionSize(3)
           .withNumPartitions(3)
           .withDataDirectory(new File("target/test-logs/" + id + "/core"))
+          .build());
+    } else {
+      builder.withSystemPartitionGroup(PrimaryBackupPartitionGroup.builder("system")
+          .withNumPartitions(1)
           .build());
     }
     return builder;

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -72,9 +72,13 @@ public abstract class AbstractAtomixTest {
 
     Atomix.Builder builder = Atomix.builder()
         .withClusterName("test")
-        .withDataDirectory(new File("target/test-logs/" + id))
         .withLocalNode(localNode)
         .withNodes(nodes)
+        .withSystemPartitionGroup(RaftPartitionGroup.builder("system")
+            .withPartitionSize(3)
+            .withNumPartitions(1)
+            .withDataDirectory(new File("target/test-logs/" + id + "/system"))
+            .build())
         .addPartitionGroup(PrimaryBackupPartitionGroup.builder("data")
             .withNumPartitions(3)
             .build());
@@ -82,7 +86,7 @@ public abstract class AbstractAtomixTest {
       builder.addPartitionGroup(RaftPartitionGroup.builder("core")
           .withPartitionSize(3)
           .withNumPartitions(3)
-          .withDataDirectory(new File("target/test-logs/core/" + id))
+          .withDataDirectory(new File("target/test-logs/" + id + "/core"))
           .build());
     }
     return builder;

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -78,6 +78,18 @@ public class AtomixTest extends AbstractAtomixTest {
   }
 
   /**
+   * Tests forming a cluster without partition groups.
+   */
+  @Test
+  public void testNoPartitionGroups() throws Exception {
+    List<CompletableFuture<Atomix>> futures = new ArrayList<>(3);
+    futures.add(startAtomix(Node.Type.EPHEMERAL, 1, Arrays.asList(), Arrays.asList(), b -> b.withSystemPartitionGroup(null).withPartitionGroups(Arrays.asList()).build()));
+    futures.add(startAtomix(Node.Type.EPHEMERAL, 2, Arrays.asList(), Arrays.asList(1), b -> b.withSystemPartitionGroup(null).withPartitionGroups(Arrays.asList()).build()));
+    futures.add(startAtomix(Node.Type.EPHEMERAL, 3, Arrays.asList(), Arrays.asList(1), b -> b.withSystemPartitionGroup(null).withPartitionGroups(Arrays.asList()).build()));
+    CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+  }
+
+  /**
    * Tests scaling up a cluster.
    */
   @Test

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroups.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroups.java
@@ -22,8 +22,6 @@ import io.atomix.utils.Services;
  * Partition groups.
  */
 public class PartitionGroups {
-  private static final String RAFT = "raft";
-  private static final String PRIMARY_BACKUP = "multi-primary";
 
   /**
    * Creates a new protocol instance from the given configuration.
@@ -54,26 +52,6 @@ public class PartitionGroups {
       }
     }
     throw new ConfigurationException("Unknown partition group type: " + type);
-  }
-
-  /**
-   * Returns the Raft partition group factory if it's available on the class path.
-   *
-   * @return the Raft partition group factory
-   * @throws ConfigurationException if the Raft partition group factory is not on the classpath
-   */
-  public static PartitionGroupFactory getRaftGroupFactory() {
-    return getGroupFactory(RAFT);
-  }
-
-  /**
-   * Returns the primary-backup partition group factory if it's available on the class path.
-   *
-   * @return the primary-backup partition group factory
-   * @throws ConfigurationException if the primary-backup partition group factory is not on the classpath
-   */
-  public static PartitionGroupFactory getPrimaryBackupGroupFactory() {
-    return getGroupFactory(PRIMARY_BACKUP);
   }
 
   private PartitionGroups() {

--- a/rest/src/test/java/io/atomix/rest/impl/VertxRestServiceTest.java
+++ b/rest/src/test/java/io/atomix/rest/impl/VertxRestServiceTest.java
@@ -32,7 +32,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.file.FileVisitResult;
@@ -281,9 +280,11 @@ public class VertxRestServiceTest {
 
     return Atomix.builder()
         .withClusterName("test")
-        .withDataDirectory(new File("target/test-logs/1"))
         .withLocalNode(localNode)
         .withNodes(nodes)
+        .withSystemPartitionGroup(PrimaryBackupPartitionGroup.builder("system")
+            .withNumPartitions(1)
+            .build())
         .addPartitionGroup(PrimaryBackupPartitionGroup.builder("data")
             .withNumPartitions(3)
             .build())


### PR DESCRIPTION
This PR adds further cleanup to node type changes and allows empty partition groups for `Atomix` instances.