### PR TITLE
Change membership to list in cluster configuration to allow anonymous members

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -111,7 +111,7 @@ public class AtomixAgent {
     if (configString != null) {
       AtomixConfig config = loadConfig(configString);
       if (localMember != null) {
-        config.getClusterConfig().getMembers().values().stream()
+        config.getClusterConfig().getMembers().stream()
             .filter(member -> member.getId().equals(localMember.getId()))
             .findAny()
             .ifPresent(localMemberConfig -> {

--- a/agent/src/test/resources/atomix.yaml
+++ b/agent/src/test/resources/atomix.yaml
@@ -2,14 +2,11 @@
 cluster:
   name: test
   members:
-    node1:
-      type: persistent
+    - id: node1
       address: localhost:5000
-    node2:
-      type: persistent
+    - id: node2
       address: localhost:5001
-    node3:
-      type: persistent
+    - id: node3
       address: localhost:5002
 # The management partition group from which primitives and additional partition groups are managed
 management-group:

--- a/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -275,7 +275,6 @@ public class AtomixCluster implements Managed<Void> {
     return new DefaultClusterMembershipService(
         localMember,
         config.getMembers()
-            .values()
             .stream()
             .map(Member::new)
             .collect(Collectors.toList()), messagingService, broadcastService, config.getMembershipConfig());

--- a/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
@@ -19,8 +19,8 @@ import io.atomix.utils.config.Config;
 import io.atomix.utils.net.Address;
 import io.atomix.utils.net.MalformedAddressException;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Cluster configuration.
@@ -33,7 +33,7 @@ public class ClusterConfig implements Config {
   private String name = DEFAULT_CLUSTER_NAME;
   private String localMemberId;
   private MemberConfig localMember;
-  private Map<String, MemberConfig> members = new HashMap<>();
+  private List<MemberConfig> members = new ArrayList<>();
   private boolean multicastEnabled = false;
   private Address multicastAddress;
   private GroupMembershipConfig membershipConfig = new GroupMembershipConfig();
@@ -94,7 +94,10 @@ public class ClusterConfig implements Config {
   public MemberConfig getLocalMember() {
     MemberConfig member = localMember;
     if (member == null && localMemberId != null) {
-      member = members.get(localMemberId);
+      member = members.stream()
+          .filter(m -> m.getId().id().equals(localMemberId))
+          .findFirst()
+          .orElse(null);
     }
     return member;
   }
@@ -115,7 +118,7 @@ public class ClusterConfig implements Config {
    *
    * @return the cluster nodes
    */
-  public Map<String, MemberConfig> getMembers() {
+  public List<MemberConfig> getMembers() {
     return members;
   }
 
@@ -125,8 +128,7 @@ public class ClusterConfig implements Config {
    * @param members the cluster nodes
    * @return the cluster configuration
    */
-  public ClusterConfig setMembers(Map<String, MemberConfig> members) {
-    members.forEach((id, member) -> member.setId(id));
+  public ClusterConfig setMembers(List<MemberConfig> members) {
     this.members = members;
     return this;
   }
@@ -138,7 +140,7 @@ public class ClusterConfig implements Config {
    * @return the cluster configuration
    */
   public ClusterConfig addMember(MemberConfig member) {
-    members.put(member.getId().id(), member);
+    members.add(member);
     return this;
   }
 

--- a/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
+++ b/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.profile;
 
-import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
 import io.atomix.core.AtomixConfig;
 import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
@@ -44,13 +43,11 @@ public class ConsensusProfile implements NamedProfile {
     config.setManagementGroup(new RaftPartitionGroupConfig()
         .setName(SYSTEM_GROUP_NAME)
         .setPartitionSize((int) config.getClusterConfig().getMembers()
-            .values()
             .stream()
             .filter(member -> member.getId().type() == MemberId.Type.IDENTIFIED)
             .count())
         .setPartitions(1)
         .setMembers(config.getClusterConfig().getMembers()
-            .values()
             .stream()
             .filter(member -> member.getId().type() == MemberId.Type.IDENTIFIED)
             .map(node -> node.getId().id())
@@ -61,7 +58,6 @@ public class ConsensusProfile implements NamedProfile {
         .setPartitionSize(PARTITION_SIZE)
         .setPartitions(NUM_PARTITIONS)
         .setMembers(config.getClusterConfig().getMembers()
-            .values()
             .stream()
             .filter(member -> member.getId().type() == MemberId.Type.IDENTIFIED)
             .map(node -> node.getId().id())


### PR DESCRIPTION
This PR changes the internal representation of the cluster membership to a list to allow for anonymous cluster members. Currently, the members are keyed by the member ID, which forces all members to be explicitly identified. This change makes explicit identifiers optional.