### PR TITLE
Refactor AtomicValue service to use proxies

### DIFF
--- a/core/src/main/java/io/atomix/core/value/impl/AtomicValueClient.java
+++ b/core/src/main/java/io/atomix/core/value/impl/AtomicValueClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.value.impl;
+
+import io.atomix.primitive.event.Event;
+
+/**
+ * Atomic value client.
+ */
+public interface AtomicValueClient {
+
+  /**
+   * Notifies the client of a change event.
+   *
+   * @param newValue the updated value
+   * @param oldValue the previous value
+   */
+  @Event
+  void change(byte[] newValue, byte[] oldValue);
+
+}

--- a/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueService.java
+++ b/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueService.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.value.impl;
+
+import com.google.common.collect.Sets;
+import io.atomix.primitive.service.AbstractPrimitiveService;
+import io.atomix.primitive.service.BackupInput;
+import io.atomix.primitive.service.BackupOutput;
+import io.atomix.primitive.service.ServiceConfig;
+import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.KryoNamespaces;
+import io.atomix.utils.serializer.Serializer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+/**
+ * Raft atomic value service.
+ */
+public class DefaultAtomicValueService extends AbstractPrimitiveService<AtomicValueClient, ServiceConfig> implements AtomicValueService {
+  private static final Serializer SERIALIZER = Serializer.using(KryoNamespace.builder()
+      .register(KryoNamespaces.BASIC)
+      .register(AtomicValueOperations.NAMESPACE)
+      .register(AtomicValueEvents.NAMESPACE)
+      .build());
+
+  private byte[] value;
+  private java.util.Set<PrimitiveSession> listeners = Sets.newHashSet();
+
+  public DefaultAtomicValueService(ServiceConfig config) {
+    super(AtomicValueClient.class, config);
+  }
+
+  @Override
+  public Serializer serializer() {
+    return SERIALIZER;
+  }
+
+  @Override
+  public void backup(BackupOutput writer) {
+    writer.writeInt(value.length).writeBytes(value);
+    java.util.Set<Long> sessionIds = new HashSet<>();
+    for (PrimitiveSession session : listeners) {
+      sessionIds.add(session.sessionId().id());
+    }
+    writer.writeObject(sessionIds);
+  }
+
+  @Override
+  public void restore(BackupInput reader) {
+    value = reader.readBytes(reader.readInt());
+    listeners = new HashSet<>();
+    for (Long sessionId : reader.<java.util.Set<Long>>readObject()) {
+      listeners.add(getSession(sessionId));
+    }
+  }
+
+  private byte[] updateAndNotify(byte[] value) {
+    byte[] oldValue = this.value;
+    this.value = value;
+    listeners.forEach(s -> acceptOn(s, client -> client.change(value, oldValue)));
+    return oldValue;
+  }
+
+  @Override
+  public void set(byte[] value) {
+    if (!Arrays.equals(this.value, value)) {
+      updateAndNotify(value);
+    }
+  }
+
+  @Override
+  public byte[] get() {
+    return value;
+  }
+
+  @Override
+  public boolean compareAndSet(byte[] expect, byte[] update) {
+    if (Arrays.equals(value, expect)) {
+      updateAndNotify(update);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public byte[] getAndSet(byte[] value) {
+    if (!Arrays.equals(this.value, value)) {
+      return updateAndNotify(value);
+    }
+    return this.value;
+  }
+
+  @Override
+  public void addListener() {
+    listeners.add(getCurrentSession());
+  }
+
+  @Override
+  public void removeListener() {
+    listeners.remove(getCurrentSession());
+  }
+}

--- a/core/src/main/resources/registry.conf
+++ b/core/src/main/resources/registry.conf
@@ -103,7 +103,7 @@ primitiveTypes.value {
   builderClass: io.atomix.core.value.impl.AtomicValueProxyBuilder
   configClass: io.atomix.core.value.AtomicValueConfig
   primitiveClass: io.atomix.core.value.AtomicValue
-  serviceClass: io.atomix.core.value.impl.AtomicValueService
+  serviceClass: io.atomix.core.value.impl.DefaultAtomicValueService
   resourceClass: io.atomix.core.value.impl.AtomicValueResource
 }
 

--- a/core/src/test/java/io/atomix/core/value/impl/AtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/impl/AtomicValueTest.java
@@ -17,8 +17,13 @@ package io.atomix.core.value.impl;
 
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.value.AsyncAtomicValue;
-
+import io.atomix.core.value.AtomicValue;
+import io.atomix.core.value.AtomicValueEvent;
+import io.atomix.core.value.AtomicValueEventListener;
 import org.junit.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -40,5 +45,50 @@ public abstract class AtomicValueTest extends AbstractPrimitiveTest {
     assertEquals("b", value.get().join());
     assertEquals("b", value.getAndSet("c").join());
     assertEquals("c", value.get().join());
+  }
+
+  @Test
+  public void testEvents() throws Exception {
+    AtomicValue<String> value1 = atomix().<String>atomicValueBuilder("test-value-events", protocol()).build();
+    AtomicValue<String> value2 = atomix().<String>atomicValueBuilder("test-value-events", protocol()).build();
+
+    BlockingAtomicValueListener<String> listener1 = new BlockingAtomicValueListener<>();
+    BlockingAtomicValueListener<String> listener2 = new BlockingAtomicValueListener<>();
+
+    value2.addListener(listener2);
+
+    value1.set("Hello world!");
+    assertEquals("Hello world!", listener2.nextEvent().newValue());
+
+    value1.set("Hello world again!");
+    assertEquals("Hello world again!", listener2.nextEvent().newValue());
+
+    value1.addListener(listener1);
+
+    value2.set("Hello world back!");
+    assertEquals("Hello world back!", listener1.nextEvent().newValue());
+    assertEquals("Hello world back!", listener2.nextEvent().newValue());
+  }
+
+  private static class BlockingAtomicValueListener<T> implements AtomicValueEventListener<T> {
+    private final BlockingQueue<AtomicValueEvent<T>> events = new LinkedBlockingQueue<>();
+
+    @Override
+    public void event(AtomicValueEvent<T> event) {
+      events.add(event);
+    }
+
+    /**
+     * Returns the next event.
+     *
+     * @return the next event
+     */
+    AtomicValueEvent<T> nextEvent() {
+      try {
+        return events.take();
+      } catch (InterruptedException e) {
+        return null;
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR refactors the `AtomicValue` implementation to use service proxies and fix a couple small bugs.