### PR TITLE
Add no-topic listener to LeaderElector

### DIFF
--- a/core/src/main/java/io/atomix/core/election/AsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/AsyncLeaderElector.java
@@ -103,6 +103,24 @@ public interface AsyncLeaderElector<T> extends AsyncPrimitive {
   /**
    * Registers a listener to be notified of Leadership changes for all topics.
    *
+   * @param listener listener to notify
+   * @return CompletableFuture that is completed when the operation completes
+   */
+  CompletableFuture<Void> addListener(LeadershipEventListener<T> listener);
+
+  /**
+   * Unregisters a previously registered change notification listener.
+   * <p>
+   * If the specified listener was not previously registered, this operation will be a noop.
+   *
+   * @param listener listener to remove
+   * @return CompletableFuture that is completed when the operation completes
+   */
+  CompletableFuture<Void> removeListener(LeadershipEventListener<T> listener);
+
+  /**
+   * Registers a listener to be notified of Leadership changes for all topics.
+   *
    * @param topic    leadership topic
    * @param listener listener to notify
    * @return CompletableFuture that is completed when the operation completes

--- a/core/src/main/java/io/atomix/core/election/LeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElector.java
@@ -91,6 +91,22 @@ public interface LeaderElector<T> extends SyncPrimitive {
   /**
    * Registers a listener to be notified of Leadership changes for all topics.
    *
+   * @param listener listener to notify
+   */
+  void addListener(LeadershipEventListener<T> listener);
+
+  /**
+   * Unregisters a previously registered change notification listener.
+   * <p>
+   * If the specified listener was not previously registered, this operation will be a noop.
+   *
+   * @param listener listener to remove
+   */
+  void removeListener(LeadershipEventListener<T> listener);
+
+  /**
+   * Registers a listener to be notified of Leadership changes for all topics.
+   *
    * @param topic    leadership topic
    * @param listener listener to notify
    */

--- a/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
@@ -81,6 +81,16 @@ public class BlockingLeaderElector<T> extends Synchronous<AsyncLeaderElector<T>>
   }
 
   @Override
+  public void addListener(LeadershipEventListener<T> listener) {
+    complete(asyncElector.addListener(listener));
+  }
+
+  @Override
+  public void removeListener(LeadershipEventListener<T> listener) {
+    complete(asyncElector.removeListener(listener));
+  }
+
+  @Override
   public void addListener(String topic, LeadershipEventListener<T> listener) {
     complete(asyncElector.addListener(topic, listener));
   }

--- a/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
@@ -95,6 +95,27 @@ public class TranscodingAsyncLeaderElector<V1, V2> implements AsyncLeaderElector
   }
 
   @Override
+  public CompletableFuture<Void> addListener(LeadershipEventListener<V1> listener) {
+    synchronized (listeners) {
+      InternalLeadershipEventListener internalListener =
+          listeners.computeIfAbsent(listener, k -> new InternalLeadershipEventListener(listener));
+      return backingElector.addListener(internalListener);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Void> removeListener(LeadershipEventListener<V1> listener) {
+    synchronized (listeners) {
+      InternalLeadershipEventListener internalListener = listeners.remove(listener);
+      if (internalListener != null) {
+        return backingElector.removeListener(internalListener);
+      } else {
+        return CompletableFuture.completedFuture(null);
+      }
+    }
+  }
+
+  @Override
   public CompletableFuture<Void> addListener(String topic, LeadershipEventListener<V1> listener) {
     synchronized (listeners) {
       InternalLeadershipEventListener internalListener =

--- a/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/LeaderElectorTest.java
@@ -123,7 +123,7 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
     LeaderEventListener listener1 = new LeaderEventListener();
     elector1.addListener("foo", listener1).join();
     LeaderEventListener listener2 = new LeaderEventListener();
-    elector2.addListener("foo", listener2);
+    elector2.addListener(listener2);
     LeaderEventListener listener3 = new LeaderEventListener();
     elector3.addListener("foo", listener3).join();
 
@@ -169,9 +169,9 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
     LeaderEventListener listener1 = new LeaderEventListener();
     elector1.addListener("foo", listener1).join();
     LeaderEventListener listener2 = new LeaderEventListener();
-    elector2.addListener("foo", listener2).join();
+    elector2.addListener(listener2).join();
     LeaderEventListener listener3 = new LeaderEventListener();
-    elector3.addListener("foo", listener3).join();
+    elector3.addListener(listener3).join();
 
     elector3.promote("foo", node3).thenAccept(result -> {
       assertFalse(result);
@@ -231,7 +231,7 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
     AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-non-leader-session-close", protocol()).build().async();
     LeaderEventListener listener = new LeaderEventListener();
     elector2.run("foo", node2).join();
-    elector1.addListener("foo", listener).join();
+    elector1.addListener(listener).join();
     elector2.close().join();
     listener.nextEvent().thenAccept(result -> {
       assertEquals(node1, result.newLeadership().leader().id());


### PR DESCRIPTION
This PR adds a listener to `LeaderElector` that listens for events on all topics.