### PR TITLE
Add partition group membership service to track owning members

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -377,7 +377,7 @@ public class Atomix extends AtomixCluster<Atomix> implements PrimitivesService, 
       ClusterMembershipService clusterMembershipService,
       ClusterMessagingService messagingService,
       PrimitiveTypeRegistry primitiveTypeRegistry) {
-    List<ManagedPartitionGroup> partitionGroups = new ArrayList<>();
+    List<ManagedPartitionGroup<?>> partitionGroups = new ArrayList<>();
     for (PartitionGroupConfig partitionGroupConfig : config.getPartitionGroups().values()) {
       partitionGroups.add(PartitionGroups.createGroup(partitionGroupConfig));
     }

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -70,7 +70,6 @@ public class AtomixTest extends AbstractAtomixTest {
   }
 
 
-
   protected CompletableFuture<Atomix> startAtomix(Member.Type type, int id, List<Integer> persistentNodes, Map<String, String> metadata, Profile... profiles) {
     return startAtomix(type, id, persistentNodes, Arrays.asList(), metadata, profiles);
   }
@@ -78,7 +77,6 @@ public class AtomixTest extends AbstractAtomixTest {
   protected CompletableFuture<Atomix> startAtomix(Member.Type type, int id, List<Integer> persistentNodes, List<Integer> ephemeralNodes, Profile... profiles) {
     return startAtomix(type, id, persistentNodes, ephemeralNodes, b -> b.withProfiles(profiles).build());
   }
-
 
 
   protected CompletableFuture<Atomix> startAtomix(Member.Type type, int id, List<Integer> persistentNodes, List<Integer> ephemeralNodes, Map<String, String> metadata, Profile... profiles) {
@@ -203,11 +201,23 @@ public class AtomixTest extends AbstractAtomixTest {
    * Tests a client joining and leaving the cluster.
    */
   @Test
-  public void testClientJoinLeavePersistent() throws Exception {
+  public void testClientJoinLeaveDataGrid() throws Exception {
+    testClientJoinLeave(Profile.DATA_GRID);
+  }
+
+  /**
+   * Tests a client joining and leaving the cluster.
+   */
+  @Test
+  public void testClientJoinLeaveConsensus() throws Exception {
+    testClientJoinLeave(Profile.CONSENSUS);
+  }
+
+  private void testClientJoinLeave(Profile profile) throws Exception {
     List<CompletableFuture<Atomix>> futures = new ArrayList<>();
-    futures.add(startAtomix(Member.Type.PERSISTENT, 1, Arrays.asList(1, 2, 3), Profile.CONSENSUS));
-    futures.add(startAtomix(Member.Type.PERSISTENT, 2, Arrays.asList(1, 2, 3), Profile.CONSENSUS));
-    futures.add(startAtomix(Member.Type.PERSISTENT, 3, Arrays.asList(1, 2, 3), Profile.CONSENSUS));
+    futures.add(startAtomix(Member.Type.PERSISTENT, 1, Arrays.asList(1, 2, 3), profile));
+    futures.add(startAtomix(Member.Type.PERSISTENT, 2, Arrays.asList(1, 2, 3), profile));
+    futures.add(startAtomix(Member.Type.PERSISTENT, 3, Arrays.asList(1, 2, 3), profile));
     Futures.allOf(futures).join();
 
     TestClusterMembershipEventListener dataListener = new TestClusterMembershipEventListener();
@@ -256,8 +266,6 @@ public class AtomixTest extends AbstractAtomixTest {
     event1 = clientListener.event();
     assertEquals(ClusterMembershipEvent.Type.MEMBER_REMOVED, event1.type());
   }
-
-
 
   /**
    * Tests a client metadata.

--- a/primitive/src/main/java/io/atomix/primitive/partition/ManagedPartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/ManagedPartitionGroupMembershipService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.partition;
+
+import io.atomix.utils.Managed;
+
+/**
+ * Managed partition group membership service.
+ */
+public interface ManagedPartitionGroupMembershipService
+    extends PartitionGroupMembershipService, Managed<PartitionGroupMembershipService> {
+}

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembership.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembership.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.partition;
+
+import io.atomix.cluster.MemberId;
+
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * Partition group membership information.
+ */
+public final class PartitionGroupMembership {
+  private final String group;
+  private final PartitionGroupConfig config;
+  private final Set<MemberId> members;
+  private final boolean system;
+
+  public PartitionGroupMembership(String group, PartitionGroupConfig config, Set<MemberId> members, boolean system) {
+    this.group = group;
+    this.config = config;
+    this.members = members;
+    this.system = system;
+  }
+
+  /**
+   * Returns the partition group name.
+   *
+   * @return the partition group name
+   */
+  public String group() {
+    return group;
+  }
+
+  /**
+   * Returns the partition group configuration.
+   *
+   * @return the partition group configuration
+   */
+  public PartitionGroupConfig config() {
+    return config;
+  }
+
+  /**
+   * Returns the partition group members.
+   *
+   * @return the partition group members
+   */
+  public Set<MemberId> members() {
+    return members;
+  }
+
+  /**
+   * Returns whether this partition group is the system partition group.
+   *
+   * @return whether this group is the system partition group
+   */
+  public boolean system() {
+    return system;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("group", group())
+        .add("members", members())
+        .toString();
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembershipEvent.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembershipEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.partition;
+
+import io.atomix.utils.event.AbstractEvent;
+
+/**
+ * Partition group membership event.
+ */
+public class PartitionGroupMembershipEvent extends AbstractEvent<PartitionGroupMembershipEvent.Type, PartitionGroupMembership> {
+
+  /**
+   * Partition group membership event type.
+   */
+  public enum Type {
+    MEMBERS_CHANGED
+  }
+
+  public PartitionGroupMembershipEvent(Type type, PartitionGroupMembership membership) {
+    super(type, membership);
+  }
+
+  public PartitionGroupMembershipEvent(Type type, PartitionGroupMembership membership, long time) {
+    super(type, membership, time);
+  }
+
+  /**
+   * Returns the partition group membership.
+   *
+   * @return the partition group membership
+   */
+  public PartitionGroupMembership membership() {
+    return subject();
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembershipEventListener.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembershipEventListener.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.partition;
+
+import io.atomix.utils.event.EventListener;
+
+/**
+ * Partition group membership event listener.
+ */
+public interface PartitionGroupMembershipEventListener extends EventListener<PartitionGroupMembershipEvent> {
+}

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroupMembershipService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.partition;
+
+import io.atomix.utils.event.ListenerService;
+
+import java.util.Collection;
+
+/**
+ * Partition group membership service.
+ */
+public interface PartitionGroupMembershipService extends ListenerService<PartitionGroupMembershipEvent, PartitionGroupMembershipEventListener> {
+
+  /**
+   * Returns the system group membership.
+   *
+   * @return the system group membership
+   */
+  PartitionGroupMembership getSystemMembership();
+
+  /**
+   * Returns the members for the given group.
+   *
+   * @param group the group for which to return the members
+   * @return the members for the given group
+   */
+  PartitionGroupMembership getMembership(String group);
+
+  /**
+   * Returns the membership for all partition groups.
+   *
+   * @return the membership for all partition groups
+   */
+  Collection<PartitionGroupMembership> getMemberships();
+
+}

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.partition.impl;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import io.atomix.cluster.ClusterMembershipEvent;
+import io.atomix.cluster.ClusterMembershipEventListener;
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterMessagingService;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
+import io.atomix.primitive.partition.ManagedPartitionGroupMembershipService;
+import io.atomix.primitive.partition.MemberGroupStrategy;
+import io.atomix.primitive.partition.PartitionGroupConfig;
+import io.atomix.primitive.partition.PartitionGroupFactory;
+import io.atomix.primitive.partition.PartitionGroupMembership;
+import io.atomix.primitive.partition.PartitionGroupMembershipEvent;
+import io.atomix.primitive.partition.PartitionGroupMembershipEventListener;
+import io.atomix.primitive.partition.PartitionGroupMembershipService;
+import io.atomix.primitive.partition.PartitionGroups;
+import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.concurrent.SingleThreadContext;
+import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.config.ConfigurationException;
+import io.atomix.utils.event.AbstractListenerManager;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.KryoNamespaces;
+import io.atomix.utils.serializer.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.atomix.primitive.partition.PartitionGroupMembershipEvent.Type.MEMBERS_CHANGED;
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Default partition group membership service.
+ */
+public class DefaultPartitionGroupMembershipService
+    extends AbstractListenerManager<PartitionGroupMembershipEvent, PartitionGroupMembershipEventListener>
+    implements ManagedPartitionGroupMembershipService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPartitionGroupMembershipService.class);
+  private static final String BOOTSTRAP_SUBJECT = "partition-group-bootstrap";
+
+  private final ClusterMembershipService membershipService;
+  private final ClusterMessagingService messagingService;
+  private final Serializer serializer;
+  private volatile PartitionGroupMembership systemGroup;
+  private final Map<String, PartitionGroupMembership> groups = Maps.newConcurrentMap();
+  private final ClusterMembershipEventListener membershipEventListener = this::handleMembershipChange;
+  private final AtomicBoolean started = new AtomicBoolean();
+  private ThreadContext threadContext;
+
+  @SuppressWarnings("unchecked")
+  public DefaultPartitionGroupMembershipService(
+      ClusterMembershipService membershipService,
+      ClusterMessagingService messagingService,
+      ManagedPartitionGroup<?> systemGroup,
+      Collection<ManagedPartitionGroup<?>> groups) {
+    this.membershipService = membershipService;
+    this.messagingService = messagingService;
+    this.systemGroup = systemGroup != null
+        ? new PartitionGroupMembership(
+        systemGroup.name(),
+        systemGroup.config(),
+        ImmutableSet.of(membershipService.getLocalMember().id()), true) : null;
+    groups.forEach(group -> {
+      this.groups.put(group.name(), new PartitionGroupMembership(
+          group.name(),
+          group.config(),
+          ImmutableSet.of(membershipService.getLocalMember().id()), false));
+    });
+
+    KryoNamespace.Builder builder = KryoNamespace.builder()
+        .register(KryoNamespaces.BASIC)
+        .register(MemberId.class)
+        .register(PartitionGroupMembership.class)
+        .register(PartitionGroupInfo.class)
+        .register(PartitionGroupConfig.class)
+        .register(MemberGroupStrategy.class);
+    for (PartitionGroupFactory factory : PartitionGroups.getGroupFactories()) {
+      builder.register(factory.configClass());
+    }
+    serializer = Serializer.using(builder.build());
+  }
+
+  @Override
+  public PartitionGroupMembership getSystemMembership() {
+    return systemGroup;
+  }
+
+  @Override
+  public PartitionGroupMembership getMembership(String group) {
+    PartitionGroupMembership membership = groups.get(group);
+    if (membership != null) {
+      return membership;
+    }
+    return systemGroup.group().equals(group) ? systemGroup : null;
+  }
+
+  @Override
+  public Collection<PartitionGroupMembership> getMemberships() {
+    return groups.values();
+  }
+
+  /**
+   * Handles a cluster membership change.
+   */
+  private void handleMembershipChange(ClusterMembershipEvent event) {
+    if (event.type() == ClusterMembershipEvent.Type.MEMBER_ACTIVATED) {
+      bootstrap(event.subject());
+    } else if (event.type() == ClusterMembershipEvent.Type.MEMBER_DEACTIVATED) {
+      PartitionGroupMembership systemGroup = this.systemGroup;
+      if (systemGroup != null && systemGroup.members().contains(event.subject().id())) {
+        Set<MemberId> newMembers = Sets.newHashSet(systemGroup.members());
+        newMembers.remove(event.subject().id());
+        PartitionGroupMembership newMembership = new PartitionGroupMembership(systemGroup.group(), systemGroup.config(), ImmutableSet.copyOf(newMembers), true);
+        this.systemGroup = newMembership;
+        post(new PartitionGroupMembershipEvent(MEMBERS_CHANGED, newMembership));
+      }
+
+      groups.values().forEach(group -> {
+        if (group.members().contains(event.subject().id())) {
+          Set<MemberId> newMembers = Sets.newHashSet(group.members());
+          newMembers.remove(event.subject().id());
+          PartitionGroupMembership newMembership = new PartitionGroupMembership(group.group(), group.config(), ImmutableSet.copyOf(newMembers), false);
+          groups.put(group.group(), newMembership);
+          post(new PartitionGroupMembershipEvent(MEMBERS_CHANGED, newMembership));
+        }
+      });
+    }
+  }
+
+  /**
+   * Bootstraps the service.
+   */
+  private CompletableFuture<Void> bootstrap() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    Futures.allOf(membershipService.getMembers().stream()
+        .filter(node -> !node.id().equals(membershipService.getLocalMember().id()))
+        .map(node -> bootstrap(node))
+        .collect(Collectors.toList()))
+        .whenComplete((result, error) -> {
+          if (error == null) {
+            if (systemGroup == null) {
+              future.completeExceptionally(new ConfigurationException("Failed to locate system partition group"));
+            } else if (groups.isEmpty()) {
+              future.completeExceptionally(new ConfigurationException("Failed to locate partition groups"));
+            } else {
+              future.complete(null);
+            }
+          } else {
+            future.completeExceptionally(error);
+          }
+        });
+    return future;
+  }
+
+  /**
+   * Bootstraps the service from the given node.
+   */
+  @SuppressWarnings("unchecked")
+  private CompletableFuture<Void> bootstrap(Member member) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    messagingService.<MemberId, PartitionGroupInfo>send(
+        BOOTSTRAP_SUBJECT,
+        membershipService.getLocalMember().id(),
+        serializer::encode,
+        serializer::decode,
+        member.id())
+        .whenComplete((info, error) -> {
+          if (error == null) {
+            if (systemGroup == null && info.systemGroup != null) {
+              systemGroup = info.systemGroup;
+              post(new PartitionGroupMembershipEvent(MEMBERS_CHANGED, systemGroup));
+            } else if (systemGroup != null && info.systemGroup != null) {
+              if ((!systemGroup.group().equals(info.systemGroup.group()) || !systemGroup.config().getType().equals(info.systemGroup.config().getType()))) {
+                future.completeExceptionally(new ConfigurationException("Duplicate system group detected"));
+                return;
+              } else {
+                Set<MemberId> newMembers = Stream.concat(systemGroup.members().stream(), info.systemGroup.members().stream())
+                    .filter(memberId -> membershipService.getMember(memberId) != null)
+                    .collect(Collectors.toSet());
+                if (!Sets.difference(newMembers, systemGroup.members()).isEmpty()) {
+                  systemGroup = new PartitionGroupMembership(systemGroup.group(), systemGroup.config(), ImmutableSet.copyOf(newMembers), true);
+                  post(new PartitionGroupMembershipEvent(MEMBERS_CHANGED, systemGroup));
+                }
+              }
+            }
+
+            for (PartitionGroupMembership newMembership : info.groups) {
+              PartitionGroupMembership oldMembership = groups.get(newMembership.group());
+              if (oldMembership == null) {
+                groups.put(newMembership.group(), newMembership);
+              } else if ((!oldMembership.group().equals(newMembership.group()) || !oldMembership.config().getType().equals(newMembership.config().getType()))) {
+                future.completeExceptionally(new ConfigurationException("Duplicate partition group " + newMembership.group() + " detected"));
+                return;
+              } else {
+                Set<MemberId> newMembers = Stream.concat(oldMembership.members().stream(), newMembership.members().stream())
+                    .filter(memberId -> membershipService.getMember(memberId) != null)
+                    .collect(Collectors.toSet());
+                if (!Sets.difference(newMembers, oldMembership.members()).isEmpty()) {
+                  PartitionGroupMembership newGroup = new PartitionGroupMembership(oldMembership.group(), oldMembership.config(), ImmutableSet.copyOf(newMembers), false);
+                  groups.put(oldMembership.group(), newGroup);
+                  post(new PartitionGroupMembershipEvent(MEMBERS_CHANGED, newGroup));
+                }
+              }
+            }
+            future.complete(null);
+          } else {
+            future.complete(null);
+          }
+        });
+    return future;
+  }
+
+  private PartitionGroupInfo handleBootstrap(MemberId memberId) {
+    return new PartitionGroupInfo(systemGroup, Lists.newArrayList(groups.values()));
+  }
+
+  @Override
+  public CompletableFuture<PartitionGroupMembershipService> start() {
+    membershipService.addListener(membershipEventListener);
+    threadContext = new SingleThreadContext(namedThreads("atomix-partition-service-%d", LOGGER));
+    messagingService.subscribe(BOOTSTRAP_SUBJECT, serializer::decode, this::handleBootstrap, serializer::encode, threadContext);
+    return bootstrap().thenApply(v -> {
+      LOGGER.info("Started");
+      started.set(true);
+      return this;
+    });
+  }
+
+  @Override
+  public boolean isRunning() {
+    return started.get();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public CompletableFuture<Void> stop() {
+    membershipService.removeListener(membershipEventListener);
+    messagingService.unsubscribe(BOOTSTRAP_SUBJECT);
+    ThreadContext threadContext = this.threadContext;
+    if (threadContext != null) {
+      threadContext.close();
+    }
+    LOGGER.info("Stopped");
+    started.set(false);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private static class PartitionGroupInfo {
+    private final PartitionGroupMembership systemGroup;
+    private final Collection<PartitionGroupMembership> groups;
+
+    PartitionGroupInfo(PartitionGroupMembership systemGroup, Collection<PartitionGroupMembership> groups) {
+      this.systemGroup = systemGroup;
+      this.groups = groups;
+    }
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionService.java
@@ -17,33 +17,24 @@ package io.atomix.primitive.partition.impl;
 
 import com.google.common.collect.Maps;
 import io.atomix.cluster.ClusterMembershipService;
-import io.atomix.cluster.Member;
-import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterMessagingService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
+import io.atomix.primitive.partition.ManagedPartitionGroupMembershipService;
 import io.atomix.primitive.partition.ManagedPartitionService;
 import io.atomix.primitive.partition.ManagedPrimaryElectionService;
-import io.atomix.primitive.partition.MemberGroupStrategy;
-import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionGroup;
-import io.atomix.primitive.partition.PartitionGroupConfig;
-import io.atomix.primitive.partition.PartitionGroupFactory;
+import io.atomix.primitive.partition.PartitionGroupMembership;
+import io.atomix.primitive.partition.PartitionGroupMembershipEvent;
+import io.atomix.primitive.partition.PartitionGroupMembershipEventListener;
 import io.atomix.primitive.partition.PartitionGroups;
-import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.session.ManagedSessionIdService;
 import io.atomix.primitive.session.impl.DefaultSessionIdService;
 import io.atomix.primitive.session.impl.ReplicatedSessionIdService;
 import io.atomix.utils.concurrent.Futures;
-import io.atomix.utils.concurrent.SingleThreadContext;
-import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.config.ConfigurationException;
-import io.atomix.utils.serializer.KryoNamespace;
-import io.atomix.utils.serializer.KryoNamespaces;
-import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,66 +46,47 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.atomix.utils.concurrent.Threads.namedThreads;
-
 /**
  * Default partition service.
  */
 public class DefaultPartitionService implements ManagedPartitionService {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPartitionService.class);
-  private static final String BOOTSTRAP_SUBJECT = "partition-bootstrap";
 
-  private final ClusterMembershipService membershipService;
-  private final ClusterMessagingService messagingService;
+  private final ClusterMembershipService clusterMembershipService;
+  private final ClusterMessagingService clusterMessagingService;
   private final PrimitiveTypeRegistry primitiveTypeRegistry;
-  private final Serializer serializer;
-  private WrappedPartitionGroup systemGroup;
-  private WrappedPartitionGroup defaultGroup;
-  private final Map<String, WrappedPartitionGroup<?>> groups = Maps.newConcurrentMap();
+  private final ManagedPartitionGroupMembershipService groupMembershipService;
+  private ManagedPartitionGroup systemGroup;
+  private volatile PartitionManagementService partitionManagementService;
+  private final Map<String, ManagedPartitionGroup<?>> groups = Maps.newConcurrentMap();
+  private final PartitionGroupMembershipEventListener groupMembershipEventListener = this::handleMembershipChange;
   private final AtomicBoolean started = new AtomicBoolean();
-  private ThreadContext threadContext;
 
   @SuppressWarnings("unchecked")
   public DefaultPartitionService(
       ClusterMembershipService membershipService,
       ClusterMessagingService messagingService,
       PrimitiveTypeRegistry primitiveTypeRegistry,
-      ManagedPartitionGroup systemGroup,
-      Collection<ManagedPartitionGroup> groups) {
-    this.membershipService = membershipService;
-    this.messagingService = messagingService;
+      ManagedPartitionGroup<?> systemGroup,
+      Collection<ManagedPartitionGroup<?>> groups) {
+    this.clusterMembershipService = membershipService;
+    this.clusterMessagingService = messagingService;
     this.primitiveTypeRegistry = primitiveTypeRegistry;
-    this.systemGroup = systemGroup != null ? new WrappedPartitionGroup(systemGroup, true) : null;
-    groups.forEach(group -> {
-      WrappedPartitionGroup wrappedGroup = new WrappedPartitionGroup(group, true);
-      this.groups.put(group.name(), wrappedGroup);
-      if (defaultGroup == null) {
-        defaultGroup = wrappedGroup;
-      }
-    });
-
-    KryoNamespace.Builder builder = KryoNamespace.builder()
-        .register(KryoNamespaces.BASIC)
-        .register(MemberId.class)
-        .register(PartitionGroupInfo.class)
-        .register(PartitionGroupConfig.class)
-        .register(MemberGroupStrategy.class);
-    for (PartitionGroupFactory factory : PartitionGroups.getGroupFactories()) {
-      builder.register(factory.configClass());
-    }
-    serializer = Serializer.using(builder.build());
+    this.groupMembershipService = new DefaultPartitionGroupMembershipService(membershipService, messagingService, systemGroup, groups);
+    this.systemGroup = systemGroup;
+    groups.forEach(group -> this.groups.put(group.name(), group));
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public PartitionGroup getSystemPartitionGroup() {
-    return systemGroup.group;
+    return systemGroup;
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public PartitionGroup getPartitionGroup(String name) {
-    WrappedPartitionGroup group = groups.get(name);
+    ManagedPartitionGroup group = groups.get(name);
     if (group != null) {
       return group;
     }
@@ -127,105 +99,54 @@ public class DefaultPartitionService implements ManagedPartitionService {
   @Override
   @SuppressWarnings("unchecked")
   public Collection<PartitionGroup> getPartitionGroups() {
-    return groups.values()
-        .stream()
-        .map(group -> group.group)
-        .collect(Collectors.toList());
+    return (Collection) groups.values();
   }
 
-  /**
-   * Bootstraps the service.
-   */
-  private CompletableFuture<Void> bootstrap() {
-    CompletableFuture<Void> future = new CompletableFuture<>();
-    Futures.allOf(membershipService.getMembers().stream()
-        .filter(node -> !node.id().equals(membershipService.getLocalMember().id()))
-        .map(node -> bootstrap(node))
-        .collect(Collectors.toList()))
-        .whenComplete((result, error) -> {
-          if (error == null) {
-            if (systemGroup == null) {
-              future.completeExceptionally(new ConfigurationException("Failed to locate system partition group"));
-            } else if (groups.isEmpty()) {
-              future.completeExceptionally(new ConfigurationException("Failed to locate partition groups"));
-            } else {
-              future.complete(null);
-            }
+  private void handleMembershipChange(PartitionGroupMembershipEvent event) {
+    if (partitionManagementService == null) {
+      return;
+    }
+
+    if (!event.membership().system()) {
+      synchronized (groups) {
+        ManagedPartitionGroup group = groups.get(event.membership().group());
+        if (group == null) {
+          group = PartitionGroups.createGroup(event.membership().config());
+          groups.put(event.membership().group(), group);
+          if (event.membership().members().contains(clusterMembershipService.getLocalMember().id())) {
+            group.join(partitionManagementService);
           } else {
-            future.completeExceptionally(error);
+            group.connect(partitionManagementService);
           }
-        });
-    return future;
-  }
-
-  /**
-   * Bootstraps the service from the given node.
-   */
-  @SuppressWarnings("unchecked")
-  private CompletableFuture<Void> bootstrap(Member member) {
-    CompletableFuture<Void> future = new CompletableFuture<>();
-    messagingService.<MemberId, PartitionGroupInfo>send(
-        BOOTSTRAP_SUBJECT,
-        membershipService.getLocalMember().id(),
-        serializer::encode,
-        serializer::decode,
-        member.id())
-        .whenComplete((info, error) -> {
-          if (error == null) {
-            if (systemGroup != null && info.systemGroup != null &&
-                (!systemGroup.name().equals(info.systemGroup.getName()) || !systemGroup.protocol().equals(info.systemGroup.getType()))) {
-              future.completeExceptionally(new ConfigurationException("Duplicate system group detected"));
-              return;
-            } else if (systemGroup == null && info.systemGroup != null) {
-              systemGroup = new WrappedPartitionGroup(PartitionGroups.createGroup(info.systemGroup), false);
-            }
-
-            for (PartitionGroupConfig groupConfig : info.groups) {
-              ManagedPartitionGroup group = groups.get(groupConfig.getName());
-              if (group == null) {
-                WrappedPartitionGroup wrappedGroup = new WrappedPartitionGroup(PartitionGroups.createGroup(groupConfig), false);
-                groups.put(groupConfig.getName(), wrappedGroup);
-                if (defaultGroup == null) {
-                  defaultGroup = wrappedGroup;
-                }
-              } else if (!group.protocol().equals(groupConfig.getType())) {
-                future.completeExceptionally(new ConfigurationException("Duplicate partition group " + groupConfig.getName() + " detected"));
-                return;
-              }
-            }
-            future.complete(null);
-          } else {
-            future.complete(null);
-          }
-        });
-    return future;
-  }
-
-  private PartitionGroupInfo handleBootstrap(MemberId memberId) {
-    return new PartitionGroupInfo(
-        systemGroup != null ? systemGroup.config() : null,
-        groups.values()
-            .stream()
-            .map(group -> group.config())
-            .collect(Collectors.toList()));
+        }
+      }
+    }
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public CompletableFuture<PartitionService> start() {
-    threadContext = new SingleThreadContext(namedThreads("atomix-partition-service-%d", LOGGER));
-    messagingService.subscribe(BOOTSTRAP_SUBJECT, serializer::decode, this::handleBootstrap, serializer::encode, threadContext);
-    return bootstrap()
+    groupMembershipService.addListener(groupMembershipEventListener);
+    return groupMembershipService.start()
         .thenCompose(v -> {
-          PartitionManagementService managementService = new DefaultPartitionManagementService(
-              membershipService,
-              messagingService,
-              primitiveTypeRegistry,
-              new HashBasedPrimaryElectionService(membershipService, messagingService),
-              new DefaultSessionIdService());
-          if (systemGroup.isMember()) {
-            return systemGroup.join(managementService);
+          PartitionGroupMembership systemGroupMembership = groupMembershipService.getSystemMembership();
+          if (systemGroupMembership != null) {
+            if (systemGroup == null) {
+              systemGroup = PartitionGroups.createGroup(systemGroupMembership.config());
+            }
+            PartitionManagementService managementService = new DefaultPartitionManagementService(
+                clusterMembershipService,
+                clusterMessagingService,
+                primitiveTypeRegistry,
+                new HashBasedPrimaryElectionService(clusterMembershipService, groupMembershipService, clusterMessagingService),
+                new DefaultSessionIdService());
+            if (systemGroupMembership.members().contains(clusterMembershipService.getLocalMember().id())) {
+              return systemGroup.join(managementService);
+            } else {
+              return systemGroup.connect(managementService);
+            }
           } else {
-            return systemGroup.connect(managementService);
+            return Futures.exceptionalFuture(new ConfigurationException("No system partition group found"));
           }
         })
         .thenCompose(v -> {
@@ -234,19 +155,28 @@ public class DefaultPartitionService implements ManagedPartitionService {
           return systemElectionService.start()
               .thenCompose(v2 -> systemSessionIdService.start())
               .thenApply(v2 -> new DefaultPartitionManagementService(
-                  membershipService,
-                  messagingService,
+                  clusterMembershipService,
+                  clusterMessagingService,
                   primitiveTypeRegistry,
                   systemElectionService,
                   systemSessionIdService));
         })
         .thenCompose(managementService -> {
-          List<CompletableFuture> futures = groups.values().stream()
-              .map(group -> {
-                if (group.isMember()) {
-                  return group.join((PartitionManagementService) managementService);
+          this.partitionManagementService = (PartitionManagementService) managementService;
+          List<CompletableFuture> futures = groupMembershipService.getMemberships().stream()
+              .map(membership -> {
+                ManagedPartitionGroup group;
+                synchronized (groups) {
+                  group = groups.get(membership.group());
+                  if (group == null) {
+                    group = PartitionGroups.createGroup(membership.config());
+                    groups.put(group.name(), group);
+                  }
+                }
+                if (membership.members().contains(clusterMembershipService.getLocalMember().id())) {
+                  return group.join(partitionManagementService);
                 } else {
-                  return group.connect((PartitionManagementService) managementService);
+                  return group.connect(partitionManagementService);
                 }
               })
               .collect(Collectors.toList());
@@ -266,98 +196,14 @@ public class DefaultPartitionService implements ManagedPartitionService {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<Void> stop() {
-    messagingService.unsubscribe(BOOTSTRAP_SUBJECT);
-
+    groupMembershipService.removeListener(groupMembershipEventListener);
     Stream<CompletableFuture<Void>> systemStream = Stream.of(systemGroup != null ? systemGroup.close() : CompletableFuture.completedFuture(null));
     Stream<CompletableFuture<Void>> groupStream = groups.values().stream().map(ManagedPartitionGroup::close);
     List<CompletableFuture<Void>> futures = Stream.concat(systemStream, groupStream).collect(Collectors.toList());
 
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).thenRun(() -> {
-      ThreadContext threadContext = this.threadContext;
-      if (threadContext != null) {
-        threadContext.close();
-      }
       LOGGER.info("Stopped");
       started.set(false);
     });
-  }
-
-  private static class PartitionGroupInfo {
-    private final PartitionGroupConfig systemGroup;
-    private final Collection<PartitionGroupConfig> groups;
-
-    PartitionGroupInfo(PartitionGroupConfig systemGroup, Collection<PartitionGroupConfig> groups) {
-      this.systemGroup = systemGroup;
-      this.groups = groups;
-    }
-  }
-
-  private static class WrappedPartitionGroup<P extends Partition> implements ManagedPartitionGroup<P> {
-    private final ManagedPartitionGroup<P> group;
-    private final boolean member;
-
-    public WrappedPartitionGroup(ManagedPartitionGroup group, boolean member) {
-      this.group = group;
-      this.member = member;
-    }
-
-    public boolean isMember() {
-      return member;
-    }
-
-    @Override
-    public PartitionGroupConfig config() {
-      return group.config();
-    }
-
-    @Override
-    public String name() {
-      return group.name();
-    }
-
-    @Override
-    public Type type() {
-      return group.type();
-    }
-
-    @Override
-    public PrimitiveProtocol.Type protocol() {
-      return group.protocol();
-    }
-
-    @Override
-    public PrimitiveProtocol newProtocol() {
-      return group.newProtocol();
-    }
-
-    @Override
-    public P getPartition(PartitionId partitionId) {
-      return group.getPartition(partitionId);
-    }
-
-    @Override
-    public Collection<P> getPartitions() {
-      return group.getPartitions();
-    }
-
-    @Override
-    public List<PartitionId> getPartitionIds() {
-      return group.getPartitionIds();
-    }
-
-    @Override
-    public CompletableFuture<ManagedPartitionGroup<P>> join(PartitionManagementService managementService) {
-      return group.join(managementService);
-    }
-
-    @Override
-    public CompletableFuture<ManagedPartitionGroup<P>> connect(PartitionManagementService managementService) {
-      return group.connect(managementService);
-    }
-
-    @Override
-    public CompletableFuture<Void> close() {
-      return group.close();
-    }
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/HashBasedPrimaryElection.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/HashBasedPrimaryElection.java
@@ -15,24 +15,40 @@
  */
 package io.atomix.primitive.partition.impl;
 
+import com.google.common.collect.Maps;
 import com.google.common.hash.Hashing;
-import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.messaging.ClusterMessagingService;
 import io.atomix.primitive.partition.GroupMember;
 import io.atomix.primitive.partition.MemberGroupId;
+import io.atomix.primitive.partition.PartitionGroupMembership;
+import io.atomix.primitive.partition.PartitionGroupMembershipEvent;
+import io.atomix.primitive.partition.PartitionGroupMembershipEventListener;
+import io.atomix.primitive.partition.PartitionGroupMembershipService;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PrimaryElection;
 import io.atomix.primitive.partition.PrimaryElectionEvent;
 import io.atomix.primitive.partition.PrimaryElectionEventListener;
 import io.atomix.primitive.partition.PrimaryTerm;
 import io.atomix.utils.event.AbstractListenerManager;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.KryoNamespaces;
+import io.atomix.utils.serializer.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Hash-based primary election.
@@ -40,19 +56,50 @@ import java.util.concurrent.CompletableFuture;
 public class HashBasedPrimaryElection
     extends AbstractListenerManager<PrimaryElectionEvent, PrimaryElectionEventListener>
     implements PrimaryElection {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HashBasedPrimaryElection.class);
+  private static final long BROADCAST_INTERVAL = 5000;
+
+  private static final Serializer SERIALIZER = Serializer.using(KryoNamespace.builder()
+      .register(KryoNamespaces.BASIC)
+      .register(MemberId.class)
+      .build());
 
   private final PartitionId partitionId;
   private final ClusterMembershipService clusterMembershipService;
-  private final HashBasedPrimaryElectionService electionService;
-  private final ClusterMembershipEventListener membershipEventListener = e -> recomputeTerm();
+  private final PartitionGroupMembershipService groupMembershipService;
+  private final ClusterMessagingService clusterMessagingService;
+  private final Map<MemberId, Integer> counters = Maps.newConcurrentMap();
+  private final String subject;
+  private final ScheduledFuture<?> broadcastFuture;
   private volatile PrimaryTerm currentTerm;
 
-  public HashBasedPrimaryElection(PartitionId partitionId, ClusterMembershipService clusterMembershipService, HashBasedPrimaryElectionService electionService) {
+  private final PartitionGroupMembershipEventListener membershipEventListener = new PartitionGroupMembershipEventListener() {
+    @Override
+    public void onEvent(PartitionGroupMembershipEvent event) {
+      recomputeTerm(event.membership());
+    }
+
+    @Override
+    public boolean isRelevant(PartitionGroupMembershipEvent event) {
+      return event.membership().group().equals(partitionId.group());
+    }
+  };
+
+  public HashBasedPrimaryElection(
+      PartitionId partitionId,
+      ClusterMembershipService clusterMembershipService,
+      PartitionGroupMembershipService groupMembershipService,
+      ClusterMessagingService clusterMessagingService,
+      ScheduledExecutorService executor) {
     this.partitionId = partitionId;
     this.clusterMembershipService = clusterMembershipService;
-    this.electionService = electionService;
-    recomputeTerm();
-    clusterMembershipService.addListener(membershipEventListener);
+    this.groupMembershipService = groupMembershipService;
+    this.clusterMessagingService = clusterMessagingService;
+    this.subject = String.format("primary-election-counter-%s-%d", partitionId.group(), partitionId.id());
+    recomputeTerm(groupMembershipService.getMembership(partitionId.group()));
+    groupMembershipService.addListener(membershipEventListener);
+    clusterMessagingService.subscribe(subject, SERIALIZER::decode, this::updateCounters, executor);
+    broadcastFuture = executor.scheduleAtFixedRate(this::broadcastCounters, BROADCAST_INTERVAL, BROADCAST_INTERVAL, TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -66,24 +113,97 @@ public class HashBasedPrimaryElection
   }
 
   /**
+   * Returns the current term.
+   *
+   * @return the current term
+   */
+  private long currentTerm() {
+    return counters.values().stream().mapToInt(v -> v).sum();
+  }
+
+  /**
+   * Increments and returns the current term.
+   *
+   * @return the current term
+   */
+  private long incrementTerm() {
+    counters.compute(clusterMembershipService.getLocalMember().id(), (id, value) -> value != null ? value + 1 : 1);
+    broadcastCounters();
+    return currentTerm();
+  }
+
+  private void updateCounters(Map<MemberId, Integer> counters) {
+    for (Map.Entry<MemberId, Integer> entry : counters.entrySet()) {
+      this.counters.compute(entry.getKey(), (key, value) -> {
+        if (value == null || value < entry.getValue()) {
+          return entry.getValue();
+        }
+        return value;
+      });
+    }
+    updateTerm(currentTerm());
+  }
+
+  private void broadcastCounters() {
+    clusterMessagingService.broadcast(subject, counters, SERIALIZER::encode);
+  }
+
+  private void updateTerm(long term) {
+    if (term > currentTerm.term()) {
+      recomputeTerm(groupMembershipService.getMembership(partitionId.group()));
+    }
+  }
+
+  /**
    * Recomputes the current term.
    */
-  private void recomputeTerm() {
+  private synchronized void recomputeTerm(PartitionGroupMembership membership) {
+    if (membership == null) {
+      return;
+    }
+
+    // Create a list of candidates based on the availability of members in the group.
     List<GroupMember> candidates = new ArrayList<>();
-    for (Member member : clusterMembershipService.getMembers()) {
-      if (member.getState() == Member.State.ACTIVE) {
+    for (MemberId memberId : membership.members()) {
+      Member member = clusterMembershipService.getMember(memberId);
+      if (member != null && member.getState() == Member.State.ACTIVE) {
         candidates.add(new GroupMember(member.id(), MemberGroupId.from(member.id().id())));
       }
     }
+
+    // Sort the candidates by a hash of their member ID.
     candidates.sort((a, b) -> {
       int aoffset = Hashing.murmur3_32().hashString(a.memberId().id(), StandardCharsets.UTF_8).asInt() % partitionId.id();
       int boffset = Hashing.murmur3_32().hashString(b.memberId().id(), StandardCharsets.UTF_8).asInt() % partitionId.id();
       return aoffset - boffset;
     });
-    currentTerm = new PrimaryTerm(
-        electionService.incrementTerm(),
-        candidates.isEmpty() ? null : candidates.get(0),
-        candidates.isEmpty() ? Collections.emptyList() : candidates.subList(1, candidates.size()));
-    post(new PrimaryElectionEvent(PrimaryElectionEvent.Type.CHANGED, partitionId, currentTerm));
+
+    // Store the current term in a local variable avoid repeated volatile reads.
+    PrimaryTerm currentTerm = this.currentTerm;
+
+    // Compute the primary from the sorted candidates list.
+    GroupMember primary = candidates.isEmpty() ? null : candidates.get(0);
+
+    // If the primary has changed, increment the term. Otherwise, use the current term from the replicated counter.
+    long term = currentTerm != null && currentTerm.primary().equals(primary) ? currentTerm() : incrementTerm();
+
+    // Remove the primary from the candidates list.
+    candidates = candidates.isEmpty() ? Collections.emptyList() : candidates.subList(1, candidates.size());
+
+    // Create the new primary term. If the term has changed update the term and trigger an event.
+    PrimaryTerm newTerm = new PrimaryTerm(term, primary, candidates);
+    if (!Objects.equals(currentTerm, newTerm)) {
+      this.currentTerm = newTerm;
+      LOGGER.warn("Recomputed term for partition {}: {}", partitionId, newTerm);
+      post(new PrimaryElectionEvent(PrimaryElectionEvent.Type.CHANGED, partitionId, newTerm));
+    }
+  }
+
+  /**
+   * Closes the election.
+   */
+  void close() {
+    broadcastFuture.cancel(false);
+    groupMembershipService.removeListener(membershipEventListener);
   }
 }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionClient.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionClient.java
@@ -35,7 +35,7 @@ public class PrimaryBackupPartitionClient implements Managed<PrimaryBackupPartit
   private final PrimaryBackupPartition partition;
   private final PartitionManagementService managementService;
   private final ThreadContextFactory threadFactory;
-  private PrimaryBackupClient client;
+  private volatile PrimaryBackupClient client;
 
   public PrimaryBackupPartitionClient(
       PrimaryBackupPartition partition,


### PR DESCRIPTION
This PR adds a `PartitionGroupMembershipService` to be used by the `HashBasedPrimaryElection` to ensure only nodes participating in a partition group participate in eventually consistent primary elections.