### PR TITLE
Change transaction service partition

### DIFF
--- a/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
@@ -102,7 +102,7 @@ public class CoreTransactionService implements ManagedTransactionService {
   public CompletableFuture<TransactionService> start() {
     return ConsistentMapType.<TransactionId, TransactionState>instance()
         .newPrimitiveBuilder("atomix-transactions", managementService)
-        .withProtocol(managementService.getPartitionService().getDefaultPartitionGroup().newProtocol())
+        .withProtocol(managementService.getPartitionService().getSystemPartitionGroup().newProtocol())
         .withSerializer(SERIALIZER)
         .buildAsync()
         .thenApply(transactions -> {

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxy.java
@@ -415,10 +415,7 @@ public class ConsistentMapProxy extends AbstractAsyncPrimitive<AsyncConsistentMa
 
     return Futures.allOf(transactionsByMap.entrySet()
         .stream()
-        .map(e -> this.<TransactionPrepare, PrepareResult>invokeOn(
-            e.getKey(),
-            PREPARE,
-            new TransactionPrepare(transactionLog))
+        .map(e -> this.<TransactionPrepare, PrepareResult>invokeOn(e.getKey(), PREPARE, new TransactionPrepare(transactionLog))
             .thenApply(v -> v == PrepareResult.OK || v == PrepareResult.PARTIAL_FAILURE))
         .collect(Collectors.toList()))
         .thenApply(list -> list.stream().reduce(Boolean::logicalAnd).orElse(true));

--- a/core/src/test/java/io/atomix/core/map/impl/RaftConsistentMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/RaftConsistentMapTest.java
@@ -17,6 +17,7 @@ package io.atomix.core.map.impl;
 
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import io.atomix.protocols.raft.ReadConsistency;
 
 import java.time.Duration;
 
@@ -29,6 +30,7 @@ public class RaftConsistentMapTest extends ConsistentMapTest {
     return MultiRaftProtocol.builder()
         .withMaxTimeout(Duration.ofSeconds(1))
         .withMaxRetries(5)
+        .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .build();
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/DistributedPrimitiveBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/DistributedPrimitiveBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.primitive;
 
+import com.google.common.base.Joiner;
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocolConfig;
@@ -28,6 +29,7 @@ import io.atomix.utils.serializer.SerializerConfig;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -166,7 +168,10 @@ public abstract class DistributedPrimitiveBuilder<B extends DistributedPrimitive
         if (partitionGroups.size() == 1) {
           protocol = partitionGroups.iterator().next().newProtocol();
         } else {
-          throw new ConfigurationException("Primitive protocol is ambiguous: " + partitionGroups.size() + " partition groups found");
+          String groups = Joiner.on(", ").join(partitionGroups.stream()
+              .map(group -> String.format("%s:%s", group.type().name(), group.name()))
+              .collect(Collectors.toList()));
+          throw new ConfigurationException(String.format("Primitive protocol is ambiguous: %d partition groups found (%s)", partitionGroups.size(), groups));
         }
       } else {
         protocol = PrimitiveProtocols.createProtocol(protocolConfig);

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
@@ -61,9 +61,7 @@ public interface PartitionService {
    */
   @SuppressWarnings("unchecked")
   default <P extends Partition> PartitionGroup<P> getPartitionGroup(PrimitiveProtocol protocol) {
-    if (protocol == null) {
-      return getDefaultPartitionGroup();
-    } else if (protocol.group() != null) {
+    if (protocol.group() != null) {
       PartitionGroup<P> group = getPartitionGroup(protocol.group());
       if (group != null) {
         return group;
@@ -74,16 +72,6 @@ public interface PartitionService {
       }
     }
     return getPartitionGroup(protocol.type());
-  }
-
-  /**
-   * Returns the default partition group.
-   *
-   * @return the default partition group
-   */
-  @SuppressWarnings("unchecked")
-  default <P extends Partition> PartitionGroup<P> getDefaultPartitionGroup() {
-    return getPartitionGroups().iterator().next();
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
@@ -112,12 +112,6 @@ public class DefaultPartitionService implements ManagedPartitionService {
 
   @Override
   @SuppressWarnings("unchecked")
-  public PartitionGroup getDefaultPartitionGroup() {
-    return defaultGroup.group;
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
   public PartitionGroup getPartitionGroup(String name) {
     WrappedPartitionGroup group = groups.get(name);
     if (group != null) {


### PR DESCRIPTION
The `TransactionService` is currently using the default partition group for transaction state. This should be done in the system partition. This also removes the default partition group and defaults the partition group only if a single group is provided. This is because groups are no longer ordered since they can be discovered from other nodes.