### PR TITLE
Block synchronous lock operations

### DIFF
--- a/core/src/main/java/io/atomix/core/lock/impl/BlockingDistributedLock.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/BlockingDistributedLock.java
@@ -44,17 +44,17 @@ public class BlockingDistributedLock extends Synchronous<AsyncDistributedLock> i
 
   @Override
   public Version lock() {
-    return complete(asyncLock.lock());
+    return asyncLock.lock().join();
   }
 
   @Override
   public Optional<Version> tryLock() {
-    return complete(asyncLock.tryLock());
+    return asyncLock.tryLock().join();
   }
 
   @Override
   public Optional<Version> tryLock(Duration timeout) {
-    return complete(asyncLock.tryLock(timeout));
+    return asyncLock.tryLock(timeout).join();
   }
 
   @Override

--- a/core/src/test/java/io/atomix/core/TestTest.java
+++ b/core/src/test/java/io/atomix/core/TestTest.java
@@ -1,7 +1,0 @@
-package io.atomix.core;
-
-/**
- *
- */
-public class TestTest {
-}

--- a/core/src/test/java/io/atomix/core/TestTest.java
+++ b/core/src/test/java/io/atomix/core/TestTest.java
@@ -1,0 +1,7 @@
+package io.atomix.core;
+
+/**
+ *
+ */
+public class TestTest {
+}


### PR DESCRIPTION
This PR fixes #544: synchronous lock operations should be blocked, and the underlying proxy should be responsible for timing out lock attempts. Otherwise, a lock can be acquired after the attempt is timed out and may never be released.