### PR TITLE
Fix NPE in Netty connection pool

### DIFF
--- a/messaging/src/main/java/io/atomix/messaging/impl/NettyMessagingService.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/NettyMessagingService.java
@@ -409,11 +409,14 @@ public class NettyMessagingService implements ManagedMessagingService {
     finalFuture.whenComplete((channel, error) -> {
       if (error == null) {
         if (!channel.isActive()) {
-          final CompletableFuture<Channel> currentFuture;
+          CompletableFuture<Channel> currentFuture;
           synchronized (channelPool) {
             currentFuture = channelPool.get(offset);
             if (currentFuture == finalFuture) {
               channelPool.set(offset, null);
+            } else if (currentFuture == null) {
+              currentFuture = openChannel(address);
+              channelPool.set(offset, currentFuture);
             }
           }
 


### PR DESCRIPTION
This PR fixes an NPE in the Netty connection pool which can occur due to a race condition. It just adds another `null` check.