### PR TITLE
Provide a list of all partition members via Partition interface

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/partition/Partition.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/Partition.java
@@ -40,6 +40,13 @@ public interface Partition {
   long term();
 
   /**
+   * Returns the collection of all members in the partition.
+   *
+   * @return the collection of all members in the partition
+   */
+  Collection<MemberId> members();
+
+  /**
    * Returns the partition's current primary.
    *
    * @return the partition's current primary

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
@@ -61,6 +61,16 @@ public class PrimaryBackupPartition implements Partition {
   }
 
   @Override
+  public Collection<MemberId> members() {
+    return election.getTerm()
+        .join()
+        .candidates()
+        .stream()
+        .map(GroupMember::memberId)
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public MemberId primary() {
     return election.getTerm()
         .join()

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -90,11 +90,7 @@ public class RaftPartition implements Partition {
         .collect(Collectors.toSet());
   }
 
-  /**
-   * Returns the identifiers of partition members.
-   *
-   * @return partition member instance ids
-   */
+  @Override
   public Collection<MemberId> members() {
     return partition != null ? partition.members() : Collections.emptyList();
   }


### PR DESCRIPTION
This PR adds a method to the `Partition` interface to provide the list of members that participate in a partition.