### PR TITLE
Add support for Atomix instance profiles

### DIFF
--- a/config/src/main/java/io/atomix/core/config/jackson/JacksonConfigProvider.java
+++ b/config/src/main/java/io/atomix/core/config/jackson/JacksonConfigProvider.java
@@ -34,6 +34,8 @@ import io.atomix.core.config.jackson.impl.NodeProfileDeserializer;
 import io.atomix.core.config.jackson.impl.PartitionGroupDeserializer;
 import io.atomix.core.config.jackson.impl.PrimitiveConfigDeserializer;
 import io.atomix.core.config.jackson.impl.PrimitiveProtocolDeserializer;
+import io.atomix.core.config.jackson.impl.ProfileDeserializer;
+import io.atomix.core.profile.Profile;
 import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.partition.MemberFilter;
 import io.atomix.primitive.partition.PartitionGroupConfig;
@@ -151,6 +153,7 @@ public class JacksonConfigProvider implements ConfigProvider {
     module.addDeserializer(MemberFilter.class, new MemberFilterDeserializer());
     module.addDeserializer(PrimitiveProtocolConfig.class, new PrimitiveProtocolDeserializer());
     module.addDeserializer(PrimitiveConfig.class, new PrimitiveConfigDeserializer());
+    module.addDeserializer(Profile.class, new ProfileDeserializer());
     module.addDeserializer(ClusterProfile.class, new ClusterProfileDeserializer());
     module.addDeserializer(NodeProfile.class, new NodeProfileDeserializer());
     mapper.registerModule(module);

--- a/config/src/main/java/io/atomix/core/config/jackson/impl/ProfileDeserializer.java
+++ b/config/src/main/java/io/atomix/core/config/jackson/impl/ProfileDeserializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.config.jackson.impl;
+
+import io.atomix.core.profile.Profile;
+import io.atomix.core.profile.Profiles;
+
+/**
+ * Atomix profile deserializer.
+ */
+public class ProfileDeserializer extends PolymorphicTypeDeserializer<Profile> {
+  @SuppressWarnings("unchecked")
+  public ProfileDeserializer() {
+    super(Profile.class, name -> Profiles.getNamedProfile(name).getClass());
+  }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,13 +41,11 @@
       <groupId>io.atomix</groupId>
       <artifactId>atomix-raft</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>
       <artifactId>atomix-primary-backup</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.atomix</groupId>

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -28,6 +28,7 @@ import io.atomix.core.map.AtomicCounterMap;
 import io.atomix.core.map.ConsistentMap;
 import io.atomix.core.map.ConsistentTreeMap;
 import io.atomix.core.multimap.ConsistentMultimap;
+import io.atomix.core.profile.Profile;
 import io.atomix.core.queue.WorkQueue;
 import io.atomix.core.set.DistributedSet;
 import io.atomix.core.transaction.TransactionBuilder;
@@ -142,6 +143,7 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
 
   public Atomix(AtomixConfig config) {
     super(config.getClusterConfig());
+    config.getProfiles().forEach(profile -> profile.configure(config));
     this.executorService = Executors.newScheduledThreadPool(
         Runtime.getRuntime().availableProcessors(),
         Threads.namedThreads("atomix-primitive-%d", LOGGER));
@@ -442,6 +444,38 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
      */
     public Builder withShutdownHook(boolean enabled) {
       config.setEnableShutdownHook(enabled);
+      return this;
+    }
+
+    /**
+     * Sets the Atomix profiles.
+     *
+     * @param profiles the profiles
+     * @return the Atomix builder
+     */
+    public Builder withProfiles(Profile... profiles) {
+      return withProfiles(Arrays.asList(checkNotNull(profiles)));
+    }
+
+    /**
+     * Sets the Atomix profiles.
+     *
+     * @param profiles the profiles
+     * @return the Atomix builder
+     */
+    public Builder withProfiles(Collection<Profile> profiles) {
+      profiles.forEach(config::addProfile);
+      return this;
+    }
+
+    /**
+     * Adds an Atomix profile.
+     *
+     * @param profile the profile to add
+     * @return the Atomix builder
+     */
+    public Builder addProfile(Profile profile) {
+      config.addProfile(profile);
       return this;
     }
 

--- a/core/src/main/java/io/atomix/core/AtomixConfig.java
+++ b/core/src/main/java/io/atomix/core/AtomixConfig.java
@@ -16,6 +16,8 @@
 package io.atomix.core;
 
 import io.atomix.cluster.ClusterConfig;
+import io.atomix.core.profile.Profile;
+import io.atomix.core.profile.Profiles;
 import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionGroupConfig;
@@ -24,7 +26,9 @@ import io.atomix.utils.config.Config;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -38,6 +42,7 @@ public class AtomixConfig implements Config {
   private Collection<PartitionGroupConfig> partitionGroups = new ArrayList<>();
   private Collection<Class<? extends PrimitiveType>> types = new ArrayList<>();
   private Map<String, PrimitiveConfig> primitives = new HashMap<>();
+  private List<Profile> profiles = new ArrayList<>();
 
   /**
    * Returns the cluster configuration.
@@ -203,5 +208,38 @@ public class AtomixConfig implements Config {
   @SuppressWarnings("unchecked")
   public <C extends PrimitiveConfig<C>> C getPrimitive(String name) {
     return (C) primitives.get(name);
+  }
+
+  /**
+   * Returns the Atomix profile.
+   *
+   * @return the Atomix profile
+   */
+  public List<Profile> getProfiles() {
+    return profiles;
+  }
+
+  /**
+   * Sets the Atomix profile.
+   *
+   * @param profiles the profiles
+   * @return the Atomix configuration
+   */
+  public AtomixConfig setProfiles(List<String> profiles) {
+    this.profiles = profiles.stream()
+        .map(name -> Profiles.getNamedProfile(name))
+        .collect(Collectors.toList());
+    return this;
+  }
+
+  /**
+   * Adds an Atomix profile.
+   *
+   * @param profile the profile to add
+   * @return the Atomix configuration
+   */
+  public AtomixConfig addProfile(Profile profile) {
+    profiles.add(checkNotNull(profile, "profile cannot be null"));
+    return this;
   }
 }

--- a/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
+++ b/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.profile;
+
+import io.atomix.cluster.Node;
+import io.atomix.core.AtomixConfig;
+import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
+
+import java.io.File;
+
+/**
+ * Consensus profile.
+ */
+public class ConsensusProfile implements NamedProfile {
+  private static final String NAME = "consensus";
+
+  private static final String SYSTEM_GROUP_NAME = "system";
+  private static final String GROUP_NAME = "consensus";
+  private static final int PARTITION_SIZE = 3;
+  private static final int NUM_PARTITIONS = 7;
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public void configure(AtomixConfig config) {
+    config.setSystemPartitionGroup(new RaftPartitionGroupConfig()
+        .setName(SYSTEM_GROUP_NAME)
+        .setPartitionSize((int) config.getClusterConfig().getNodes()
+            .stream()
+            .filter(node -> node.getType() == Node.Type.PERSISTENT)
+            .count())
+        .setPartitions(1)
+        .setDataDirectory(new File(System.getProperty("user.dir", SYSTEM_GROUP_NAME))));
+    config.addPartitionGroup(new RaftPartitionGroupConfig()
+        .setName(GROUP_NAME)
+        .setPartitionSize(PARTITION_SIZE)
+        .setPartitions(NUM_PARTITIONS)
+        .setDataDirectory(new File(System.getProperty("user.dir"), GROUP_NAME)));
+  }
+}

--- a/core/src/main/java/io/atomix/core/profile/DataGridProfile.java
+++ b/core/src/main/java/io/atomix/core/profile/DataGridProfile.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.profile;
+
+import io.atomix.core.AtomixConfig;
+import io.atomix.primitive.partition.MemberGroupStrategy;
+import io.atomix.protocols.backup.partition.PrimaryBackupPartitionGroupConfig;
+
+/**
+ * In-memory data grid profile.
+ */
+public class DataGridProfile implements NamedProfile {
+  private static final String NAME = "data-grid";
+
+  private static final String SYSTEM_GROUP_NAME = "system";
+  private static final String GROUP_NAME = "data";
+  private static final int NUM_PARTITIONS = 71;
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public void configure(AtomixConfig config) {
+    if (config.getSystemPartitionGroup() == null) {
+      config.setSystemPartitionGroup(new PrimaryBackupPartitionGroupConfig()
+          .setName(SYSTEM_GROUP_NAME)
+          .setPartitions(1)
+          .setMemberGroupStrategy(MemberGroupStrategy.RACK_AWARE));
+    }
+    config.addPartitionGroup(new PrimaryBackupPartitionGroupConfig()
+        .setName(GROUP_NAME)
+        .setPartitions(NUM_PARTITIONS)
+        .setMemberGroupStrategy(MemberGroupStrategy.RACK_AWARE));
+  }
+}

--- a/core/src/main/java/io/atomix/core/profile/NamedProfile.java
+++ b/core/src/main/java/io/atomix/core/profile/NamedProfile.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.profile;
+
+/**
+ * Named Atomix profile.
+ */
+public interface NamedProfile extends Profile {
+
+  /**
+   * Returns the profile name.
+   *
+   * @return the profile name
+   */
+  String name();
+
+}

--- a/core/src/main/java/io/atomix/core/profile/Profile.java
+++ b/core/src/main/java/io/atomix/core/profile/Profile.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.profile;
+
+import io.atomix.core.AtomixConfig;
+
+/**
+ * Atomix profile.
+ */
+public interface Profile {
+
+  /**
+   * Configures the Atomix instance.
+   *
+   * @param config the Atomix configuration
+   */
+  void configure(AtomixConfig config);
+
+}

--- a/core/src/main/java/io/atomix/core/profile/Profiles.java
+++ b/core/src/main/java/io/atomix/core/profile/Profiles.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.profile;
+
+import io.atomix.utils.Services;
+import io.atomix.utils.config.ConfigurationException;
+
+/**
+ * Atomix profiles.
+ */
+public final class Profiles {
+  public static final ConsensusProfile CONSENSUS = new ConsensusProfile();
+  public static final DataGridProfile DATA_GRID = new DataGridProfile();
+
+  /**
+   * Returns the Atomix profile for the given name
+   *
+   * @param profileName the name for which to return the Atomix profile
+   * @return the Atomix profile for the given name
+   */
+  public static NamedProfile getNamedProfile(String profileName) {
+    for (NamedProfile type : Services.loadAll(NamedProfile.class)) {
+      if (type.name().toLowerCase().replace("_", "-").equals(profileName.toLowerCase().replace("_", "-"))) {
+        return type;
+      }
+    }
+    throw new ConfigurationException("Unknown Atomix profile: " + profileName);
+  }
+
+  private Profiles() {
+  }
+}

--- a/core/src/main/resources/META-INF/services/io.atomix.core.profile.NamedProfile
+++ b/core/src/main/resources/META-INF/services/io.atomix.core.profile.NamedProfile
@@ -1,0 +1,17 @@
+#
+# Copyright 2018-present Open Networking Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+io.atomix.core.profile.ConsensusProfile
+io.atomix.core.profile.DataGridProfile


### PR DESCRIPTION
This PR adds support for Atomix instance profiles:

```java
Atomix atomix = Atomix.builder()
  .withLocalNode(...)
  .withNodes(...)
  .withProfiles(Profiles.CONSENSUS, Profiles.DATA_GRID)
  .build();
```