### PR TITLE
Eventually consistent primary election fixes

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -329,6 +329,7 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
   @Override
   protected CompletableFuture<Void> completeShutdown() {
     executorService.shutdownNow();
+    threadContext.close();
     return super.completeShutdown();
   }
 

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
@@ -145,9 +145,9 @@ public class CorePrimitiveRegistry implements ManagedPrimitiveRegistry {
 
   @Override
   public CompletableFuture<Void> stop() {
-    if (started.compareAndSet(true, false)) {
-      return primitives.close()
-          .exceptionally(e -> null);
+    if (started.get()) {
+      primitives.close();
+      started.set(false);
     }
     return CompletableFuture.completedFuture(null);
   }

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -258,6 +258,9 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
   public CompletableFuture<Void> stop() {
     return transactionService.stop()
         .thenCompose(v -> primitiveRegistry.stop())
-        .whenComplete((r, e) -> started.set(false));
+        .whenComplete((r, e) -> {
+          started.set(false);
+          LOGGER.info("Stopped");
+        });
   }
 }

--- a/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
@@ -59,6 +59,7 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
 
   @BeforeClass
   public static void setupAtomix() throws Exception {
+    AbstractAtomixTest.setupAtomix();
     Function<Atomix.Builder, Atomix> build = builder ->
         builder.withManagementGroup(RaftPartitionGroup.builder("system")
             .withNumPartitions(1)
@@ -72,7 +73,6 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
                 .withNumPartitions(7)
                 .build())
             .build();
-    AbstractAtomixTest.setupAtomix();
     instances = new ArrayList<>();
     instances.add(createAtomix(Member.Type.PERSISTENT, 1, Arrays.asList(1, 2, 3), Arrays.asList(), build));
     instances.add(createAtomix(Member.Type.PERSISTENT, 2, Arrays.asList(1, 2, 3), Arrays.asList(), build));

--- a/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
@@ -16,11 +16,12 @@
 package io.atomix.core;
 
 import io.atomix.cluster.Member;
-import io.atomix.cluster.MemberId;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.protocols.backup.partition.PrimaryBackupPartitionGroup;
 import io.atomix.protocols.raft.partition.RaftPartitionGroup;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.util.ArrayList;
@@ -35,7 +36,8 @@ import java.util.stream.Collectors;
  * Base Atomix test.
  */
 public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
-  private static List<Atomix> instances;
+  private static List<Atomix> servers;
+  private static List<Atomix> clients;
   private static int id = 10;
 
   /**
@@ -52,13 +54,13 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
    */
   protected Atomix atomix() throws Exception {
     Atomix instance = createAtomix(Member.Type.EPHEMERAL, id++, Arrays.asList(1, 2, 3), Arrays.asList());
-    instance.start().get(10, TimeUnit.SECONDS);
-    instances.add(instance);
+    clients.add(instance);
+    instance.start().get(30, TimeUnit.SECONDS);
     return instance;
   }
 
   @BeforeClass
-  public static void setupAtomix() throws Exception {
+  public static void setupCluster() throws Exception {
     AbstractAtomixTest.setupAtomix();
     Function<Atomix.Builder, Atomix> build = builder ->
         builder.withManagementGroup(RaftPartitionGroup.builder("system")
@@ -73,22 +75,38 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
                 .withNumPartitions(7)
                 .build())
             .build();
-    instances = new ArrayList<>();
-    instances.add(createAtomix(Member.Type.PERSISTENT, 1, Arrays.asList(1, 2, 3), Arrays.asList(), build));
-    instances.add(createAtomix(Member.Type.PERSISTENT, 2, Arrays.asList(1, 2, 3), Arrays.asList(), build));
-    instances.add(createAtomix(Member.Type.PERSISTENT, 3, Arrays.asList(1, 2, 3), Arrays.asList(), build));
-    List<CompletableFuture<Atomix>> futures = instances.stream().map(a -> a.start().thenApply(v -> a)).collect(Collectors.toList());
+    servers = new ArrayList<>();
+    servers.add(createAtomix(Member.Type.PERSISTENT, 1, Arrays.asList(1, 2, 3), Arrays.asList(), build));
+    servers.add(createAtomix(Member.Type.PERSISTENT, 2, Arrays.asList(1, 2, 3), Arrays.asList(), build));
+    servers.add(createAtomix(Member.Type.PERSISTENT, 3, Arrays.asList(1, 2, 3), Arrays.asList(), build));
+    List<CompletableFuture<Atomix>> futures = servers.stream().map(a -> a.start().thenApply(v -> a)).collect(Collectors.toList());
     CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(30, TimeUnit.SECONDS);
   }
 
   @AfterClass
-  public static void teardownAtomix() throws Exception {
-    List<CompletableFuture<Void>> futures = instances.stream().map(Atomix::stop).collect(Collectors.toList());
+  public static void teardownCluster() throws Exception {
+    List<CompletableFuture<Void>> futures = servers.stream().map(Atomix::stop).collect(Collectors.toList());
     try {
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
     } catch (Exception e) {
       // Do nothing
     }
     AbstractAtomixTest.teardownAtomix();
+  }
+
+  @Before
+  public void setupTest() throws Exception {
+    clients = new ArrayList<>();
+    id = 10;
+  }
+
+  @After
+  public void teardownTest() throws Exception {
+    List<CompletableFuture<Void>> futures = clients.stream().map(Atomix::stop).collect(Collectors.toList());
+    try {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).join();
+    } catch (Exception e) {
+      // Do nothing
+    }
   }
 }

--- a/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/impl/ConsistentSetMultimapTest.java
@@ -54,7 +54,7 @@ public abstract class ConsistentSetMultimapTest extends AbstractPrimitiveTest {
   public void testSize() throws Throwable {
     AsyncConsistentMultimap<String, String> map = createResource("testOneMap");
     //Simplest operation case
-    map.isEmpty().thenAccept(result -> assertTrue(result));
+    map.isEmpty().thenAccept(result -> assertTrue(result)).join();
     map.put(one, one).
         thenAccept(result -> assertTrue(result)).join();
     map.isEmpty().thenAccept(result -> assertFalse(result));

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -22,7 +22,7 @@
     </appender>
 
     <logger name="io.atomix.protocols.backup" level="${root.logging.level:-TRACE}" />
-    <logger name="io.atomix.protocols.raft" level="${root.logging.level:-INFO}" />
+    <logger name="io.atomix.protocols.raft" level="${root.logging.level:-TRACE}" />
     <logger name="io.atomix.messaging" level="INFO" />
 
     <root level="${root.logging.level:-INFO}">

--- a/messaging/src/main/java/io/atomix/messaging/impl/NettyBroadcastService.java
+++ b/messaging/src/main/java/io/atomix/messaging/impl/NettyBroadcastService.java
@@ -241,6 +241,7 @@ public class NettyBroadcastService implements ManagedBroadcastService {
       CompletableFuture<Void> future = new CompletableFuture<>();
       clientChannel.leaveGroup(groupAddress, iface).addListener(f -> {
         started.set(false);
+        group.shutdownGracefully();
         future.complete(null);
       });
       return future;

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
@@ -135,10 +135,10 @@ public class DefaultPartitionGroupMembershipService
    * Handles a cluster membership change.
    */
   private void handleMembershipChange(ClusterMembershipEvent event) {
-    threadContext.execute(() -> {
-      if (event.type() == ClusterMembershipEvent.Type.MEMBER_ACTIVATED) {
-        bootstrap(event.subject());
-      } else if (event.type() == ClusterMembershipEvent.Type.MEMBER_DEACTIVATED) {
+    if (event.type() == ClusterMembershipEvent.Type.MEMBER_ACTIVATED) {
+      bootstrap(event.subject());
+    } else if (event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED) {
+      threadContext.execute(() -> {
         PartitionGroupMembership systemGroup = this.systemGroup;
         if (systemGroup != null && systemGroup.members().contains(event.subject().id())) {
           Set<MemberId> newMembers = Sets.newHashSet(systemGroup.members());
@@ -157,8 +157,8 @@ public class DefaultPartitionGroupMembershipService
             post(new PartitionGroupMembershipEvent(MEMBERS_CHANGED, newMembership));
           }
         });
-      }
-    });
+      });
+    }
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
@@ -268,7 +268,7 @@ public class DefaultPartitionGroupMembershipService
 
   @Override
   public CompletableFuture<PartitionGroupMembershipService> start() {
-    threadContext = new SingleThreadContext(namedThreads("atomix-partition-service-%d", LOGGER));
+    threadContext = new SingleThreadContext(namedThreads("atomix-partition-group-membership-service-%d", LOGGER));
     membershipService.addListener(membershipEventListener);
     messagingService.subscribe(BOOTSTRAP_SUBJECT, serializer::decode, this::handleBootstrap, serializer::encode, threadContext);
     return bootstrap().thenApply(v -> {

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
@@ -77,7 +77,7 @@ public class DefaultPartitionGroupMembershipService
   private final Map<String, PartitionGroupMembership> groups = Maps.newConcurrentMap();
   private final ClusterMembershipEventListener membershipEventListener = this::handleMembershipChange;
   private final AtomicBoolean started = new AtomicBoolean();
-  private ThreadContext threadContext;
+  private volatile ThreadContext threadContext;
 
   @SuppressWarnings("unchecked")
   public DefaultPartitionGroupMembershipService(
@@ -268,8 +268,8 @@ public class DefaultPartitionGroupMembershipService
 
   @Override
   public CompletableFuture<PartitionGroupMembershipService> start() {
-    membershipService.addListener(membershipEventListener);
     threadContext = new SingleThreadContext(namedThreads("atomix-partition-service-%d", LOGGER));
+    membershipService.addListener(membershipEventListener);
     messagingService.subscribe(BOOTSTRAP_SUBJECT, serializer::decode, this::handleBootstrap, serializer::encode, threadContext);
     return bootstrap().thenApply(v -> {
       LOGGER.info("Started");

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
@@ -191,8 +191,15 @@ public class DefaultPartitionGroupMembershipService
    */
   @SuppressWarnings("unchecked")
   private CompletableFuture<Void> bootstrap(Member member) {
+    return bootstrap(member, new CompletableFuture<>());
+  }
+
+  /**
+   * Bootstraps the service from the given node.
+   */
+  @SuppressWarnings("unchecked")
+  private CompletableFuture<Void> bootstrap(Member member, CompletableFuture<Void> future) {
     LOGGER.debug("{} - Bootstrapping from member {}", membershipService.getLocalMember().id(), member);
-    CompletableFuture<Void> future = new CompletableFuture<>();
     messagingService.<MemberId, PartitionGroupInfo>send(
         BOOTSTRAP_SUBJECT,
         membershipService.getLocalMember().id(),
@@ -246,7 +253,7 @@ public class DefaultPartitionGroupMembershipService
           } else {
             error = Throwables.getRootCause(error);
             if (error instanceof MessagingException.NoRemoteHandler || error instanceof TimeoutException) {
-              threadContext.schedule(Duration.ofSeconds(1), () -> bootstrap(member));
+              threadContext.schedule(Duration.ofSeconds(1), () -> bootstrap(member, future));
             } else {
               future.complete(null);
             }

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/HashBasedPrimaryElectionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/HashBasedPrimaryElectionService.java
@@ -85,6 +85,7 @@ public class HashBasedPrimaryElectionService
     if (started.compareAndSet(true, false)) {
       elections.values().forEach(election -> election.close());
     }
+    executor.shutdownNow();
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
@@ -192,7 +192,7 @@ public class PrimaryBackupProxy implements PartitionProxy {
                   threadContext.schedule(Duration.ofMillis(RETRY_DELAY), () -> execute(operation, attempt + 1, future));
                 }
               } else {
-                Throwable cause = Throwables.getRootCause(error);
+                Throwable cause = Throwables.getRootCause(termError);
                 if (cause instanceof PrimitiveException.Unavailable || cause instanceof TimeoutException) {
                   threadContext.schedule(Duration.ofMillis(RETRY_DELAY), () -> execute(operation, attempt + 1, future));
                 } else {

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupProxy.java
@@ -63,7 +63,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Primary-backup proxy.
  */
 public class PrimaryBackupProxy implements PartitionProxy {
-  private static final int MAX_ATTEMPTS = 3;
+  private static final int MAX_ATTEMPTS = 50;
   private static final int RETRY_DELAY = 100;
   private Logger log;
   private final PrimitiveType primitiveType;

--- a/rest/src/test/resources/logback.xml
+++ b/rest/src/test/resources/logback.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2017-present Open Networking Laboratory
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.atomix" level="${root.logging.level:-DEBUG}" />
+    <logger name="io.atomix.protocols" level="${root.logging.level:-TRACE}" />
+    <logger name="io.atomix.messaging" level="INFO" />
+
+    <root level="${root.logging.level:-INFO}">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
This PR fixes race conditions in the eventually consistent primary election. To resolve the race conditions, we ensure membership changes are computed on the same thread. It also makes some minor improvements to the primary-backup proxy client.