### PR TITLE
Support for primitive service configurations

### DIFF
--- a/config/src/main/java/io/atomix/core/config/jackson/impl/PrimitiveConfigDeserializer.java
+++ b/config/src/main/java/io/atomix/core/config/jackson/impl/PrimitiveConfigDeserializer.java
@@ -24,6 +24,6 @@ import io.atomix.primitive.PrimitiveTypes;
 public class PrimitiveConfigDeserializer extends PolymorphicTypeDeserializer<PrimitiveConfig> {
   @SuppressWarnings("unchecked")
   public PrimitiveConfigDeserializer() {
-    super(PrimitiveConfig.class, type -> PrimitiveTypes.getPrimitiveType(type).configClass());
+    super(PrimitiveConfig.class, type -> PrimitiveTypes.getPrimitiveType(type).primitiveConfigClass());
   }
 }

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -175,7 +175,7 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
   @Override
   public <B extends DistributedPrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends DistributedPrimitive> B primitiveBuilder(
       String name,
-      PrimitiveType<B, C, P> primitiveType) {
+      PrimitiveType<B, C, P, ?> primitiveType) {
     return primitives.primitiveBuilder(name, primitiveType);
   }
 
@@ -245,7 +245,7 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
   }
 
   @Override
-  public <C extends PrimitiveConfig<C>, P extends DistributedPrimitive> P getPrimitive(String name, PrimitiveType<?, C, P> primitiveType, C primitiveConfig) {
+  public <C extends PrimitiveConfig<C>, P extends DistributedPrimitive> P getPrimitive(String name, PrimitiveType<?, C, P, ?> primitiveType, C primitiveConfig) {
     return primitives.getPrimitive(name, primitiveType, primitiveConfig);
   }
 

--- a/core/src/main/java/io/atomix/core/PrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/PrimitivesService.java
@@ -59,8 +59,8 @@ import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveInfo;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.util.Collection;
 
@@ -512,7 +512,10 @@ public interface PrimitivesService {
    * @param <P>             the primitive type
    * @return the primitive instance
    */
-  <C extends PrimitiveConfig<C>, P extends DistributedPrimitive> P getPrimitive(String name, PrimitiveType<?, C, P> primitiveType, C primitiveConfig);
+  <C extends PrimitiveConfig<C>, P extends DistributedPrimitive> P getPrimitive(
+      String name,
+      PrimitiveType<?, C, P, ?> primitiveType,
+      C primitiveConfig);
 
   /**
    * Returns a primitive builder of the given type.
@@ -525,7 +528,7 @@ public interface PrimitivesService {
    */
   <B extends DistributedPrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends DistributedPrimitive> B primitiveBuilder(
       String name,
-      PrimitiveType<B, C, P> primitiveType);
+      PrimitiveType<B, C, P, ?> primitiveType);
 
   /**
    * Returns a primitive builder of the given type.
@@ -539,7 +542,7 @@ public interface PrimitivesService {
    */
   default <B extends DistributedPrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends DistributedPrimitive> B primitiveBuilder(
       String name,
-      PrimitiveType<B, C, P> primitiveType,
+      PrimitiveType<B, C, P, ?> primitiveType,
       PrimitiveProtocol protocol) {
     return primitiveBuilder(name, primitiveType).withProtocol(protocol);
   }

--- a/core/src/main/java/io/atomix/core/counter/AtomicCounterType.java
+++ b/core/src/main/java/io/atomix/core/counter/AtomicCounterType.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.counter;
 
+import io.atomix.core.counter.impl.AtomicCounterOperations;
 import io.atomix.core.counter.impl.AtomicCounterProxyBuilder;
 import io.atomix.core.counter.impl.AtomicCounterResource;
 import io.atomix.core.counter.impl.AtomicCounterService;
@@ -22,17 +23,22 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.KryoNamespaces;
+import io.atomix.utils.serializer.Namespace;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Atomic counter primitive type.
  */
-public class AtomicCounterType implements PrimitiveType<AtomicCounterBuilder, AtomicCounterConfig, AtomicCounter> {
+public class AtomicCounterType implements PrimitiveType<AtomicCounterBuilder, AtomicCounterConfig, AtomicCounter, ServiceConfig> {
   private static final String NAME = "COUNTER";
+  private static final Namespace NAMESPACE = KryoNamespace.builder()
+      .register(KryoNamespaces.BASIC)
+      .register(AtomicCounterOperations.NAMESPACE)
+      .build();
 
   /**
    * Returns a new atomic counter type.
@@ -49,13 +55,13 @@ public class AtomicCounterType implements PrimitiveType<AtomicCounterBuilder, At
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return AtomicCounterService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new AtomicCounterService(config);
   }
 
   @Override
-  public Function<AtomicCounter, PrimitiveResource> resourceFactory() {
-    return AtomicCounterResource::new;
+  public PrimitiveResource newResource(AtomicCounter primitive) {
+    return new AtomicCounterResource(primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/counter/AtomicCounterType.java
+++ b/core/src/main/java/io/atomix/core/counter/AtomicCounterType.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.counter;
 
-import io.atomix.core.counter.impl.AtomicCounterOperations;
 import io.atomix.core.counter.impl.AtomicCounterProxyBuilder;
 import io.atomix.core.counter.impl.AtomicCounterResource;
 import io.atomix.core.counter.impl.AtomicCounterService;
@@ -24,9 +23,6 @@ import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
-import io.atomix.utils.serializer.KryoNamespace;
-import io.atomix.utils.serializer.KryoNamespaces;
-import io.atomix.utils.serializer.Namespace;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -34,11 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Atomic counter primitive type.
  */
 public class AtomicCounterType implements PrimitiveType<AtomicCounterBuilder, AtomicCounterConfig, AtomicCounter, ServiceConfig> {
-  private static final String NAME = "COUNTER";
-  private static final Namespace NAMESPACE = KryoNamespace.builder()
-      .register(KryoNamespaces.BASIC)
-      .register(AtomicCounterOperations.NAMESPACE)
-      .build();
+  private static final String NAME = "counter";
 
   /**
    * Returns a new atomic counter type.

--- a/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterProxyBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.counter.AtomicCounterBuilder;
 import io.atomix.core.counter.AtomicCounterConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -37,6 +38,7 @@ public class AtomicCounterProxyBuilder extends AtomicCounterBuilder {
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicCounterProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterResource.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterResource.java
@@ -16,7 +16,6 @@
 package io.atomix.core.counter.impl;
 
 import io.atomix.core.counter.AsyncAtomicCounter;
-import io.atomix.core.counter.AtomicCounter;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,30 +31,25 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Atomic counter resource.
  */
-public class AtomicCounterResource extends PrimitiveResource<AtomicCounter> {
+public class AtomicCounterResource implements PrimitiveResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(AtomicCounterResource.class);
 
-  public AtomicCounterResource(AtomicCounter primitive) {
-    super(primitive);
-  }
+  private final AsyncAtomicCounter counter;
 
-  /**
-   * Returns the counter primitive.
-   *
-   * @return the counter primitive
-   */
-  private AsyncAtomicCounter counter() {
-    return primitive.async();
+  public AtomicCounterResource(AsyncAtomicCounter counter) {
+    this.counter = checkNotNull(counter);
   }
 
   @GET
   @Path("/")
   @Produces(MediaType.APPLICATION_JSON)
   public void get(@Suspended AsyncResponse response) {
-    counter().get().whenComplete((result, error) -> {
+    counter.get().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -69,7 +63,7 @@ public class AtomicCounterResource extends PrimitiveResource<AtomicCounter> {
   @Path("/")
   @Consumes(MediaType.TEXT_PLAIN)
   public void set(Long value, @Suspended AsyncResponse response) {
-    counter().set(value).whenComplete((result, error) -> {
+    counter.set(value).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {
@@ -83,7 +77,7 @@ public class AtomicCounterResource extends PrimitiveResource<AtomicCounter> {
   @Path("/inc")
   @Produces(MediaType.APPLICATION_JSON)
   public void incrementAndGet(@Suspended AsyncResponse response) {
-    counter().incrementAndGet().whenComplete((result, error) -> {
+    counter.incrementAndGet().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {

--- a/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterService.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterService.java
@@ -23,6 +23,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.KryoNamespaces;
@@ -50,6 +51,10 @@ public class AtomicCounterService extends AbstractPrimitiveService {
       .build());
 
   private Long value = 0L;
+
+  public AtomicCounterService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/main/java/io/atomix/core/election/LeaderElectionType.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectionType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Leader elector primitive type.
  */
 public class LeaderElectionType<T> implements PrimitiveType<LeaderElectionBuilder<T>, LeaderElectionConfig, LeaderElection<T>, ServiceConfig> {
-  private static final String NAME = "LEADER_ELECTION";
+  private static final String NAME = "leader-election";
 
   /**
    * Returns a new leader elector type.

--- a/core/src/main/java/io/atomix/core/election/LeaderElectionType.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectionType.java
@@ -22,16 +22,14 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Leader elector primitive type.
  */
-public class LeaderElectionType<T> implements PrimitiveType<LeaderElectionBuilder<T>, LeaderElectionConfig, LeaderElection<T>> {
+public class LeaderElectionType<T> implements PrimitiveType<LeaderElectionBuilder<T>, LeaderElectionConfig, LeaderElection<T>, ServiceConfig> {
   private static final String NAME = "LEADER_ELECTION";
 
   /**
@@ -50,14 +48,14 @@ public class LeaderElectionType<T> implements PrimitiveType<LeaderElectionBuilde
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return LeaderElectionService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new LeaderElectionService(config);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Function<LeaderElection<T>, PrimitiveResource> resourceFactory() {
-    return election -> new LeaderElectionResource((LeaderElection<String>) election);
+  public PrimitiveResource newResource(LeaderElection<T> primitive) {
+    return new LeaderElectionResource((AsyncLeaderElection<String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/LeaderElectorType.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectorType.java
@@ -28,7 +28,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Leader elector primitive type.
  */
 public class LeaderElectorType<T> implements PrimitiveType<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>, ServiceConfig> {
-  private static final String NAME = "LEADER_ELECTOR";
+  private static final String NAME = "leader-elector";
 
   /**
    * Returns a new leader elector type.

--- a/core/src/main/java/io/atomix/core/election/LeaderElectorType.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectorType.java
@@ -20,15 +20,14 @@ import io.atomix.core.election.impl.LeaderElectorService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Leader elector primitive type.
  */
-public class LeaderElectorType<T> implements PrimitiveType<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>> {
+public class LeaderElectorType<T> implements PrimitiveType<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>, ServiceConfig> {
   private static final String NAME = "LEADER_ELECTOR";
 
   /**
@@ -47,8 +46,8 @@ public class LeaderElectorType<T> implements PrimitiveType<LeaderElectorBuilder<
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return LeaderElectorService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new LeaderElectorService(config);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectionProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectionProxyBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.election.LeaderElectionBuilder;
 import io.atomix.core.election.LeaderElectionConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +39,7 @@ public class LeaderElectionProxyBuilder<T> extends LeaderElectionBuilder<T> {
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new LeaderElectionProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectionResource.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectionResource.java
@@ -16,7 +16,6 @@
 package io.atomix.core.election.impl;
 
 import io.atomix.core.election.AsyncLeaderElection;
-import io.atomix.core.election.LeaderElection;
 import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEvent;
 import io.atomix.core.election.LeadershipEventListener;
@@ -44,27 +43,20 @@ import java.util.UUID;
 /**
  * Leader election resource.
  */
-public class LeaderElectionResource extends PrimitiveResource<LeaderElection<String>> {
+public class LeaderElectionResource implements PrimitiveResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(LeaderElectionResource.class);
 
-  public LeaderElectionResource(LeaderElection<String> leaderElection) {
-    super(leaderElection);
-  }
+  private final AsyncLeaderElection<String> election;
 
-  /**
-   * Returns the election primitive.
-   *
-   * @return the election primitive
-   */
-  private AsyncLeaderElection<String> election() {
-    return primitive.async();
+  public LeaderElectionResource(AsyncLeaderElection<String> election) {
+    this.election = election;
   }
 
   /**
    * Returns an event log name for the given identifier.
    */
   private String getEventLogName(String id) {
-    return String.format("%s-%s", election().name(), id);
+    return String.format("%s-%s", election.name(), id);
   }
 
   @POST
@@ -74,9 +66,9 @@ public class LeaderElectionResource extends PrimitiveResource<LeaderElection<Str
     EventLog<LeadershipEventListener<String>, LeadershipEvent<String>> eventLog = events.getOrCreateEventLog(
         AsyncLeaderElection.class, getEventLogName(id), l -> e -> l.addEvent(e));
 
-    election().addListener(eventLog.listener()).whenComplete((listenResult, listenError) -> {
+    election.addListener(eventLog.listener()).whenComplete((listenResult, listenError) -> {
       if (listenError == null) {
-        election().run(id).whenComplete((runResult, runError) -> {
+        election.run(id).whenComplete((runResult, runError) -> {
           if (runError == null) {
             response.resume(Response.ok(id).build());
           } else {
@@ -94,7 +86,7 @@ public class LeaderElectionResource extends PrimitiveResource<LeaderElection<Str
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   public void getLeadership(@Suspended AsyncResponse response) {
-    election().getLeadership().whenComplete((result, error) -> {
+    election.getLeadership().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(new LeadershipResponse(result)).build());
       } else {
@@ -121,7 +113,7 @@ public class LeaderElectionResource extends PrimitiveResource<LeaderElection<Str
         if (event.newLeadership().leader() != null && event.newLeadership().leader().id().equals(id)) {
           response.resume(Response.ok(new LeadershipResponse(event.newLeadership())).build());
         } else if (event.newLeadership().candidates().stream().noneMatch(c -> c.equals(id))) {
-          election().removeListener(eventLog.listener()).whenComplete((removeResult, removeError) -> {
+          election.removeListener(eventLog.listener()).whenComplete((removeResult, removeError) -> {
             response.resume(Response.status(Status.NOT_FOUND).build());
           });
         }
@@ -137,8 +129,8 @@ public class LeaderElectionResource extends PrimitiveResource<LeaderElection<Str
     EventLog<LeadershipEventListener<String>, LeadershipEvent<String>> eventLog = events.removeEventLog(
         AsyncLeaderElection.class, getEventLogName(id));
     if (eventLog != null && eventLog.close()) {
-      election().removeListener(eventLog.listener()).whenComplete((removeResult, removeError) -> {
-        election().withdraw(id).whenComplete((withdrawResult, withdrawError) -> {
+      election.removeListener(eventLog.listener()).whenComplete((removeResult, removeError) -> {
+        election.withdraw(id).whenComplete((withdrawResult, withdrawError) -> {
           if (withdrawError == null) {
             response.resume(Response.ok().build());
           } else {
@@ -155,7 +147,7 @@ public class LeaderElectionResource extends PrimitiveResource<LeaderElection<Str
   @POST
   @Path("/{id}/anoint")
   public void anoint(@PathParam("id") String id, @Suspended AsyncResponse response) {
-    election().anoint(id).whenComplete((result, error) -> {
+    election.anoint(id).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {
@@ -168,7 +160,7 @@ public class LeaderElectionResource extends PrimitiveResource<LeaderElection<Str
   @POST
   @Path("/{id}/promote")
   public void promote(@PathParam("id") String id, @Suspended AsyncResponse response) {
-    election().promote(id).whenComplete((result, error) -> {
+    election.promote(id).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {
@@ -181,7 +173,7 @@ public class LeaderElectionResource extends PrimitiveResource<LeaderElection<Str
   @POST
   @Path("/{id}/evict")
   public void evict(@PathParam("id") String id, @Suspended AsyncResponse response) {
-    election().evict(id).whenComplete((result, error) -> {
+    election.evict(id).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectionService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectionService.java
@@ -33,6 +33,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.misc.ArraySizeHashPrinter;
@@ -77,6 +78,10 @@ public class LeaderElectionService extends AbstractPrimitiveService {
   private List<Registration> registrations = new LinkedList<>();
   private AtomicLong termCounter = new AtomicLong();
   private Map<Long, PrimitiveSession> listeners = new LinkedHashMap<>();
+
+  public LeaderElectionService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxyBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.election.LeaderElectorBuilder;
 import io.atomix.core.election.LeaderElectorConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +39,7 @@ public class LeaderElectorProxyBuilder<T> extends LeaderElectorBuilder<T> {
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new LeaderElectorProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorService.java
@@ -38,6 +38,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.misc.ArraySizeHashPrinter;
@@ -84,6 +85,10 @@ public class LeaderElectorService extends AbstractPrimitiveService {
   private Map<String, AtomicLong> termCounters = new HashMap<>();
   private Map<String, ElectionState> elections = new HashMap<>();
   private Map<Long, PrimitiveSession> listeners = new LinkedHashMap<>();
+
+  public LeaderElectorService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/main/java/io/atomix/core/generator/AtomicIdGeneratorType.java
+++ b/core/src/main/java/io/atomix/core/generator/AtomicIdGeneratorType.java
@@ -22,16 +22,14 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Atomic ID generator primitive type.
  */
-public class AtomicIdGeneratorType implements PrimitiveType<AtomicIdGeneratorBuilder, AtomicIdGeneratorConfig, AtomicIdGenerator> {
+public class AtomicIdGeneratorType implements PrimitiveType<AtomicIdGeneratorBuilder, AtomicIdGeneratorConfig, AtomicIdGenerator, ServiceConfig> {
   private static final String NAME = "ID_GENERATOR";
 
   /**
@@ -49,13 +47,13 @@ public class AtomicIdGeneratorType implements PrimitiveType<AtomicIdGeneratorBui
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return AtomicCounterService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new AtomicCounterService(config);
   }
 
   @Override
-  public Function<AtomicIdGenerator, PrimitiveResource> resourceFactory() {
-    return AtomicIdGeneratorResource::new;
+  public PrimitiveResource newResource(AtomicIdGenerator primitive) {
+    return new AtomicIdGeneratorResource(primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/generator/AtomicIdGeneratorType.java
+++ b/core/src/main/java/io/atomix/core/generator/AtomicIdGeneratorType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Atomic ID generator primitive type.
  */
 public class AtomicIdGeneratorType implements PrimitiveType<AtomicIdGeneratorBuilder, AtomicIdGeneratorConfig, AtomicIdGenerator, ServiceConfig> {
-  private static final String NAME = "ID_GENERATOR";
+  private static final String NAME = "id-generator";
 
   /**
    * Returns a new atomic ID generator type.

--- a/core/src/main/java/io/atomix/core/generator/impl/AtomicIdGeneratorResource.java
+++ b/core/src/main/java/io/atomix/core/generator/impl/AtomicIdGeneratorResource.java
@@ -16,7 +16,6 @@
 package io.atomix.core.generator.impl;
 
 import io.atomix.core.generator.AsyncAtomicIdGenerator;
-import io.atomix.core.generator.AtomicIdGenerator;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,26 +30,19 @@ import javax.ws.rs.core.Response;
 /**
  * Unique ID generator resource.
  */
-public class AtomicIdGeneratorResource extends PrimitiveResource<AtomicIdGenerator> {
+public class AtomicIdGeneratorResource implements PrimitiveResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(AtomicIdGeneratorResource.class);
 
-  public AtomicIdGeneratorResource(AtomicIdGenerator idGenerator) {
-    super(idGenerator);
-  }
+  private final AsyncAtomicIdGenerator idGenerator;
 
-  /**
-   * Returns the ID generator primitive.
-   *
-   * @return the ID generator primitive
-   */
-  private AsyncAtomicIdGenerator idGenerator() {
-    return primitive.async();
+  public AtomicIdGeneratorResource(AsyncAtomicIdGenerator idGenerator) {
+    this.idGenerator = idGenerator;
   }
 
   @PUT
   @Produces(MediaType.APPLICATION_JSON)
   public void next(@Suspended AsyncResponse response) {
-    idGenerator().nextId().whenComplete((result, error) -> {
+    idGenerator.nextId().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {

--- a/core/src/main/java/io/atomix/core/generator/impl/DelegatingAtomicIdGeneratorBuilder.java
+++ b/core/src/main/java/io/atomix/core/generator/impl/DelegatingAtomicIdGeneratorBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.generator.AtomicIdGeneratorBuilder;
 import io.atomix.core.generator.AtomicIdGeneratorConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -38,6 +39,7 @@ public class DelegatingAtomicIdGeneratorBuilder extends AtomicIdGeneratorBuilder
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicCounterProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
@@ -29,6 +29,7 @@ import io.atomix.primitive.PrimitiveTypes;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.KryoNamespaces;
 import io.atomix.utils.serializer.Serializer;
 
@@ -121,6 +122,7 @@ public class CorePrimitiveRegistry implements ManagedPrimitiveRegistry {
     PrimitiveProxy proxy = protocol.newProxy(
         "primitives",
         ConsistentMapType.instance(),
+        new ServiceConfig(),
         partitionService);
     return proxy.connect()
         .thenApply(v -> {

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -180,7 +180,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
 
   @Override
   public <B extends DistributedPrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends DistributedPrimitive> B primitiveBuilder(
-      String name, PrimitiveType<B, C, P> primitiveType) {
+      String name, PrimitiveType<B, C, P, ?> primitiveType) {
     return primitiveType.newPrimitiveBuilder(name, managementService);
   }
 
@@ -196,7 +196,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
 
         PrimitiveConfig primitiveConfig = config.getPrimitive(name);
         if (primitiveConfig == null) {
-          primitiveConfig = (PrimitiveConfig) info.type().configClass().newInstance();
+          primitiveConfig = (PrimitiveConfig) info.type().primitiveConfigClass().newInstance();
         }
         return info.type().newPrimitiveBuilder(name, primitiveConfig, managementService).build();
       });
@@ -208,7 +208,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
   @Override
   @SuppressWarnings("unchecked")
   public <C extends PrimitiveConfig<C>, P extends DistributedPrimitive> P getPrimitive(
-      String name, PrimitiveType<?, C, P> primitiveType, C primitiveConfig) {
+      String name, PrimitiveType<?, C, P, ?> primitiveType, C primitiveConfig) {
     try {
       return (P) cache.get(name, () -> {
         if (primitiveConfig == null) {

--- a/core/src/main/java/io/atomix/core/lock/DistributedLockType.java
+++ b/core/src/main/java/io/atomix/core/lock/DistributedLockType.java
@@ -22,16 +22,14 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Distributed lock primitive type.
  */
-public class DistributedLockType implements PrimitiveType<DistributedLockBuilder, DistributedLockConfig, DistributedLock> {
+public class DistributedLockType implements PrimitiveType<DistributedLockBuilder, DistributedLockConfig, DistributedLock, ServiceConfig> {
   private static final String NAME = "LOCK";
 
   /**
@@ -49,13 +47,14 @@ public class DistributedLockType implements PrimitiveType<DistributedLockBuilder
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return DistributedLockService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new DistributedLockService(config);
   }
 
   @Override
-  public Function<DistributedLock, PrimitiveResource> resourceFactory() {
-    return DistributedLockResource::new;
+  @SuppressWarnings("unchecked")
+  public PrimitiveResource newResource(DistributedLock primitive) {
+    return new DistributedLockResource(primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/lock/DistributedLockType.java
+++ b/core/src/main/java/io/atomix/core/lock/DistributedLockType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Distributed lock primitive type.
  */
 public class DistributedLockType implements PrimitiveType<DistributedLockBuilder, DistributedLockConfig, DistributedLock, ServiceConfig> {
-  private static final String NAME = "LOCK";
+  private static final String NAME = "lock";
 
   /**
    * Returns a new distributed lock type.

--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxyBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.lock.DistributedLockBuilder;
 import io.atomix.core.lock.DistributedLockConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -38,6 +39,7 @@ public class DistributedLockProxyBuilder extends DistributedLockBuilder {
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new DistributedLockProxy(proxy, managementService.getPrimitiveRegistry(), managementService.getExecutorService())
         .connect()

--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockResource.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockResource.java
@@ -16,7 +16,6 @@
 package io.atomix.core.lock.impl;
 
 import io.atomix.core.lock.AsyncDistributedLock;
-import io.atomix.core.lock.DistributedLock;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,26 +31,19 @@ import javax.ws.rs.core.Response;
 /**
  * Distributed lock resource.
  */
-public class DistributedLockResource extends PrimitiveResource<DistributedLock> {
+public class DistributedLockResource implements PrimitiveResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(DistributedLockResource.class);
 
-  public DistributedLockResource(DistributedLock lock) {
-    super(lock);
-  }
+  private final AsyncDistributedLock lock;
 
-  /**
-   * Returns the lock primitive.
-   *
-   * @return the lock primitive
-   */
-  private AsyncDistributedLock lock() {
-    return primitive.async();
+  public DistributedLockResource(AsyncDistributedLock lock) {
+    this.lock = lock;
   }
 
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   public void lock(@Suspended AsyncResponse response) {
-    lock().lock().whenComplete((result, error) -> {
+    lock.lock().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result.value()).build());
       } else {
@@ -63,7 +55,7 @@ public class DistributedLockResource extends PrimitiveResource<DistributedLock> 
 
   @DELETE
   public void unlock(@Suspended AsyncResponse response) {
-    lock().unlock().whenComplete((result, error) -> {
+    lock.unlock().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {

--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockService.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockService.java
@@ -21,6 +21,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.concurrent.Scheduled;
@@ -54,6 +55,10 @@ public class DistributedLockService extends AbstractPrimitiveService {
   private LockHolder lock;
   private Queue<LockHolder> queue = new ArrayDeque<>();
   private final Map<Long, Scheduled> timers = new HashMap<>();
+
+  public DistributedLockService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/main/java/io/atomix/core/map/AtomicCounterMapType.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicCounterMapType.java
@@ -28,7 +28,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Atomic counter map primitive type.
  */
 public class AtomicCounterMapType<K> implements PrimitiveType<AtomicCounterMapBuilder<K>, AtomicCounterMapConfig, AtomicCounterMap<K>, ServiceConfig> {
-  private static final String NAME = "COUNTER_MAP";
+  private static final String NAME = "counter-map";
 
   /**
    * Returns a new atomic counter map type.

--- a/core/src/main/java/io/atomix/core/map/AtomicCounterMapType.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicCounterMapType.java
@@ -20,15 +20,14 @@ import io.atomix.core.map.impl.AtomicCounterMapService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Atomic counter map primitive type.
  */
-public class AtomicCounterMapType<K> implements PrimitiveType<AtomicCounterMapBuilder<K>, AtomicCounterMapConfig, AtomicCounterMap<K>> {
+public class AtomicCounterMapType<K> implements PrimitiveType<AtomicCounterMapBuilder<K>, AtomicCounterMapConfig, AtomicCounterMap<K>, ServiceConfig> {
   private static final String NAME = "COUNTER_MAP";
 
   /**
@@ -47,8 +46,8 @@ public class AtomicCounterMapType<K> implements PrimitiveType<AtomicCounterMapBu
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return AtomicCounterMapService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new AtomicCounterMapService(config);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/ConsistentMapType.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentMapType.java
@@ -15,23 +15,32 @@
  */
 package io.atomix.core.map;
 
+import io.atomix.core.map.impl.ConsistentMapEvents;
+import io.atomix.core.map.impl.ConsistentMapOperations;
 import io.atomix.core.map.impl.ConsistentMapProxyBuilder;
 import io.atomix.core.map.impl.ConsistentMapResource;
 import io.atomix.core.map.impl.ConsistentMapService;
+import io.atomix.core.transaction.TransactionId;
+import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
+import io.atomix.primitive.resource.PrimitiveResourceFactory;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.PrimitiveServiceFactory;
+import io.atomix.primitive.service.ServiceConfig;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.KryoNamespaces;
+import io.atomix.utils.serializer.Namespace;
 
-import java.util.function.Function;
-import java.util.function.Supplier;
+import java.util.HashMap;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Consistent map primitive type.
  */
-public class ConsistentMapType<K, V> implements PrimitiveType<ConsistentMapBuilder<K, V>, ConsistentMapConfig, ConsistentMap<K, V>> {
+public class ConsistentMapType<K, V> implements PrimitiveType<ConsistentMapBuilder<K, V>, ConsistentMapConfig, ConsistentMap<K, V>, ServiceConfig> {
   private static final String NAME = "CONSISTENT_MAP";
 
   /**
@@ -51,14 +60,14 @@ public class ConsistentMapType<K, V> implements PrimitiveType<ConsistentMapBuild
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return ConsistentMapService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new ConsistentMapService(config);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Function<ConsistentMap<K, V>, PrimitiveResource> resourceFactory() {
-    return map -> new ConsistentMapResource((ConsistentMap<String, String>) map);
+  public PrimitiveResource newResource(ConsistentMap<K, V> primitive) {
+    return new ConsistentMapResource((AsyncConsistentMap<String, String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/ConsistentMapType.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentMapType.java
@@ -41,7 +41,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Consistent map primitive type.
  */
 public class ConsistentMapType<K, V> implements PrimitiveType<ConsistentMapBuilder<K, V>, ConsistentMapConfig, ConsistentMap<K, V>, ServiceConfig> {
-  private static final String NAME = "CONSISTENT_MAP";
+  private static final String NAME = "consistent-map";
 
   /**
    * Returns a new consistent map type.

--- a/core/src/main/java/io/atomix/core/map/ConsistentTreeMapType.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentTreeMapType.java
@@ -20,8 +20,7 @@ import io.atomix.core.map.impl.ConsistentTreeMapService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -29,7 +28,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Consistent tree map primitive type.
  */
 public class ConsistentTreeMapType<V>
-    implements PrimitiveType<ConsistentTreeMapBuilder<V>, ConsistentTreeMapConfig, ConsistentTreeMap<V>> {
+    implements PrimitiveType<ConsistentTreeMapBuilder<V>, ConsistentTreeMapConfig, ConsistentTreeMap<V>, ServiceConfig> {
   private static final String NAME = "CONSISTENT_TREEMAP";
 
   /**
@@ -48,8 +47,8 @@ public class ConsistentTreeMapType<V>
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return ConsistentTreeMapService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new ConsistentTreeMapService(config);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/ConsistentTreeMapType.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentTreeMapType.java
@@ -29,7 +29,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  */
 public class ConsistentTreeMapType<V>
     implements PrimitiveType<ConsistentTreeMapBuilder<V>, ConsistentTreeMapConfig, ConsistentTreeMap<V>, ServiceConfig> {
-  private static final String NAME = "CONSISTENT_TREEMAP";
+  private static final String NAME = "consistent-tree-map";
 
   /**
    * Returns a new consistent tree map type.

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapProxyBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.map.AtomicCounterMapBuilder;
 import io.atomix.core.map.AtomicCounterMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -39,6 +40,7 @@ public class AtomicCounterMapProxyBuilder<K> extends AtomicCounterMapBuilder<K> 
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicCounterMapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapService.java
@@ -31,6 +31,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.KryoNamespaces;
@@ -71,6 +72,10 @@ public class AtomicCounterMapService extends AbstractPrimitiveService {
       .build());
 
   private Map<String, Long> map = new HashMap<>();
+
+  public AtomicCounterMapService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapProxyBuilder.java
@@ -22,6 +22,7 @@ import io.atomix.core.map.ConsistentMapBuilder;
 import io.atomix.core.map.ConsistentMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -43,6 +44,7 @@ public class ConsistentMapProxyBuilder<K, V> extends ConsistentMapBuilder<K, V> 
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new ConsistentMapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapResource.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapResource.java
@@ -16,7 +16,6 @@
 package io.atomix.core.map.impl;
 
 import io.atomix.core.map.AsyncConsistentMap;
-import io.atomix.core.map.ConsistentMap;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.utils.time.Versioned;
 import org.slf4j.Logger;
@@ -38,27 +37,20 @@ import javax.ws.rs.core.Response;
 /**
  * Consistent map resource.
  */
-public class ConsistentMapResource extends PrimitiveResource<ConsistentMap<String, String>> {
+public class ConsistentMapResource implements PrimitiveResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(ConsistentMapResource.class);
 
-  public ConsistentMapResource(ConsistentMap<String, String> map) {
-    super(map);
-  }
+  private final AsyncConsistentMap<String, String> map;
 
-  /**
-   * Returns the consistent map primitive.
-   *
-   * @return the consistent map primitive
-   */
-  private AsyncConsistentMap<String, String> map() {
-    return primitive.async();
+  public ConsistentMapResource(AsyncConsistentMap<String, String> map) {
+    this.map = map;
   }
 
   @GET
   @Path("/{key}")
   @Produces(MediaType.APPLICATION_JSON)
   public void get(@PathParam("key") String key, @Suspended AsyncResponse response) {
-    map().get(key).whenComplete((result, error) -> {
+    map.get(key).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result != null ? new VersionedResult(result) : null).build());
       } else {
@@ -73,7 +65,7 @@ public class ConsistentMapResource extends PrimitiveResource<ConsistentMap<Strin
   @Consumes(MediaType.TEXT_PLAIN)
   @Produces(MediaType.APPLICATION_JSON)
   public void put(@PathParam("key") String key, String value, @Suspended AsyncResponse response) {
-    map().put(key, value).whenComplete((result, error) -> {
+    map.put(key, value).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result != null ? new VersionedResult(result) : null).build());
       } else {
@@ -87,7 +79,7 @@ public class ConsistentMapResource extends PrimitiveResource<ConsistentMap<Strin
   @Path("/{key}")
   @Produces(MediaType.APPLICATION_JSON)
   public void remove(@PathParam("key") String key, @Suspended AsyncResponse response) {
-    map().remove(key).whenComplete((result, error) -> {
+    map.remove(key).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result != null ? new VersionedResult(result) : null).build());
       } else {
@@ -101,7 +93,7 @@ public class ConsistentMapResource extends PrimitiveResource<ConsistentMap<Strin
   @Path("/keys")
   @Produces(MediaType.APPLICATION_JSON)
   public void keys(@Suspended AsyncResponse response) {
-    map().keySet().whenComplete((result, error) -> {
+    map.keySet().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -115,7 +107,7 @@ public class ConsistentMapResource extends PrimitiveResource<ConsistentMap<Strin
   @Path("/size")
   @Produces(MediaType.APPLICATION_JSON)
   public void size(@Suspended AsyncResponse response) {
-    map().size().whenComplete((result, error) -> {
+    map.size().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -128,7 +120,7 @@ public class ConsistentMapResource extends PrimitiveResource<ConsistentMap<Strin
   @POST
   @Path("/clear")
   public void clear(@Suspended AsyncResponse response) {
-    map().clear().whenComplete((result, error) -> {
+    map.clear().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.noContent().build());
       } else {

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapService.java
@@ -44,6 +44,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.concurrent.Scheduled;
@@ -118,7 +119,8 @@ public class ConsistentMapService extends AbstractPrimitiveService {
   protected Map<TransactionId, TransactionScope> activeTransactions = Maps.newHashMap();
   protected long currentVersion;
 
-  public ConsistentMapService() {
+  public ConsistentMapService(ServiceConfig config) {
+    super(config);
     map = createMap();
   }
 

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentTreeMapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentTreeMapProxyBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.map.ConsistentTreeMapBuilder;
 import io.atomix.core.map.ConsistentTreeMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -41,6 +42,7 @@ public class ConsistentTreeMapProxyBuilder<V> extends ConsistentTreeMapBuilder<V
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new ConsistentTreeMapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentTreeMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentTreeMapService.java
@@ -29,6 +29,7 @@ import io.atomix.core.map.impl.ConsistentTreeMapOperations.SubMap;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -75,6 +76,10 @@ public class ConsistentTreeMapService extends ConsistentMapService {
       .register(new HashMap().keySet().getClass())
       .register(TreeMap.class)
       .build());
+
+  public ConsistentTreeMapService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   protected TreeMap<String, MapEntryValue> createMap() {

--- a/core/src/main/java/io/atomix/core/multimap/ConsistentMultimapType.java
+++ b/core/src/main/java/io/atomix/core/multimap/ConsistentMultimapType.java
@@ -20,16 +20,15 @@ import io.atomix.core.multimap.impl.ConsistentSetMultimapService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Consistent multimap primitive type.
  */
-public class ConsistentMultimapType<K, V> implements PrimitiveType<ConsistentMultimapBuilder<K, V>, ConsistentMultimapConfig, ConsistentMultimap<K, V>> {
-  private static final String NAME = "CONSISTENT_MULTIMAP";
+public class ConsistentMultimapType<K, V> implements PrimitiveType<ConsistentMultimapBuilder<K, V>, ConsistentMultimapConfig, ConsistentMultimap<K, V>, ServiceConfig> {
+  private static final String NAME = "consistent-multimap";
 
   /**
    * Returns a new consistent multimap type.
@@ -48,8 +47,8 @@ public class ConsistentMultimapType<K, V> implements PrimitiveType<ConsistentMul
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return ConsistentSetMultimapService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new ConsistentSetMultimapService(config);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/ConsistentMultimapProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/ConsistentMultimapProxyBuilder.java
@@ -23,6 +23,7 @@ import io.atomix.core.multimap.ConsistentMultimapBuilder;
 import io.atomix.core.multimap.ConsistentMultimapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -41,6 +42,7 @@ public class ConsistentMultimapProxyBuilder<K, V> extends ConsistentMultimapBuil
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new ConsistentSetMultimapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/multimap/impl/ConsistentSetMultimapService.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/ConsistentSetMultimapService.java
@@ -40,6 +40,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.misc.Match;
@@ -117,6 +118,10 @@ public class ConsistentSetMultimapService extends AbstractPrimitiveService {
   private AtomicLong globalVersion = new AtomicLong(1);
   private Map<Long, PrimitiveSession> listeners = new LinkedHashMap<>();
   private Map<String, MapEntryValue> backingMap = Maps.newHashMap();
+
+  public ConsistentSetMultimapService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/main/java/io/atomix/core/queue/WorkQueueType.java
+++ b/core/src/main/java/io/atomix/core/queue/WorkQueueType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Work queue primitive type.
  */
 public class WorkQueueType<E> implements PrimitiveType<WorkQueueBuilder<E>, WorkQueueConfig, WorkQueue<E>, ServiceConfig> {
-  private static final String NAME = "WORK_QUEUE";
+  private static final String NAME = "work-queue";
 
   /**
    * Returns a new work queue type instance.

--- a/core/src/main/java/io/atomix/core/queue/WorkQueueType.java
+++ b/core/src/main/java/io/atomix/core/queue/WorkQueueType.java
@@ -22,16 +22,14 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Work queue primitive type.
  */
-public class WorkQueueType<E> implements PrimitiveType<WorkQueueBuilder<E>, WorkQueueConfig, WorkQueue<E>> {
+public class WorkQueueType<E> implements PrimitiveType<WorkQueueBuilder<E>, WorkQueueConfig, WorkQueue<E>, ServiceConfig> {
   private static final String NAME = "WORK_QUEUE";
 
   /**
@@ -50,14 +48,14 @@ public class WorkQueueType<E> implements PrimitiveType<WorkQueueBuilder<E>, Work
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return WorkQueueService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new WorkQueueService(config);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Function<WorkQueue<E>, PrimitiveResource> resourceFactory() {
-    return queue -> new WorkQueueResource((WorkQueue<String>) queue);
+  public PrimitiveResource newResource(WorkQueue<E> primitive) {
+    return new WorkQueueResource((AsyncWorkQueue<String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/queue/impl/WorkQueueProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/WorkQueueProxyBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.queue.WorkQueueBuilder;
 import io.atomix.core.queue.WorkQueueConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +39,7 @@ public class WorkQueueProxyBuilder<E> extends WorkQueueBuilder<E> {
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new WorkQueueProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/queue/impl/WorkQueueService.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/WorkQueueService.java
@@ -30,6 +30,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -77,6 +78,10 @@ public class WorkQueueService extends AbstractPrimitiveService {
   private Queue<Task<byte[]>> unassignedTasks = Queues.newArrayDeque();
   private Map<String, TaskAssignment> assignments = Maps.newHashMap();
   private Map<Long, PrimitiveSession> registeredWorkers = Maps.newHashMap();
+
+  public WorkQueueService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/main/java/io/atomix/core/set/DistributedSetType.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSetType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Distributed set primitive type.
  */
 public class DistributedSetType<E> implements PrimitiveType<DistributedSetBuilder<E>, DistributedSetConfig, DistributedSet<E>, ServiceConfig> {
-  private static final String NAME = "SET";
+  private static final String NAME = "set";
 
   /**
    * Returns a new distributed set type.

--- a/core/src/main/java/io/atomix/core/set/DistributedSetType.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSetType.java
@@ -15,24 +15,21 @@
  */
 package io.atomix.core.set;
 
+import io.atomix.core.map.impl.ConsistentMapService;
+import io.atomix.core.set.impl.DelegatingDistributedSetBuilder;
 import io.atomix.core.set.impl.DistributedSetResource;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-import io.atomix.core.map.ConsistentMapType;
-import io.atomix.core.map.impl.ConsistentMapService;
-import io.atomix.core.set.impl.DelegatingDistributedSetBuilder;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Distributed set primitive type.
  */
-public class DistributedSetType<E> implements PrimitiveType<DistributedSetBuilder<E>, DistributedSetConfig, DistributedSet<E>> {
+public class DistributedSetType<E> implements PrimitiveType<DistributedSetBuilder<E>, DistributedSetConfig, DistributedSet<E>, ServiceConfig> {
   private static final String NAME = "SET";
 
   /**
@@ -51,14 +48,14 @@ public class DistributedSetType<E> implements PrimitiveType<DistributedSetBuilde
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return ConsistentMapService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new ConsistentMapService(config);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Function<DistributedSet<E>, PrimitiveResource> resourceFactory() {
-    return set -> new DistributedSetResource((DistributedSet<String>) set);
+  public PrimitiveResource newResource(DistributedSet<E> primitive) {
+    return new DistributedSetResource((AsyncDistributedSet<String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
@@ -26,6 +26,7 @@ import io.atomix.core.set.DistributedSetBuilder;
 import io.atomix.core.set.DistributedSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -46,6 +47,7 @@ public class DelegatingDistributedSetBuilder<E> extends DistributedSetBuilder<E>
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new ConsistentMapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/set/impl/DistributedSetResource.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DistributedSetResource.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set.impl;
 
-import io.atomix.core.set.DistributedSet;
+import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,17 +34,19 @@ import javax.ws.rs.core.Response;
 /**
  * Distributed set resource.
  */
-public class DistributedSetResource extends PrimitiveResource<DistributedSet<String>> {
+public class DistributedSetResource implements PrimitiveResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(DistributedSetResource.class);
 
-  public DistributedSetResource(DistributedSet<String> set) {
-    super(set);
+  private final AsyncDistributedSet<String> set;
+
+  public DistributedSetResource(AsyncDistributedSet<String> set) {
+    this.set = set;
   }
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   public void get(@Suspended AsyncResponse response) {
-    primitive.async().getAsImmutableSet().whenComplete((result, error) -> {
+    set.getAsImmutableSet().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -58,7 +60,7 @@ public class DistributedSetResource extends PrimitiveResource<DistributedSet<Str
   @Path("/{element}")
   @Produces(MediaType.APPLICATION_JSON)
   public void add(@PathParam("element") String element, @Suspended AsyncResponse response) {
-    primitive.async().add(element).whenComplete((result, error) -> {
+    set.add(element).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -72,7 +74,7 @@ public class DistributedSetResource extends PrimitiveResource<DistributedSet<Str
   @Path("/{element}")
   @Produces(MediaType.APPLICATION_JSON)
   public void contains(@PathParam("element") String element, @Suspended AsyncResponse response) {
-    primitive.async().contains(element).whenComplete((result, error) -> {
+    set.contains(element).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -86,7 +88,7 @@ public class DistributedSetResource extends PrimitiveResource<DistributedSet<Str
   @Path("/{element}")
   @Produces(MediaType.APPLICATION_JSON)
   public void remove(@PathParam("element") String element, @Suspended AsyncResponse response) {
-    primitive.async().remove(element).whenComplete((result, error) -> {
+    set.remove(element).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -100,7 +102,7 @@ public class DistributedSetResource extends PrimitiveResource<DistributedSet<Str
   @Path("/size")
   @Produces(MediaType.APPLICATION_JSON)
   public void size(@Suspended AsyncResponse response) {
-    primitive.async().size().whenComplete((result, error) -> {
+    set.size().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -112,7 +114,7 @@ public class DistributedSetResource extends PrimitiveResource<DistributedSet<Str
 
   @DELETE
   public void clear(@Suspended AsyncResponse response) {
-    primitive.async().clear().whenComplete((result, error) -> {
+    set.clear().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {

--- a/core/src/main/java/io/atomix/core/transaction/TransactionType.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionType.java
@@ -28,7 +28,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Transaction primitive type.
  */
 public class TransactionType implements PrimitiveType<TransactionBuilder, TransactionConfig, Transaction, ServiceConfig> {
-  private static final String NAME = "TRANSACTION";
+  private static final String NAME = "transaction";
   private static final TransactionType INSTANCE = new TransactionType();
 
   /**

--- a/core/src/main/java/io/atomix/core/transaction/TransactionType.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionType.java
@@ -20,15 +20,14 @@ import io.atomix.core.transaction.impl.DefaultTransactionBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Transaction primitive type.
  */
-public class TransactionType implements PrimitiveType<TransactionBuilder, TransactionConfig, Transaction> {
+public class TransactionType implements PrimitiveType<TransactionBuilder, TransactionConfig, Transaction, ServiceConfig> {
   private static final String NAME = "TRANSACTION";
   private static final TransactionType INSTANCE = new TransactionType();
 
@@ -47,7 +46,7 @@ public class TransactionType implements PrimitiveType<TransactionBuilder, Transa
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
+  public PrimitiveService newService(ServiceConfig config) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/io/atomix/core/tree/DocumentTreeType.java
+++ b/core/src/main/java/io/atomix/core/tree/DocumentTreeType.java
@@ -18,21 +18,18 @@ package io.atomix.core.tree;
 import io.atomix.core.tree.impl.DocumentTreeProxyBuilder;
 import io.atomix.core.tree.impl.DocumentTreeResource;
 import io.atomix.core.tree.impl.DocumentTreeService;
-import io.atomix.primitive.Ordering;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Document tree primitive type.
  */
-public class DocumentTreeType<V> implements PrimitiveType<DocumentTreeBuilder<V>, DocumentTreeConfig, DocumentTree<V>> {
+public class DocumentTreeType<V> implements PrimitiveType<DocumentTreeBuilder<V>, DocumentTreeConfig, DocumentTree<V>, ServiceConfig> {
   private static final String NAME = "DOCUMENT_TREE";
 
   /**
@@ -51,14 +48,14 @@ public class DocumentTreeType<V> implements PrimitiveType<DocumentTreeBuilder<V>
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return () -> new DocumentTreeService(Ordering.NATURAL);
+  public PrimitiveService newService(ServiceConfig config) {
+    return new DocumentTreeService(config);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Function<DocumentTree<V>, PrimitiveResource> resourceFactory() {
-    return tree -> new DocumentTreeResource((DocumentTree<String>) tree);
+  public PrimitiveResource newResource(DocumentTree<V> primitive) {
+    return new DocumentTreeResource((AsyncDocumentTree<String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/DocumentTreeType.java
+++ b/core/src/main/java/io/atomix/core/tree/DocumentTreeType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Document tree primitive type.
  */
 public class DocumentTreeType<V> implements PrimitiveType<DocumentTreeBuilder<V>, DocumentTreeConfig, DocumentTree<V>, ServiceConfig> {
-  private static final String NAME = "DOCUMENT_TREE";
+  private static final String NAME = "document-tree";
 
   /**
    * Returns a new document tree type.

--- a/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeProxyBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.tree.DocumentTreeBuilder;
 import io.atomix.core.tree.DocumentTreeConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -41,6 +42,7 @@ public class DocumentTreeProxyBuilder<V> extends DocumentTreeBuilder<V> {
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new DocumentTreeProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeService.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeService.java
@@ -41,6 +41,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.misc.Match;
@@ -118,8 +119,9 @@ public class DocumentTreeService extends AbstractPrimitiveService {
   private DocumentTree<byte[]> docTree;
   private Set<DocumentPath> preparedKeys = Sets.newHashSet();
 
-  public DocumentTreeService(Ordering ordering) {
-    this.docTree = new DefaultDocumentTree<>(versionCounter::incrementAndGet, ordering);
+  public DocumentTreeService(ServiceConfig config) {
+    super(config);
+    this.docTree = new DefaultDocumentTree<>(versionCounter::incrementAndGet, Ordering.NATURAL);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/value/AtomicValueType.java
+++ b/core/src/main/java/io/atomix/core/value/AtomicValueType.java
@@ -22,16 +22,14 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Atomic value primitive type.
  */
-public class AtomicValueType<V> implements PrimitiveType<AtomicValueBuilder<V>, AtomicValueConfig, AtomicValue<V>> {
+public class AtomicValueType<V> implements PrimitiveType<AtomicValueBuilder<V>, AtomicValueConfig, AtomicValue<V>, ServiceConfig> {
   private static final String NAME = "VALUE";
 
   /**
@@ -50,14 +48,14 @@ public class AtomicValueType<V> implements PrimitiveType<AtomicValueBuilder<V>, 
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return AtomicValueService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new AtomicValueService(config);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Function<AtomicValue<V>, PrimitiveResource> resourceFactory() {
-    return value -> new AtomicValueResource((AtomicValue<String>) value);
+  public PrimitiveResource newResource(AtomicValue<V> primitive) {
+    return new AtomicValueResource((AsyncAtomicValue<String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/value/AtomicValueType.java
+++ b/core/src/main/java/io/atomix/core/value/AtomicValueType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  * Atomic value primitive type.
  */
 public class AtomicValueType<V> implements PrimitiveType<AtomicValueBuilder<V>, AtomicValueConfig, AtomicValue<V>, ServiceConfig> {
-  private static final String NAME = "VALUE";
+  private static final String NAME = "value";
 
   /**
    * Returns a new value type.

--- a/core/src/main/java/io/atomix/core/value/impl/AtomicValueProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/impl/AtomicValueProxyBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.value.AtomicValueBuilder;
 import io.atomix.core.value.AtomicValueConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
@@ -40,6 +41,7 @@ public class AtomicValueProxyBuilder<V> extends AtomicValueBuilder<V> {
     PrimitiveProxy proxy = protocol().newProxy(
         name(),
         primitiveType(),
+        new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicValueProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()

--- a/core/src/main/java/io/atomix/core/value/impl/AtomicValueResource.java
+++ b/core/src/main/java/io/atomix/core/value/impl/AtomicValueResource.java
@@ -16,7 +16,6 @@
 package io.atomix.core.value.impl;
 
 import io.atomix.core.value.AsyncAtomicValue;
-import io.atomix.core.value.AtomicValue;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,26 +34,19 @@ import javax.ws.rs.core.Response;
 /**
  * Atomic value resource.
  */
-public class AtomicValueResource extends PrimitiveResource<AtomicValue<String>> {
+public class AtomicValueResource implements PrimitiveResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(AtomicValueResource.class);
 
-  public AtomicValueResource(AtomicValue<String> value) {
-    super(value);
-  }
+  private final AsyncAtomicValue<String> value;
 
-  /**
-   * Returns the atomic value primitive.
-   *
-   * @return the atomic value primitive
-   */
-  private AsyncAtomicValue<String> value() {
-    return primitive.async();
+  public AtomicValueResource(AsyncAtomicValue<String> value) {
+    this.value = value;
   }
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   public void get(@Suspended AsyncResponse response) {
-    value().get().whenComplete((result, error) -> {
+    value.get().whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -67,7 +59,7 @@ public class AtomicValueResource extends PrimitiveResource<AtomicValue<String>> 
   @PUT
   @Consumes(MediaType.TEXT_PLAIN)
   public void set(String body, @Suspended AsyncResponse response) {
-    value().set(body).whenComplete((result, error) -> {
+    value.set(body).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {
@@ -81,7 +73,7 @@ public class AtomicValueResource extends PrimitiveResource<AtomicValue<String>> 
   @Path("/cas")
   @Produces(MediaType.APPLICATION_JSON)
   public void compareAndSet(CompareAndSetRequest request, @Suspended AsyncResponse response) {
-    value().compareAndSet(request.getExpect(), request.getUpdate()).whenComplete((result, error) -> {
+    value.compareAndSet(request.getExpect(), request.getUpdate()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {

--- a/core/src/main/java/io/atomix/core/value/impl/AtomicValueService.java
+++ b/core/src/main/java/io/atomix/core/value/impl/AtomicValueService.java
@@ -24,6 +24,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -53,6 +54,10 @@ public class AtomicValueService extends AbstractPrimitiveService {
 
   private byte[] value;
   private java.util.Set<PrimitiveSession> listeners = Sets.newHashSet();
+
+  public AtomicValueService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/core/src/test/java/io/atomix/core/counter/impl/AtomicCounterServiceTest.java
+++ b/core/src/test/java/io/atomix/core/counter/impl/AtomicCounterServiceTest.java
@@ -16,6 +16,7 @@
 package io.atomix.core.counter.impl;
 
 import io.atomix.core.counter.impl.AtomicCounterOperations.Set;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.primitive.service.impl.DefaultCommit;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.mock;
 public class AtomicCounterServiceTest {
   @Test
   public void testSnapshot() throws Exception {
-    AtomicCounterService service = new AtomicCounterService();
+    AtomicCounterService service = new AtomicCounterService(new ServiceConfig());
     service.set(new DefaultCommit<>(
         2,
         SET,
@@ -46,7 +47,7 @@ public class AtomicCounterServiceTest {
     Buffer buffer = HeapBuffer.allocate();
     service.backup(new DefaultBackupOutput(buffer, service.serializer()));
 
-    service = new AtomicCounterService();
+    service = new AtomicCounterService(new ServiceConfig());
     service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
 
     long value = service.get(new DefaultCommit<>(

--- a/core/src/test/java/io/atomix/core/election/impl/LeaderElectionServiceTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/LeaderElectionServiceTest.java
@@ -19,6 +19,7 @@ import io.atomix.core.election.LeaderElectionType;
 import io.atomix.core.election.Leadership;
 import io.atomix.core.election.impl.LeaderElectionOperations.Run;
 import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
@@ -51,7 +52,7 @@ public class LeaderElectionServiceTest {
     PrimitiveSession session = mock(PrimitiveSession.class);
     when(session.sessionId()).thenReturn(SessionId.from(1));
 
-    LeaderElectionService service = new LeaderElectionService();
+    LeaderElectionService service = new LeaderElectionService(new ServiceConfig());
     service.init(context);
 
     byte[] id = "a".getBytes();
@@ -65,7 +66,7 @@ public class LeaderElectionServiceTest {
     Buffer buffer = HeapBuffer.allocate();
     service.backup(new DefaultBackupOutput(buffer, service.serializer()));
 
-    service = new LeaderElectionService();
+    service = new LeaderElectionService(new ServiceConfig());
     service.init(context);
     service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
 

--- a/core/src/test/java/io/atomix/core/map/impl/AtomicCounterMapServiceTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/AtomicCounterMapServiceTest.java
@@ -17,6 +17,7 @@ package io.atomix.core.map.impl;
 
 import io.atomix.core.map.impl.AtomicCounterMapOperations.Get;
 import io.atomix.core.map.impl.AtomicCounterMapOperations.Put;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.primitive.service.impl.DefaultCommit;
@@ -36,7 +37,7 @@ import static org.mockito.Mockito.mock;
 public class AtomicCounterMapServiceTest {
   @Test
   public void testSnapshot() throws Exception {
-    AtomicCounterMapService service = new AtomicCounterMapService();
+    AtomicCounterMapService service = new AtomicCounterMapService(new ServiceConfig());
     service.put(new DefaultCommit<>(
         2,
         PUT,
@@ -47,7 +48,7 @@ public class AtomicCounterMapServiceTest {
     Buffer buffer = HeapBuffer.allocate();
     service.backup(new DefaultBackupOutput(buffer, service.serializer()));
 
-    service = new AtomicCounterMapService();
+    service = new AtomicCounterMapService(new ServiceConfig());
     service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
 
     long value = service.get(new DefaultCommit<>(

--- a/core/src/test/java/io/atomix/core/map/impl/ConsistentMapServiceTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/ConsistentMapServiceTest.java
@@ -17,6 +17,7 @@ package io.atomix.core.map.impl;
 
 import io.atomix.core.map.impl.ConsistentMapOperations.Get;
 import io.atomix.core.map.impl.ConsistentMapOperations.Put;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.primitive.service.impl.DefaultCommit;
@@ -45,7 +46,7 @@ public class ConsistentMapServiceTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testSnapshot() throws Exception {
-    ConsistentMapService service = new TestConsistentMapService();
+    ConsistentMapService service = new TestConsistentMapService(new ServiceConfig());
 
     service.put(new DefaultCommit<>(
         2,
@@ -57,7 +58,7 @@ public class ConsistentMapServiceTest {
     Buffer buffer = HeapBuffer.allocate();
     service.backup(new DefaultBackupOutput(buffer, service.serializer()));
 
-    service = new TestConsistentMapService();
+    service = new TestConsistentMapService(new ServiceConfig());
     service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
 
     Versioned<byte[]> value = service.get(new DefaultCommit<>(
@@ -73,6 +74,10 @@ public class ConsistentMapServiceTest {
   }
 
   private static class TestConsistentMapService extends ConsistentMapService {
+    TestConsistentMapService(ServiceConfig config) {
+      super(config);
+    }
+
     @Override
     protected Scheduler getScheduler() {
       return new Scheduler() {

--- a/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapServiceTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapServiceTest.java
@@ -17,6 +17,7 @@ package io.atomix.core.multimap.impl;
 
 import io.atomix.core.multimap.impl.ConsistentSetMultimapOperations.Get;
 import io.atomix.core.multimap.impl.ConsistentSetMultimapOperations.Put;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.primitive.service.impl.DefaultCommit;
@@ -44,7 +45,7 @@ public class ConsistentSetMultimapServiceTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testSnapshot() throws Exception {
-    ConsistentSetMultimapService service = new ConsistentSetMultimapService();
+    ConsistentSetMultimapService service = new ConsistentSetMultimapService(new ServiceConfig());
     service.put(new DefaultCommit<>(
         2,
         PUT,
@@ -56,7 +57,7 @@ public class ConsistentSetMultimapServiceTest {
     Buffer buffer = HeapBuffer.allocate();
     service.backup(new DefaultBackupOutput(buffer, service.serializer()));
 
-    service = new ConsistentSetMultimapService();
+    service = new ConsistentSetMultimapService(new ServiceConfig());
     service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
 
     Versioned<Collection<? extends byte[]>> value = service.get(new DefaultCommit<>(

--- a/core/src/test/java/io/atomix/core/queue/impl/WorkQueueServiceTest.java
+++ b/core/src/test/java/io/atomix/core/queue/impl/WorkQueueServiceTest.java
@@ -20,6 +20,7 @@ import io.atomix.core.queue.WorkQueueType;
 import io.atomix.core.queue.impl.WorkQueueOperations.Add;
 import io.atomix.core.queue.impl.WorkQueueOperations.Take;
 import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
@@ -55,7 +56,7 @@ public class WorkQueueServiceTest {
     PrimitiveSession session = mock(PrimitiveSession.class);
     when(session.sessionId()).thenReturn(SessionId.from(1));
 
-    WorkQueueService service = new WorkQueueService();
+    WorkQueueService service = new WorkQueueService(new ServiceConfig());
     service.init(context);
 
     service.add(new DefaultCommit<>(
@@ -68,7 +69,7 @@ public class WorkQueueServiceTest {
     Buffer buffer = HeapBuffer.allocate();
     service.backup(new DefaultBackupOutput(buffer, service.serializer()));
 
-    service = new WorkQueueService();
+    service = new WorkQueueService(new ServiceConfig());
     service.init(context);
     service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
 

--- a/core/src/test/java/io/atomix/core/tree/impl/DocumentTreeServiceTest.java
+++ b/core/src/test/java/io/atomix/core/tree/impl/DocumentTreeServiceTest.java
@@ -18,15 +18,15 @@ package io.atomix.core.tree.impl;
 import io.atomix.core.tree.DocumentPath;
 import io.atomix.core.tree.impl.DocumentTreeOperations.Get;
 import io.atomix.core.tree.impl.DocumentTreeOperations.Update;
-import io.atomix.primitive.Ordering;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.primitive.service.impl.DefaultCommit;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.HeapBuffer;
-import io.atomix.utils.time.Versioned;
 import io.atomix.utils.misc.Match;
+import io.atomix.utils.time.Versioned;
 import org.junit.Test;
 
 import java.util.Optional;
@@ -43,17 +43,8 @@ import static org.mockito.Mockito.mock;
 public class DocumentTreeServiceTest {
 
   @Test
-  public void testNaturalOrderedSnapshot() throws Exception {
-    testSnapshot(Ordering.NATURAL);
-  }
-
-  @Test
-  public void testInsertionOrderedSnapshot() throws Exception {
-    testSnapshot(Ordering.INSERTION);
-  }
-
-  private void testSnapshot(Ordering ordering) throws Exception {
-    DocumentTreeService service = new DocumentTreeService(ordering);
+  public void testSnapshot() throws Exception {
+    DocumentTreeService service = new DocumentTreeService(new ServiceConfig());
     service.update(new DefaultCommit<>(
         2,
         UPDATE,
@@ -68,7 +59,7 @@ public class DocumentTreeServiceTest {
     Buffer buffer = HeapBuffer.allocate();
     service.backup(new DefaultBackupOutput(buffer, service.serializer()));
 
-    service = new DocumentTreeService(ordering);
+    service = new DocumentTreeService(new ServiceConfig());
     service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
 
     Versioned<byte[]> value = service.get(new DefaultCommit<>(

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveType.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveType.java
@@ -75,7 +75,8 @@ public interface PrimitiveType<B extends DistributedPrimitiveBuilder<B, C, P>, C
    */
   @SuppressWarnings("unchecked")
   default Class<? extends ServiceConfig> serviceConfigClass() {
-    return (Class<? extends ServiceConfig>) Generics.getGenericInterfaceType(this, ServiceConfig.class, 3);
+    Class<? extends ServiceConfig> serviceConfigClass = (Class<? extends ServiceConfig>) Generics.getGenericInterfaceType(this, ServiceConfig.class, 3);
+    return serviceConfigClass != null ? serviceConfigClass : ServiceConfig.class;
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveType.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveType.java
@@ -17,16 +17,18 @@ package io.atomix.primitive;
 
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.Generics;
 import io.atomix.utils.Identifier;
-
-import java.util.function.Function;
-import java.util.function.Supplier;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.KryoNamespaces;
+import io.atomix.utils.serializer.Namespace;
 
 /**
  * Raft service type.
  */
-public interface PrimitiveType<B extends DistributedPrimitiveBuilder<B, C, P>, C extends PrimitiveConfig, P extends DistributedPrimitive> extends Identifier<String> {
+public interface PrimitiveType<B extends DistributedPrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends DistributedPrimitive, S extends ServiceConfig>
+    extends Identifier<String> {
 
   /**
    * Returns the primitive type name.
@@ -52,7 +54,7 @@ public interface PrimitiveType<B extends DistributedPrimitiveBuilder<B, C, P>, C
    * @return the primitive type configuration class
    */
   @SuppressWarnings("unchecked")
-  default Class<? extends PrimitiveConfig> configClass() {
+  default Class<? extends PrimitiveConfig> primitiveConfigClass() {
     return (Class<? extends PrimitiveConfig>) Generics.getGenericInterfaceType(this, PrimitiveType.class, 1);
   }
 
@@ -67,18 +69,42 @@ public interface PrimitiveType<B extends DistributedPrimitiveBuilder<B, C, P>, C
   }
 
   /**
+   * Returns the service configuration class.
+   *
+   * @return the service configuration class
+   */
+  @SuppressWarnings("unchecked")
+  default Class<? extends ServiceConfig> serviceConfigClass() {
+    return (Class<? extends ServiceConfig>) Generics.getGenericInterfaceType(this, ServiceConfig.class, 3);
+  }
+
+  /**
+   * Returns the primitive namespace.
+   *
+   * @return the primitive namespace
+   */
+  default Namespace namespace() {
+    return KryoNamespace.builder()
+        .register(KryoNamespaces.BASIC)
+        .register(serviceConfigClass())
+        .build();
+  }
+
+  /**
    * Returns the primitive service factory.
    *
+   * @param config the primitive service configuration
    * @return the primitive service factory.
    */
-  Supplier<PrimitiveService> serviceFactory();
+  PrimitiveService newService(S config);
 
   /**
    * Returns the primitive resource factory.
    *
+   * @param primitive the primitive instance
    * @return the primitive resource factory
    */
-  default Function<P, PrimitiveResource> resourceFactory() {
+  default PrimitiveResource newResource(P primitive) {
     return null;
   }
 

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPrimaryElectionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPrimaryElectionService.java
@@ -27,6 +27,7 @@ import io.atomix.primitive.partition.PrimaryElectionEvent;
 import io.atomix.primitive.partition.PrimaryElectionEventListener;
 import io.atomix.primitive.partition.PrimaryElectionService;
 import io.atomix.primitive.proxy.PartitionProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.Serializer;
 
@@ -87,7 +88,7 @@ public class DefaultPrimaryElectionService implements ManagedPrimaryElectionServ
   @SuppressWarnings("unchecked")
   public CompletableFuture<PrimaryElectionService> start() {
     return partitions.getPartitions().iterator().next().getProxyClient()
-        .proxyBuilder(PRIMITIVE_NAME, PrimaryElectorType.instance())
+        .proxyBuilder(PRIMITIVE_NAME, PrimaryElectorType.instance(), new ServiceConfig())
         .build()
         .connect()
         .thenAccept(proxy -> {

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorService.java
@@ -27,6 +27,7 @@ import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.utils.concurrent.Scheduled;
@@ -68,6 +69,10 @@ public class PrimaryElectorService extends AbstractPrimitiveService {
   private Map<PartitionId, ElectionState> elections = new HashMap<>();
   private Map<Long, PrimitiveSession> listeners = new LinkedHashMap<>();
   private Scheduled rebalanceTimer;
+
+  public PrimaryElectorService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorType.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorType.java
@@ -20,8 +20,7 @@ import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -47,8 +46,8 @@ public class PrimaryElectorType implements PrimitiveType {
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return PrimaryElectorService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new PrimaryElectorService(config);
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
@@ -18,6 +18,7 @@ package io.atomix.primitive.protocol;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 
 /**
  * Primitive protocol.
@@ -53,12 +54,13 @@ public interface PrimitiveProtocol {
   /**
    * Returns a new primitive proxy for the given partition group.
    *
-   * @param primitiveName the primitive name
-   * @param primitiveType the primitive type
+   * @param primitiveName    the primitive name
+   * @param primitiveType    the primitive type
+   * @param serviceConfig    the service configuration
    * @param partitionService the partition service
    * @return the proxy for the given partition group
    */
-  PrimitiveProxy newProxy(String primitiveName, PrimitiveType primitiveType, PartitionService partitionService);
+  PrimitiveProxy newProxy(String primitiveName, PrimitiveType primitiveType, ServiceConfig serviceConfig, PartitionService partitionService);
 
   /**
    * Primitive protocol.

--- a/primitive/src/main/java/io/atomix/primitive/proxy/ProxyClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/ProxyClient.java
@@ -16,8 +16,7 @@
 package io.atomix.primitive.proxy;
 
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.proxy.PartitionProxy;
+import io.atomix.primitive.service.ServiceConfig;
 
 /**
  * Proxy client.
@@ -27,10 +26,11 @@ public interface ProxyClient {
   /**
    * Returns a new proxy builder for the given primitive type.
    *
-   * @param primitiveName     the proxy name
-   * @param primitiveType     the type for which to return a new proxy builder
+   * @param primitiveName the proxy name
+   * @param primitiveType the type for which to return a new proxy builder
+   * @param serviceConfig the primitive service configuration
    * @return a new proxy builder for the given primitive type
    */
-  PartitionProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType);
+  PartitionProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType, ServiceConfig serviceConfig);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/resource/PrimitiveResourceFactory.java
+++ b/primitive/src/main/java/io/atomix/primitive/resource/PrimitiveResourceFactory.java
@@ -15,8 +15,20 @@
  */
 package io.atomix.primitive.resource;
 
+import io.atomix.primitive.DistributedPrimitive;
+
 /**
- * Primitive resource.
+ * Primitive resource factory.
  */
-public interface PrimitiveResource {
+@FunctionalInterface
+public interface PrimitiveResourceFactory<P extends DistributedPrimitive> {
+
+  /**
+   * Creates a new primitive resource.
+   *
+   * @param primitive the primitive instance
+   * @return the resource instance
+   */
+  PrimitiveResource create(P primitive);
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/service/AbstractPrimitiveService.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/AbstractPrimitiveService.java
@@ -31,10 +31,15 @@ import org.slf4j.Logger;
 /**
  * Raft service.
  */
-public abstract class AbstractPrimitiveService implements PrimitiveService {
+public abstract class AbstractPrimitiveService<C extends ServiceConfig> implements PrimitiveService {
+  private final C config;
   private Logger log;
   private ServiceContext context;
   private ServiceExecutor executor;
+
+  protected AbstractPrimitiveService(C config) {
+    this.config = config;
+  }
 
   /**
    * Encodes the given object using the configured {@link #serializer()}.
@@ -125,6 +130,15 @@ public abstract class AbstractPrimitiveService implements PrimitiveService {
    */
   protected String getServiceName() {
     return context.serviceName();
+  }
+
+  /**
+   * Returns the service configuration.
+   *
+   * @return the service configuration
+   */
+  protected C getServiceConfig() {
+    return config;
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/service/PrimitiveServiceFactory.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/PrimitiveServiceFactory.java
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.resource;
+package io.atomix.primitive.service;
 
 /**
- * Primitive resource.
+ * Primitive service factory.
  */
-public interface PrimitiveResource {
+@FunctionalInterface
+public interface PrimitiveServiceFactory {
+
+  /**
+   * Creates a new primitive service instance.
+   *
+   * @return the primitive service instance
+   */
+  PrimitiveService create();
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/service/ServiceConfig.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/ServiceConfig.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.resource;
+package io.atomix.primitive.service;
+
+import io.atomix.utils.config.Config;
 
 /**
- * Primitive resource.
+ * Service configuration class.
  */
-public interface PrimitiveResource {
+public class ServiceConfig implements Config {
 }

--- a/primitive/src/main/java/io/atomix/primitive/service/ServiceContext.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/ServiceContext.java
@@ -55,6 +55,14 @@ public interface ServiceContext {
   PrimitiveType serviceType();
 
   /**
+   * Returns the service configuration.
+   *
+   * @param <C> the configuration type
+   * @return the service configuration
+   */
+  <C extends ServiceConfig> C serviceConfig();
+
+  /**
    * Returns the current state machine index.
    * <p>
    * The state index is indicative of the index of the current operation

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/ReplicatedSessionIdService.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/ReplicatedSessionIdService.java
@@ -17,6 +17,7 @@ package io.atomix.primitive.session.impl;
 
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.proxy.PartitionProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.ManagedSessionIdService;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.primitive.session.SessionIdService;
@@ -56,7 +57,7 @@ public class ReplicatedSessionIdService implements ManagedSessionIdService {
   @Override
   public CompletableFuture<SessionIdService> start() {
     return systemPartitionGroup.getPartitions().iterator().next().getProxyClient()
-        .proxyBuilder(PRIMITIVE_NAME, SessionIdGeneratorType.instance())
+        .proxyBuilder(PRIMITIVE_NAME, SessionIdGeneratorType.instance(), new ServiceConfig())
         .build()
         .connect()
         .thenApply(proxy -> {

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/SessionIdGeneratorService.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/SessionIdGeneratorService.java
@@ -18,6 +18,7 @@ package io.atomix.primitive.session.impl;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.Serializer;
@@ -32,6 +33,10 @@ public class SessionIdGeneratorService extends AbstractPrimitiveService {
       .build());
 
   private long id;
+
+  public SessionIdGeneratorService(ServiceConfig config) {
+    super(config);
+  }
 
   @Override
   public Serializer serializer() {

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/SessionIdGeneratorType.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/SessionIdGeneratorType.java
@@ -20,8 +20,7 @@ import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -47,8 +46,8 @@ public class SessionIdGeneratorType implements PrimitiveType {
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return SessionIdGeneratorService::new;
+  public PrimitiveService newService(ServiceConfig config) {
+    return new SessionIdGeneratorService(config);
   }
 
   @Override

--- a/primitive/src/test/java/io/atomix/primitive/TestPrimitiveType.java
+++ b/primitive/src/test/java/io/atomix/primitive/TestPrimitiveType.java
@@ -16,8 +16,7 @@
 package io.atomix.primitive;
 
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 /**
  * Test primitive type.
@@ -29,7 +28,7 @@ public class TestPrimitiveType implements PrimitiveType {
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
+  public PrimitiveService newService(ServiceConfig config) {
     throw new UnsupportedOperationException();
   }
 

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -25,6 +25,7 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.PartitionProxy;
 import io.atomix.primitive.proxy.PrimitiveProxy;
 import io.atomix.primitive.proxy.impl.PartitionedPrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.protocols.backup.partition.PrimaryBackupPartition;
 
 import java.time.Duration;
@@ -89,11 +90,11 @@ public class MultiPrimaryProtocol implements PrimitiveProtocol {
   }
 
   @Override
-  public PrimitiveProxy newProxy(String primitiveName, PrimitiveType primitiveType, PartitionService partitionService) {
+  public PrimitiveProxy newProxy(String primitiveName, PrimitiveType primitiveType, ServiceConfig serviceConfig, PartitionService partitionService) {
     Collection<PartitionProxy> partitions = partitionService.<PrimaryBackupPartition>getPartitionGroup(this)
         .getPartitions()
         .stream()
-        .map(partition -> partition.getProxyClient().proxyBuilder(primitiveName, primitiveType)
+        .map(partition -> partition.getProxyClient().proxyBuilder(primitiveName, primitiveType, serviceConfig)
             .withConsistency(config.getConsistency())
             .withReplication(config.getReplication())
             .withRecovery(config.getRecovery())

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupClient.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupClient.java
@@ -25,6 +25,7 @@ import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.BlockingAwarePartitionProxy;
 import io.atomix.primitive.proxy.impl.RecoveringPartitionProxy;
 import io.atomix.primitive.proxy.impl.RetryingPartitionProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionIdService;
 import io.atomix.protocols.backup.protocol.PrimaryBackupClientProtocol;
 import io.atomix.protocols.backup.protocol.PrimitiveDescriptor;
@@ -34,6 +35,7 @@ import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.concurrent.ThreadModel;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
+import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
@@ -85,7 +87,8 @@ public class PrimaryBackupClient implements ProxyClient {
   }
 
   @Override
-  public PrimaryBackupProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType) {
+  public PrimaryBackupProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType, ServiceConfig serviceConfig) {
+    byte[] configBytes = Serializer.using(primitiveType.namespace()).encode(serviceConfig);
     return new PrimaryBackupProxy.Builder() {
       @Override
       public PartitionProxy build() {
@@ -97,6 +100,7 @@ public class PrimaryBackupClient implements ProxyClient {
             new PrimitiveDescriptor(
                 primitiveName,
                 primitiveType.id(),
+                configBytes,
                 numBackups,
                 replication),
             clusterMembershipService,

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/protocol/PrimitiveDescriptor.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/protocol/PrimitiveDescriptor.java
@@ -25,28 +25,59 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class PrimitiveDescriptor {
   private final String name;
   private final String type;
+  private final byte[] config;
   private final int backups;
   private final Replication replication;
 
-  public PrimitiveDescriptor(String name, String type, int backups, Replication replication) {
+  public PrimitiveDescriptor(String name, String type, byte[] config, int backups, Replication replication) {
     this.name = name;
     this.type = type;
+    this.config = config;
     this.backups = backups;
     this.replication = replication;
   }
 
+  /**
+   * Returns the primitive name.
+   *
+   * @return the primitive name
+   */
   public String name() {
     return name;
   }
 
+  /**
+   * Returns the primitive type name.
+   *
+   * @return the primitive type name
+   */
   public String type() {
     return type;
   }
 
+  /**
+   * Returns the primitive service configuration.
+   *
+   * @return the primitive service configuration
+   */
+  public byte[] config() {
+    return config;
+  }
+
+  /**
+   * Returns the number of backups.
+   *
+   * @return the number of backups
+   */
   public int backups() {
     return backups;
   }
 
+  /**
+   * Returns the primitive service replication strategy.
+   *
+   * @return the primitive service replication strategy
+   */
   public Replication replication() {
     return replication;
   }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
@@ -29,6 +29,7 @@ import io.atomix.primitive.partition.PrimaryElection;
 import io.atomix.primitive.partition.PrimaryElectionEventListener;
 import io.atomix.primitive.partition.PrimaryTerm;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.primitive.session.SessionId;
@@ -52,6 +53,7 @@ import io.atomix.utils.concurrent.ComposableFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
+import io.atomix.utils.serializer.Serializer;
 import io.atomix.utils.time.LogicalClock;
 import io.atomix.utils.time.LogicalTimestamp;
 import io.atomix.utils.time.WallClock;
@@ -74,6 +76,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
   private final String serverName;
   private final PrimitiveId primitiveId;
   private final PrimitiveType primitiveType;
+  private final ServiceConfig serviceConfig;
   private final PrimitiveDescriptor descriptor;
   private final PrimitiveService service;
   private final PrimaryBackupServiceSessions sessions = new PrimaryBackupServiceSessions();
@@ -107,10 +110,11 @@ public class PrimaryBackupServiceContext implements ServiceContext {
   private final ClusterMembershipEventListener membershipEventListener = this::handleClusterEvent;
   private final PrimaryElectionEventListener primaryElectionListener = event -> changeRole(event.term());
 
+  @SuppressWarnings("unchecked")
   public PrimaryBackupServiceContext(
       String serverName,
       PrimitiveId primitiveId,
-      PrimitiveType<?, ?, ?> primitiveType,
+      PrimitiveType primitiveType,
       PrimitiveDescriptor descriptor,
       ThreadContext threadContext,
       ClusterMembershipService clusterMembershipService,
@@ -121,8 +125,9 @@ public class PrimaryBackupServiceContext implements ServiceContext {
     this.serverName = checkNotNull(serverName);
     this.primitiveId = checkNotNull(primitiveId);
     this.primitiveType = checkNotNull(primitiveType);
+    this.serviceConfig = Serializer.using(primitiveType.namespace()).decode(descriptor.config());
     this.descriptor = checkNotNull(descriptor);
-    this.service = primitiveType.serviceFactory().get();
+    this.service = primitiveType.newService(serviceConfig);
     this.threadContext = checkNotNull(threadContext);
     this.clusterMembershipService = checkNotNull(clusterMembershipService);
     this.memberGroupService = checkNotNull(memberGroupService);
@@ -200,6 +205,12 @@ public class PrimaryBackupServiceContext implements ServiceContext {
   @Override
   public PrimitiveType serviceType() {
     return primitiveType;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <C extends ServiceConfig> C serviceConfig() {
+    return (C) serviceConfig;
   }
 
   @Override

--- a/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
+++ b/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
@@ -34,6 +34,7 @@ import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.primitive.session.SessionId;
@@ -53,7 +54,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
 
 import static io.atomix.primitive.operation.PrimitiveOperation.operation;
 import static org.junit.Assert.assertEquals;
@@ -442,7 +442,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
    * Creates a new primary-backup proxy.
    */
   private PartitionProxy createProxy(PrimaryBackupClient client, int backups, Replication replication) {
-    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE)
+    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE, new ServiceConfig())
         .withNumBackups(backups)
         .withReplication(replication)
         .build()
@@ -485,8 +485,8 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
     }
 
     @Override
-    public Supplier<PrimitiveService> serviceFactory() {
-      return TestPrimitiveService::new;
+    public PrimitiveService newService(ServiceConfig config) {
+      return new TestPrimitiveService(config);
     }
 
     @Override
@@ -506,6 +506,10 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
   public static class TestPrimitiveService extends AbstractPrimitiveService {
     private Commit<Void> expire;
     private Commit<Void> close;
+
+    public TestPrimitiveService(ServiceConfig config) {
+      super(config);
+    }
 
     @Override
     public Serializer serializer() {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
@@ -23,6 +23,7 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.PartitionProxy;
 import io.atomix.primitive.proxy.PrimitiveProxy;
 import io.atomix.primitive.proxy.impl.PartitionedPrimitiveProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.protocols.raft.partition.RaftPartition;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 
@@ -88,11 +89,11 @@ public class MultiRaftProtocol implements PrimitiveProtocol {
   }
 
   @Override
-  public PrimitiveProxy newProxy(String primitiveName, PrimitiveType primitiveType, PartitionService partitionService) {
+  public PrimitiveProxy newProxy(String primitiveName, PrimitiveType primitiveType, ServiceConfig serviceConfig, PartitionService partitionService) {
     Collection<PartitionProxy> partitions = partitionService.<RaftPartition>getPartitionGroup(this)
         .getPartitions()
         .stream()
-        .map(partition -> partition.getProxyClient().proxyBuilder(primitiveName, primitiveType)
+        .map(partition -> partition.getProxyClient().proxyBuilder(primitiveName, primitiveType, serviceConfig)
             .withMinTimeout(config.getMinTimeout())
             .withMaxTimeout(config.getMaxTimeout())
             .withReadConsistency(config.getReadConsistency())

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
@@ -19,6 +19,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.proxy.ProxyClient;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.protocols.raft.impl.DefaultRaftClient;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
@@ -134,7 +135,7 @@ public interface RaftClient extends ProxyClient {
   RaftMetadataClient metadata();
 
   @Override
-  RaftProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType);
+  RaftProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType, ServiceConfig serviceConfig);
 
   /**
    * Connects the client to Raft cluster via the default server address.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
@@ -23,6 +23,7 @@ import io.atomix.primitive.proxy.PartitionProxy;
 import io.atomix.primitive.proxy.impl.BlockingAwarePartitionProxy;
 import io.atomix.primitive.proxy.impl.RecoveringPartitionProxy;
 import io.atomix.primitive.proxy.impl.RetryingPartitionProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.protocols.raft.RaftClient;
 import io.atomix.protocols.raft.RaftMetadataClient;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
@@ -124,7 +125,7 @@ public class DefaultRaftClient implements RaftClient {
   }
 
   @Override
-  public RaftProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType) {
+  public RaftProxy.Builder proxyBuilder(String primitiveName, PrimitiveType primitiveType, ServiceConfig serviceConfig) {
     return new RaftProxy.Builder() {
       @Override
       public PartitionProxy build() {
@@ -132,6 +133,7 @@ public class DefaultRaftClient implements RaftClient {
         Supplier<PartitionProxy> proxyFactory = () -> new DefaultRaftProxy(
             primitiveName,
             primitiveType,
+            serviceConfig,
             partitionId,
             DefaultRaftClient.this.protocol,
             selectorManager,

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/OpenSessionRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/OpenSessionRequest.java
@@ -42,14 +42,16 @@ public class OpenSessionRequest extends AbstractRaftRequest {
   private final String node;
   private final String name;
   private final String typeName;
+  private final byte[] config;
   private final ReadConsistency readConsistency;
   private final long minTimeout;
   private final long maxTimeout;
 
-  public OpenSessionRequest(String node, String name, String typeName, ReadConsistency readConsistency, long minTimeout, long maxTimeout) {
+  public OpenSessionRequest(String node, String name, String typeName, byte[] config, ReadConsistency readConsistency, long minTimeout, long maxTimeout) {
     this.node = node;
     this.name = name;
     this.typeName = typeName;
+    this.config = config;
     this.readConsistency = readConsistency;
     this.minTimeout = minTimeout;
     this.maxTimeout = maxTimeout;
@@ -80,6 +82,15 @@ public class OpenSessionRequest extends AbstractRaftRequest {
    */
   public String serviceType() {
     return typeName;
+  }
+
+  /**
+   * Returns the service configuration.
+   *
+   * @return the service configuration
+   */
+  public byte[] serviceConfig() {
+    return config;
   }
 
   /**
@@ -147,6 +158,7 @@ public class OpenSessionRequest extends AbstractRaftRequest {
     private String memberId;
     private String serviceName;
     private String serviceType;
+    private byte[] serviceConfig;
     private ReadConsistency readConsistency = ReadConsistency.LINEARIZABLE;
     private long minTimeout;
     private long maxTimeout;
@@ -184,6 +196,18 @@ public class OpenSessionRequest extends AbstractRaftRequest {
      */
     public Builder withServiceType(PrimitiveType primitiveType) {
       this.serviceType = checkNotNull(primitiveType, "serviceType cannot be null").id();
+      return this;
+    }
+
+    /**
+     * Sets the service configuration.
+     *
+     * @param config the service configuration
+     * @return the open session request builder
+     * @throws NullPointerException if the configuration is {@code null}
+     */
+    public Builder withServiceConfig(byte[] config) {
+      this.serviceConfig = checkNotNull(config, "config cannot be null");
       return this;
     }
 
@@ -231,6 +255,7 @@ public class OpenSessionRequest extends AbstractRaftRequest {
       checkNotNull(memberId, "memberId cannot be null");
       checkNotNull(serviceName, "name cannot be null");
       checkNotNull(serviceType, "typeName cannot be null");
+      checkNotNull(serviceConfig, "serviceConfig cannot be null");
       checkArgument(minTimeout >= 0, "minTimeout must be positive");
       checkArgument(maxTimeout >= 0, "maxTimeout must be positive");
     }
@@ -241,7 +266,7 @@ public class OpenSessionRequest extends AbstractRaftRequest {
     @Override
     public OpenSessionRequest build() {
       validate();
-      return new OpenSessionRequest(memberId, serviceName, serviceType, readConsistency, minTimeout, maxTimeout);
+      return new OpenSessionRequest(memberId, serviceName, serviceType, serviceConfig, readConsistency, minTimeout, maxTimeout);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
@@ -169,6 +169,7 @@ public class DefaultRaftProxy implements RaftProxy {
     return sessionManager.openSession(
         serviceName,
         primitiveType,
+        serviceConfig,
         readConsistency,
         communicationStrategy,
         minTimeout,

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftProxy.java
@@ -22,6 +22,7 @@ import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.proxy.PartitionProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
@@ -59,6 +60,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class DefaultRaftProxy implements RaftProxy {
   private final String serviceName;
   private final PrimitiveType primitiveType;
+  private final ServiceConfig serviceConfig;
   private final PartitionId partitionId;
   private final Duration minTimeout;
   private final Duration maxTimeout;
@@ -76,6 +78,7 @@ public class DefaultRaftProxy implements RaftProxy {
   public DefaultRaftProxy(
       String serviceName,
       PrimitiveType primitiveType,
+      ServiceConfig serviceConfig,
       PartitionId partitionId,
       RaftClientProtocol protocol,
       MemberSelectorManager selectorManager,
@@ -87,6 +90,7 @@ public class DefaultRaftProxy implements RaftProxy {
       Duration maxTimeout) {
     this.serviceName = checkNotNull(serviceName, "serviceName cannot be null");
     this.primitiveType = checkNotNull(primitiveType, "serviceType cannot be null");
+    this.serviceConfig = checkNotNull(serviceConfig, "serviceConfig cannot be null");
     this.partitionId = checkNotNull(partitionId, "partitionId cannot be null");
     this.protocol = checkNotNull(protocol, "protocol cannot be null");
     this.selectorManager = checkNotNull(selectorManager, "selectorManager cannot be null");

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
@@ -21,6 +21,7 @@ import com.google.common.primitives.Longs;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.proxy.PartitionProxy;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.raft.RaftClient;
 import io.atomix.protocols.raft.RaftException;
@@ -39,6 +40,7 @@ import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
+import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 
 import java.time.Duration;
@@ -153,6 +155,7 @@ public class RaftProxyManager {
   public CompletableFuture<RaftProxyState> openSession(
       String serviceName,
       PrimitiveType primitiveType,
+      ServiceConfig config,
       ReadConsistency readConsistency,
       CommunicationStrategy communicationStrategy,
       Duration minTimeout,
@@ -167,6 +170,7 @@ public class RaftProxyManager {
         .withMemberId(memberId)
         .withServiceName(serviceName)
         .withServiceType(primitiveType)
+        .withServiceConfig(Serializer.using(primitiveType.namespace()).encode(config))
         .withReadConsistency(readConsistency)
         .withMinTimeout(minTimeout.toMillis())
         .withMaxTimeout(maxTimeout.toMillis())

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -820,7 +820,16 @@ public final class LeaderRole extends ActiveRole {
     logRequest(request);
 
     CompletableFuture<OpenSessionResponse> future = new CompletableFuture<>();
-    appendAndCompact(new OpenSessionEntry(term, timestamp, request.node(), request.serviceName(), request.serviceType(), request.readConsistency(), minTimeout, maxTimeout))
+    appendAndCompact(new OpenSessionEntry(
+        term,
+        timestamp,
+        request.node(),
+        request.serviceName(),
+        request.serviceType(),
+        request.serviceConfig(),
+        request.readConsistency(),
+        minTimeout,
+        maxTimeout))
         .whenCompleteAsync((entry, error) -> {
           if (error != null) {
             future.complete(logResponse(OpenSessionResponse.builder()

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/OpenSessionEntry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/OpenSessionEntry.java
@@ -16,6 +16,7 @@
 package io.atomix.protocols.raft.storage.log.entry;
 
 import io.atomix.protocols.raft.ReadConsistency;
+import io.atomix.utils.misc.ArraySizeHashPrinter;
 import io.atomix.utils.misc.TimestampPrinter;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -27,15 +28,26 @@ public class OpenSessionEntry extends TimestampedEntry {
   private final String memberId;
   private final String serviceName;
   private final String serviceType;
+  private final byte[] serviceConfig;
   private final ReadConsistency readConsistency;
   private final long minTimeout;
   private final long maxTimeout;
 
-  public OpenSessionEntry(long term, long timestamp, String memberId, String serviceName, String serviceType, ReadConsistency readConsistency, long minTimeout, long maxTimeout) {
+  public OpenSessionEntry(
+      long term,
+      long timestamp,
+      String memberId,
+      String serviceName,
+      String serviceType,
+      byte[] serviceConfig,
+      ReadConsistency readConsistency,
+      long minTimeout,
+      long maxTimeout) {
     super(term, timestamp);
     this.memberId = memberId;
     this.serviceName = serviceName;
     this.serviceType = serviceType;
+    this.serviceConfig = serviceConfig;
     this.readConsistency = readConsistency;
     this.minTimeout = minTimeout;
     this.maxTimeout = maxTimeout;
@@ -66,6 +78,15 @@ public class OpenSessionEntry extends TimestampedEntry {
    */
   public String serviceType() {
     return serviceType;
+  }
+
+  /**
+   * Returns the service configuration.
+   *
+   * @return the service configuration
+   */
+  public byte[] serviceConfig() {
+    return serviceConfig;
   }
 
   /**
@@ -103,6 +124,7 @@ public class OpenSessionEntry extends TimestampedEntry {
         .add("node", memberId)
         .add("serviceName", serviceName)
         .add("serviceType", serviceType)
+        .add("serviceConfig", ArraySizeHashPrinter.of(serviceConfig))
         .add("readConsistency", readConsistency)
         .add("minTimeout", minTimeout)
         .add("maxTimeout", maxTimeout)

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -33,6 +33,7 @@ import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.PrimitiveSession;
 import io.atomix.primitive.session.SessionMetadata;
@@ -82,7 +83,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.atomix.primitive.operation.PrimitiveOperation.operation;
@@ -1267,7 +1267,7 @@ public class RaftTest extends ConcurrentTestCase {
    * Creates a test session.
    */
   private PartitionProxy createSession(RaftClient client, ReadConsistency consistency) throws Exception {
-    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE)
+    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE, new ServiceConfig())
         .withReadConsistency(consistency)
         .withMinTimeout(Duration.ofMillis(250))
         .withMaxTimeout(Duration.ofSeconds(5))
@@ -1347,8 +1347,8 @@ public class RaftTest extends ConcurrentTestCase {
     }
 
     @Override
-    public Supplier<PrimitiveService> serviceFactory() {
-      return TestPrimitiveService::new;
+    public PrimitiveService newService(ServiceConfig config) {
+      return new TestPrimitiveService(config);
     }
 
     @Override
@@ -1368,6 +1368,10 @@ public class RaftTest extends ConcurrentTestCase {
   public static class TestPrimitiveService extends AbstractPrimitiveService {
     private Commit<Void> expire;
     private Commit<Void> close;
+
+    public TestPrimitiveService(ServiceConfig config) {
+      super(config);
+    }
 
     @Override
     public Serializer serializer() {

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/TestPrimitiveType.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/TestPrimitiveType.java
@@ -20,8 +20,7 @@ import io.atomix.primitive.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.service.PrimitiveService;
-
-import java.util.function.Supplier;
+import io.atomix.primitive.service.ServiceConfig;
 
 /**
  * Test primitive type.
@@ -33,8 +32,8 @@ public class TestPrimitiveType implements PrimitiveType {
   }
 
   @Override
-  public Supplier<PrimitiveService> serviceFactory() {
-    return null;
+  public PrimitiveService newService(ServiceConfig config) {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -16,6 +16,7 @@
 package io.atomix.protocols.raft.storage.log;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;
@@ -28,10 +29,10 @@ import io.atomix.protocols.raft.storage.log.entry.MetadataEntry;
 import io.atomix.protocols.raft.storage.log.entry.OpenSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.QueryEntry;
 import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
-import io.atomix.utils.serializer.Serializer;
-import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.Indexed;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.Serializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -107,7 +108,16 @@ public abstract class AbstractLogTest {
     // Append a couple entries.
     Indexed<RaftLogEntry> indexed;
     assertEquals(writer.getNextIndex(), 1);
-    indexed = writer.append(new OpenSessionEntry(1, System.currentTimeMillis(), "client", "test1", "test", ReadConsistency.LINEARIZABLE, 100, 1000));
+    indexed = writer.append(new OpenSessionEntry(
+        1,
+        System.currentTimeMillis(),
+        "client",
+        "test1",
+        "test",
+        new byte[0],
+        ReadConsistency.LINEARIZABLE,
+        100,
+        1000));
     assertEquals(indexed.index(), 1);
 
     assertEquals(writer.getNextIndex(), 2);

--- a/rest/src/main/java/io/atomix/rest/resources/PrimitivesResource.java
+++ b/rest/src/main/java/io/atomix/rest/resources/PrimitivesResource.java
@@ -41,7 +41,7 @@ public class PrimitivesResource extends AbstractRestResource {
   @SuppressWarnings("unchecked")
   public PrimitiveResource getPrimitive(@PathParam("name") String name, @Context PrimitivesService primitives) {
     DistributedPrimitive primitive = primitives.getPrimitive(name);
-    return (PrimitiveResource) primitive.primitiveType().resourceFactory().apply(primitive);
+    return primitive.primitiveType().newResource(primitive);
   }
 
   /**

--- a/tests/src/main/java/io/atomix/protocols/raft/test/RaftFuzzTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/test/RaftFuzzTest.java
@@ -27,13 +27,13 @@ import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.OperationType;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.operation.impl.DefaultOperationId;
-import io.atomix.primitive.partition.impl.PrimaryElectorService;
 import io.atomix.primitive.proxy.PartitionProxy;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.raft.RaftClient;
@@ -58,7 +58,6 @@ import io.atomix.protocols.raft.protocol.KeepAliveRequest;
 import io.atomix.protocols.raft.protocol.KeepAliveResponse;
 import io.atomix.protocols.raft.protocol.LeaveRequest;
 import io.atomix.protocols.raft.protocol.LeaveResponse;
-import io.atomix.protocols.raft.test.protocol.LocalRaftProtocolFactory;
 import io.atomix.protocols.raft.protocol.MetadataRequest;
 import io.atomix.protocols.raft.protocol.MetadataResponse;
 import io.atomix.protocols.raft.protocol.OpenSessionRequest;
@@ -68,10 +67,8 @@ import io.atomix.protocols.raft.protocol.PollResponse;
 import io.atomix.protocols.raft.protocol.PublishRequest;
 import io.atomix.protocols.raft.protocol.QueryRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
-import io.atomix.protocols.raft.test.protocol.RaftClientMessagingProtocol;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.protocol.RaftResponse;
-import io.atomix.protocols.raft.test.protocol.RaftServerMessagingProtocol;
 import io.atomix.protocols.raft.protocol.RaftServerProtocol;
 import io.atomix.protocols.raft.protocol.ReconfigureRequest;
 import io.atomix.protocols.raft.protocol.ReconfigureResponse;
@@ -89,6 +86,9 @@ import io.atomix.protocols.raft.storage.log.entry.MetadataEntry;
 import io.atomix.protocols.raft.storage.log.entry.OpenSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.QueryEntry;
 import io.atomix.protocols.raft.storage.system.Configuration;
+import io.atomix.protocols.raft.test.protocol.LocalRaftProtocolFactory;
+import io.atomix.protocols.raft.test.protocol.RaftClientMessagingProtocol;
+import io.atomix.protocols.raft.test.protocol.RaftServerMessagingProtocol;
 import io.atomix.storage.StorageLevel;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
@@ -122,7 +122,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.atomix.primitive.operation.PrimitiveOperation.operation;
@@ -624,7 +623,7 @@ public class RaftFuzzTest implements Runnable {
    * Creates a test session.
    */
   private PartitionProxy createProxy(RaftClient client, ReadConsistency consistency) {
-    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE)
+    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE, new ServiceConfig())
         .withReadConsistency(consistency)
         .withCommunicationStrategy(COMMUNICATION_STRATEGY)
         .build()
@@ -649,8 +648,8 @@ public class RaftFuzzTest implements Runnable {
     }
 
     @Override
-    public Supplier<PrimitiveService> serviceFactory() {
-      return PrimaryElectorService::new;
+    public PrimitiveService newService(ServiceConfig config) {
+      return new FuzzStateMachine(config);
     }
 
     @Override
@@ -669,6 +668,10 @@ public class RaftFuzzTest implements Runnable {
    */
   public static class FuzzStateMachine extends AbstractPrimitiveService {
     private Map<String, String> map = new HashMap<>();
+
+    public FuzzStateMachine(ServiceConfig config) {
+      super(config);
+    }
 
     @Override
     public Serializer serializer() {

--- a/tests/src/main/java/io/atomix/protocols/raft/test/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/test/RaftPerformanceTest.java
@@ -41,6 +41,7 @@ import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.raft.RaftClient;
@@ -67,7 +68,6 @@ import io.atomix.protocols.raft.protocol.KeepAliveRequest;
 import io.atomix.protocols.raft.protocol.KeepAliveResponse;
 import io.atomix.protocols.raft.protocol.LeaveRequest;
 import io.atomix.protocols.raft.protocol.LeaveResponse;
-import io.atomix.protocols.raft.test.protocol.LocalRaftProtocolFactory;
 import io.atomix.protocols.raft.protocol.MetadataRequest;
 import io.atomix.protocols.raft.protocol.MetadataResponse;
 import io.atomix.protocols.raft.protocol.OpenSessionRequest;
@@ -77,10 +77,8 @@ import io.atomix.protocols.raft.protocol.PollResponse;
 import io.atomix.protocols.raft.protocol.PublishRequest;
 import io.atomix.protocols.raft.protocol.QueryRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
-import io.atomix.protocols.raft.test.protocol.RaftClientMessagingProtocol;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.protocol.RaftResponse;
-import io.atomix.protocols.raft.test.protocol.RaftServerMessagingProtocol;
 import io.atomix.protocols.raft.protocol.RaftServerProtocol;
 import io.atomix.protocols.raft.protocol.ReconfigureRequest;
 import io.atomix.protocols.raft.protocol.ReconfigureResponse;
@@ -98,6 +96,9 @@ import io.atomix.protocols.raft.storage.log.entry.MetadataEntry;
 import io.atomix.protocols.raft.storage.log.entry.OpenSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.QueryEntry;
 import io.atomix.protocols.raft.storage.system.Configuration;
+import io.atomix.protocols.raft.test.protocol.LocalRaftProtocolFactory;
+import io.atomix.protocols.raft.test.protocol.RaftClientMessagingProtocol;
+import io.atomix.protocols.raft.test.protocol.RaftServerMessagingProtocol;
 import io.atomix.storage.StorageLevel;
 import io.atomix.utils.concurrent.ThreadModel;
 import io.atomix.utils.net.Address;
@@ -128,7 +129,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.atomix.primitive.operation.PrimitiveOperation.operation;
@@ -538,7 +538,7 @@ public class RaftPerformanceTest implements Runnable {
    * Creates a test session.
    */
   private PartitionProxy createProxy(RaftClient client) {
-    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE)
+    return client.proxyBuilder("test", TestPrimitiveType.INSTANCE, new ServiceConfig())
         .withReadConsistency(READ_CONSISTENCY)
         .withCommunicationStrategy(COMMUNICATION_STRATEGY)
         .build();
@@ -561,8 +561,8 @@ public class RaftPerformanceTest implements Runnable {
     }
 
     @Override
-    public Supplier<PrimitiveService> serviceFactory() {
-      return PerformanceService::new;
+    public PrimitiveService newService(ServiceConfig config) {
+      return new PerformanceService(config);
     }
 
     @Override
@@ -581,6 +581,10 @@ public class RaftPerformanceTest implements Runnable {
    */
   public static class PerformanceService extends AbstractPrimitiveService {
     private Map<String, String> map = new HashMap<>();
+
+    public PerformanceService(ServiceConfig config) {
+      super(config);
+    }
 
     @Override
     public Serializer serializer() {

--- a/utils/src/main/java/io/atomix/utils/Generics.java
+++ b/utils/src/main/java/io/atomix/utils/Generics.java
@@ -34,9 +34,13 @@ public class Generics {
   public static Type getGenericClassType(Object instance, Class<?> clazz, int position) {
     Class<?> type = instance.getClass();
     while (type != Object.class) {
-      ParameterizedType genericSuperclass = (ParameterizedType) type.getGenericSuperclass();
-      if (genericSuperclass.getRawType() == clazz) {
-        return genericSuperclass.getActualTypeArguments()[position];
+      if (type.getGenericSuperclass() instanceof ParameterizedType) {
+        ParameterizedType genericSuperclass = (ParameterizedType) type.getGenericSuperclass();
+        if (genericSuperclass.getRawType() == clazz) {
+          return genericSuperclass.getActualTypeArguments()[position];
+        } else {
+          type = type.getSuperclass();
+        }
       } else {
         type = type.getSuperclass();
       }
@@ -56,9 +60,11 @@ public class Generics {
     Class<?> type = instance.getClass();
     while (type != Object.class) {
       for (Type genericType : type.getGenericInterfaces()) {
-        ParameterizedType parameterizedType = (ParameterizedType) genericType;
-        if (parameterizedType.getRawType() == iface) {
-          return parameterizedType.getActualTypeArguments()[position];
+        if (genericType instanceof ParameterizedType) {
+          ParameterizedType parameterizedType = (ParameterizedType) genericType;
+          if (parameterizedType.getRawType() == iface) {
+            return parameterizedType.getActualTypeArguments()[position];
+          }
         }
       }
       type = type.getSuperclass();

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoNamespaces.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoNamespaces.java
@@ -92,6 +92,7 @@ public final class KryoNamespaces {
             .register(char[].class)
             .register(String[].class)
             .register(boolean[].class)
+            .register(Object[].class)
             .build("BASIC");
 
     /**


### PR DESCRIPTION
This PR adds support for primitive service configurations. This is needed to be able to add configurations that need to be represented in primitive services. For example, `ConsistentTreeMap` sort order, `ConsistentMultimap` collection type, or `DistributedSemaphore` permit count. Service configuration classes can be defined by the `PrimitiveType` and are provided to the primitive service factory method.