### PR TITLE
Replicate member metadata changes in ClusterMembershipService

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/ClusterMembershipEvent.java
+++ b/cluster/src/main/java/io/atomix/cluster/ClusterMembershipEvent.java
@@ -35,6 +35,11 @@ public class ClusterMembershipEvent extends AbstractEvent<ClusterMembershipEvent
     MEMBER_ADDED,
 
     /**
+     * Signifies that a member's state has changed.
+     */
+    MEMBER_UPDATED,
+
+    /**
      * Signifies that a member has been removed.
      */
     MEMBER_REMOVED,

--- a/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -15,10 +15,10 @@
  */
 package io.atomix.cluster;
 
-import com.google.common.collect.ImmutableMap;
 import io.atomix.utils.config.Configured;
 import io.atomix.utils.net.Address;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -154,7 +154,7 @@ public class Member implements Configured<MemberConfig> {
     this.zone = config.getZone();
     this.rack = config.getRack();
     this.host = config.getHost();
-    this.metadata = ImmutableMap.copyOf(config.getMetadata());
+    this.metadata = new HashMap<>(config.getMetadata());
   }
 
   protected Member(MemberId id, Address address, String zone, String rack, String host, Map<String, String> metadata) {
@@ -163,7 +163,7 @@ public class Member implements Configured<MemberConfig> {
     this.zone = zone;
     this.rack = rack;
     this.host = host;
-    this.metadata = ImmutableMap.copyOf(metadata);
+    this.metadata = new HashMap<>(metadata);
   }
 
   /**

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
@@ -246,20 +246,13 @@ public class DefaultClusterMembershipService
   /**
    * Activates the given member.
    */
-  private void activateMember(Member member) {
+  private void activateMember(StatefulMember member) {
     StatefulMember existingMember = members.get(member.id());
     if (existingMember == null) {
-      StatefulMember statefulMember = new StatefulMember(
-          member.id(),
-          member.address(),
-          member.zone(),
-          member.rack(),
-          member.host(),
-          member.metadata());
-      LOGGER.info("{} - Member activated: {}", localMember.id(), statefulMember);
-      statefulMember.setState(State.ACTIVE);
-      members.put(statefulMember.id(), statefulMember);
-      post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, statefulMember));
+      member.setState(State.ACTIVE);
+      LOGGER.info("{} - Member activated: {}", localMember.id(), member);
+      members.put(member.id(), member);
+      post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, member));
       sendHeartbeat(member.address(), SERIALIZER.encode(new ClusterHeartbeat(
           localMember.id(),
           localMember.zone(),
@@ -270,6 +263,11 @@ public class DefaultClusterMembershipService
       LOGGER.info("{} - Member activated: {}", localMember.id(), existingMember);
       existingMember.setState(State.ACTIVE);
       post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, existingMember));
+    } else if (!existingMember.metadata().equals(member.metadata())) {
+      member.setState(State.ACTIVE);
+      LOGGER.info("{} - Member updated: {}", localMember.id(), member);
+      members.put(member.id(), member);
+      post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_UPDATED, member));
     }
   }
 


### PR DESCRIPTION
This PR makes the `Member#metadata()` map modifiable and adds an event to notify listeners of changes to the metadata. This can be used to replicate state changes associated with nodes.