### PR TITLE
Distributed primitive proxies

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitive.java
@@ -63,6 +63,7 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive> implement
 
   private final PrimitiveProxy proxy;
   private final PrimitiveRegistry registry;
+  private final Serializer serializer;
   private final Set<Consumer<Status>> statusChangeListeners = Sets.newCopyOnWriteArraySet();
   private final Map<EventType, Map<PartitionId, Map<Object, Consumer>>> eventListeners = Maps.newIdentityHashMap();
   private final Map<BiConsumer<PartitionId, Proxy.State>, Map<PartitionId, Consumer<Proxy.State>>> stateChangeListeners =
@@ -71,6 +72,7 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive> implement
   public AbstractAsyncPrimitive(PrimitiveProxy proxy, PrimitiveRegistry registry) {
     this.proxy = checkNotNull(proxy, "proxy cannot be null");
     this.registry = checkNotNull(registry, "registry cannot be null");
+    this.serializer = Serializer.using(proxy.type().namespace());
     proxy.addStateChangeListener(this::onStateChange);
   }
 
@@ -89,13 +91,15 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive> implement
    *
    * @return the serializer for the primitive operations
    */
-  protected abstract Serializer serializer();
+  protected Serializer serializer() {
+    return serializer;
+  }
 
   /**
    * Encodes the given object using the configured {@link #serializer()}.
    *
    * @param object the object to encode
-   * @param <T> the object type
+   * @param <T>    the object type
    * @return the encoded bytes
    */
   protected <T> byte[] encode(T object) {
@@ -106,7 +110,7 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive> implement
    * Decodes the given object using the configured {@link #serializer()}.
    *
    * @param bytes the bytes to decode
-   * @param <T> the object type
+   * @param <T>   the object type
    * @return the decoded object
    */
   protected <T> T decode(byte[] bytes) {

--- a/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitiveProxy.java
+++ b/primitive/src/main/java/io/atomix/primitive/impl/AbstractAsyncPrimitiveProxy.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.impl;
+
+import com.google.common.base.Defaults;
+import com.google.common.collect.Maps;
+import io.atomix.primitive.AsyncPrimitive;
+import io.atomix.primitive.PrimitiveException;
+import io.atomix.primitive.PrimitiveRegistry;
+import io.atomix.primitive.operation.OperationId;
+import io.atomix.primitive.operation.Operations;
+import io.atomix.primitive.operation.PrimitiveOperation;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.proxy.PartitionProxy;
+import io.atomix.primitive.proxy.PrimitiveProxy;
+import io.atomix.utils.concurrent.Futures;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Abstract asynchronous primitive that provides proxies.
+ */
+public abstract class AbstractAsyncPrimitiveProxy<A extends AsyncPrimitive, S> extends AbstractAsyncPrimitive<A> {
+  private final Map<PartitionId, ServiceProxy<S>> serviceProxies = Maps.newConcurrentMap();
+
+  @SuppressWarnings("unchecked")
+  public AbstractAsyncPrimitiveProxy(Class<S> serviceType, PrimitiveProxy proxy, PrimitiveRegistry registry) {
+    super(proxy, registry);
+    for (PartitionProxy partition : proxy.getPartitions()) {
+      ServiceProxyHandler serviceProxyHandler = new ServiceProxyHandler(serviceType, partition);
+      S serviceProxy = (S) java.lang.reflect.Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{serviceType}, serviceProxyHandler);
+      serviceProxies.put(partition.partitionId(), new ServiceProxy<>(serviceProxy, serviceProxyHandler));
+    }
+  }
+
+  /**
+   * Returns the collection of service proxies.
+   *
+   * @return the collection of service proxies
+   */
+  private Collection<ServiceProxy<S>> getServiceProxies() {
+    return serviceProxies.values();
+  }
+
+  /**
+   * Returns the service proxy for the given partition ID.
+   *
+   * @param partitionId the partition ID for which to return the service proxy
+   * @return the service proxy for the given partition ID
+   */
+  private ServiceProxy<S> getServiceProxy(PartitionId partitionId) {
+    return serviceProxies.get(partitionId);
+  }
+
+  /**
+   * Returns the service proxy for the given key.
+   *
+   * @param key the key for which to return the service proxy
+   * @return the service proxy for the given key
+   */
+  private ServiceProxy<S> getServiceProxy(String key) {
+    return getServiceProxy(getProxy().getPartitionId(key));
+  }
+
+  /**
+   * Submits an empty operation to all partitions.
+   *
+   * @param operation the operation identifier
+   * @return A completable future to be completed with the operation result. The future is guaranteed to be completed after all
+   * {@link PrimitiveOperation} submission futures that preceded it.
+   * @throws NullPointerException if {@code operation} is null
+   */
+  protected CompletableFuture<Void> acceptAll(Consumer<S> operation) {
+    return Futures.allOf(getServiceProxies().stream().map(proxy -> proxy.accept(operation))).thenApply(v -> null);
+  }
+
+  /**
+   * Submits an empty operation to all partitions.
+   *
+   * @param operation the operation identifier
+   * @param <R>       the operation result type
+   * @return A completable future to be completed with the operation result. The future is guaranteed to be completed after all
+   * {@link PrimitiveOperation} submission futures that preceded it.
+   * @throws NullPointerException if {@code operation} is null
+   */
+  protected <R> CompletableFuture<Stream<R>> applyAll(Function<S, R> operation) {
+    return Futures.allOf(getServiceProxies().stream().map(proxy -> proxy.apply(operation)));
+  }
+
+  /**
+   * Submits an empty operation to the given partition.
+   *
+   * @param partitionId the partition in which to execute the operation
+   * @param operation   the operation identifier
+   * @return A completable future to be completed with the operation result. The future is guaranteed to be completed after all
+   * {@link PrimitiveOperation} submission futures that preceded it.
+   * @throws NullPointerException if {@code operation} is null
+   */
+  protected CompletableFuture<Void> acceptOn(PartitionId partitionId, Consumer<S> operation) {
+    return getServiceProxy(partitionId).accept(operation);
+  }
+
+  /**
+   * Submits an empty operation to the given partition.
+   *
+   * @param partitionId the partition in which to execute the operation
+   * @param operation   the operation identifier
+   * @param <R>         the operation result type
+   * @return A completable future to be completed with the operation result. The future is guaranteed to be completed after all
+   * {@link PrimitiveOperation} submission futures that preceded it.
+   * @throws NullPointerException if {@code operation} is null
+   */
+  protected <R> CompletableFuture<R> applyOn(PartitionId partitionId, Function<S, R> operation) {
+    return getServiceProxy(partitionId).apply(operation);
+  }
+
+  /**
+   * Submits an empty operation to the owning partition for the given key.
+   *
+   * @param key       the key for which to submit the operation
+   * @param operation the operation
+   * @return A completable future to be completed with the operation result. The future is guaranteed to be completed after all
+   * {@link PrimitiveOperation} submission futures that preceded it.
+   * @throws NullPointerException if {@code operation} is null
+   */
+  protected CompletableFuture<Void> acceptBy(String key, Consumer<S> operation) {
+    return getServiceProxy(key).accept(operation);
+  }
+
+  /**
+   * Submits an empty operation to the owning partition for the given key.
+   *
+   * @param key       the key for which to submit the operation
+   * @param operation the operation
+   * @param <R>       the operation result type
+   * @return A completable future to be completed with the operation result. The future is guaranteed to be completed after all
+   * {@link PrimitiveOperation} submission futures that preceded it.
+   * @throws NullPointerException if {@code operation} is null
+   */
+  protected <R> CompletableFuture<R> applyBy(String key, Function<S, R> operation) {
+    return getServiceProxy(key).apply(operation);
+  }
+
+  /**
+   * Service proxy container.
+   */
+  private class ServiceProxy<S> {
+    private final S proxy;
+    private final ServiceProxyHandler handler;
+
+    ServiceProxy(S proxy, ServiceProxyHandler handler) {
+      this.proxy = proxy;
+      this.handler = handler;
+    }
+
+    /**
+     * Invokes a void method on the underlying proxy.
+     *
+     * @param operation the operation to perform on the proxy
+     * @return the resulting void future
+     */
+    CompletableFuture<Void> accept(Consumer<S> operation) {
+      operation.accept(proxy);
+      return handler.getResultFuture();
+    }
+
+    /**
+     * Invokes a function on the underlying proxy.
+     *
+     * @param operation the operation to perform on the proxy
+     * @param <T>       the operation return type
+     * @return the future result
+     */
+    <T> CompletableFuture<T> apply(Function<S, T> operation) {
+      operation.apply(proxy);
+      return handler.getResultFuture();
+    }
+  }
+
+  /**
+   * Service proxy invocation handler.
+   * <p>
+   * The invocation handler
+   */
+  private class ServiceProxyHandler implements InvocationHandler {
+    private final PartitionProxy proxy;
+    private final ThreadLocal<CompletableFuture> future = new ThreadLocal<>();
+    private final Map<Method, OperationId> operations = new ConcurrentHashMap<>();
+
+    private ServiceProxyHandler(Class<?> type, PartitionProxy proxy) {
+      this.proxy = proxy;
+      this.operations.putAll(Operations.getMethodMap(type));
+    }
+
+    @Override
+    public Object invoke(Object object, Method method, Object[] args) throws Throwable {
+      OperationId operationId = operations.get(method);
+      if (operationId != null) {
+        future.set(proxy.execute(PrimitiveOperation.operation(operationId, encode(args)))
+            .thenApply(AbstractAsyncPrimitiveProxy.this::decode));
+      } else {
+        throw new PrimitiveException("Unknown primitive operation: " + method.getName());
+      }
+      return Defaults.defaultValue(method.getReturnType());
+    }
+
+    /**
+     * Returns the result future for the operation.
+     *
+     * @param <T> the future result type
+     * @return the result future
+     */
+    @SuppressWarnings("unchecked")
+    <T> CompletableFuture<T> getResultFuture() {
+      return future.get();
+    }
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/operation/Operation.java
+++ b/primitive/src/main/java/io/atomix/primitive/operation/Operation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.operation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Operation annotation.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Operation {
+
+  /**
+   * The operation name.
+   */
+  String value() default "";
+
+  /**
+   * The operation type.
+   */
+  OperationType type() default OperationType.COMMAND;
+
+}

--- a/primitive/src/main/java/io/atomix/primitive/operation/Operations.java
+++ b/primitive/src/main/java/io/atomix/primitive/operation/Operations.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.operation;
+
+import io.atomix.utils.config.ConfigurationException;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Operation utilities.
+ */
+public final class Operations {
+
+  /**
+   * Returns the collection of operations provided by the given service interface.
+   *
+   * @param serviceInterface the service interface
+   * @return the operations provided by the given service interface
+   */
+  public static Map<Method, OperationId> getMethodMap(Class<?> serviceInterface) {
+    if (!serviceInterface.isInterface()) {
+      throw new ConfigurationException("Service type must be an interface");
+    }
+    return findMethods(serviceInterface);
+  }
+
+  /**
+   * Recursively finds operations defined by the given type and its implemented interfaces.
+   *
+   * @param type the type for which to find operations
+   * @return the operations defined by the given type and its parent interfaces
+   */
+  private static Map<Method, OperationId> findMethods(Class<?> type) {
+    Map<Method, OperationId> operations = new HashMap<>();
+    for (Method method : type.getDeclaredMethods()) {
+      Operation operation = method.getAnnotation(Operation.class);
+      if (operation != null) {
+        String name = operation.value().equals("") ? method.getName() : operation.value();
+        operations.put(method, OperationId.from(name, operation.type()));
+      }
+    }
+    for (Class<?> iface : type.getInterfaces()) {
+      operations.putAll(findMethods(iface));
+    }
+    return operations;
+  }
+
+  /**
+   * Returns the collection of operations provided by the given service interface.
+   *
+   * @param serviceInterface the service interface
+   * @return the operations provided by the given service interface
+   */
+  public static Map<OperationId, Method> getOperationMap(Class<?> serviceInterface) {
+    if (!serviceInterface.isInterface()) {
+      throw new ConfigurationException("Service type must be an interface");
+    }
+    return findOperations(serviceInterface);
+  }
+
+  /**
+   * Recursively finds operations defined by the given type and its implemented interfaces.
+   *
+   * @param type the type for which to find operations
+   * @return the operations defined by the given type and its parent interfaces
+   */
+  private static Map<OperationId, Method> findOperations(Class<?> type) {
+    Map<OperationId, Method> operations = new HashMap<>();
+    for (Method method : type.getDeclaredMethods()) {
+      Operation operation = method.getAnnotation(Operation.class);
+      if (operation != null) {
+        String name = operation.value().equals("") ? method.getName() : operation.value();
+        operations.put(OperationId.from(name, operation.type()), method);
+      }
+    }
+    for (Class<?> iface : type.getInterfaces()) {
+      operations.putAll(findOperations(iface));
+    }
+    return operations;
+  }
+
+  private Operations() {
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/proxy/PrimitiveProxy.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/PrimitiveProxy.java
@@ -52,6 +52,16 @@ public interface PrimitiveProxy extends Proxy<PrimitiveProxy> {
    * @param key the key for which to return the partition proxy
    * @return the partition proxy for the given key
    */
-  PartitionProxy getPartition(String key);
+  default PartitionProxy getPartition(String key) {
+    return getPartition(getPartitionId(key));
+  }
+
+  /**
+   * Returns the partition ID for the given key.
+   *
+   * @param key the key for which to return the partition ID
+   * @return the partition ID for the given key
+   */
+  PartitionId getPartitionId(String key);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/PartitionedPrimitiveProxy.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/PartitionedPrimitiveProxy.java
@@ -96,8 +96,8 @@ public class PartitionedPrimitiveProxy implements PrimitiveProxy {
   }
 
   @Override
-  public PartitionProxy getPartition(String key) {
-    return getPartition(partitioner.partition(key, partitionIds));
+  public PartitionId getPartitionId(String key) {
+    return partitioner.partition(key, partitionIds);
   }
 
   @Override

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
@@ -300,6 +300,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
     operationIndex = index;
     currentIndex = index;
     currentTimestamp = timestamp;
+    service.tick(new WallClockTimestamp(currentTimestamp));
   }
 
   /**

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoNamespaces.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoNamespaces.java
@@ -43,64 +43,64 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public final class KryoNamespaces {
 
-    public static final int BASIC_MAX_SIZE = 50;
-    public static final KryoNamespace BASIC = KryoNamespace.builder()
-            .nextId(KryoNamespace.FLOATING_ID)
-            .register(byte[].class)
-            .register(AtomicBoolean.class)
-            .register(AtomicInteger.class)
-            .register(AtomicLong.class)
-            .register(new ImmutableListSerializer(),
-                      ImmutableList.class,
-                      ImmutableList.of(1).getClass(),
-                      ImmutableList.of(1, 2).getClass(),
-                      ImmutableList.of(1, 2, 3).subList(1, 3).getClass())
-            .register(new ImmutableSetSerializer(),
-                      ImmutableSet.class,
-                      ImmutableSet.of().getClass(),
-                      ImmutableSet.of(1).getClass(),
-                      ImmutableSet.of(1, 2).getClass())
-            .register(new ImmutableMapSerializer(),
-                      ImmutableMap.class,
-                      ImmutableMap.of().getClass(),
-                      ImmutableMap.of("a", 1).getClass(),
-                      ImmutableMap.of("R", 2, "D", 2).getClass())
-            .register(Collections.unmodifiableSet(Collections.emptySet()).getClass())
-            .register(HashMap.class)
-            .register(ConcurrentHashMap.class)
-            .register(CopyOnWriteArraySet.class)
-            .register(ArrayList.class,
-                      LinkedList.class,
-                      HashSet.class,
-                      LinkedHashSet.class
-            )
-            .register(HashMultiset.class)
-            .register(Sets.class)
-            .register(Maps.immutableEntry("a", "b").getClass())
-            .register(new ArraysAsListSerializer(), Arrays.asList().getClass())
-            .register(Collections.singletonList(1).getClass())
-            .register(Duration.class)
-            .register(Collections.emptySet().getClass())
-            .register(Optional.class)
-            .register(Collections.emptyList().getClass())
-            .register(Collections.singleton(Object.class).getClass())
-            .register(int[].class)
-            .register(long[].class)
-            .register(short[].class)
-            .register(double[].class)
-            .register(float[].class)
-            .register(char[].class)
-            .register(String[].class)
-            .register(boolean[].class)
-            .register(Object[].class)
-            .build("BASIC");
+  public static final int BASIC_MAX_SIZE = 50;
+  public static final KryoNamespace BASIC = KryoNamespace.builder()
+      .nextId(KryoNamespace.FLOATING_ID)
+      .register(byte[].class)
+      .register(AtomicBoolean.class)
+      .register(AtomicInteger.class)
+      .register(AtomicLong.class)
+      .register(new ImmutableListSerializer(),
+          ImmutableList.class,
+          ImmutableList.of(1).getClass(),
+          ImmutableList.of(1, 2).getClass(),
+          ImmutableList.of(1, 2, 3).subList(1, 3).getClass())
+      .register(new ImmutableSetSerializer(),
+          ImmutableSet.class,
+          ImmutableSet.of().getClass(),
+          ImmutableSet.of(1).getClass(),
+          ImmutableSet.of(1, 2).getClass())
+      .register(new ImmutableMapSerializer(),
+          ImmutableMap.class,
+          ImmutableMap.of().getClass(),
+          ImmutableMap.of("a", 1).getClass(),
+          ImmutableMap.of("R", 2, "D", 2).getClass())
+      .register(Collections.unmodifiableSet(Collections.emptySet()).getClass())
+      .register(HashMap.class)
+      .register(ConcurrentHashMap.class)
+      .register(CopyOnWriteArraySet.class)
+      .register(ArrayList.class,
+          LinkedList.class,
+          HashSet.class,
+          LinkedHashSet.class
+      )
+      .register(HashMultiset.class)
+      .register(Sets.class)
+      .register(Maps.immutableEntry("a", "b").getClass())
+      .register(new ArraysAsListSerializer(), Arrays.asList().getClass())
+      .register(Collections.singletonList(1).getClass())
+      .register(Duration.class)
+      .register(Collections.emptySet().getClass())
+      .register(Optional.class)
+      .register(Collections.emptyList().getClass())
+      .register(Collections.singleton(Object.class).getClass())
+      .register(int[].class)
+      .register(long[].class)
+      .register(short[].class)
+      .register(double[].class)
+      .register(float[].class)
+      .register(char[].class)
+      .register(String[].class)
+      .register(boolean[].class)
+      .register(Object[].class)
+      .build("BASIC");
 
-    /**
-     * Kryo registration Id for user custom registration.
-     */
-    public static final int BEGIN_USER_CUSTOM_ID = 500;
+  /**
+   * Kryo registration Id for user custom registration.
+   */
+  public static final int BEGIN_USER_CUSTOM_ID = 500;
 
-    // not to be instantiated
-    private KryoNamespaces() {
-    }
+  // not to be instantiated
+  private KryoNamespaces() {
+  }
 }

--- a/utils/src/main/java/io/atomix/utils/serializer/KryoNamespaces.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/KryoNamespaces.java
@@ -42,7 +42,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class KryoNamespaces {
-
   public static final int BASIC_MAX_SIZE = 50;
   public static final KryoNamespace BASIC = KryoNamespace.builder()
       .nextId(KryoNamespace.FLOATING_ID)


### PR DESCRIPTION
This PR refactors the client-side primitive APIs to support the use of Java proxies for primitive state machines. The proxies work by providing a proxy interface for the primitive service to implement, e.g.:

```java
public interface ConsistentMapService {
  @Operation(value = "containsKey", type = OperationType.QUERY)
  boolean containsKey(String key);

  @Operation(value = "containsValue", type = OperationType.QUERY)
  boolean containsValue(byte[] value);

  @Operation(value = "get", type = OperationType.QUERY)
  Versioned<byte[]> get(String key);

  @Operation(value = "put", type = OperationType.COMMAND)
  Versioned<byte[]> put(String key, byte[] value);
}
```

The proxy interface must then be implemented by the service implementation:

```java
public class ConsistentMapServiceImpl extends AbstractPrimitiveService implements ConsistentMapService {
  ...
}
```

Then, the service interface can be used as a proxy in the asynchronous primitive client:

```java
public class ConsistentMapProxy extends AbstractAsyncPrimitiveProxy<AsyncConsistentMap<String, byte[]>, ConsistentMapProxy> implements AsyncConsistentMap<String, byte[]> {
  public ConsistentMapProxy(PrimitiveProxy proxy, PrimitiveRegistry registry) {
    super(ConsistentMapService.class, proxy, registry);
  }

  @Override
  public CompletableFuture<Boolean> containsKey(String key) {
    return applyBy(key, partition -> partition.containsKey(key));
  }

  @Override
  public CompletableFuture<Boolean> containsValue(byte[] value) {
    return applyAll(partition -> partition.containsValue(value))
      .thenApply(results -> results.filter(Predicate.isEqual(true)).findFirst().orElse(false));
  }

  @Override
  public CompletableFuture<Versioned<byte[]>> put(String key, byte[] value) {
    return applyBy(key, partition -> partition.put(key, value));
  }
}
```

The `acceptAll`/`acceptOn`/`acceptBy` and `applyAll`/`applyOn`/`applyBy` methods provide a service proxy to a `Consumer` or `Function` for operating on all partitions or on a specific partition. The method call is then converted into a `PrimitiveOperation` to execute on the partitions. So, `applyBy(key, partition -> partition.containsKey(key))` essentially invokes the `containsKey` method on the service in the partition to which the given key maps, and `applyAll(partition -> partition.containsValue(value))` invokes the `containsValue` method on the services in every partition, aggregating the results into a `Stream`.