### PR TITLE
Ensure revisions are correctly restored from snapshots

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -503,6 +503,16 @@ public class RaftServiceManager implements AutoCloseable {
         new ServiceRevision(revision, propagationStrategy));
     if (service != null) {
       service.installSnapshot(reader);
+
+      DefaultServiceContext previousService = raft.getServices().getPreviousRevision(service.serviceName(), service.revision());
+      if (previousService != null) {
+        previousService.setNextRevision(service);
+      }
+
+      DefaultServiceContext nextService = raft.getServices().getNextRevision(service.serviceName(), service.revision());
+      if (nextService != null) {
+        service.setNextRevision(nextService);
+      }
     }
   }
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceRegistryTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceRegistryTest.java
@@ -28,6 +28,8 @@ import io.atomix.utils.concurrent.ThreadContextFactory;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -44,6 +46,12 @@ public class RaftServiceRegistryTest {
     registry.registerService(createService("foo", 2));
     assertEquals(2, registry.getCurrentRevision("foo").revision().revision());
     assertEquals(2, registry.getRevisions("foo").size());
+
+    assertNull(registry.getPreviousRevision("foo", new ServiceRevision(1, PropagationStrategy.NONE)));
+    assertNotNull(registry.getPreviousRevision("foo", new ServiceRevision(2, PropagationStrategy.NONE)));
+
+    assertNotNull(registry.getPreviousRevision("foo", new ServiceRevision(2, PropagationStrategy.NONE)));
+    assertNull(registry.getPreviousRevision("foo", new ServiceRevision(1, PropagationStrategy.NONE)));
   }
 
   private DefaultServiceContext createService(String name, int revision) {


### PR DESCRIPTION
This PR fixes a bug with restoring primitive services from snapshots. It correctly populates existing services with previous/next revision information for propagation.