### PR TITLE
Handle empty candidates in HashBasedPrimaryElection

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/HashBasedPrimaryElection.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/HashBasedPrimaryElection.java
@@ -30,6 +30,7 @@ import io.atomix.utils.event.AbstractListenerManager;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -79,7 +80,10 @@ public class HashBasedPrimaryElection
       int boffset = Hashing.murmur3_32().hashString(b.memberId().id(), StandardCharsets.UTF_8).asInt() % partitionId.id();
       return aoffset - boffset;
     });
-    currentTerm = new PrimaryTerm(electionService.incrementTerm(), candidates.get(0), candidates.subList(1, candidates.size()));
+    currentTerm = new PrimaryTerm(
+        electionService.incrementTerm(),
+        candidates.isEmpty() ? null : candidates.get(0),
+        candidates.isEmpty() ? Collections.emptyList() : candidates.subList(1, candidates.size()));
     post(new PrimaryElectionEvent(PrimaryElectionEvent.Type.CHANGED, partitionId, currentTerm));
   }
 }


### PR DESCRIPTION
Fixes an exception that occurs when no nodes are candidates in a primary election:

```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:657) ~[na:1.8.0_151]
	at java.util.ArrayList.get(ArrayList.java:433) ~[na:1.8.0_151]
	at io.atomix.primitive.partition.impl.HashBasedPrimaryElection.recomputeTerm(HashBasedPrimaryElection.java:82) ~[classes/:na]
	at io.atomix.primitive.partition.impl.HashBasedPrimaryElection.lambda$new$0(HashBasedPrimaryElection.java:46) ~[classes/:na]
	at io.atomix.utils.event.ListenerRegistry.process(ListenerRegistry.java:66) ~[classes/:na]
	at io.atomix.utils.event.AbstractListenerManager.post(AbstractListenerManager.java:41) [classes/:na]
	at io.atomix.cluster.impl.DefaultClusterMembershipService.lambda$sendHeartbeat$8(DefaultClusterMembershipService.java:227) [classes/:na]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[na:1.8.0_151]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[na:1.8.0_151]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[na:1.8.0_151]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1962) ~[na:1.8.0_151]
	at io.atomix.messaging.impl.NettyMessagingService.lambda$null$11(NettyMessagingService.java:487) ~[classes/:na]
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399) ~[guava-22.0.jar:na]
	at io.atomix.messaging.impl.NettyMessagingService.lambda$null$14(NettyMessagingService.java:487) ~[classes/:na]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[na:1.8.0_151]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) ~[na:1.8.0_151]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[na:1.8.0_151]
	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1962) ~[na:1.8.0_151]
	at io.atomix.messaging.impl.NettyMessagingService$Callback.complete(NettyMessagingService.java:801) ~[classes/:na]
	at io.atomix.messaging.impl.NettyMessagingService$RemoteClientConnection.dispatch(NettyMessagingService.java:1040) ~[classes/:na]
	at io.atomix.messaging.impl.NettyMessagingService$RemoteClientConnection.access$1000(NettyMessagingService.java:991) ~[classes/:na]
	at io.atomix.messaging.impl.NettyMessagingService$InboundMessageDispatcher.channelRead0(NettyMessagingService.java:735) ~[classes/:na]
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310) ~[netty-codec-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284) ~[netty-codec-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1414) ~[netty-transport-4.1.22.Final.jar:4.1.22.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362) ~[
```