### PR TITLE
Allow local member to be configured by name only

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -360,6 +360,17 @@ public class AtomixCluster<T extends AtomixCluster<T>> implements Managed<T> {
     }
 
     /**
+     * Sets the local member name.
+     *
+     * @param localMember the local member name
+     * @return the cluster builder
+     */
+    public Builder withLocalMember(String localMember) {
+      config.setLocalMemberId(localMember);
+      return this;
+    }
+
+    /**
      * Sets the local node metadata.
      *
      * @param localMember the local node metadata

--- a/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
@@ -31,6 +31,7 @@ public class ClusterConfig implements Config {
   private static final int DEFAULT_MULTICAST_PORT = 54321;
 
   private String name = DEFAULT_CLUSTER_NAME;
+  private String localMemberId;
   private MemberConfig localMember;
   private Map<String, MemberConfig> members = new HashMap<>();
   private boolean multicastEnabled = false;
@@ -66,12 +67,36 @@ public class ClusterConfig implements Config {
   }
 
   /**
+   * Returns the local member identifier.
+   *
+   * @return the local member identifier
+   */
+  public String getLocalMemberId() {
+    return localMemberId;
+  }
+
+  /**
+   * Sets the local member identifier.
+   *
+   * @param localMemberId the local member identifier
+   * @return the cluster configuration
+   */
+  public ClusterConfig setLocalMemberId(String localMemberId) {
+    this.localMemberId = localMemberId;
+    return this;
+  }
+
+  /**
    * Returns the local node configuration.
    *
    * @return the local node configuration
    */
   public MemberConfig getLocalMember() {
-    return localMember;
+    MemberConfig member = localMember;
+    if (member == null && localMemberId != null) {
+      member = members.get(localMemberId);
+    }
+    return member;
   }
 
   /**

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
@@ -93,7 +93,7 @@ public class DefaultClusterMembershipService
 
   private final AtomicBoolean started = new AtomicBoolean();
   private final StatefulMember localMember;
-  private final Map<MemberId, StatefulMember> nodes = Maps.newConcurrentMap();
+  private final Map<MemberId, StatefulMember> members = Maps.newConcurrentMap();
   private final Map<MemberId, PhiAccrualFailureDetector> failureDetectors = Maps.newConcurrentMap();
   private final ClusterMetadataEventListener metadataEventListener = this::handleMetadataEvent;
   private final Consumer<byte[]> broadcastListener = this::handleBroadcastMessage;
@@ -135,7 +135,7 @@ public class DefaultClusterMembershipService
 
   @Override
   public Set<Member> getMembers() {
-    return ImmutableSet.copyOf(nodes.values()
+    return ImmutableSet.copyOf(members.values()
         .stream()
         .filter(node -> node.type() == Member.Type.PERSISTENT || node.getState() == State.ACTIVE)
         .collect(Collectors.toList()));
@@ -143,7 +143,7 @@ public class DefaultClusterMembershipService
 
   @Override
   public Member getMember(MemberId memberId) {
-    Member member = nodes.get(memberId);
+    Member member = members.get(memberId);
     return member != null && (member.type() == Member.Type.PERSISTENT || member.getState() == State.ACTIVE) ? member : null;
   }
 
@@ -159,7 +159,7 @@ public class DefaultClusterMembershipService
    */
   private void handleBroadcastMessage(byte[] message) {
     StatefulMember node = SERIALIZER.decode(message);
-    if (nodes.putIfAbsent(node.id(), node) == null) {
+    if (members.putIfAbsent(node.id(), node) == null) {
       post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, node));
       post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ACTIVATED, node));
       sendHeartbeats();
@@ -170,14 +170,14 @@ public class DefaultClusterMembershipService
    * Sends heartbeats to all peers.
    */
   private CompletableFuture<Void> sendHeartbeats() {
-    Stream<StatefulMember> clusterNodes = this.nodes.values()
+    Stream<StatefulMember> clusterNodes = this.members.values()
         .stream()
         .filter(node -> !node.id().equals(getLocalMember().id()));
 
     Stream<StatefulMember> bootstrapNodes = bootstrapMetadataService.getMetadata()
         .nodes()
         .stream()
-        .filter(node -> !node.id().equals(getLocalMember().id()) && !nodes.containsKey(node.id()))
+        .filter(node -> !node.id().equals(getLocalMember().id()) && !members.containsKey(node.id()))
         .map(node -> new StatefulMember(
             node.id(),
             node.type(),
@@ -222,7 +222,7 @@ public class DefaultClusterMembershipService
         Collection<StatefulMember> nodes = SERIALIZER.decode(response);
         boolean sendHeartbeats = false;
         for (StatefulMember node : nodes) {
-          if (this.nodes.putIfAbsent(node.id(), node) == null) {
+          if (this.members.putIfAbsent(node.id(), node) == null) {
             post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, node));
             post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ACTIVATED, node));
             sendHeartbeats = true;
@@ -253,7 +253,7 @@ public class DefaultClusterMembershipService
         heartbeat.rack(),
         heartbeat.host(),
         heartbeat.tags()));
-    return SERIALIZER.encode(nodes.values().stream()
+    return SERIALIZER.encode(members.values().stream()
         .filter(node -> node.type() == Member.Type.EPHEMERAL)
         .collect(Collectors.toList()));
   }
@@ -262,7 +262,7 @@ public class DefaultClusterMembershipService
    * Activates the given node.
    */
   private void activateNode(Member member) {
-    StatefulMember existingNode = nodes.get(member.id());
+    StatefulMember existingNode = members.get(member.id());
     if (existingNode == null) {
       StatefulMember statefulNode = new StatefulMember(
           member.id(),
@@ -274,7 +274,7 @@ public class DefaultClusterMembershipService
           member.tags());
       LOGGER.info("{} - Node activated: {}", localMember.id(), statefulNode);
       statefulNode.setState(State.ACTIVE);
-      nodes.put(statefulNode.id(), statefulNode);
+      members.put(statefulNode.id(), statefulNode);
       post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, statefulNode));
       post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ACTIVATED, statefulNode));
       sendHeartbeat(member.address(), SERIALIZER.encode(new ClusterHeartbeat(
@@ -295,7 +295,7 @@ public class DefaultClusterMembershipService
    * Deactivates the given node.
    */
   private void deactivateNode(Member member) {
-    StatefulMember existingNode = nodes.get(member.id());
+    StatefulMember existingNode = members.get(member.id());
     if (existingNode != null && existingNode.getState() == State.ACTIVE) {
       LOGGER.info("{} - Node deactivated: {}", localMember.id(), existingNode);
       existingNode.setState(State.INACTIVE);
@@ -321,7 +321,7 @@ public class DefaultClusterMembershipService
     // Collect the bootstrap node IDs into a set.
     Set<MemberId> bootstrapNodes = event.subject().nodes().stream()
         .map(node -> {
-          StatefulMember existingNode = nodes.get(node.id());
+          StatefulMember existingNode = members.get(node.id());
           if (existingNode == null) {
             StatefulMember newNode = new StatefulMember(
                 node.id(),
@@ -331,14 +331,14 @@ public class DefaultClusterMembershipService
                 node.rack(),
                 node.host(),
                 node.tags());
-            nodes.put(newNode.id(), newNode);
+            members.put(newNode.id(), newNode);
             post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, newNode));
           }
           return node.id();
         }).collect(Collectors.toSet());
 
     // Filter the set of core node IDs from the local node information.
-    Set<MemberId> dataNodes = nodes.entrySet().stream()
+    Set<MemberId> dataNodes = members.entrySet().stream()
         .filter(entry -> entry.getValue().type() == Member.Type.PERSISTENT)
         .map(entry -> entry.getKey())
         .collect(Collectors.toSet());
@@ -348,7 +348,7 @@ public class DefaultClusterMembershipService
 
     // For each missing data node, remove the node and trigger a NODE_REMOVED event.
     for (MemberId memberId : missingNodes) {
-      StatefulMember existingNode = nodes.remove(memberId);
+      StatefulMember existingNode = members.remove(memberId);
       if (existingNode != null) {
         post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_REMOVED, existingNode));
       }
@@ -362,9 +362,9 @@ public class DefaultClusterMembershipService
       broadcastService.addListener(broadcastListener);
       LOGGER.info("{} - Node activated: {}", localMember.id(), localMember);
       localMember.setState(State.ACTIVE);
-      nodes.put(localMember.id(), localMember);
+      members.put(localMember.id(), localMember);
       persistentMetadataService.getMetadata().nodes()
-          .forEach(node -> nodes.putIfAbsent(node.id(), new StatefulMember(
+          .forEach(node -> members.putIfAbsent(node.id(), new StatefulMember(
               node.id(),
               node.type(),
               node.address(),
@@ -405,7 +405,7 @@ public class DefaultClusterMembershipService
       heartbeatExecutor.shutdownNow();
       LOGGER.info("{} - Node deactivated: {}", localMember.id(), localMember);
       localMember.setState(State.INACTIVE);
-      nodes.clear();
+      members.clear();
       heartbeatFuture.cancel(true);
       messagingService.unregisterHandler(HEARTBEAT_MESSAGE);
       persistentMetadataService.removeListener(metadataEventListener);

--- a/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Atomix cluster test.
+ */
+public class AtomixClusterTest {
+  @Test
+  public void testMembers() throws Exception {
+    Collection<Member> members = Arrays.asList(
+        Member.builder("foo")
+            .withType(Member.Type.EPHEMERAL)
+            .withAddress("localhost:5000")
+            .build(),
+        Member.builder("bar")
+            .withType(Member.Type.EPHEMERAL)
+            .withAddress("localhost:5001")
+            .build(),
+        Member.builder("baz")
+            .withType(Member.Type.EPHEMERAL)
+            .withAddress("localhost:5002")
+            .build());
+
+    AtomixCluster cluster1 = AtomixCluster.builder()
+        .withLocalMember("foo")
+        .withMembers(members)
+        .build();
+    cluster1.start().join();
+
+    assertEquals("foo", cluster1.membershipService().getLocalMember().id().id());
+
+    AtomixCluster cluster2 = AtomixCluster.builder()
+        .withLocalMember("bar")
+        .withMembers(members)
+        .build();
+    cluster2.start().join();
+
+    assertEquals("bar", cluster2.membershipService().getLocalMember().id().id());
+
+    AtomixCluster cluster3 = AtomixCluster.builder()
+        .withLocalMember("baz")
+        .withMembers(members)
+        .build();
+    cluster3.start().join();
+
+    assertEquals("baz", cluster3.membershipService().getLocalMember().id().id());
+  }
+}


### PR DESCRIPTION
This PR allows the local member to be configured by name only if the member is listed in the members list:

```java
    Atomix atomix = Atomix.builder()
        .withLocalMember("foo")
        .withMembers(
            Member.builder("foo")
                .withType(Member.Type.EPHEMERAL)
                .withAddress("localhost:5000")
                .build(),
            Member.builder("bar")
                .withType(Member.Type.EPHEMERAL)
                .withAddress("localhost:5001")
                .build(),
            Member.builder("baz")
                .withType(Member.Type.EPHEMERAL)
                .withAddress("localhost:5002")
                .build())
        ...
        .build();
```