### PR TITLE
Add flush-on-commit option to Raft partition group configuration

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -42,14 +42,16 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class RaftPartition implements Partition {
   private final PartitionId partitionId;
   private final StorageLevel storageLevel;
+  private final boolean flushOnCommit;
   private final File dataDirectory;
   private PartitionMetadata partition;
   private RaftPartitionClient client;
   private RaftPartitionServer server;
 
-  public RaftPartition(PartitionId partitionId, StorageLevel storageLevel, File dataDirectory) {
+  public RaftPartition(PartitionId partitionId, StorageLevel storageLevel, boolean flushOnCommit, File dataDirectory) {
     this.partitionId = partitionId;
     this.storageLevel = storageLevel;
+    this.flushOnCommit = flushOnCommit;
     this.dataDirectory = dataDirectory;
   }
 
@@ -104,6 +106,15 @@ public class RaftPartition implements Partition {
    */
   public StorageLevel storageLevel() {
     return storageLevel;
+  }
+
+  /**
+   * Returns whether to flush logs to disk on commit.
+   *
+   * @return whether to flush logs to disk on commit
+   */
+  public boolean flushOnCommit() {
+    return flushOnCommit;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
@@ -90,6 +90,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
       partitions.add(new RaftPartition(
           PartitionId.from(config.getName(), i + 1),
           StorageLevel.valueOf(config.getStorageLevel().toUpperCase()),
+          config.isFlushOnCommit(),
           new File(partitionsDir, String.valueOf(i + 1))));
     }
     return partitions;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
@@ -33,6 +33,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   private Set<String> members = new HashSet<>();
   private int partitionSize;
   private String storageLevel = StorageLevel.MAPPED.name();
+  private boolean flushOnCommit = true;
   private String dataDirectory;
 
   @Override
@@ -103,6 +104,26 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   public RaftPartitionGroupConfig setStorageLevel(String storageLevel) {
     StorageLevel.valueOf(storageLevel.toUpperCase());
     this.storageLevel = storageLevel;
+    return this;
+  }
+
+  /**
+   * Returns whether to flush logs to disk on commit.
+   *
+   * @return whether to flush logs to disk on commit
+   */
+  public boolean isFlushOnCommit() {
+    return flushOnCommit;
+  }
+
+  /**
+   * Sets whether to flush logs to disk on commit.
+   *
+   * @param flushOnCommit whether to flush logs to disk on commit
+   * @return the Raft partition group configuration
+   */
+  public RaftPartitionGroupConfig setFlushOnCommit(boolean flushOnCommit) {
+    this.flushOnCommit = flushOnCommit;
     return this;
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -145,6 +145,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withStorage(RaftStorage.builder()
             .withPrefix(partition.name())
             .withStorageLevel(partition.storageLevel())
+            .withFlushOnCommit(partition.flushOnCommit())
             .withSerializer(Serializer.using(RaftNamespaces.RAFT_STORAGE))
             .withDirectory(partition.dataDirectory())
             .withMaxSegmentSize(MAX_SEGMENT_SIZE)


### PR DESCRIPTION
This PR adds the `flush-on-commit` option of `RaftStorage` to the Raft partition group configuration.