### PR TITLE
Add node tags for generic classification of nodes

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/Node.java
+++ b/cluster/src/main/java/io/atomix/cluster/Node.java
@@ -15,9 +15,12 @@
  */
 package io.atomix.cluster;
 
+import com.google.common.collect.ImmutableSet;
 import io.atomix.utils.net.Address;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -144,18 +147,20 @@ public class Node {
   private final String zone;
   private final String rack;
   private final String host;
+  private final Set<String> tags;
 
   public Node(NodeConfig config) {
-    this(config.getId(), config.getType(), config.getAddress(), config.getZone(), config.getRack(), config.getHost());
+    this(config.getId(), config.getType(), config.getAddress(), config.getZone(), config.getRack(), config.getHost(), config.getTags());
   }
 
-  protected Node(NodeId id, Type type, Address address, String zone, String rack, String host) {
+  protected Node(NodeId id, Type type, Address address, String zone, String rack, String host, Set<String> tags) {
     this.id = checkNotNull(id, "id cannot be null");
     this.type = checkNotNull(type, "type cannot be null");
     this.address = checkNotNull(address, "address cannot be null");
     this.zone = zone;
     this.rack = rack;
     this.host = host;
+    this.tags = ImmutableSet.copyOf(tags);
   }
 
   /**
@@ -221,6 +226,15 @@ public class Node {
     return host;
   }
 
+  /**
+   * Returns the node tags.
+   *
+   * @return the node tags
+   */
+  public Set<String> tags() {
+    return tags;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id);
@@ -254,6 +268,7 @@ public class Node {
     protected String zone;
     protected String rack;
     protected String host;
+    protected Set<String> tags = new HashSet<>();
 
     protected Builder(NodeId id) {
       this.id = id;
@@ -360,12 +375,36 @@ public class Node {
       return this;
     }
 
+    /**
+     * Sets the node tags.
+     *
+     * @param tags the node tags
+     * @return the node builder
+     * @throws NullPointerException if the tags are null
+     */
+    public Builder withTags(Set<String> tags) {
+      this.tags = checkNotNull(tags, "tags cannot be null");
+      return this;
+    }
+
+    /**
+     * Adds a tag to the node.
+     *
+     * @param tag the tag to add
+     * @return the node builder
+     * @throws NullPointerException if the tag is null
+     */
+    public Builder addTag(String tag) {
+      tags.add(checkNotNull(tag, "tag cannot be null"));
+      return this;
+    }
+
     @Override
     public Node build() {
       if (id == null) {
         id = NodeId.from(address.address().getHostName());
       }
-      return new Node(id, type, address, zone, rack, host);
+      return new Node(id, type, address, zone, rack, host, tags);
     }
   }
 }

--- a/cluster/src/main/java/io/atomix/cluster/NodeConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/NodeConfig.java
@@ -17,6 +17,9 @@ package io.atomix.cluster;
 
 import io.atomix.utils.net.Address;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Node configuration.
  */
@@ -27,6 +30,7 @@ public class NodeConfig {
   private String zone;
   private String rack;
   private String host;
+  private Set<String> tags = new HashSet<>();
 
   /**
    * Returns the node identifier.
@@ -165,6 +169,26 @@ public class NodeConfig {
    */
   public NodeConfig setHost(String host) {
     this.host = host;
+    return this;
+  }
+
+  /**
+   * Returns the node tags.
+   *
+   * @return the node tags
+   */
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  /**
+   * Sets the node tags.
+   *
+   * @param tags the node tags
+   * @return the node configuration
+   */
+  public NodeConfig setTags(Set<String> tags) {
+    this.tags = tags;
     return this;
   }
 }

--- a/cluster/src/main/java/io/atomix/cluster/impl/ClusterHeartbeat.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/ClusterHeartbeat.java
@@ -18,6 +18,8 @@ package io.atomix.cluster.impl;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeId;
 
+import java.util.Set;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
@@ -29,13 +31,15 @@ final class ClusterHeartbeat {
   private final String zone;
   private final String rack;
   private final String host;
+  private final Set<String> tags;
 
-  ClusterHeartbeat(NodeId nodeId, Node.Type type, String zone, String rack, String host) {
+  ClusterHeartbeat(NodeId nodeId, Node.Type type, String zone, String rack, String host, Set<String> tags) {
     this.nodeId = nodeId;
     this.type = type;
     this.zone = zone;
     this.rack = rack;
     this.host = host;
+    this.tags = tags;
   }
 
   /**
@@ -81,6 +85,15 @@ final class ClusterHeartbeat {
    */
   public String host() {
     return host;
+  }
+
+  /**
+   * Returns the node tags.
+   *
+   * @return the node tags
+   */
+  public Set<String> tags() {
+    return tags;
   }
 
   @Override

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterService.java
@@ -121,7 +121,8 @@ public class DefaultClusterService
         localNode.address(),
         localNode.zone(),
         localNode.rack(),
-        localNode.host());
+        localNode.host(),
+        localNode.tags());
   }
 
   @Override
@@ -180,14 +181,16 @@ public class DefaultClusterService
             node.address(),
             node.zone(),
             node.rack(),
-            node.host()));
+            node.host(),
+            node.tags()));
 
     byte[] payload = SERIALIZER.encode(new ClusterHeartbeat(
         localNode.id(),
         localNode.type(),
         localNode.zone(),
         localNode.rack(),
-        localNode.host()));
+        localNode.host(),
+        localNode.tags()));
     return Futures.allOf(Stream.concat(clusterNodes, bootstrapNodes).map(node -> {
       LOGGER.trace("{} - Sending heartbeat: {}", localNode.id(), node.id());
       CompletableFuture<Void> future = sendHeartbeat(node.address(), payload);
@@ -245,7 +248,8 @@ public class DefaultClusterService
         address,
         heartbeat.zone(),
         heartbeat.rack(),
-        heartbeat.host()));
+        heartbeat.host(),
+        heartbeat.tags()));
     return SERIALIZER.encode(nodes.values().stream()
         .filter(node -> node.type() == Node.Type.CLIENT)
         .collect(Collectors.toList()));
@@ -263,7 +267,8 @@ public class DefaultClusterService
           node.address(),
           node.zone(),
           node.rack(),
-          node.host());
+          node.host(),
+          node.tags());
       LOGGER.info("{} - Node activated: {}", localNode.id(), statefulNode);
       statefulNode.setState(State.ACTIVE);
       nodes.put(statefulNode.id(), statefulNode);
@@ -274,7 +279,8 @@ public class DefaultClusterService
           localNode.type(),
           localNode.zone(),
           localNode.rack(),
-          localNode.host())));
+          localNode.host(),
+          localNode.tags())));
     } else if (existingNode.getState() == State.INACTIVE) {
       LOGGER.info("{} - Node activated: {}", localNode.id(), existingNode);
       existingNode.setState(State.ACTIVE);
@@ -321,7 +327,8 @@ public class DefaultClusterService
                 node.address(),
                 node.zone(),
                 node.rack(),
-                node.host());
+                node.host(),
+                node.tags());
             nodes.put(newNode.id(), newNode);
             post(new ClusterEvent(ClusterEvent.Type.NODE_ADDED, newNode));
           }
@@ -361,7 +368,8 @@ public class DefaultClusterService
               node.address(),
               node.zone(),
               node.rack(),
-              node.host())));
+              node.host(),
+              node.tags())));
       messagingService.registerHandler(HEARTBEAT_MESSAGE, this::handleHeartbeat, heartbeatExecutor);
 
       ComposableFuture<Void> future = new ComposableFuture<>();

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultPersistentMetadataService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultPersistentMetadataService.java
@@ -104,6 +104,7 @@ public class DefaultPersistentMetadataService
         node.zone(),
         node.rack(),
         node.host(),
+        node.tags(),
         new LogicalTimestamp(0),
         false)));
     this.messagingService = messagingService;
@@ -130,6 +131,7 @@ public class DefaultPersistentMetadataService
             node.zone(),
             node.rack(),
             node.host(),
+            node.tags(),
             timestamp,
             false);
         nodes.put(replicatedNode.id(), replicatedNode);
@@ -151,6 +153,7 @@ public class DefaultPersistentMetadataService
           node.zone(),
           node.rack(),
           node.host(),
+          node.tags(),
           timestamp,
           true);
       nodes.put(replicatedNode.id(), replicatedNode);
@@ -312,6 +315,7 @@ public class DefaultPersistentMetadataService
                 node.zone(),
                 node.rack(),
                 node.host(),
+                node.tags(),
                 digest.timestamp(),
                 true));
             post(new ClusterMetadataEvent(ClusterMetadataEvent.Type.METADATA_CHANGED, getMetadata()));

--- a/cluster/src/main/java/io/atomix/cluster/impl/ReplicatedNode.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/ReplicatedNode.java
@@ -21,6 +21,8 @@ import io.atomix.utils.net.Address;
 import io.atomix.utils.time.LogicalTimestamp;
 import io.atomix.utils.time.Timestamp;
 
+import java.util.Set;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -37,9 +39,10 @@ public class ReplicatedNode extends Node {
       String zone,
       String rack,
       String host,
+      Set<String> tags,
       LogicalTimestamp timestamp,
       boolean tombstone) {
-    super(id, type, address, zone, rack, host);
+    super(id, type, address, zone, rack, host, tags);
     this.timestamp = checkNotNull(timestamp, "timestamp cannot be null");
     this.tombstone = tombstone;
   }

--- a/cluster/src/main/java/io/atomix/cluster/impl/StatefulNode.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/StatefulNode.java
@@ -19,6 +19,8 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeId;
 import io.atomix.utils.net.Address;
 
+import java.util.Set;
+
 /**
  * Default cluster node.
  */
@@ -31,8 +33,9 @@ public class StatefulNode extends Node {
       Address address,
       String zone,
       String rack,
-      String host) {
-    super(id, type, address, zone, rack, host);
+      String host,
+      Set<String> tags) {
+    super(id, type, address, zone, rack, host, tags);
   }
 
   /**


### PR DESCRIPTION
This PR adds support for assigning arbitrary tags to nodes for use in member groups and for other general information about nodes.

```java
Node node = Node.builder("foo")
  .withAddress("localhost:5000")
  .withTags("foo", "bar")
  .build();
```