### PR TITLE
Remove redundant 'Primitive' prefix from 'PrimitiveSession'

### DIFF
--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectionService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectionService.java
@@ -25,7 +25,7 @@ import io.atomix.core.election.Leadership;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.misc.ArraySizeHashPrinter;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -241,7 +241,7 @@ public class DefaultLeaderElectionService extends AbstractPrimitiveService<Leade
     return new Leadership<>(leader(), candidates());
   }
 
-  private void onSessionEnd(PrimitiveSession session) {
+  private void onSessionEnd(Session session) {
     listeners.remove(session.sessionId());
     Leadership<byte[]> oldLeadership = leadership();
     cleanup(session);
@@ -301,7 +301,7 @@ public class DefaultLeaderElectionService extends AbstractPrimitiveService<Leade
     }
   }
 
-  protected void cleanup(PrimitiveSession session) {
+  protected void cleanup(Session session) {
     Optional<Registration> registration =
         registrations.stream().filter(r -> r.sessionId() == session.sessionId().id()).findFirst();
     if (registration.isPresent()) {
@@ -353,12 +353,12 @@ public class DefaultLeaderElectionService extends AbstractPrimitiveService<Leade
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     onSessionEnd(session);
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     onSessionEnd(session);
   }
 }

--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
@@ -28,7 +28,7 @@ import io.atomix.core.election.LeadershipEvent;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.misc.ArraySizeHashPrinter;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -242,7 +242,7 @@ public class DefaultLeaderElectorService extends AbstractPrimitiveService<Leader
     return electionState == null ? new LinkedList<>() : electionState.candidates();
   }
 
-  private void onSessionEnd(PrimitiveSession session) {
+  private void onSessionEnd(Session session) {
     listeners.remove(session.sessionId());
     Set<String> topics = elections.keySet();
     topics.forEach(topic -> {
@@ -342,7 +342,7 @@ public class DefaultLeaderElectorService extends AbstractPrimitiveService<Leader
           .count();
     }
 
-    public ElectionState cleanup(String topic, PrimitiveSession session, Supplier<Long> termCounter) {
+    public ElectionState cleanup(String topic, Session session, Supplier<Long> termCounter) {
       Optional<Registration> registration =
           registrations.stream().filter(r -> r.sessionId() == session.sessionId().id()).findFirst();
       if (registration.isPresent()) {
@@ -471,12 +471,12 @@ public class DefaultLeaderElectorService extends AbstractPrimitiveService<Leader
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     onSessionEnd(session);
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     onSessionEnd(session);
   }
 

--- a/core/src/main/java/io/atomix/core/lock/impl/DefaultDistributedLockService.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DefaultDistributedLockService.java
@@ -19,7 +19,7 @@ import io.atomix.core.lock.DistributedLockType;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -76,7 +76,7 @@ public class DefaultDistributedLockService extends AbstractPrimitiveService<Dist
         timers.put(holder.index, getScheduler().schedule(Duration.ofMillis(holder.expire - getWallClock().getTime().unixTimestamp()), () -> {
           timers.remove(holder.index);
           queue.remove(holder);
-          PrimitiveSession session = getSession(holder.session);
+          Session session = getSession(holder.session);
           if (session != null && session.getState().active()) {
             acceptOn(holder.session, service -> service.failed(holder.id));
           }
@@ -86,18 +86,18 @@ public class DefaultDistributedLockService extends AbstractPrimitiveService<Dist
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     releaseSession(session);
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     releaseSession(session);
   }
 
   @Override
   public void lock(int id, long timeout) {
-    PrimitiveSession session = getCurrentSession();
+    Session session = getCurrentSession();
     // If the lock is not already owned, immediately grant the lock to the requester.
     // Note that we still have to publish an event to the session. The event is guaranteed to be received
     // by the client-side primitive after the LOCK response.
@@ -166,7 +166,7 @@ public class DefaultDistributedLockService extends AbstractPrimitiveService<Dist
         }
 
         // Notify the client that it has acquired the lock.
-        PrimitiveSession lockSession = getSession(lock.session);
+        Session lockSession = getSession(lock.session);
         if (lockSession != null && lockSession.getState().active()) {
           acceptOn(lock.session, service -> service.locked(lock.id, getCurrentIndex()));
           break;
@@ -185,7 +185,7 @@ public class DefaultDistributedLockService extends AbstractPrimitiveService<Dist
    *
    * @param session the closed session
    */
-  private void releaseSession(PrimitiveSession session) {
+  private void releaseSession(Session session) {
     // Remove all instances of the session from the lock queue.
     queue.removeIf(lock -> lock.session.equals(session.sessionId()));
 
@@ -201,7 +201,7 @@ public class DefaultDistributedLockService extends AbstractPrimitiveService<Dist
         }
 
         // Notify the client that it has acquired the lock.
-        PrimitiveSession lockSession = getSession(lock.session);
+        Session lockSession = getSession(lock.session);
         if (lockSession != null && lockSession.getState().active()) {
           acceptOn(lock.session, service -> service.locked(lock.id, lock.index));
           break;

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentMapService.java
@@ -27,7 +27,7 @@ import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -782,12 +782,12 @@ public class DefaultConsistentMapService
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     listeners.remove(session.sessionId());
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     listeners.remove(session.sessionId());
   }
 

--- a/core/src/main/java/io/atomix/core/multimap/impl/DefaultConsistentSetMultimapService.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/DefaultConsistentSetMultimapService.java
@@ -28,7 +28,7 @@ import io.atomix.core.multimap.ConsistentMultimapType;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.misc.Match;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -108,12 +108,12 @@ public class DefaultConsistentSetMultimapService extends AbstractPrimitiveServic
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     listeners.remove(session.sessionId());
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     listeners.remove(session.sessionId());
   }
 

--- a/core/src/main/java/io/atomix/core/queue/impl/DefaultWorkQueueService.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/DefaultWorkQueueService.java
@@ -27,7 +27,7 @@ import io.atomix.core.queue.WorkQueueType;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.Serializer;
@@ -176,12 +176,12 @@ public class DefaultWorkQueueService extends AbstractPrimitiveService<WorkQueueC
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     evictWorker(session.sessionId());
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     evictWorker(session.sessionId());
   }
 

--- a/core/src/main/java/io/atomix/core/semaphore/impl/DefaultDistributedSemaphoreService.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/DefaultDistributedSemaphoreService.java
@@ -23,7 +23,7 @@ import io.atomix.core.semaphore.QueueStatus;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.serializer.KryoNamespace;
@@ -82,18 +82,18 @@ public class DefaultDistributedSemaphoreService extends AbstractPrimitiveService
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     releaseSession(session);
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     releaseSession(session);
   }
 
   @Override
   public void acquire(long id, int permits, long timeout) {
-    PrimitiveSession session = getCurrentSession();
+    Session session = getCurrentSession();
     if (available >= permits) {
       acquire(session.sessionId(), id, permits, getCurrentIndex());
     } else {
@@ -212,7 +212,7 @@ public class DefaultDistributedSemaphoreService extends AbstractPrimitiveService
     acceptOn(sessionId, client -> client.failed(operationId));
   }
 
-  private void releaseSession(PrimitiveSession session) {
+  private void releaseSession(Session session) {
     if (holders.containsKey(session.sessionId().id())) {
       release(session.sessionId().id(), holders.get(session.sessionId().id()));
     }

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
@@ -31,7 +31,7 @@ import io.atomix.primitive.Ordering;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.Serializer;
@@ -270,12 +270,12 @@ public class DefaultDocumentTreeService extends AbstractPrimitiveService<Documen
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     closeListener(session.sessionId());
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     closeListener(session.sessionId());
   }
 

--- a/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueService.java
+++ b/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueService.java
@@ -20,7 +20,7 @@ import io.atomix.core.value.AtomicValueType;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -30,7 +30,7 @@ import java.util.HashSet;
  */
 public class DefaultAtomicValueService extends AbstractPrimitiveService<AtomicValueClient> implements AtomicValueService {
   private byte[] value;
-  private java.util.Set<PrimitiveSession> listeners = Sets.newHashSet();
+  private java.util.Set<Session> listeners = Sets.newHashSet();
 
   public DefaultAtomicValueService() {
     super(AtomicValueType.instance(), AtomicValueClient.class);
@@ -40,7 +40,7 @@ public class DefaultAtomicValueService extends AbstractPrimitiveService<AtomicVa
   public void backup(BackupOutput writer) {
     writer.writeInt(value.length).writeBytes(value);
     java.util.Set<Long> sessionIds = new HashSet<>();
-    for (PrimitiveSession session : listeners) {
+    for (Session session : listeners) {
       sessionIds.add(session.sessionId().id());
     }
     writer.writeObject(sessionIds);

--- a/core/src/test/java/io/atomix/core/election/impl/DefaultLeaderElectionServiceTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/DefaultLeaderElectionServiceTest.java
@@ -21,7 +21,7 @@ import io.atomix.primitive.PrimitiveId;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.HeapBuffer;
@@ -45,7 +45,7 @@ public class DefaultLeaderElectionServiceTest {
     when(context.serviceId()).thenReturn(PrimitiveId.from(1));
     when(context.wallClock()).thenReturn(new WallClock());
 
-    PrimitiveSession session = mock(PrimitiveSession.class);
+    Session session = mock(Session.class);
     when(session.sessionId()).thenReturn(SessionId.from(1));
     when(context.currentSession()).thenReturn(session);
 

--- a/core/src/test/java/io/atomix/core/map/impl/DefaultConsistentMapServiceTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/DefaultConsistentMapServiceTest.java
@@ -20,7 +20,7 @@ import io.atomix.primitive.PrimitiveId;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.HeapBuffer;
@@ -51,7 +51,7 @@ public class DefaultConsistentMapServiceTest {
     when(context.serviceId()).thenReturn(PrimitiveId.from(1));
     when(context.wallClock()).thenReturn(new WallClock());
 
-    PrimitiveSession session = mock(PrimitiveSession.class);
+    Session session = mock(Session.class);
     when(session.sessionId()).thenReturn(SessionId.from(1));
 
     DefaultConsistentMapService service = new TestConsistentMapService();

--- a/core/src/test/java/io/atomix/core/multimap/impl/DefaultConsistentSetMultimapServiceTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/impl/DefaultConsistentSetMultimapServiceTest.java
@@ -20,7 +20,7 @@ import io.atomix.primitive.PrimitiveId;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.HeapBuffer;
@@ -49,7 +49,7 @@ public class DefaultConsistentSetMultimapServiceTest {
     when(context.serviceId()).thenReturn(PrimitiveId.from(1));
     when(context.wallClock()).thenReturn(new WallClock());
 
-    PrimitiveSession session = mock(PrimitiveSession.class);
+    Session session = mock(Session.class);
     when(session.sessionId()).thenReturn(SessionId.from(1));
 
     DefaultConsistentSetMultimapService service = new DefaultConsistentSetMultimapService();

--- a/core/src/test/java/io/atomix/core/queue/impl/DefaultWorkQueueServiceTest.java
+++ b/core/src/test/java/io/atomix/core/queue/impl/DefaultWorkQueueServiceTest.java
@@ -21,7 +21,7 @@ import io.atomix.primitive.PrimitiveId;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.HeapBuffer;
@@ -47,7 +47,7 @@ public class DefaultWorkQueueServiceTest {
     when(context.serviceName()).thenReturn("test");
     when(context.serviceId()).thenReturn(PrimitiveId.from(1));
 
-    PrimitiveSession session = mock(PrimitiveSession.class);
+    Session session = mock(Session.class);
     when(session.sessionId()).thenReturn(SessionId.from(1));
     when(context.currentSession()).thenReturn(session);
 

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorService.java
@@ -28,7 +28,7 @@ import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.Commit;
 import io.atomix.primitive.service.ServiceExecutor;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.serializer.KryoNamespace;
 import io.atomix.utils.serializer.Serializer;
@@ -66,7 +66,7 @@ public class PrimaryElectorService extends AbstractPrimitiveService {
       .build());
 
   private Map<PartitionId, ElectionState> elections = new HashMap<>();
-  private Map<Long, PrimitiveSession> listeners = new LinkedHashMap<>();
+  private Map<Long, Session> listeners = new LinkedHashMap<>();
   private Scheduled rebalanceTimer;
 
   public PrimaryElectorService() {
@@ -216,7 +216,7 @@ public class PrimaryElectorService extends AbstractPrimitiveService {
     return electionState != null ? electionState.term() : null;
   }
 
-  private void onSessionEnd(PrimitiveSession session) {
+  private void onSessionEnd(Session session) {
     listeners.remove(session.sessionId().id());
     Set<PartitionId> partitions = elections.keySet();
     partitions.forEach(partitionId -> {
@@ -300,7 +300,7 @@ public class PrimaryElectorService extends AbstractPrimitiveService {
       this.elections = elections;
     }
 
-    ElectionState cleanup(PrimitiveSession session) {
+    ElectionState cleanup(Session session) {
       Optional<Registration> registration =
           registrations.stream().filter(r -> r.sessionId() == session.sessionId().id()).findFirst();
       if (registration.isPresent()) {
@@ -441,17 +441,17 @@ public class PrimaryElectorService extends AbstractPrimitiveService {
   }
 
   @Override
-  public void onOpen(PrimitiveSession session) {
+  public void onOpen(Session session) {
     listeners.put(session.sessionId().id(), session);
   }
 
   @Override
-  public void onExpire(PrimitiveSession session) {
+  public void onExpire(Session session) {
     onSessionEnd(session);
   }
 
   @Override
-  public void onClose(PrimitiveSession session) {
+  public void onClose(Session session) {
     onSessionEnd(session);
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/service/AbstractPrimitiveService.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/AbstractPrimitiveService.java
@@ -25,7 +25,7 @@ import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.Operations;
 import io.atomix.primitive.service.impl.DefaultServiceExecutor;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.concurrent.Scheduler;
 import io.atomix.utils.logging.ContextualLoggerFactory;
@@ -235,7 +235,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    *
    * @return the current session
    */
-  protected PrimitiveSession getCurrentSession() {
+  protected Session getCurrentSession() {
     return context.currentSession();
   }
 
@@ -272,7 +272,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * @param sessionId the session identifier
    * @return the primitive session
    */
-  protected PrimitiveSession getSession(long sessionId) {
+  protected Session getSession(long sessionId) {
     return getSession(SessionId.from(sessionId));
   }
 
@@ -282,7 +282,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * @param sessionId the session identifier
    * @return the primitive session
    */
-  protected PrimitiveSession getSession(SessionId sessionId) {
+  protected Session getSession(SessionId sessionId) {
     SessionProxy sessionProxy = sessions.get(sessionId);
     return sessionProxy != null ? sessionProxy.session : null;
   }
@@ -292,7 +292,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    *
    * @return the collection of open sessions
    */
-  protected Collection<PrimitiveSession> getSessions() {
+  protected Collection<Session> getSessions() {
     return sessions.values().stream().map(sessionProxy -> sessionProxy.session).collect(Collectors.toList());
   }
 
@@ -302,7 +302,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * @param session the session to which to publish the event
    * @param event   the event to publish
    */
-  protected void acceptOn(PrimitiveSession session, Consumer<C> event) {
+  protected void acceptOn(Session session, Consumer<C> event) {
     acceptOn(session.sessionId(), event);
   }
 
@@ -332,7 +332,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
 
   @Override
   @SuppressWarnings("unchecked")
-  public final void register(PrimitiveSession session) {
+  public final void register(Session session) {
     SessionProxyHandler sessionProxyHandler = new SessionProxyHandler(session);
     if (clientInterface != null) {
       C sessionProxy = (C) java.lang.reflect.Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{clientInterface}, sessionProxyHandler);
@@ -364,7 +364,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * <p>
    * A session is registered when a new client connects to the cluster or an existing client recovers its
    * session after being partitioned from the cluster. It's important to note that when this method is called,
-   * the {@link PrimitiveSession} is <em>not yet open</em> and so events cannot be {@link PrimitiveSession#publish(PrimitiveEvent) published}
+   * the {@link Session} is <em>not yet open</em> and so events cannot be {@link Session#publish(PrimitiveEvent) published}
    * to the registered session. This is because clients cannot reliably track messages pushed from server state machines
    * to the client until the session has been fully registered. Session event messages may still be published to
    * other already-registered sessions in reaction to a session being registered.
@@ -382,10 +382,10 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * and notify the client before the event message is sent. Published event messages sent via this method will
    * be sent the next time an operation is applied to the state machine.
    *
-   * @param session The session that was registered. State machines <em>cannot</em> {@link PrimitiveSession#publish(PrimitiveEvent)} session
+   * @param session The session that was registered. State machines <em>cannot</em> {@link Session#publish(PrimitiveEvent)} session
    *                events to this session.
    */
-  protected void onOpen(PrimitiveSession session) {
+  protected void onOpen(Session session) {
 
   }
 
@@ -394,17 +394,17 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * <p>
    * This method is called when a client fails to keep its session alive with the cluster. If the leader hasn't heard
    * from a client for a configurable time interval, the leader will expire the session to free the related memory.
-   * This method will always be called for a given session before {@link #onClose(PrimitiveSession)}, and {@link #onClose(PrimitiveSession)}
+   * This method will always be called for a given session before {@link #onClose(Session)}, and {@link #onClose(Session)}
    * will always be called following this method.
    * <p>
-   * State machines are free to {@link PrimitiveSession#publish(PrimitiveEvent)} session event messages to any session except
+   * State machines are free to {@link Session#publish(PrimitiveEvent)} session event messages to any session except
    * the one that expired. Session event messages sent to the session that expired will be lost since the session is closed once this
    * method call completes.
    *
-   * @param session The session that was expired. State machines <em>cannot</em> {@link PrimitiveSession#publish(PrimitiveEvent)} session
+   * @param session The session that was expired. State machines <em>cannot</em> {@link Session#publish(PrimitiveEvent)} session
    *                events to this session.
    */
-  protected void onExpire(PrimitiveSession session) {
+  protected void onExpire(Session session) {
 
   }
 
@@ -413,14 +413,14 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * <p>
    * This method is called when a client explicitly closes a session.
    * <p>
-   * State machines are free to {@link PrimitiveSession#publish(PrimitiveEvent)} session event messages to any session except
+   * State machines are free to {@link Session#publish(PrimitiveEvent)} session event messages to any session except
    * the one that was closed. Session event messages sent to the session that was closed will be lost since the session is closed once this
    * method call completes.
    *
-   * @param session The session that was closed. State machines <em>cannot</em> {@link PrimitiveSession#publish(PrimitiveEvent)} session
+   * @param session The session that was closed. State machines <em>cannot</em> {@link Session#publish(PrimitiveEvent)} session
    *                events to this session.
    */
-  protected void onClose(PrimitiveSession session) {
+  protected void onClose(Session session) {
 
   }
 
@@ -428,10 +428,10 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * Session proxy.
    */
   private final class SessionProxy {
-    private final PrimitiveSession session;
+    private final Session session;
     private final C proxy;
 
-    public SessionProxy(PrimitiveSession session, C proxy) {
+    public SessionProxy(Session session, C proxy) {
       this.session = session;
       this.proxy = proxy;
     }
@@ -450,10 +450,10 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
    * Session proxy invocation handler.
    */
   private final class SessionProxyHandler implements InvocationHandler {
-    private final PrimitiveSession session;
+    private final Session session;
     private final Map<Method, EventType> events;
 
-    private SessionProxyHandler(PrimitiveSession session) {
+    private SessionProxyHandler(Session session) {
       this.session = session;
       this.events = clientInterface != null ? Events.getMethodMap(clientInterface) : Maps.newHashMap();
     }

--- a/primitive/src/main/java/io/atomix/primitive/service/Commit.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/Commit.java
@@ -18,7 +18,7 @@ package io.atomix.primitive.service;
 import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.PrimitiveOperation;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.utils.time.LogicalTimestamp;
 import io.atomix.utils.time.WallClockTimestamp;
 
@@ -47,13 +47,13 @@ public interface Commit<T> {
   /**
    * Returns the session that submitted the operation.
    * <p>
-   * The returned {@link PrimitiveSession} is representative of the session that submitted the operation
-   * that resulted in this {@link Commit}. The session can be used to {@link PrimitiveSession#publish(PrimitiveEvent)}
+   * The returned {@link Session} is representative of the session that submitted the operation
+   * that resulted in this {@link Commit}. The session can be used to {@link Session#publish(PrimitiveEvent)}
    * event messages to the client.
    *
    * @return The session that created the commit.
    */
-  PrimitiveSession session();
+  Session session();
 
   /**
    * Returns the logical time at which the operation was committed.

--- a/primitive/src/main/java/io/atomix/primitive/service/PrimitiveService.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/PrimitiveService.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.primitive.service;
 
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.Serializer;
 import io.atomix.utils.time.WallClockTimestamp;
@@ -78,7 +78,7 @@ public interface PrimitiveService {
    *
    * @param session the session to register
    */
-  void register(PrimitiveSession session);
+  void register(Session session);
 
   /**
    * Expires the session with the given identifier.

--- a/primitive/src/main/java/io/atomix/primitive/service/ServiceContext.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/ServiceContext.java
@@ -19,8 +19,8 @@ package io.atomix.primitive.service;
 import io.atomix.primitive.PrimitiveId;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.operation.OperationType;
-import io.atomix.primitive.session.PrimitiveSession;
-import io.atomix.primitive.session.PrimitiveSessions;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.Sessions;
 import io.atomix.utils.time.LogicalClock;
 import io.atomix.utils.time.WallClock;
 
@@ -29,7 +29,7 @@ import io.atomix.utils.time.WallClock;
  * <p>
  * The context is reflective of the current position and state of the Raft state machine. In particular,
  * it exposes the current approximate {@link ServiceContext#wallClock() time} and all open
- * {@link PrimitiveSessions}.
+ * {@link Sessions}.
  */
 public interface ServiceContext {
 
@@ -78,7 +78,7 @@ public interface ServiceContext {
    *
    * @return the current session
    */
-  PrimitiveSession currentSession();
+  Session currentSession();
 
   /**
    * Returns the current operation type.

--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultCommit.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultCommit.java
@@ -17,7 +17,7 @@ package io.atomix.primitive.service.impl;
 
 import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.service.Commit;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.utils.misc.ArraySizeHashPrinter;
 import io.atomix.utils.time.LogicalTimestamp;
 import io.atomix.utils.time.WallClockTimestamp;
@@ -32,12 +32,12 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  */
 public class DefaultCommit<T> implements Commit<T> {
   private final long index;
-  private final PrimitiveSession session;
+  private final Session session;
   private final long timestamp;
   private final OperationId operation;
   private final T value;
 
-  public DefaultCommit(long index, OperationId operation, T value, PrimitiveSession session, long timestamp) {
+  public DefaultCommit(long index, OperationId operation, T value, Session session, long timestamp) {
     this.index = index;
     this.session = session;
     this.timestamp = timestamp;
@@ -51,7 +51,7 @@ public class DefaultCommit<T> implements Commit<T> {
   }
 
   @Override
-  public PrimitiveSession session() {
+  public Session session() {
     return session;
   }
 

--- a/primitive/src/main/java/io/atomix/primitive/session/Session.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/Session.java
@@ -29,7 +29,7 @@ import io.atomix.primitive.event.PrimitiveEvent;
  * expired or closed, linearizability, sequential consistency, and other guarantees for events and operations are
  * effectively lost. Session implementations guarantee linearizability for session messages by coordinating between
  * the client and a single server at any given time. This means messages {@link #publish(PrimitiveEvent) published}
- * via the {@link PrimitiveSession} are guaranteed to arrive on the other side of the connection exactly once and in the order
+ * via the {@link Session} are guaranteed to arrive on the other side of the connection exactly once and in the order
  * in which they are sent by replicated state machines. In the event of a server-to-client message being lost, the
  * message will be resent so long as at least one Raft server is able to communicate with the client and the client's
  * session does not expire while switching between servers.
@@ -43,7 +43,7 @@ import io.atomix.primitive.event.PrimitiveEvent;
  * When the message is published, it will be queued to be sent to the other side of the connection. Raft guarantees
  * that the message will eventually be received by the client unless the session itself times out or is closed.
  */
-public interface PrimitiveSession {
+public interface Session {
 
   /**
    * Returns the session identifier.

--- a/primitive/src/main/java/io/atomix/primitive/session/SessionEvent.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/SessionEvent.java
@@ -20,7 +20,7 @@ import io.atomix.utils.event.AbstractEvent;
 /**
  * Raft session event.
  */
-public class PrimitiveSessionEvent extends AbstractEvent<PrimitiveSessionEvent.Type, PrimitiveSession> {
+public class SessionEvent extends AbstractEvent<SessionEvent.Type, Session> {
 
   /**
    * Raft session type.
@@ -42,11 +42,11 @@ public class PrimitiveSessionEvent extends AbstractEvent<PrimitiveSessionEvent.T
     CLOSE,
   }
 
-  public PrimitiveSessionEvent(PrimitiveSessionEvent.Type type, PrimitiveSession subject) {
+  public SessionEvent(SessionEvent.Type type, Session subject) {
     super(type, subject);
   }
 
-  public PrimitiveSessionEvent(PrimitiveSessionEvent.Type type, PrimitiveSession subject, long time) {
+  public SessionEvent(SessionEvent.Type type, Session subject, long time) {
     super(type, subject, time);
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/session/SessionEventListener.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/SessionEventListener.java
@@ -21,5 +21,5 @@ import io.atomix.utils.event.EventListener;
  * Raft session event listener.
  */
 @FunctionalInterface
-public interface PrimitiveSessionEventListener extends EventListener<PrimitiveSessionEvent> {
+public interface SessionEventListener extends EventListener<SessionEvent> {
 }

--- a/primitive/src/main/java/io/atomix/primitive/session/SessionListener.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/SessionListener.java
@@ -23,14 +23,14 @@ import io.atomix.primitive.service.PrimitiveService;
  * <p>
  * When implemented by a {@link PrimitiveService StateMachine}, this interface provides
  * support to state machines for reacting to changes in the sessions connected to the cluster. State machines
- * can react to clients {@link #onOpen(PrimitiveSession) registering} and {@link #onClose(PrimitiveSession) unregistering}
- * sessions and servers {@link #onExpire(PrimitiveSession) expiring} sessions.
+ * can react to clients {@link #onOpen(Session) registering} and {@link #onClose(Session) unregistering}
+ * sessions and servers {@link #onExpire(Session) expiring} sessions.
  * <p>
- * {@link PrimitiveSession}s represent a single client's open connection to a cluster. Within the context of a session,
+ * {@link Session}s represent a single client's open connection to a cluster. Within the context of a session,
  * Raft provides additional guarantees for clients like linearizability for writes and sequential consistency
  * for reads. Additionally, state machines can push messages to specific clients via sessions. Typically, all
  * state machines that rely on session-based messaging should implement this interface to track when a session
- * is {@link #onClose(PrimitiveSession) closed}.
+ * is {@link #onClose(Session) closed}.
  */
 public interface SessionListener {
 
@@ -39,7 +39,7 @@ public interface SessionListener {
    * <p>
    * A session is registered when a new client connects to the cluster or an existing client recovers its
    * session after being partitioned from the cluster. It's important to note that when this method is called,
-   * the {@link PrimitiveSession} is <em>not yet open</em> and so events cannot be {@link PrimitiveSession#publish(PrimitiveEvent) published}
+   * the {@link Session} is <em>not yet open</em> and so events cannot be {@link Session#publish(PrimitiveEvent) published}
    * to the registered session. This is because clients cannot reliably track messages pushed from server state machines
    * to the client until the session has been fully registered. Session event messages may still be published to
    * other already-registered sessions in reaction to a session being registered.
@@ -57,40 +57,40 @@ public interface SessionListener {
    * and notify the client before the event message is sent. Published event messages sent via this method will
    * be sent the next time an operation is applied to the state machine.
    *
-   * @param session The session that was registered. State machines <em>cannot</em> {@link PrimitiveSession#publish(PrimitiveEvent)} session
+   * @param session The session that was registered. State machines <em>cannot</em> {@link Session#publish(PrimitiveEvent)} session
    *                events to this session.
    */
-  void onOpen(PrimitiveSession session);
+  void onOpen(Session session);
 
   /**
    * Called when a session is expired by the system.
    * <p>
    * This method is called when a client fails to keep its session alive with the cluster. If the leader hasn't heard
    * from a client for a configurable time interval, the leader will expire the session to free the related memory.
-   * This method will always be called for a given session before {@link #onClose(PrimitiveSession)}, and {@link #onClose(PrimitiveSession)}
+   * This method will always be called for a given session before {@link #onClose(Session)}, and {@link #onClose(Session)}
    * will always be called following this method.
    * <p>
-   * State machines are free to {@link PrimitiveSession#publish(PrimitiveEvent)} session event messages to any session except
+   * State machines are free to {@link Session#publish(PrimitiveEvent)} session event messages to any session except
    * the one that expired. Session event messages sent to the session that expired will be lost since the session is closed once this
    * method call completes.
    *
-   * @param session The session that was expired. State machines <em>cannot</em> {@link PrimitiveSession#publish(PrimitiveEvent)} session
+   * @param session The session that was expired. State machines <em>cannot</em> {@link Session#publish(PrimitiveEvent)} session
    *                events to this session.
    */
-  void onExpire(PrimitiveSession session);
+  void onExpire(Session session);
 
   /**
    * Called when a session was closed by the client.
    * <p>
    * This method is called when a client explicitly closes a session.
    * <p>
-   * State machines are free to {@link PrimitiveSession#publish(PrimitiveEvent)} session event messages to any session except
+   * State machines are free to {@link Session#publish(PrimitiveEvent)} session event messages to any session except
    * the one that was closed. Session event messages sent to the session that was closed will be lost since the session is closed once this
    * method call completes.
    *
-   * @param session The session that was closed. State machines <em>cannot</em> {@link PrimitiveSession#publish(PrimitiveEvent)} session
+   * @param session The session that was closed. State machines <em>cannot</em> {@link Session#publish(PrimitiveEvent)} session
    *                events to this session.
    */
-  void onClose(PrimitiveSession session);
+  void onClose(Session session);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/session/Sessions.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/Sessions.java
@@ -25,9 +25,9 @@ import io.atomix.primitive.event.PrimitiveEvent;
  * state machine. Session sets are guaranteed to be deterministic. All state machines will see the same set of
  * open sessions at the same point in the log except in cases where a session has already been closed and removed.
  * If a session has already been closed on another server, the session is guaranteed to have been expired on all
- * servers and thus operations like {@link PrimitiveSession#publish(PrimitiveEvent)} are effectively no-ops.
+ * servers and thus operations like {@link Session#publish(PrimitiveEvent)} are effectively no-ops.
  */
-public interface PrimitiveSessions extends Iterable<PrimitiveSession> {
+public interface Sessions extends Iterable<Session> {
 
   /**
    * Returns a session by session ID.
@@ -35,7 +35,7 @@ public interface PrimitiveSessions extends Iterable<PrimitiveSession> {
    * @param sessionId The session ID.
    * @return The session or {@code null} if no session with the given {@code sessionId} exists.
    */
-  PrimitiveSession getSession(long sessionId);
+  Session getSession(long sessionId);
 
   /**
    * Adds a listener to the sessions.
@@ -44,7 +44,7 @@ public interface PrimitiveSessions extends Iterable<PrimitiveSession> {
    * @return The sessions.
    * @throws NullPointerException if the session {@code listener} is {@code null}
    */
-  PrimitiveSessions addListener(SessionListener listener);
+  Sessions addListener(SessionListener listener);
 
   /**
    * Removes a listener from the sessions.
@@ -52,6 +52,6 @@ public interface PrimitiveSessions extends Iterable<PrimitiveSession> {
    * @param listener The listener to remove.
    * @return The sessions.
    */
-  PrimitiveSessions removeListener(SessionListener listener);
+  Sessions removeListener(SessionListener listener);
 
 }

--- a/primitive/src/test/java/io/atomix/primitive/service/DefaultServiceExecutorTest.java
+++ b/primitive/src/test/java/io/atomix/primitive/service/DefaultServiceExecutorTest.java
@@ -21,7 +21,7 @@ import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.OperationType;
 import io.atomix.primitive.service.impl.DefaultCommit;
 import io.atomix.primitive.service.impl.DefaultServiceExecutor;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.utils.serializer.KryoNamespaces;
 import io.atomix.utils.serializer.Serializer;
 import io.atomix.utils.time.WallClockTimestamp;
@@ -103,6 +103,6 @@ public class DefaultServiceExecutorTest {
 
   @SuppressWarnings("unchecked")
   private <T> Commit<T> commit(OperationId operation, long index, T value, long timestamp) {
-    return new DefaultCommit<T>(index, operation, value, mock(PrimitiveSession.class), timestamp);
+    return new DefaultCommit<T>(index, operation, value, mock(Session.class), timestamp);
   }
 }

--- a/primitive/src/test/java/io/atomix/primitive/session/SessionEventTest.java
+++ b/primitive/src/test/java/io/atomix/primitive/session/SessionEventTest.java
@@ -23,13 +23,13 @@ import static org.mockito.Mockito.mock;
 /**
  * Raft session event test.
  */
-public class PrimitiveSessionEventTest {
+public class SessionEventTest {
   @Test
   public void testRaftSessionEvent() throws Exception {
-    PrimitiveSession session = mock(PrimitiveSession.class);
+    Session session = mock(Session.class);
     long timestamp = System.currentTimeMillis();
-    PrimitiveSessionEvent event = new PrimitiveSessionEvent(PrimitiveSessionEvent.Type.OPEN, session, timestamp);
-    assertEquals(PrimitiveSessionEvent.Type.OPEN, event.type());
+    SessionEvent event = new SessionEvent(SessionEvent.Type.OPEN, session, timestamp);
+    assertEquals(SessionEvent.Type.OPEN, event.type());
     assertEquals(session, event.subject());
     assertEquals(timestamp, event.time());
   }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/impl/PrimaryBackupSession.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/impl/PrimaryBackupSession.java
@@ -19,7 +19,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.event.EventType;
 import io.atomix.primitive.event.PrimitiveEvent;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.backup.PrimaryBackupServer.Role;
 import io.atomix.protocols.backup.service.impl.PrimaryBackupServiceContext;
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 /**
  * Primary-backup session.
  */
-public class PrimaryBackupSession implements PrimitiveSession {
+public class PrimaryBackupSession implements Session {
   private final Logger log;
   private final SessionId sessionId;
   private final MemberId memberId;

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/roles/BackupRole.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/roles/BackupRole.java
@@ -18,7 +18,7 @@ package io.atomix.protocols.backup.roles;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultCommit;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.protocols.backup.PrimaryBackupServer.Role;
 import io.atomix.protocols.backup.impl.PrimaryBackupSession;
 import io.atomix.protocols.backup.protocol.BackupOperation;
@@ -108,7 +108,7 @@ public class BackupRole extends PrimaryBackupRole {
    * Applies an execute operation to the service.
    */
   private void applyExecute(ExecuteOperation operation) {
-    PrimitiveSession session = context.getOrCreateSession(operation.session(), operation.node());
+    Session session = context.getOrCreateSession(operation.session(), operation.node());
     if (operation.operation() != null) {
       try {
         context.service().apply(new DefaultCommit<>(

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/roles/PrimaryRole.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/roles/PrimaryRole.java
@@ -18,7 +18,7 @@ package io.atomix.protocols.backup.roles;
 import io.atomix.primitive.operation.OperationType;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.primitive.service.impl.DefaultCommit;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.protocols.backup.PrimaryBackupServer.Role;
 import io.atomix.protocols.backup.impl.PrimaryBackupSession;
 import io.atomix.protocols.backup.protocol.CloseOperation;
@@ -115,9 +115,9 @@ public class PrimaryRole extends PrimaryBackupRole {
 
   private CompletableFuture<ExecuteResponse> executeQuery(ExecuteRequest request) {
     // If the session doesn't exist, create and replicate a new session before applying the query.
-    PrimitiveSession session = context.getSession(request.session());
+    Session session = context.getSession(request.session());
     if (session == null) {
-      PrimitiveSession newSession = context.createSession(request.session(), request.node());
+      Session newSession = context.createSession(request.session(), request.node());
       long index = context.nextIndex();
       long timestamp = System.currentTimeMillis();
       return replicator.replicate(new ExecuteOperation(
@@ -136,7 +136,7 @@ public class PrimaryRole extends PrimaryBackupRole {
     }
   }
 
-  private ExecuteResponse applyQuery(ExecuteRequest request, PrimitiveSession session) {
+  private ExecuteResponse applyQuery(ExecuteRequest request, Session session) {
     try {
       byte[] result = context.service().apply(new DefaultCommit<>(
           context.getIndex(),
@@ -162,7 +162,7 @@ public class PrimaryRole extends PrimaryBackupRole {
     HeapBuffer buffer = HeapBuffer.allocate();
     Collection<PrimaryBackupSession> sessions = context.getSessions();
     buffer.writeInt(sessions.size());
-    for (PrimitiveSession session : sessions) {
+    for (Session session : sessions) {
       buffer.writeLong(session.sessionId().id());
       buffer.writeString(session.memberId().id());
     }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceContext.java
@@ -33,7 +33,7 @@ import io.atomix.primitive.partition.PrimaryTerm;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceContext;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.backup.PrimaryBackupServer.Role;
 import io.atomix.protocols.backup.impl.PrimaryBackupSession;
@@ -93,7 +93,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
   private List<MemberId> backups;
   private long currentTerm;
   private long currentIndex;
-  private PrimitiveSession currentSession;
+  private Session currentSession;
   private long currentTimestamp;
   private long operationIndex;
   private long commitIndex;
@@ -220,7 +220,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
   }
 
   @Override
-  public PrimitiveSession currentSession() {
+  public Session currentSession() {
     return currentSession;
   }
 
@@ -333,7 +333,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
    * @param session the current session
    * @return the updated session
    */
-  public PrimitiveSession setSession(PrimitiveSession session) {
+  public Session setSession(Session session) {
     this.currentSession = session;
     return session;
   }
@@ -565,7 +565,7 @@ public class PrimaryBackupServiceContext implements ServiceContext {
    */
   private void handleClusterEvent(ClusterMembershipEvent event) {
     if (event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED) {
-      for (PrimitiveSession session : sessions.values()) {
+      for (Session session : sessions.values()) {
         if (session.memberId().equals(event.subject().id())) {
           role.expire((PrimaryBackupSession) session);
         }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceSessions.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/service/impl/PrimaryBackupServiceSessions.java
@@ -17,9 +17,9 @@ package io.atomix.protocols.backup.service.impl;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionListener;
-import io.atomix.primitive.session.PrimitiveSessions;
+import io.atomix.primitive.session.Sessions;
 import io.atomix.protocols.backup.impl.PrimaryBackupSession;
 
 import java.util.Iterator;
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * State machine sessions.
  */
-public class PrimaryBackupServiceSessions implements PrimitiveSessions {
+public class PrimaryBackupServiceSessions implements Sessions {
   private final Map<Long, PrimaryBackupSession> sessions = Maps.newConcurrentMap();
   private final Set<SessionListener> listeners = Sets.newIdentityHashSet();
 
@@ -73,20 +73,20 @@ public class PrimaryBackupServiceSessions implements PrimitiveSessions {
   }
 
   @Override
-  public PrimitiveSessions addListener(SessionListener listener) {
+  public Sessions addListener(SessionListener listener) {
     listeners.add(listener);
     return this;
   }
 
   @Override
-  public PrimitiveSessions removeListener(SessionListener listener) {
+  public Sessions removeListener(SessionListener listener) {
     listeners.remove(listener);
     return this;
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Iterator<PrimitiveSession> iterator() {
+  public Iterator<Session> iterator() {
     return (Iterator) sessions.values().iterator();
   }
 }

--- a/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
+++ b/protocols/primary-backup/src/test/java/io/atomix/protocols/backup/PrimaryBackupTest.java
@@ -36,7 +36,7 @@ import io.atomix.primitive.service.Commit;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.backup.PrimaryBackupServer.Role;
 import io.atomix.protocols.backup.protocol.TestPrimaryBackupProtocolFactory;
@@ -523,14 +523,14 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
     }
 
     @Override
-    public void onExpire(PrimitiveSession session) {
+    public void onExpire(Session session) {
       if (expire != null) {
         expire.session().publish(EXPIRE_EVENT);
       }
     }
 
     @Override
-    public void onClose(PrimitiveSession session) {
+    public void onClose(Session session) {
       if (close != null && !session.equals(close.session())) {
         close.session().publish(CLOSE_EVENT);
       }
@@ -558,7 +558,7 @@ public class PrimaryBackupTest extends ConcurrentTestCase {
       if (commit.value()) {
         commit.session().publish(CHANGE_EVENT, commit.index());
       } else {
-        for (PrimitiveSession session : getSessions()) {
+        for (Session session : getSessions()) {
           session.publish(CHANGE_EVENT, commit.index());
         }
       }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
@@ -28,7 +28,7 @@ import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.primitive.service.impl.DefaultCommit;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.ReadConsistency;
@@ -69,7 +69,7 @@ public class RaftServiceContext implements ServiceContext {
   private final RaftSessionRegistry sessions;
   private final ThreadContextFactory threadContextFactory;
   private long currentIndex;
-  private PrimitiveSession currentSession;
+  private Session currentSession;
   private long currentTimestamp;
   private OperationType currentOperation;
   private final LogicalClock logicalClock = new LogicalClock() {
@@ -140,7 +140,7 @@ public class RaftServiceContext implements ServiceContext {
   }
 
   @Override
-  public PrimitiveSession currentSession() {
+  public Session currentSession() {
     return currentSession;
   }
 
@@ -321,7 +321,7 @@ public class RaftServiceContext implements ServiceContext {
     tick(index, timestamp);
 
     // The session may have been closed by the time this update was executed on the service thread.
-    if (session.getState() != PrimitiveSession.State.CLOSED) {
+    if (session.getState() != Session.State.CLOSED) {
       // Update the session's timestamp to prevent it from being expired.
       session.setLastUpdated(timestamp);
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -21,7 +21,7 @@ import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.event.EventType;
 import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.OperationType;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.impl.OperationResult;
@@ -52,7 +52,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * Raft session.
  */
-public class RaftSession implements PrimitiveSession {
+public class RaftSession implements Session {
   private final Logger log;
   private final SessionId sessionId;
   private final MemberId member;
@@ -110,7 +110,7 @@ public class RaftSession implements PrimitiveSession {
     this.context = context;
     this.server = server;
     this.eventExecutor = threadContextFactory.createContext();
-    this.log = ContextualLoggerFactory.getLogger(getClass(), LoggerContext.builder(PrimitiveSession.class)
+    this.log = ContextualLoggerFactory.getLogger(getClass(), LoggerContext.builder(Session.class)
         .addValue(sessionId)
         .add("type", context.serviceType())
         .add("name", context.serviceName())
@@ -606,7 +606,7 @@ public class RaftSession implements PrimitiveSession {
 
   @Override
   public boolean equals(Object object) {
-    return object instanceof PrimitiveSession && ((PrimitiveSession) object).sessionId() == sessionId;
+    return object instanceof Session && ((Session) object).sessionId() == sessionId;
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/package-info.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Provides a {@link io.atomix.primitive.session.PrimitiveSession} implementation for the Raft consensus protocol.
+ * Provides a {@link io.atomix.primitive.session.Session} implementation for the Raft consensus protocol.
  */
 package io.atomix.protocols.raft.session;

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -41,7 +41,7 @@ import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
-import io.atomix.primitive.session.PrimitiveSession;
+import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.primitive.session.SessionMetadata;
 import io.atomix.protocols.raft.cluster.RaftClusterEvent;
@@ -1499,14 +1499,14 @@ public class RaftTest extends ConcurrentTestCase {
     }
 
     @Override
-    public void onExpire(PrimitiveSession session) {
+    public void onExpire(Session session) {
       if (expire != null) {
         acceptOn(expire, client -> client.expire("Hello world!"));
       }
     }
 
     @Override
-    public void onClose(PrimitiveSession session) {
+    public void onClose(Session session) {
       if (close != null && !session.sessionId().equals(close)) {
         acceptOn(close, client -> client.close("Hello world!"));
       }
@@ -1537,7 +1537,7 @@ public class RaftTest extends ConcurrentTestCase {
       if (sender) {
         acceptOn(getCurrentSession().sessionId(), service -> service.event(getCurrentIndex()));
       } else {
-        for (PrimitiveSession session : getSessions()) {
+        for (Session session : getSessions()) {
           acceptOn(session.sessionId(), service -> service.event(getCurrentIndex()));
         }
       }


### PR DESCRIPTION
More naming cleanup