### PR TITLE
Truncate Raft log on reset

### DIFF
--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -235,6 +235,12 @@ public abstract class AbstractLogTest {
     RaftLogReader reader = log.openReader(1, RaftLogReader.Mode.ALL);
 
     assertEquals(0, writer.getLastIndex());
+    writer.append(new InitializeEntry(1, System.currentTimeMillis()));
+    writer.append(new InitializeEntry(1, System.currentTimeMillis()));
+    writer.reset(1);
+    assertEquals(0, writer.getLastIndex());
+    writer.append(new InitializeEntry(2, System.currentTimeMillis()));
+    assertEquals(2, reader.next().entry().term());
     writer.reset(1);
     assertEquals(0, writer.getLastIndex());
     writer.append(new InitializeEntry(1, System.currentTimeMillis()));

--- a/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
+++ b/storage/journal/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
@@ -54,10 +54,14 @@ public class SegmentedJournalWriter<E> implements JournalWriter<E> {
    * @param index the index to which to reset the head of the journal
    */
   public void reset(long index) {
-    currentWriter.close();
-    currentSegment = journal.resetSegments(index);
-    currentWriter = currentSegment.writer();
-    journal.resetHead(index);
+    if (index > currentWriter.firstIndex()) {
+      currentWriter.close();
+      currentSegment = journal.resetSegments(index);
+      currentWriter = currentSegment.writer();
+      journal.resetHead(index);
+    } else {
+      truncate(index - 1);
+    }
   }
 
   @Override


### PR DESCRIPTION
This PR fixes a bug that prevents a node from truncating inconsistent entries at the beginning of its log.