### PR TITLE
Do not override local member metadata when replicated

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -275,6 +275,7 @@ public class Member implements Configured<MemberConfig> {
         .add("zone", zone)
         .add("rack", rack)
         .add("host", host)
+        .add("metadata", metadata)
         .omitNullValues()
         .toString();
   }


### PR DESCRIPTION
Fixes a race condition in member metadata replication. The local member should be the source of truth for its own metadata and not accept metadata changes for itself.