### PR TITLE
Add Command/Query annotations to reduce code

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/operation/Command.java
+++ b/primitive/src/main/java/io/atomix/primitive/operation/Command.java
@@ -13,40 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.core.lock.impl;
+package io.atomix.primitive.operation;
 
-import io.atomix.primitive.operation.Command;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Distributed lock service.
+ * Command annotation.
  */
-public interface DistributedLockService {
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Command {
 
   /**
-   * Attempts to acquire a lock.
-   *
-   * @param lockId the lock identifier
+   * The operation name.
    */
-  @Command("lock")
-  default void lock(int lockId) {
-    lock(lockId, -1);
-  }
-
-  /**
-   * Attempts to acquire a lock.
-   *
-   * @param lockId  the lock identifier
-   * @param timeout the lock to acquire
-   */
-  @Command("lockWithTimeout")
-  void lock(int lockId, long timeout);
-
-  /**
-   * Unlocks an owned lock.
-   *
-   * @param lockId the lock identifier
-   */
-  @Command("unlock")
-  void unlock(int lockId);
+  String value() default "";
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/operation/Query.java
+++ b/primitive/src/main/java/io/atomix/primitive/operation/Query.java
@@ -13,40 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.core.lock.impl;
+package io.atomix.primitive.operation;
 
-import io.atomix.primitive.operation.Command;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Distributed lock service.
+ * Query annotation.
  */
-public interface DistributedLockService {
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Query {
 
   /**
-   * Attempts to acquire a lock.
-   *
-   * @param lockId the lock identifier
+   * The operation name.
    */
-  @Command("lock")
-  default void lock(int lockId) {
-    lock(lockId, -1);
-  }
-
-  /**
-   * Attempts to acquire a lock.
-   *
-   * @param lockId  the lock identifier
-   * @param timeout the lock to acquire
-   */
-  @Command("lockWithTimeout")
-  void lock(int lockId, long timeout);
-
-  /**
-   * Unlocks an owned lock.
-   *
-   * @param lockId the lock identifier
-   */
-  @Command("unlock")
-  void unlock(int lockId);
+  String value() default "";
 
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -25,9 +25,10 @@ import io.atomix.primitive.PrimitiveRegistry;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.SyncPrimitive;
 import io.atomix.primitive.event.Event;
-import io.atomix.primitive.operation.Operation;
+import io.atomix.primitive.operation.Command;
 import io.atomix.primitive.operation.OperationType;
 import io.atomix.primitive.operation.PrimitiveOperation;
+import io.atomix.primitive.operation.Query;
 import io.atomix.primitive.operation.impl.DefaultOperationId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.proxy.PartitionProxy;
@@ -1373,19 +1374,19 @@ public class RaftTest extends ConcurrentTestCase {
    * Test primitive service interface.
    */
   public interface TestPrimitiveService {
-    @Operation(value = "write", type = OperationType.COMMAND)
+    @Command
     long write(String value);
 
-    @Operation(value = "read", type = OperationType.QUERY)
+    @Query
     long read();
 
-    @Operation(value = "sendEvent", type = OperationType.COMMAND)
+    @Command
     long sendEvent(boolean sender);
 
-    @Operation(value = "onExpire", type = OperationType.COMMAND)
+    @Command
     void onExpire();
 
-    @Operation(value = "onClose", type = OperationType.COMMAND)
+    @Command
     void onClose();
   }
 


### PR DESCRIPTION
Adds `@Command` and `@Query` annotations which can be used instead of `@Operation(value = "something", type = OperationType.COMMAND)`