### PR TITLE
Refactor configuration file format

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -132,7 +132,7 @@ public class AtomixAgent {
     if (configString != null) {
       AtomixConfig config = loadConfig(configString);
       if (localMember != null) {
-        config.getClusterConfig().getMembers().stream()
+        config.getClusterConfig().getMembers().values().stream()
             .filter(member -> member.getId().equals(localMember.getId()))
             .findAny()
             .ifPresent(localMemberConfig -> {

--- a/agent/src/test/resources/atomix.yaml
+++ b/agent/src/test/resources/atomix.yaml
@@ -2,18 +2,19 @@
 cluster:
   name: test
   members:
-    - id: node1
+    node1:
       type: persistent
       address: localhost:5000
-    - id: node2
+    node2:
       type: persistent
       address: localhost:5001
-    - id: node3
+    node3:
       type: persistent
       address: localhost:5002
-system-partition-group:
-  name: system
+# The management partition group from which primitives and additional partition groups are managed
+management-group:
   type: raft
+  partitions: 1
   data-directory: target/test-logs/system
   members:
     - node1
@@ -21,8 +22,8 @@ system-partition-group:
     - node3
 # A list of partition groups
 partition-groups:
-  - type: raft
-    name: core
+  raft:
+    type: raft
     storage-level: memory
     partitions: 7
     partition-size: 3
@@ -31,8 +32,8 @@ partition-groups:
       - node1
       - node2
       - node3
-  - type: multi-primary
-    name: data
+  data:
+    type: multi-primary
     partitions: 7
 # Distributed primitive configurations
 primitives:

--- a/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
@@ -19,8 +19,8 @@ import io.atomix.utils.config.Config;
 import io.atomix.utils.net.Address;
 import io.atomix.utils.net.MalformedAddressException;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Cluster configuration.
@@ -32,10 +32,10 @@ public class ClusterConfig implements Config {
 
   private String name = DEFAULT_CLUSTER_NAME;
   private MemberConfig localMember;
-  private Collection<MemberConfig> members = new ArrayList<>();
+  private Map<String, MemberConfig> members = new HashMap<>();
   private boolean multicastEnabled = false;
   private Address multicastAddress;
-  private GroupMembershipConfig membership = new GroupMembershipConfig();
+  private GroupMembershipConfig membershipConfig = new GroupMembershipConfig();
 
   public ClusterConfig() {
     try {
@@ -90,7 +90,7 @@ public class ClusterConfig implements Config {
    *
    * @return the cluster nodes
    */
-  public Collection<MemberConfig> getMembers() {
+  public Map<String, MemberConfig> getMembers() {
     return members;
   }
 
@@ -100,8 +100,20 @@ public class ClusterConfig implements Config {
    * @param members the cluster nodes
    * @return the cluster configuration
    */
-  public ClusterConfig setMembers(Collection<MemberConfig> members) {
+  public ClusterConfig setMembers(Map<String, MemberConfig> members) {
+    members.forEach((id, member) -> member.setId(id));
     this.members = members;
+    return this;
+  }
+
+  /**
+   * Adds a member to the configuration.
+   *
+   * @param member the member to add
+   * @return the cluster configuration
+   */
+  public ClusterConfig addMember(MemberConfig member) {
+    members.put(member.getId().id(), member);
     return this;
   }
 
@@ -150,18 +162,18 @@ public class ClusterConfig implements Config {
    *
    * @return the group membership configuration
    */
-  public GroupMembershipConfig getMembership() {
-    return membership;
+  public GroupMembershipConfig getMembershipConfig() {
+    return membershipConfig;
   }
 
   /**
    * Sets the group membership configuration.
    *
-   * @param membership the group membership configuration
+   * @param membershipConfig the group membership configuration
    * @return the cluster configuration
    */
-  public ClusterConfig setMembership(GroupMembershipConfig membership) {
-    this.membership = membership;
+  public ClusterConfig setMembershipConfig(GroupMembershipConfig membershipConfig) {
+    this.membershipConfig = membershipConfig;
     return this;
   }
 }

--- a/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
+++ b/config/src/test/java/io/atomix/core/config/jackson/JacksonConfigProviderTest.java
@@ -58,7 +58,7 @@ public class JacksonConfigProviderTest {
     File file = new File(getClass().getClassLoader().getResource("env.yaml").getFile());
     assertTrue(provider.isConfigFile(file));
     AtomixConfig config = provider.load(file, AtomixConfig.class);
-    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
+    assertEquals("test", config.getPartitionGroups().values().iterator().next().getName());
   }
 
   @Test
@@ -67,8 +67,8 @@ public class JacksonConfigProviderTest {
     ConfigProvider provider = new JacksonConfigProvider();
     File file = new File(getClass().getClassLoader().getResource("env.yaml").getFile());
     AtomixConfig config = provider.load(IOUtils.toString(file.toURI(), StandardCharsets.UTF_8), AtomixConfig.class);
-    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
-    assertEquals(3, config.getPartitionGroups().iterator().next().getPartitions());
+    assertEquals("test", config.getPartitionGroups().values().iterator().next().getName());
+    assertEquals(3, config.getPartitionGroups().values().iterator().next().getPartitions());
   }
 
   @Test
@@ -78,7 +78,7 @@ public class JacksonConfigProviderTest {
     File file = new File(getClass().getClassLoader().getResource("sys.yaml").getFile());
     assertTrue(provider.isConfigFile(file));
     AtomixConfig config = provider.load(file, AtomixConfig.class);
-    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
+    assertEquals("test", config.getPartitionGroups().values().iterator().next().getName());
   }
 
   @Test
@@ -88,6 +88,6 @@ public class JacksonConfigProviderTest {
     File file = new File(getClass().getClassLoader().getResource("sys.yaml").getFile());
     assertTrue(provider.isConfigFile(file));
     AtomixConfig config = provider.load(IOUtils.toString(file.toURI(), StandardCharsets.UTF_8), AtomixConfig.class);
-    assertEquals("test", config.getPartitionGroups().iterator().next().getName());
+    assertEquals("test", config.getPartitionGroups().values().iterator().next().getName());
   }
 }

--- a/config/src/test/resources/config.json
+++ b/config/src/test/resources/config.json
@@ -11,7 +11,7 @@
       "serializer": {
         "types": [
           {
-            "type": "io.atomix.cluster.NodeId"
+            "type": "io.atomix.cluster.MemberId"
           }
         ]
       }

--- a/config/src/test/resources/config.yaml
+++ b/config/src/test/resources/config.yaml
@@ -3,14 +3,11 @@ cluster:
 primitive-types:
   - io.atomix.core.map.ConsistentMapType
 partition-groups:
-  - name: foo
+  foo:
     type: multi-primary
-    member-filter:
-      type: tag
-      tag: test
 primitives:
   foo:
     type: consistent-map
     serializer:
       types:
-        - type: io.atomix.cluster.NodeId
+        - type: io.atomix.cluster.MemberId

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -43,7 +43,6 @@ import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.ManagedPartitionService;
-import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.primitive.partition.PartitionGroups;
 import io.atomix.primitive.partition.PartitionService;
@@ -66,7 +65,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -362,7 +360,7 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
    * Builds the core partition group.
    */
   private static ManagedPartitionGroup buildSystemPartitionGroup(AtomixConfig config) {
-    return config.getSystemPartitionGroup() != null ? PartitionGroups.createGroup(config.getSystemPartitionGroup()) : null;
+    return config.getManagementGroup() != null ? PartitionGroups.createGroup(config.getManagementGroup()) : null;
   }
 
   /**
@@ -374,7 +372,7 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
       ClusterMessagingService messagingService,
       PrimitiveTypeRegistry primitiveTypeRegistry) {
     List<ManagedPartitionGroup> partitionGroups = new ArrayList<>();
-    for (PartitionGroupConfig partitionGroupConfig : config.getPartitionGroups()) {
+    for (PartitionGroupConfig partitionGroupConfig : config.getPartitionGroups().values()) {
       partitionGroups.add(PartitionGroups.createGroup(partitionGroupConfig));
     }
     return new DefaultPartitionService(clusterMembershipService, messagingService, primitiveTypeRegistry, buildSystemPartitionGroup(config), partitionGroups);
@@ -448,13 +446,13 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
     }
 
     /**
-     * Sets the system partition group.
+     * Sets the system management partition group.
      *
-     * @param systemPartitionGroup the system partition group
+     * @param systemManagementGroup the system management partition group
      * @return the Atomix builder
      */
-    public Builder withSystemPartitionGroup(ManagedPartitionGroup systemPartitionGroup) {
-      config.setSystemPartitionGroup(systemPartitionGroup.config());
+    public Builder withManagementGroup(ManagedPartitionGroup systemManagementGroup) {
+      config.setManagementGroup(systemManagementGroup.config());
       return this;
     }
 
@@ -477,7 +475,7 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
      * @throws NullPointerException if the partition groups are null
      */
     public Builder withPartitionGroups(Collection<ManagedPartitionGroup> partitionGroups) {
-      config.setPartitionGroups(partitionGroups.stream().map(PartitionGroup::config).collect(Collectors.toList()));
+      partitionGroups.forEach(group -> config.addPartitionGroup(group.config()));
       return this;
     }
 

--- a/core/src/main/java/io/atomix/core/AtomixConfig.java
+++ b/core/src/main/java/io/atomix/core/AtomixConfig.java
@@ -36,10 +36,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Atomix configuration.
  */
 public class AtomixConfig implements Config {
+  private static final String MANAGEMENT_GROUP_NAME = "system";
+
   private ClusterConfig cluster = new ClusterConfig();
   private boolean enableShutdownHook;
-  private PartitionGroupConfig systemPartitionGroup;
-  private Collection<PartitionGroupConfig> partitionGroups = new ArrayList<>();
+  private PartitionGroupConfig managementGroup;
+  private Map<String, PartitionGroupConfig> partitionGroups = new HashMap<>();
   private Collection<Class<? extends PrimitiveType>> types = new ArrayList<>();
   private Map<String, PrimitiveConfig> primitives = new HashMap<>();
   private List<Profile> profiles = new ArrayList<>();
@@ -85,22 +87,23 @@ public class AtomixConfig implements Config {
   }
 
   /**
-   * Returns the system partition group.
+   * Returns the system management partition group.
    *
-   * @return the system partition group
+   * @return the system management partition group
    */
-  public PartitionGroupConfig getSystemPartitionGroup() {
-    return systemPartitionGroup;
+  public PartitionGroupConfig getManagementGroup() {
+    return managementGroup;
   }
 
   /**
-   * Sets the system partition group.
+   * Sets the system management partition group.
    *
-   * @param systemPartitionGroup the system partition group
+   * @param managementGroup the system management partition group
    * @return the Atomix configuration
    */
-  public AtomixConfig setSystemPartitionGroup(PartitionGroupConfig systemPartitionGroup) {
-    this.systemPartitionGroup = systemPartitionGroup;
+  public AtomixConfig setManagementGroup(PartitionGroupConfig managementGroup) {
+    managementGroup.setName(MANAGEMENT_GROUP_NAME);
+    this.managementGroup = managementGroup;
     return this;
   }
 
@@ -109,7 +112,7 @@ public class AtomixConfig implements Config {
    *
    * @return the partition group configurations
    */
-  public Collection<PartitionGroupConfig> getPartitionGroups() {
+  public Map<String, PartitionGroupConfig> getPartitionGroups() {
     return partitionGroups;
   }
 
@@ -119,7 +122,8 @@ public class AtomixConfig implements Config {
    * @param partitionGroups the partition group configurations
    * @return the Atomix configuration
    */
-  public AtomixConfig setPartitionGroups(Collection<PartitionGroupConfig> partitionGroups) {
+  public AtomixConfig setPartitionGroups(Map<String, PartitionGroupConfig> partitionGroups) {
+    partitionGroups.forEach((name, group) -> group.setName(name));
     this.partitionGroups = partitionGroups;
     return this;
   }
@@ -131,7 +135,7 @@ public class AtomixConfig implements Config {
    * @return the Atomix configuration
    */
   public AtomixConfig addPartitionGroup(PartitionGroupConfig partitionGroup) {
-    partitionGroups.add(partitionGroup);
+    partitionGroups.put(partitionGroup.getName(), partitionGroup);
     return this;
   }
 

--- a/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
+++ b/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
@@ -40,14 +40,16 @@ public class ConsensusProfile implements NamedProfile {
 
   @Override
   public void configure(AtomixConfig config) {
-    config.setSystemPartitionGroup(new RaftPartitionGroupConfig()
+    config.setManagementGroup(new RaftPartitionGroupConfig()
         .setName(SYSTEM_GROUP_NAME)
         .setPartitionSize((int) config.getClusterConfig().getMembers()
+            .values()
             .stream()
             .filter(node -> node.getType() == Member.Type.PERSISTENT)
             .count())
         .setPartitions(1)
         .setMembers(config.getClusterConfig().getMembers()
+            .values()
             .stream()
             .filter(node -> node.getType() == Member.Type.PERSISTENT)
             .map(node -> node.getId().id())
@@ -58,6 +60,7 @@ public class ConsensusProfile implements NamedProfile {
         .setPartitionSize(PARTITION_SIZE)
         .setPartitions(NUM_PARTITIONS)
         .setMembers(config.getClusterConfig().getMembers()
+            .values()
             .stream()
             .filter(node -> node.getType() == Member.Type.PERSISTENT)
             .map(node -> node.getId().id())

--- a/core/src/main/java/io/atomix/core/profile/DataGridProfile.java
+++ b/core/src/main/java/io/atomix/core/profile/DataGridProfile.java
@@ -36,8 +36,8 @@ public class DataGridProfile implements NamedProfile {
 
   @Override
   public void configure(AtomixConfig config) {
-    if (config.getSystemPartitionGroup() == null) {
-      config.setSystemPartitionGroup(new PrimaryBackupPartitionGroupConfig()
+    if (config.getManagementGroup() == null) {
+      config.setManagementGroup(new PrimaryBackupPartitionGroupConfig()
           .setName(SYSTEM_GROUP_NAME)
           .setPartitions(1)
           .setMemberGroupStrategy(MemberGroupStrategy.RACK_AWARE));

--- a/rest/src/test/java/io/atomix/rest/impl/VertxRestServiceTest.java
+++ b/rest/src/test/java/io/atomix/rest/impl/VertxRestServiceTest.java
@@ -282,7 +282,7 @@ public class VertxRestServiceTest {
         .withClusterName("test")
         .withLocalMember(localMember)
         .withMembers(members)
-        .withSystemPartitionGroup(PrimaryBackupPartitionGroup.builder("system")
+        .withManagementGroup(PrimaryBackupPartitionGroup.builder("system")
             .withNumPartitions(1)
             .build())
         .addPartitionGroup(PrimaryBackupPartitionGroup.builder("data")


### PR DESCRIPTION
This PR refactors the configuration file format to use maps rather than lists wherever entries should be unique, e.g.:

```
members:
  - type: ephemeral
     name: member-1
     address: localhost:5001
  - type: ephemeral
     name: member-2
     address: localhost:5001
```

becomes

```
members:
  member-1:
    type: ephemeral
    address: localhost:5000
  member-2:
    type: ephemeral
    address: localhost:5001
```

This guarantees that all members of the cluster have unique identifiers.