### PR TITLE
Lookup local member in members list

### DIFF
--- a/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
+++ b/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
@@ -50,7 +50,7 @@ public class AtomixAgentTest {
   @Test
   public void testParseMemberId() throws Exception {
     assertNull(AtomixAgent.parseMemberId("127.0.0.1"));
-    assertEquals(MemberId.from("foo"), AtomixAgent.parseMemberId("foo"));
+    assertNull(AtomixAgent.parseMemberId("foo"));
     assertNull(AtomixAgent.parseMemberId("127.0.0.1:1234"));
     assertEquals(MemberId.from("foo"), AtomixAgent.parseMemberId("foo@127.0.0.1:1234"));
     assertEquals(MemberId.from("foo"), AtomixAgent.parseMemberId("foo@127.0.0.1"));
@@ -58,7 +58,7 @@ public class AtomixAgentTest {
 
   @Test
   public void testParseAddress() throws Exception {
-    assertEquals("0.0.0.0:5679", AtomixAgent.parseAddress("foo").toString());
+    assertEquals(5679, AtomixAgent.parseAddress("foo").port());
     assertEquals("127.0.0.1:5679", AtomixAgent.parseAddress("127.0.0.1").toString());
     assertEquals("127.0.0.1:5679", AtomixAgent.parseAddress("foo@127.0.0.1").toString());
     assertEquals("127.0.0.1:1234", AtomixAgent.parseAddress("127.0.0.1:1234").toString());

--- a/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -267,7 +267,7 @@ public class AtomixCluster implements Managed<Void> {
     // If the local node has not be configured, create a default node.
     Member localMember;
     if (config.getLocalMember() == null) {
-      Address address = Address.all();
+      Address address = Address.local();
       localMember = Member.member(address);
     } else {
       localMember = new Member(config.getLocalMember());

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -139,7 +139,7 @@ public class NettyMessagingService implements ManagedMessagingService {
     @Override
     public ManagedMessagingService build() {
       if (address == null) {
-        address = Address.all();
+        address = Address.local();
       }
       return new NettyMessagingService(name.hashCode(), address);
     }

--- a/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -39,8 +39,8 @@ public final class Address {
    *
    * @return the address
    */
-  public static Address all() {
-    return from("0.0.0.0", DEFAULT_PORT);
+  public static Address local() {
+    return from(DEFAULT_PORT);
   }
 
   /**


### PR DESCRIPTION
This PR modifies the `AtomixAgent` to lookup the local member in the existing configuration if possible. This allows a node ID or IP to be provided as the local member if the member's configuration is provided elsewhere.