### PR TITLE
Implement generalized solution for detecting and handling blocked threads

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
@@ -20,6 +20,7 @@ import io.atomix.protocols.raft.impl.DefaultRaftClient;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 import io.atomix.protocols.raft.proxy.RaftProxy;
+import io.atomix.utils.concurrent.ThreadModel;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -25,6 +25,7 @@ import io.atomix.protocols.raft.service.RaftService;
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.protocols.raft.storage.log.RaftLog;
 import io.atomix.storage.StorageLevel;
+import io.atomix.utils.concurrent.ThreadModel;
 
 import java.time.Duration;
 import java.util.Arrays;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -18,7 +18,7 @@ package io.atomix.protocols.raft.impl;
 import io.atomix.protocols.raft.RaftError;
 import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.RaftServer;
-import io.atomix.protocols.raft.ThreadModel;
+import io.atomix.utils.concurrent.ThreadModel;
 import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxy.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftProxy.java
@@ -19,13 +19,12 @@ import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.event.EventType;
 import io.atomix.protocols.raft.operation.OperationId;
 import io.atomix.protocols.raft.operation.RaftOperation;
-import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.protocols.raft.service.PropagationStrategy;
+import io.atomix.protocols.raft.service.ServiceType;
 import io.atomix.utils.Managed;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -194,7 +193,6 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
     protected ReadConsistency readConsistency = ReadConsistency.LINEARIZABLE;
     protected int maxRetries = 0;
     protected Duration retryDelay = Duration.ofMillis(100);
-    protected Executor executor;
     protected CommunicationStrategy communicationStrategy = CommunicationStrategy.LEADER;
     protected RecoveryStrategy recoveryStrategy = RecoveryStrategy.RECOVER;
     protected Duration minTimeout = Duration.ofMillis(250);
@@ -283,7 +281,7 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
      * Sets the operation retry delay.
      *
      * @param retryDelay the delay between operation retries
-     * @param timeUnit the delay time unit
+     * @param timeUnit   the delay time unit
      * @return the proxy builder
      * @throws NullPointerException if the time unit is null
      */
@@ -387,18 +385,6 @@ public interface RaftProxy extends RaftProxyExecutor, Managed<RaftProxy> {
     public Builder withMaxTimeout(Duration timeout) {
       checkArgument(!checkNotNull(timeout).isNegative(), "timeout must be positive");
       this.maxTimeout = timeout;
-      return this;
-    }
-
-    /**
-     * Sets the executor with which to complete proxy futures.
-     *
-     * @param executor The executor with which to complete proxy futures.
-     * @return The proxy builder.
-     * @throws NullPointerException if the executor is null
-     */
-    public Builder withExecutor(Executor executor) {
-      this.executor = checkNotNull(executor, "executor cannot be null");
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RetryingRaftProxyClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RetryingRaftProxyClient.java
@@ -20,6 +20,7 @@ import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.operation.RaftOperation;
 import io.atomix.protocols.raft.proxy.RaftProxy;
 import io.atomix.protocols.raft.proxy.RaftProxyClient;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.Scheduler;
 import io.atomix.utils.logging.ContextualLoggerFactory;
@@ -71,7 +72,7 @@ public class RetryingRaftProxyClient extends DelegatingRaftProxyClient {
     if (getState() == RaftProxy.State.CLOSED) {
       return Futures.exceptionalFuture(new RaftException.Unavailable("Cluster is unavailable"));
     }
-    CompletableFuture<byte[]> future = new CompletableFuture<>();
+    CompletableFuture<byte[]> future = new AtomixFuture<>();
     execute(operation, 1, future);
     return future;
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -40,13 +40,14 @@ import java.util.stream.Collectors;
  * Follower state.
  */
 public final class FollowerRole extends ActiveRole {
-  private final PhiAccrualFailureDetector failureDetector = new PhiAccrualFailureDetector();
+  private final PhiAccrualFailureDetector failureDetector;
   private final Random random = new Random();
   private Scheduled heartbeatTimer;
   private Scheduled heartbeatTimeout;
 
   public FollowerRole(RaftContext context) {
     super(context);
+    this.failureDetector = new PhiAccrualFailureDetector(25, context.getHeartbeatInterval().toMillis() / 2);
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceExecutor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceExecutor.java
@@ -22,8 +22,9 @@ import io.atomix.protocols.raft.operation.OperationType;
 import io.atomix.protocols.raft.operation.RaftOperation;
 import io.atomix.storage.buffer.HeapBytes;
 import io.atomix.time.WallClockTimestamp;
-import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.Scheduler;
 
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -67,7 +68,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @see RaftService
  * @see ServiceContext
  */
-public interface RaftServiceExecutor extends ThreadContext {
+public interface RaftServiceExecutor extends Scheduler, Executor {
 
   /**
    * Increments the service clock.
@@ -88,7 +89,7 @@ public interface RaftServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   void handle(OperationId operationId, Function<Commit<byte[]>, byte[]> callback);
@@ -97,7 +98,7 @@ public interface RaftServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   default void register(OperationId operationId, Runnable callback) {
@@ -113,8 +114,8 @@ public interface RaftServiceExecutor extends ThreadContext {
    * Registers a no argument operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
-   * @param encoder result encoder
+   * @param callback    the operation callback
+   * @param encoder     result encoder
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   default <R> void register(OperationId operationId, Supplier<R> callback, Function<R, byte[]> encoder) {
@@ -127,7 +128,7 @@ public interface RaftServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   default void register(OperationId operationId, Consumer<Commit<Void>> callback) {
@@ -143,8 +144,8 @@ public interface RaftServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
-   * @param encoder result encoder
+   * @param callback    the operation callback
+   * @param encoder     result encoder
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   default <R> void register(OperationId operationId, Function<Commit<Void>, R> callback, Function<R, byte[]> encoder) {
@@ -158,8 +159,8 @@ public interface RaftServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param decoder the operation decoder
-   * @param callback the operation callback
+   * @param decoder     the operation decoder
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   default <T> void register(OperationId operationId, Function<byte[], T> decoder, Consumer<Commit<T>> callback) {
@@ -176,9 +177,9 @@ public interface RaftServiceExecutor extends ThreadContext {
    * Registers an operation callback.
    *
    * @param operationId the operation identifier
-   * @param decoder the operation decoder
-   * @param callback the operation callback
-   * @param encoder the output encoder
+   * @param decoder     the operation decoder
+   * @param callback    the operation callback
+   * @param encoder     the output encoder
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   default <T, R> void register(OperationId operationId, Function<byte[], T> decoder, Function<Commit<T>, R> callback, Function<R, byte[]> encoder) {
@@ -187,9 +188,5 @@ public interface RaftServiceExecutor extends ThreadContext {
     checkNotNull(callback, "callback cannot be null");
     checkNotNull(encoder, "encoder cannot be null");
     handle(operationId, commit -> encoder.apply(callback.apply(commit.map(decoder))));
-  }
-
-  @Override
-  default void close() {
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionContext.java
@@ -72,7 +72,7 @@ public class RaftSessionContext implements RaftSession {
   private volatile State state = State.CLOSED;
   private volatile long lastUpdated;
   private long lastHeartbeat;
-  private PhiAccrualFailureDetector failureDetector = new PhiAccrualFailureDetector();
+  private PhiAccrualFailureDetector failureDetector;
   private long requestSequence;
   private volatile long commandSequence;
   private volatile long lastApplied;
@@ -114,6 +114,7 @@ public class RaftSessionContext implements RaftSession {
     this.context = context;
     this.server = server;
     this.eventExecutor = threadContextFactory.createContext();
+    this.failureDetector = new PhiAccrualFailureDetector(25, minTimeout / 2);
     this.log = ContextualLoggerFactory.getLogger(getClass(), LoggerContext.builder(RaftSession.class)
         .addValue(sessionId)
         .add("type", context.serviceType())
@@ -223,7 +224,7 @@ public class RaftSessionContext implements RaftSession {
    */
   public void resetHeartbeats() {
     this.lastHeartbeat = 0;
-    this.failureDetector = new PhiAccrualFailureDetector();
+    this.failureDetector = new PhiAccrualFailureDetector(25, minTimeout() / 2);
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
@@ -16,7 +16,7 @@
 package io.atomix.protocols.raft.impl;
 
 import io.atomix.protocols.raft.ReadConsistency;
-import io.atomix.protocols.raft.ThreadModel;
+import io.atomix.utils.concurrent.ThreadModel;
 import io.atomix.protocols.raft.cluster.MemberId;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvokerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvokerTest.java
@@ -307,6 +307,21 @@ public class RaftProxyInvokerTest {
     public void execute(Runnable command) {
       command.run();
     }
+
+    @Override
+    public boolean isBlocked() {
+      return false;
+    }
+
+    @Override
+    public void block() {
+
+    }
+
+    @Override
+    public void unblock() {
+
+    }
   }
 
 }

--- a/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/RaftPerformanceTest.java
@@ -85,6 +85,7 @@ import io.atomix.protocols.raft.storage.system.Configuration;
 import io.atomix.serializer.Serializer;
 import io.atomix.serializer.kryo.KryoNamespace;
 import io.atomix.storage.StorageLevel;
+import io.atomix.utils.concurrent.ThreadModel;
 
 import java.io.File;
 import java.io.IOException;

--- a/utils/src/main/java/io/atomix/utils/concurrent/AbstractThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/AbstractThreadContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+/**
+ * Abstract thread context.
+ */
+public abstract class AbstractThreadContext implements ThreadContext {
+  private volatile boolean blocked;
+
+  @Override
+  public boolean isBlocked() {
+    return blocked;
+  }
+
+  @Override
+  public void block() {
+    blocked = true;
+  }
+
+  @Override
+  public void unblock() {
+    blocked = false;
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/AtomixFuture.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/AtomixFuture.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A {@link CompletableFuture} that tracks whether the future or one of its descendants has been blocked on
+ * a {@link CompletableFuture#get()} or {@link CompletableFuture#join()} call.
+ */
+public class AtomixFuture<T> extends CompletableFuture<T> {
+
+  /**
+   * Wraps the given future in a new blockable future.
+   *
+   * @param future the future to wrap
+   * @param <T>    the future value type
+   * @return a new blockable future
+   */
+  public static <T> AtomixFuture<T> wrap(CompletableFuture<T> future) {
+    AtomixFuture<T> newFuture = new AtomixFuture<>();
+    future.whenComplete((result, error) -> {
+      if (error == null) {
+        newFuture.complete(result);
+      } else {
+        newFuture.completeExceptionally(error);
+      }
+    });
+    return newFuture;
+  }
+
+  private static ThreadContext NULL_CONTEXT = new NullThreadContext();
+
+  private ThreadContext getThreadContext() {
+    ThreadContext context = ThreadContext.currentContext();
+    return context != null ? context : NULL_CONTEXT;
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    ThreadContext context = getThreadContext();
+    context.block();
+    try {
+      return super.get();
+    } finally {
+      context.unblock();
+    }
+  }
+
+  @Override
+  public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    ThreadContext context = getThreadContext();
+    context.block();
+    try {
+      return super.get(timeout, unit);
+    } finally {
+      context.unblock();
+    }
+  }
+
+  @Override
+  public synchronized T join() {
+    ThreadContext context = getThreadContext();
+    context.block();
+    try {
+      return super.join();
+    } finally {
+      context.unblock();
+    }
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenApply(Function<? super T, ? extends U> fn) {
+    return wrap(super.thenApply(fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn) {
+    return wrap(super.thenApplyAsync(fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenApplyAsync(Function<? super T, ? extends U> fn, Executor executor) {
+    return wrap(super.thenApplyAsync(fn, executor));
+  }
+
+  @Override
+  public CompletableFuture<Void> thenAccept(Consumer<? super T> action) {
+    return wrap(super.thenAccept(action));
+  }
+
+  @Override
+  public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action) {
+    return wrap(super.thenAcceptAsync(action));
+  }
+
+  @Override
+  public CompletableFuture<Void> thenAcceptAsync(Consumer<? super T> action, Executor executor) {
+    return wrap(super.thenAcceptAsync(action, executor));
+  }
+
+  @Override
+  public CompletableFuture<Void> thenRun(Runnable action) {
+    return wrap(super.thenRun(action));
+  }
+
+  @Override
+  public CompletableFuture<Void> thenRunAsync(Runnable action) {
+    return wrap(super.thenRunAsync(action));
+  }
+
+  @Override
+  public CompletableFuture<Void> thenRunAsync(Runnable action, Executor executor) {
+    return wrap(super.thenRunAsync(action, executor));
+  }
+
+  @Override
+  public <U, V> CompletableFuture<V> thenCombine(
+      CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+    return wrap(super.thenCombine(other, fn));
+  }
+
+  @Override
+  public <U, V> CompletableFuture<V> thenCombineAsync(
+      CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+    return wrap(super.thenCombineAsync(other, fn));
+  }
+
+  @Override
+  public <U, V> CompletableFuture<V> thenCombineAsync(
+      CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn, Executor executor) {
+    return wrap(super.thenCombineAsync(other, fn, executor));
+  }
+
+  @Override
+  public <U> CompletableFuture<Void> thenAcceptBoth(
+      CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
+    return wrap(super.thenAcceptBoth(other, action));
+  }
+
+  @Override
+  public <U> CompletableFuture<Void> thenAcceptBothAsync(
+      CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
+    return wrap(super.thenAcceptBothAsync(other, action));
+  }
+
+  @Override
+  public <U> CompletableFuture<Void> thenAcceptBothAsync(
+      CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action, Executor executor) {
+    return wrap(super.thenAcceptBothAsync(other, action, executor));
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
+    return wrap(super.runAfterBoth(other, action));
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
+    return wrap(super.runAfterBothAsync(other, action));
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action, Executor executor) {
+    return wrap(super.runAfterBothAsync(other, action, executor));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> applyToEither(CompletionStage<? extends T> other, Function<? super T, U> fn) {
+    return wrap(super.applyToEither(other, fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> applyToEitherAsync(CompletionStage<? extends T> other, Function<? super T, U> fn) {
+    return wrap(super.applyToEitherAsync(other, fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> applyToEitherAsync(
+      CompletionStage<? extends T> other, Function<? super T, U> fn, Executor executor) {
+    return wrap(super.applyToEitherAsync(other, fn, executor));
+  }
+
+  @Override
+  public CompletableFuture<Void> acceptEither(CompletionStage<? extends T> other, Consumer<? super T> action) {
+    return wrap(super.acceptEither(other, action));
+  }
+
+  @Override
+  public CompletableFuture<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action) {
+    return wrap(super.acceptEitherAsync(other, action));
+  }
+
+  @Override
+  public CompletableFuture<Void> acceptEitherAsync(
+      CompletionStage<? extends T> other, Consumer<? super T> action, Executor executor) {
+    return wrap(super.acceptEitherAsync(other, action, executor));
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
+    return wrap(super.runAfterEither(other, action));
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
+    return wrap(super.runAfterEitherAsync(other, action));
+  }
+
+  @Override
+  public CompletableFuture<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action, Executor executor) {
+    return wrap(super.runAfterEitherAsync(other, action, executor));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
+    return wrap(super.thenCompose(fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
+    return wrap(super.thenComposeAsync(fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> thenComposeAsync(
+      Function<? super T, ? extends CompletionStage<U>> fn, Executor executor) {
+    return wrap(super.thenComposeAsync(fn, executor));
+  }
+
+  @Override
+  public CompletableFuture<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
+    return wrap(super.whenComplete(action));
+  }
+
+  @Override
+  public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action) {
+    return wrap(super.whenCompleteAsync(action));
+  }
+
+  @Override
+  public CompletableFuture<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action, Executor executor) {
+    return wrap(super.whenCompleteAsync(action, executor));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
+    return wrap(super.handle(fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn) {
+    return wrap(super.handleAsync(fn));
+  }
+
+  @Override
+  public <U> CompletableFuture<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn, Executor executor) {
+    return wrap(super.handleAsync(fn, executor));
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Blocking aware single thread context.
+ */
+public class BlockingAwareSingleThreadContext extends SingleThreadContext {
+  private final Executor threadPoolExecutor;
+
+  public BlockingAwareSingleThreadContext(String nameFormat, Executor threadPoolExecutor) {
+    this(namedThreads(nameFormat, LOGGER), threadPoolExecutor);
+  }
+
+  public BlockingAwareSingleThreadContext(ThreadFactory factory, Executor threadPoolExecutor) {
+    super(factory);
+    this.threadPoolExecutor = threadPoolExecutor;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    if (isBlocked()) {
+      threadPoolExecutor.execute(command);
+    } else {
+      super.execute(command);
+    }
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContextFactory.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContextFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Single thread context factory.
+ */
+public class BlockingAwareSingleThreadContextFactory implements ThreadContextFactory {
+  private final ThreadFactory threadFactory;
+  private final Executor threadPoolExecutor;
+
+  public BlockingAwareSingleThreadContextFactory(String nameFormat, int threadPoolSize, Logger logger) {
+    this(threadPoolSize, namedThreads(nameFormat, logger));
+  }
+
+  public BlockingAwareSingleThreadContextFactory(int threadPoolSize, ThreadFactory threadFactory) {
+    this(threadFactory, Executors.newScheduledThreadPool(threadPoolSize, threadFactory));
+  }
+
+  public BlockingAwareSingleThreadContextFactory(ThreadFactory threadFactory, Executor threadPoolExecutor) {
+    this.threadFactory = checkNotNull(threadFactory);
+    this.threadPoolExecutor = checkNotNull(threadPoolExecutor);
+  }
+
+  @Override
+  public ThreadContext createContext() {
+    return new BlockingAwareSingleThreadContext(threadFactory, threadPoolExecutor);
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Blocking aware thread pool context.
+ */
+public class BlockingAwareThreadPoolContext extends ThreadPoolContext {
+  public BlockingAwareThreadPoolContext(ScheduledExecutorService parent) {
+    super(parent);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    if (isBlocked()) {
+      parent.execute(command);
+    } else {
+      super.execute(command);
+    }
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContextFactory.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContextFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import org.slf4j.Logger;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Thread pool context factory.
+ */
+public class BlockingAwareThreadPoolContextFactory implements ThreadContextFactory {
+  private final ScheduledExecutorService executor;
+
+  public BlockingAwareThreadPoolContextFactory(String name, int threadPoolSize, Logger logger) {
+    this(threadPoolSize, namedThreads(name, logger));
+  }
+
+  public BlockingAwareThreadPoolContextFactory(int threadPoolSize, ThreadFactory threadFactory) {
+    this(Executors.newScheduledThreadPool(threadPoolSize, threadFactory));
+  }
+
+  public BlockingAwareThreadPoolContextFactory(ScheduledExecutorService executor) {
+    this.executor = executor;
+  }
+
+  @Override
+  public ThreadContext createContext() {
+    return new BlockingAwareThreadPoolContext(executor);
+  }
+
+  @Override
+  public void close() {
+    executor.shutdownNow();
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/NullThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/NullThreadContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import java.time.Duration;
+
+/**
+ * Null thread context.
+ */
+public class NullThreadContext implements ThreadContext {
+  @Override
+  public Scheduled schedule(Duration delay, Runnable callback) {
+    return null;
+  }
+
+  @Override
+  public Scheduled schedule(Duration initialDelay, Duration interval, Runnable callback) {
+    return null;
+  }
+
+  @Override
+  public boolean isBlocked() {
+    return false;
+  }
+
+  @Override
+  public void block() {
+
+  }
+
+  @Override
+  public void unblock() {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public void execute(Runnable command) {
+
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
@@ -41,7 +41,7 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class SingleThreadContext implements ThreadContext {
+public class SingleThreadContext extends AbstractThreadContext {
   protected static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadContext.class);
   private final ScheduledExecutorService executor;
   private final Executor wrappedExecutor = new Executor() {

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadContext.java
@@ -72,6 +72,23 @@ public interface ThreadContext extends AutoCloseable, Executor, Scheduler {
   }
 
   /**
+   * Returns whether the thread context is currently marked blocked.
+   *
+   * @return whether the thread context is currently marked blocked
+   */
+  boolean isBlocked();
+
+  /**
+   * Marks the thread context as blocked.
+   */
+  void block();
+
+  /**
+   * Marks the thread context as unblocked.
+   */
+  void unblock();
+
+  /**
    * Closes the context.
    */
   @Override

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadModel.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadModel.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.protocols.raft;
+package io.atomix.utils.concurrent;
 
-import io.atomix.utils.concurrent.SingleThreadContextFactory;
-import io.atomix.utils.concurrent.ThreadContextFactory;
-import io.atomix.utils.concurrent.ThreadPoolContextFactory;
 import org.slf4j.Logger;
 
 /**
@@ -31,7 +28,7 @@ public enum ThreadModel {
   SHARED_THREAD_POOL {
     @Override
     public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
-      return new ThreadPoolContextFactory(nameFormat, threadPoolSize, logger);
+      return new BlockingAwareThreadPoolContextFactory(nameFormat, threadPoolSize, logger);
     }
   },
 
@@ -41,16 +38,16 @@ public enum ThreadModel {
   THREAD_PER_SERVICE {
     @Override
     public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
-      return new SingleThreadContextFactory(nameFormat, logger);
+      return new BlockingAwareSingleThreadContextFactory(nameFormat, threadPoolSize, logger);
     }
   };
 
   /**
    * Returns a thread context factory.
    *
-   * @param nameFormat the thread name format
+   * @param nameFormat     the thread name format
    * @param threadPoolSize the thread pool size
-   * @param logger the thread logger
+   * @param logger         the thread logger
    * @return the thread context factory
    */
   public abstract ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger);

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContext.java
@@ -36,9 +36,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class ThreadPoolContext implements ThreadContext {
+public class ThreadPoolContext extends AbstractThreadContext {
   private static final Logger LOGGER = LoggerFactory.getLogger(ThreadPoolContext.class);
-  private final ScheduledExecutorService parent;
+  protected final ScheduledExecutorService parent;
   private final Runnable runner;
   private final LinkedList<Runnable> tasks = new LinkedList<>();
   private boolean running;


### PR DESCRIPTION
This PR implements a generalized solution for detecting and handling blocked event threads. It detects blocked threads by setting a flag in the `ThreadContext`. This allows the context to avoid executing operations on a blocked thread until it's unblocked.