### PR TITLE
Ensure system partition group is closed

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.atomix.utils.concurrent.Threads.namedThreads;
 
@@ -269,11 +270,14 @@ public class DefaultPartitionService implements ManagedPartitionService {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public CompletableFuture<Void> stop() {
     messagingService.unsubscribe(BOOTSTRAP_SUBJECT);
-    List<CompletableFuture<Void>> futures = groups.values().stream()
-        .map(ManagedPartitionGroup::close)
-        .collect(Collectors.toList());
+
+    Stream<CompletableFuture<Void>> systemStream = Stream.of(systemGroup != null ? systemGroup.close() : CompletableFuture.completedFuture(null));
+    Stream<CompletableFuture<Void>> groupStream = groups.values().stream().map(ManagedPartitionGroup::close);
+    List<CompletableFuture<Void>> futures = Stream.concat(systemStream, groupStream).collect(Collectors.toList());
+
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).thenRun(() -> {
       ThreadContext threadContext = this.threadContext;
       if (threadContext != null) {

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
@@ -577,6 +577,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
   public CompletableFuture<Void> close() {
     clusterMembershipService.removeListener(membershipEventListener);
     primaryElection.removeListener(primaryElectionListener);
+    role.close();
     return CompletableFuture.completedFuture(null);
   }
 }


### PR DESCRIPTION
This PR fixes a leak when shutting down `Atomix` instances. Currently, the system partition group may not be shutdown. Additionally, primary-backup `PrimaryRole` threads were not being stopped when primary-backup partitions were shutdown.