### PR TITLE
Use thread context to track blocked threads

### DIFF
--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxy.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxy.java
@@ -23,21 +23,15 @@ import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveRegistry;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.proxy.ProxyClient;
-import io.atomix.utils.concurrent.OrderedExecutor;
+import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.time.Version;
 
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
-import static io.atomix.utils.concurrent.Futures.orderedFuture;
 
 /**
  * Raft lock.
@@ -45,17 +39,12 @@ import static io.atomix.utils.concurrent.Futures.orderedFuture;
 public class DistributedLockProxy
     extends AbstractAsyncPrimitive<AsyncDistributedLock, DistributedLockService>
     implements AsyncDistributedLock, DistributedLockClient {
-
-  private final ScheduledExecutorService scheduledExecutor;
-  private final Executor orderedExecutor;
   private final Map<Integer, LockAttempt> attempts = Maps.newConcurrentMap();
   private final AtomicInteger id = new AtomicInteger();
   private final AtomicInteger lock = new AtomicInteger();
 
-  public DistributedLockProxy(ProxyClient<DistributedLockService> proxy, PrimitiveRegistry registry, ScheduledExecutorService scheduledExecutor) {
+  public DistributedLockProxy(ProxyClient<DistributedLockService> proxy, PrimitiveRegistry registry) {
     super(proxy, registry);
-    this.scheduledExecutor = scheduledExecutor;
-    this.orderedExecutor = new OrderedExecutor(scheduledExecutor);
     proxy.addStateChangeListener(this::onStateChange);
   }
 
@@ -97,9 +86,7 @@ public class DistributedLockProxy
         attempt.completeExceptionally(error);
       }
     });
-
-    // Return an ordered future that can safely be blocked inside the executor thread.
-    return orderedFuture(attempt, orderedExecutor, scheduledExecutor);
+    return attempt;
   }
 
   @Override
@@ -119,10 +106,7 @@ public class DistributedLockProxy
         attempt.completeExceptionally(error);
       }
     });
-
-    // Return an ordered future that can safely be blocked inside the executor thread.
-    return orderedFuture(attempt, orderedExecutor, scheduledExecutor)
-        .thenApply(Optional::ofNullable);
+    return attempt.thenApply(Optional::ofNullable);
   }
 
   @Override
@@ -150,10 +134,7 @@ public class DistributedLockProxy
             attempt.completeExceptionally(error);
           }
         });
-
-    // Return an ordered future that can safely be blocked inside the executor thread.
-    return orderedFuture(attempt, orderedExecutor, scheduledExecutor)
-        .thenApply(Optional::ofNullable);
+    return attempt.thenApply(Optional::ofNullable);
   }
 
   @Override
@@ -161,10 +142,7 @@ public class DistributedLockProxy
     // Use the current lock ID to ensure we only unlock the lock currently held by this process.
     int lock = this.lock.getAndSet(0);
     if (lock != 0) {
-      return orderedFuture(
-          getProxyClient().acceptBy(name(), service -> service.unlock(lock)),
-          orderedExecutor,
-          scheduledExecutor);
+      return getProxyClient().acceptBy(name(), service -> service.unlock(lock));
     }
     return CompletableFuture.completedFuture(null);
   }
@@ -186,7 +164,7 @@ public class DistributedLockProxy
    */
   private class LockAttempt extends CompletableFuture<Version> {
     private final int id;
-    private final ScheduledFuture<?> scheduledFuture;
+    private final Scheduled scheduled;
 
     LockAttempt() {
       this(null, null);
@@ -194,9 +172,8 @@ public class DistributedLockProxy
 
     LockAttempt(Duration duration, Consumer<LockAttempt> callback) {
       this.id = DistributedLockProxy.this.id.incrementAndGet();
-      this.scheduledFuture = duration != null && callback != null
-          ? scheduledExecutor.schedule(() -> callback.accept(this), duration.toMillis(), TimeUnit.MILLISECONDS)
-          : null;
+      this.scheduled = duration != null && callback != null
+          ? getProxyClient().getPartition(name()).context().schedule(duration, () -> callback.accept(this)) : null;
       attempts.put(id, this);
     }
 
@@ -230,8 +207,8 @@ public class DistributedLockProxy
     }
 
     private void cancel() {
-      if (scheduledFuture != null) {
-        scheduledFuture.cancel(false);
+      if (scheduled != null) {
+        scheduled.cancel();
       }
       attempts.remove(id);
     }

--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxyBuilder.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockProxyBuilder.java
@@ -42,7 +42,7 @@ public class DistributedLockProxyBuilder extends DistributedLockBuilder {
         DistributedLockService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
-    return new DistributedLockProxy(proxy, managementService.getPrimitiveRegistry(), managementService.getExecutorService())
+    return new DistributedLockProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(AsyncDistributedLock::sync);
   }

--- a/primitive/src/main/java/io/atomix/primitive/client/SessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/client/SessionClient.java
@@ -22,6 +22,7 @@ import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.session.SessionId;
+import io.atomix.utils.concurrent.ThreadContext;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -65,6 +66,13 @@ public interface SessionClient {
    * @return the partition identifier.
    */
   PartitionId partitionId();
+
+  /**
+   * Returns the partition thread context.
+   *
+   * @return the partition thread context
+   */
+  ThreadContext context();
 
   /**
    * Executes an operation to the cluster.

--- a/primitive/src/main/java/io/atomix/primitive/client/impl/DelegatingSessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/client/impl/DelegatingSessionClient.java
@@ -24,6 +24,7 @@ import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.session.SessionId;
+import io.atomix.utils.concurrent.ThreadContext;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -50,6 +51,11 @@ public class DelegatingSessionClient implements SessionClient {
   @Override
   public PartitionId partitionId() {
     return proxy.partitionId();
+  }
+
+  @Override
+  public ThreadContext context() {
+    return proxy.context();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/proxy/ProxySession.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/ProxySession.java
@@ -18,6 +18,7 @@ package io.atomix.primitive.proxy;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.operation.PrimitiveOperation;
+import io.atomix.utils.concurrent.ThreadContext;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -41,6 +42,13 @@ public interface ProxySession<S> {
    * @return The client proxy type.
    */
   PrimitiveType type();
+
+  /**
+   * Returns the session thread context.
+   *
+   * @return the session thread context
+   */
+  ThreadContext context();
 
   /**
    * Returns the session state.

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
@@ -25,6 +25,7 @@ import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.Operations;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.proxy.ProxySession;
+import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +66,11 @@ public class DefaultProxySession<S> implements ProxySession<S> {
   @Override
   public PrimitiveType type() {
     return session.type();
+  }
+
+  @Override
+  public ThreadContext context() {
+    return session.context();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/service/ServiceExecutor.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/ServiceExecutor.java
@@ -19,9 +19,10 @@ package io.atomix.primitive.service;
 import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.OperationType;
 import io.atomix.primitive.operation.PrimitiveOperation;
-import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.Scheduler;
 import io.atomix.utils.time.WallClockTimestamp;
 
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -65,7 +66,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * @see PrimitiveService
  * @see ServiceContext
  */
-public interface ServiceExecutor extends ThreadContext {
+public interface ServiceExecutor extends Executor, Scheduler {
 
   /**
    * Increments the service clock.
@@ -86,7 +87,7 @@ public interface ServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   void handle(OperationId operationId, Function<Commit<byte[]>, byte[]> callback);
@@ -95,7 +96,7 @@ public interface ServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   default void register(OperationId operationId, Runnable callback) {
@@ -111,7 +112,7 @@ public interface ServiceExecutor extends ThreadContext {
    * Registers a no argument operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   <R> void register(OperationId operationId, Supplier<R> callback);
@@ -120,7 +121,7 @@ public interface ServiceExecutor extends ThreadContext {
    * Registers a operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   <T> void register(OperationId operationId, Consumer<Commit<T>> callback);
@@ -129,12 +130,9 @@ public interface ServiceExecutor extends ThreadContext {
    * Registers an operation callback.
    *
    * @param operationId the operation identifier
-   * @param callback the operation callback
+   * @param callback    the operation callback
    * @throws NullPointerException if the {@code operationId} or {@code callback} is null
    */
   <T, R> void register(OperationId operationId, Function<Commit<T>, R> callback);
 
-  @Override
-  default void close() {
-  }
 }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -26,7 +26,6 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
-import io.atomix.protocols.backup.partition.PrimaryBackupPartition;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -111,7 +110,6 @@ public class MultiPrimaryProtocol implements PrimitiveProtocol {
             .withNumBackups(config.getBackups())
             .withMaxRetries(config.getMaxRetries())
             .withRetryDelay(config.getRetryDelay())
-            .withExecutor(config.getExecutor())
             .build())
         .collect(Collectors.toList());
     return new DefaultProxyClient<>(primitiveName, primitiveType, serviceType, partitions, config.getPartitioner());
@@ -241,8 +239,8 @@ public class MultiPrimaryProtocol implements PrimitiveProtocol {
      * @return The proxy builder.
      * @throws NullPointerException if the executor is null
      */
+    @Deprecated
     public Builder withExecutor(Executor executor) {
-      config.setExecutor(executor);
       return this;
     }
 

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocolConfig.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocolConfig.java
@@ -36,7 +36,6 @@ public class MultiPrimaryProtocolConfig extends PrimitiveProtocolConfig<MultiPri
   private int backups = 1;
   private int maxRetries = 0;
   private Duration retryDelay = Duration.ofMillis(100);
-  private Executor executor;
 
   @Override
   public PrimitiveProtocol.Type getType() {
@@ -198,8 +197,9 @@ public class MultiPrimaryProtocolConfig extends PrimitiveProtocolConfig<MultiPri
    *
    * @return the executor
    */
+  @Deprecated
   public Executor getExecutor() {
-    return executor;
+    return null;
   }
 
   /**
@@ -208,8 +208,8 @@ public class MultiPrimaryProtocolConfig extends PrimitiveProtocolConfig<MultiPri
    * @param executor the executor
    * @return the protocol configuration
    */
+  @Deprecated
   public MultiPrimaryProtocolConfig setExecutor(Executor executor) {
-    this.executor = executor;
-    return this;
+    throw new UnsupportedOperationException();
   }
 }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
@@ -27,6 +27,7 @@ import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.protocols.backup.partition.impl.PrimaryBackupPartitionClient;
 import io.atomix.protocols.backup.partition.impl.PrimaryBackupPartitionServer;
 import io.atomix.protocols.backup.proxy.PrimaryBackupSessionClient;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 
 import java.util.Collection;
@@ -139,7 +140,7 @@ public class PrimaryBackupPartition implements Partition {
       return CompletableFuture.completedFuture(null);
     }
 
-    CompletableFuture<Void> future = new CompletableFuture<>();
+    CompletableFuture<Void> future = new AtomixFuture<>();
     client.stop().whenComplete((clientResult, clientError) -> {
       if (server != null) {
         server.stop().whenComplete((serverResult, serverError) -> {

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
@@ -31,7 +31,7 @@ import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 import io.atomix.utils.concurrent.ThreadContextFactory;
-import io.atomix.utils.concurrent.ThreadPoolContextFactory;
+import io.atomix.utils.concurrent.BlockingAwareThreadPoolContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,7 +158,7 @@ public class PrimaryBackupPartitionGroup implements ManagedPartitionGroup {
 
   @Override
   public CompletableFuture<ManagedPartitionGroup> join(PartitionManagementService managementService) {
-    threadFactory = new ThreadPoolContextFactory("atomix-" + name() + "-%d", Runtime.getRuntime().availableProcessors() * 2, LOGGER);
+    threadFactory = new BlockingAwareThreadPoolContextFactory("atomix-" + name() + "-%d", Runtime.getRuntime().availableProcessors() * 2, LOGGER);
     List<CompletableFuture<Partition>> futures = partitions.values().stream()
         .map(p -> p.join(managementService, threadFactory))
         .collect(Collectors.toList());
@@ -170,7 +170,7 @@ public class PrimaryBackupPartitionGroup implements ManagedPartitionGroup {
 
   @Override
   public CompletableFuture<ManagedPartitionGroup> connect(PartitionManagementService managementService) {
-    threadFactory = new ThreadPoolContextFactory("atomix-" + name() + "-%d", Runtime.getRuntime().availableProcessors() * 2, LOGGER);
+    threadFactory = new BlockingAwareThreadPoolContextFactory("atomix-" + name() + "-%d", Runtime.getRuntime().availableProcessors() * 2, LOGGER);
     List<CompletableFuture<Partition>> futures = partitions.values().stream()
         .map(p -> p.connect(managementService, threadFactory))
         .collect(Collectors.toList());

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupSessionClient.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupSessionClient.java
@@ -41,6 +41,7 @@ import io.atomix.protocols.backup.protocol.ExecuteRequest;
 import io.atomix.protocols.backup.protocol.PrimaryBackupClientProtocol;
 import io.atomix.protocols.backup.protocol.PrimaryBackupResponse.Status;
 import io.atomix.protocols.backup.protocol.PrimitiveDescriptor;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ComposableFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.ContextualLoggerFactory;
@@ -116,6 +117,11 @@ public class PrimaryBackupSessionClient implements SessionClient {
   @Override
   public PrimitiveType type() {
     return primitiveType;
+  }
+
+  @Override
+  public ThreadContext context() {
+    return threadContext;
   }
 
   @Override
@@ -264,7 +270,7 @@ public class PrimaryBackupSessionClient implements SessionClient {
 
   @Override
   public CompletableFuture<SessionClient> connect() {
-    CompletableFuture<SessionClient> future = new CompletableFuture<>();
+    CompletableFuture<SessionClient> future = new AtomixFuture<>();
     threadContext.execute(() -> {
       connect(1, future);
     });
@@ -302,7 +308,7 @@ public class PrimaryBackupSessionClient implements SessionClient {
 
   @Override
   public CompletableFuture<Void> close() {
-    CompletableFuture<Void> future = new CompletableFuture<>();
+    CompletableFuture<Void> future = new AtomixFuture<>();
     PrimaryTerm term = this.term;
     if (term.primary() != null) {
       protocol.close(term.primary().memberId(), new CloseRequest(descriptor, sessionId.id()))
@@ -328,7 +334,6 @@ public class PrimaryBackupSessionClient implements SessionClient {
     protected int numBackups = 1;
     protected int maxRetries = 0;
     protected Duration retryDelay = Duration.ofMillis(100);
-    protected Executor executor;
 
     /**
      * Sets the protocol consistency model.
@@ -428,9 +433,9 @@ public class PrimaryBackupSessionClient implements SessionClient {
      * @return The proxy builder.
      * @throws NullPointerException if the executor is null
      */
+    @Deprecated
     public Builder withExecutor(Executor executor) {
-      this.executor = executor;
-      return this;
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
@@ -111,7 +111,6 @@ public class MultiRaftProtocol implements PrimitiveProtocol {
             .withRecoveryStrategy(config.getRecoveryStrategy())
             .withMaxRetries(config.getMaxRetries())
             .withRetryDelay(config.getRetryDelay())
-            .withExecutor(config.getExecutor())
             .build())
         .collect(Collectors.toList());
     return new DefaultProxyClient<>(primitiveName, primitiveType, serviceType, partitions, config.getPartitioner());
@@ -243,8 +242,8 @@ public class MultiRaftProtocol implements PrimitiveProtocol {
      * @return The proxy builder.
      * @throws NullPointerException if the executor is null
      */
+    @Deprecated
     public Builder withExecutor(Executor executor) {
-      config.setExecutor(executor);
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocolConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocolConfig.java
@@ -36,7 +36,6 @@ public class MultiRaftProtocolConfig extends PrimitiveProtocolConfig<MultiRaftPr
   private Recovery recoveryStrategy = Recovery.RECOVER;
   private int maxRetries = 0;
   private Duration retryDelay = Duration.ofMillis(100);
-  private Executor executor;
 
   @Override
   public PrimitiveProtocol.Type getType() {
@@ -218,8 +217,9 @@ public class MultiRaftProtocolConfig extends PrimitiveProtocolConfig<MultiRaftPr
    *
    * @return the executor
    */
+  @Deprecated
   public Executor getExecutor() {
-    return executor;
+    return null;
   }
 
   /**
@@ -228,8 +228,8 @@ public class MultiRaftProtocolConfig extends PrimitiveProtocolConfig<MultiRaftPr
    * @param executor the executor
    * @return the protocol configuration
    */
+  @Deprecated
   public MultiRaftProtocolConfig setExecutor(Executor executor) {
-    this.executor = executor;
-    return this;
+    throw new UnsupportedOperationException();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftMetadataClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftMetadataClient.java
@@ -27,6 +27,7 @@ import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 import io.atomix.protocols.raft.proxy.impl.MemberSelectorManager;
 import io.atomix.protocols.raft.proxy.impl.RaftProxyConnection;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.LoggerContext;
 
@@ -71,7 +72,7 @@ public class DefaultRaftMetadataClient implements RaftMetadataClient {
    * @return A completable future to be completed with cluster metadata.
    */
   private CompletableFuture<MetadataResponse> getMetadata() {
-    CompletableFuture<MetadataResponse> future = new CompletableFuture<>();
+    CompletableFuture<MetadataResponse> future = new AtomixFuture<>();
     connection.metadata(MetadataRequest.builder().build()).whenComplete((response, error) -> {
       if (error == null) {
         if (response.status() == RaftResponse.Status.OK) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -21,6 +21,7 @@ import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.protocols.raft.RaftServer;
 import io.atomix.protocols.raft.cluster.RaftCluster;
 import io.atomix.protocols.raft.storage.RaftStorage;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
@@ -104,7 +105,7 @@ public class DefaultRaftServer implements RaftServer {
     if (openFuture == null) {
       synchronized (this) {
         if (openFuture == null) {
-          CompletableFuture<RaftServer> future = new CompletableFuture<>();
+          CompletableFuture<RaftServer> future = new AtomixFuture<>();
           openFuture = future;
           joiner.get().whenComplete((result, error) -> {
             if (error == null) {
@@ -153,7 +154,7 @@ public class DefaultRaftServer implements RaftServer {
       return Futures.exceptionalFuture(new IllegalStateException("context not open"));
     }
 
-    CompletableFuture<Void> future = new CompletableFuture<>();
+    CompletableFuture<Void> future = new AtomixFuture<>();
     context.getThreadContext().execute(() -> {
       started = false;
       context.transition(Role.INACTIVE);
@@ -179,7 +180,7 @@ public class DefaultRaftServer implements RaftServer {
     if (closeFuture == null) {
       synchronized (this) {
         if (closeFuture == null) {
-          closeFuture = new CompletableFuture<>();
+          closeFuture = new AtomixFuture<>();
           if (openFuture == null) {
             cluster().leave().whenComplete((leaveResult, leaveError) -> {
               shutdown().whenComplete((shutdownResult, shutdownError) -> {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftSessionClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/RaftSessionClient.java
@@ -42,7 +42,6 @@ public interface RaftSessionClient extends SessionClient {
     protected Recovery recoveryStrategy = Recovery.RECOVER;
     protected int maxRetries = 0;
     protected Duration retryDelay = Duration.ofMillis(100);
-    protected Executor executor;
 
     /**
      * Sets the minimum session timeout.
@@ -152,9 +151,9 @@ public interface RaftSessionClient extends SessionClient {
      * @return The proxy builder.
      * @throws NullPointerException if the executor is null
      */
+    @Deprecated
     public Builder withExecutor(Executor executor) {
-      this.executor = executor;
-      return this;
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftSessionClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/DefaultRaftSessionClient.java
@@ -114,6 +114,11 @@ public class DefaultRaftSessionClient implements RaftSessionClient {
   }
 
   @Override
+  public ThreadContext context() {
+    return context;
+  }
+
+  @Override
   public SessionId sessionId() {
     return state != null ? state.getSessionId() : null;
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
@@ -32,6 +32,7 @@ import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.protocol.RaftRequest;
 import io.atomix.protocols.raft.protocol.RaftResponse;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
@@ -118,7 +119,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<OpenSessionResponse> openSession(OpenSessionRequest request) {
-    CompletableFuture<OpenSessionResponse> future = new CompletableFuture<>();
+    CompletableFuture<OpenSessionResponse> future = new AtomixFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::openSession, future);
     } else {
@@ -134,7 +135,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<CloseSessionResponse> closeSession(CloseSessionRequest request) {
-    CompletableFuture<CloseSessionResponse> future = new CompletableFuture<>();
+    CompletableFuture<CloseSessionResponse> future = new AtomixFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::closeSession, future);
     } else {
@@ -150,7 +151,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<KeepAliveResponse> keepAlive(KeepAliveRequest request) {
-    CompletableFuture<KeepAliveResponse> future = new CompletableFuture<>();
+    CompletableFuture<KeepAliveResponse> future = new AtomixFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::keepAlive, future);
     } else {
@@ -166,7 +167,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<QueryResponse> query(QueryRequest request) {
-    CompletableFuture<QueryResponse> future = new CompletableFuture<>();
+    CompletableFuture<QueryResponse> future = new AtomixFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::query, future);
     } else {
@@ -182,7 +183,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<CommandResponse> command(CommandRequest request) {
-    CompletableFuture<CommandResponse> future = new CompletableFuture<>();
+    CompletableFuture<CommandResponse> future = new AtomixFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::command, future);
     } else {
@@ -198,7 +199,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<MetadataResponse> metadata(MetadataRequest request) {
-    CompletableFuture<MetadataResponse> future = new CompletableFuture<>();
+    CompletableFuture<MetadataResponse> future = new AtomixFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::metadata, future);
     } else {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
@@ -27,6 +27,7 @@ import io.atomix.protocols.raft.protocol.OperationResponse;
 import io.atomix.protocols.raft.protocol.QueryRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftResponse;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 
 import java.net.ConnectException;
@@ -88,7 +89,7 @@ final class RaftProxyInvoker {
    * @return A completable future to be completed once the command has been submitted.
    */
   public CompletableFuture<byte[]> invoke(PrimitiveOperation operation) {
-    CompletableFuture<byte[]> future = new CompletableFuture<>();
+    CompletableFuture<byte[]> future = new AtomixFuture<>();
     switch (operation.id().type()) {
       case COMMAND:
         context.execute(() -> invokeCommand(operation, future));

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
@@ -34,6 +34,7 @@ import io.atomix.protocols.raft.protocol.OpenSessionRequest;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
+import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -176,7 +177,7 @@ public class RaftProxyManager {
         .withMaxTimeout(maxTimeout.toMillis())
         .build();
 
-    CompletableFuture<RaftProxyState> future = new CompletableFuture<>();
+    CompletableFuture<RaftProxyState> future = new AtomixFuture<>();
     ThreadContext proxyContext = threadContextFactory.createContext();
     connection.openSession(request).whenCompleteAsync((response, error) -> {
       if (error == null) {
@@ -227,7 +228,7 @@ public class RaftProxyManager {
         .withSession(sessionId.id())
         .build();
 
-    CompletableFuture<Void> future = new CompletableFuture<>();
+    CompletableFuture<Void> future = new AtomixFuture<>();
     connection.closeSession(request).whenComplete((response, error) -> {
       if (error == null) {
         if (response.status() == RaftResponse.Status.OK) {
@@ -285,7 +286,7 @@ public class RaftProxyManager {
       return Futures.exceptionalFuture(new IllegalArgumentException("Unknown session: " + sessionId));
     }
 
-    CompletableFuture<Void> future = new CompletableFuture<>();
+    CompletableFuture<Void> future = new AtomixFuture<>();
 
     KeepAliveRequest request = KeepAliveRequest.builder()
         .withSessionIds(new long[]{sessionId.id()})
@@ -434,7 +435,7 @@ public class RaftProxyManager {
    */
   public CompletableFuture<Void> close() {
     if (open.compareAndSet(true, false)) {
-      CompletableFuture<Void> future = new CompletableFuture<>();
+      CompletableFuture<Void> future = new AtomixFuture<>();
       threadContext.execute(() -> {
         synchronized (this) {
           for (Scheduled keepAliveFuture : keepAliveTimers.values()) {

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvokerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvokerTest.java
@@ -316,6 +316,21 @@ public class RaftProxyInvokerTest {
     public void execute(Runnable command) {
       command.run();
     }
+
+    @Override
+    public boolean isBlocked() {
+      return false;
+    }
+
+    @Override
+    public void block() {
+
+    }
+
+    @Override
+    public void unblock() {
+
+    }
   }
 
 }

--- a/utils/src/main/java/io/atomix/utils/concurrent/AbstractThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/AbstractThreadContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+/**
+ * Abstract thread context.
+ */
+public abstract class AbstractThreadContext implements ThreadContext {
+  private volatile boolean blocked;
+
+  @Override
+  public boolean isBlocked() {
+    return blocked;
+  }
+
+  @Override
+  public void block() {
+    blocked = true;
+  }
+
+  @Override
+  public void unblock() {
+    blocked = false;
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContext.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Blocking aware single thread context.
+ */
+public class BlockingAwareSingleThreadContext extends SingleThreadContext {
+  private final Executor threadPoolExecutor;
+
+  public BlockingAwareSingleThreadContext(String nameFormat, Executor threadPoolExecutor) {
+    this(namedThreads(nameFormat, LOGGER), threadPoolExecutor);
+  }
+
+  public BlockingAwareSingleThreadContext(ThreadFactory factory, Executor threadPoolExecutor) {
+    super(factory);
+    this.threadPoolExecutor = threadPoolExecutor;
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    if (isBlocked()) {
+      threadPoolExecutor.execute(command);
+    } else {
+      super.execute(command);
+    }
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContextFactory.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareSingleThreadContextFactory.java
@@ -17,6 +17,8 @@ package io.atomix.utils.concurrent;
 
 import org.slf4j.Logger;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -25,19 +27,25 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
 /**
  * Single thread context factory.
  */
-public class SingleThreadContextFactory implements ThreadContextFactory {
+public class BlockingAwareSingleThreadContextFactory implements ThreadContextFactory {
   private final ThreadFactory threadFactory;
+  private final Executor threadPoolExecutor;
 
-  public SingleThreadContextFactory(String nameFormat, Logger logger) {
-    this(namedThreads(nameFormat, logger));
+  public BlockingAwareSingleThreadContextFactory(String nameFormat, int threadPoolSize, Logger logger) {
+    this(threadPoolSize, namedThreads(nameFormat, logger));
   }
 
-  public SingleThreadContextFactory(ThreadFactory threadFactory) {
+  public BlockingAwareSingleThreadContextFactory(int threadPoolSize, ThreadFactory threadFactory) {
+    this(threadFactory, Executors.newScheduledThreadPool(threadPoolSize, threadFactory));
+  }
+
+  public BlockingAwareSingleThreadContextFactory(ThreadFactory threadFactory, Executor threadPoolExecutor) {
     this.threadFactory = checkNotNull(threadFactory);
+    this.threadPoolExecutor = checkNotNull(threadPoolExecutor);
   }
 
   @Override
   public ThreadContext createContext() {
-    return new SingleThreadContext(threadFactory);
+    return new BlockingAwareSingleThreadContext(threadFactory, threadPoolExecutor);
   }
 }

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Blocking aware thread pool context.
+ */
+public class BlockingAwareThreadPoolContext extends ThreadPoolContext {
+  public BlockingAwareThreadPoolContext(ScheduledExecutorService parent) {
+    super(parent);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    if (isBlocked()) {
+      parent.execute(command);
+    } else {
+      super.execute(command);
+    }
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContextFactory.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/BlockingAwareThreadPoolContextFactory.java
@@ -26,24 +26,24 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
 /**
  * Thread pool context factory.
  */
-public class ThreadPoolContextFactory implements ThreadContextFactory {
+public class BlockingAwareThreadPoolContextFactory implements ThreadContextFactory {
   private final ScheduledExecutorService executor;
 
-  public ThreadPoolContextFactory(String name, int threadPoolSize, Logger logger) {
+  public BlockingAwareThreadPoolContextFactory(String name, int threadPoolSize, Logger logger) {
     this(threadPoolSize, namedThreads(name, logger));
   }
 
-  public ThreadPoolContextFactory(int threadPoolSize, ThreadFactory threadFactory) {
+  public BlockingAwareThreadPoolContextFactory(int threadPoolSize, ThreadFactory threadFactory) {
     this(Executors.newScheduledThreadPool(threadPoolSize, threadFactory));
   }
 
-  public ThreadPoolContextFactory(ScheduledExecutorService executor) {
+  public BlockingAwareThreadPoolContextFactory(ScheduledExecutorService executor) {
     this.executor = executor;
   }
 
   @Override
   public ThreadContext createContext() {
-    return new ThreadPoolContext(executor);
+    return new BlockingAwareThreadPoolContext(executor);
   }
 
   @Override

--- a/utils/src/main/java/io/atomix/utils/concurrent/Futures.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/Futures.java
@@ -95,13 +95,13 @@ public final class Futures {
   /**
    * Returns a wrapped future that will be completed on the given executor.
    *
-   * @param future the future to be completed on the given executor
+   * @param future   the future to be completed on the given executor
    * @param executor the executor with which to complete the future
-   * @param <T> the future value type
+   * @param <T>      the future value type
    * @return a wrapped future to be completed on the given executor
    */
   public static <T> CompletableFuture<T> asyncFuture(CompletableFuture<T> future, Executor executor) {
-    CompletableFuture<T> newFuture = new CompletableFuture<>();
+    CompletableFuture<T> newFuture = new AtomixFuture<>();
     future.whenComplete((result, error) -> {
       executor.execute(() -> {
         if (error == null) {
@@ -115,100 +115,18 @@ public final class Futures {
   }
 
   /**
-   * Returns a future that's completed using the given {@code orderedExecutor} if the future is not blocked or the
-   * given {@code threadPoolExecutor} if the future is blocked.
-   * <p>
-   * This method allows futures to maintain single-thread semantics via the provided {@code orderedExecutor} while
-   * ensuring user code can block without blocking completion of futures. When the returned future or any of its
-   * descendants is blocked on a {@link CompletableFuture#get()} or {@link CompletableFuture#join()} call, completion
-   * of the returned future will be done using the provided {@code threadPoolExecutor}.
-   *
-   * @param future the future to convert into an asynchronous future
-   * @param orderedExecutor the ordered executor with which to attempt to complete the future
-   * @param threadPoolExecutor the backup executor with which to complete blocked futures
-   * @param <T> future value type
-   * @return a new completable future to be completed using the provided {@code executor} once the provided
-   * {@code future} is complete
-   */
-  public static <T> CompletableFuture<T> orderedFuture(
-      CompletableFuture<T> future,
-      Executor orderedExecutor,
-      Executor threadPoolExecutor) {
-    if (future.isDone()) {
-      return future;
-    }
-
-    BlockingAwareFuture<T> newFuture = new BlockingAwareFuture<>();
-    future.whenComplete((result, error) -> {
-      Runnable completer = () -> {
-        if (future.isCompletedExceptionally()) {
-          newFuture.completeExceptionally(error);
-        } else {
-          newFuture.complete(result);
-        }
-      };
-
-      if (newFuture.isBlocked()) {
-        threadPoolExecutor.execute(completer);
-      } else {
-        orderedExecutor.execute(completer);
-      }
-    });
-    return newFuture;
-  }
-
-  /**
-   * Returns a future that's completed using the given {@code orderedExecutor} if the future is not blocked or the
-   * given {@code threadPoolExecutor} if the future is blocked.
-   * <p>
-   * This method allows futures to maintain single-thread semantics via the provided {@code orderedExecutor} while
-   * ensuring user code can block without blocking completion of futures. When the returned future or any of its
-   * descendants is blocked on a {@link CompletableFuture#get()} or {@link CompletableFuture#join()} call, completion
-   * of the returned future will be done using the provided {@code threadPoolExecutor}.
-   *
-   * @param future             the future to convert into an asynchronous future
-   * @param executor    the executor with which to attempt to complete the future
-   * @param <T>                future value type
-   * @return a new completable future to be completed using the provided {@code executor} once the provided
-   * {@code future} is complete
-   */
-  public static <T> CompletableFuture<T> blockingAwareFuture(CompletableFuture<T> future, Executor executor) {
-    if (future.isDone()) {
-      return future;
-    }
-
-    BlockingAwareFuture<T> newFuture = new BlockingAwareFuture<T>();
-    future.whenComplete((result, error) -> {
-      if (newFuture.isBlocked()) {
-        if (error == null) {
-          newFuture.complete(result);
-        } else {
-          newFuture.completeExceptionally(error);
-        }
-      } else {
-        if (error == null) {
-          executor.execute(() -> newFuture.complete(result));
-        } else {
-          executor.execute(() -> newFuture.completeExceptionally(error));
-        }
-      }
-    });
-    return newFuture;
-  }
-
-  /**
    * Returns a new CompletableFuture completed with a list of computed values
    * when all of the given CompletableFuture complete.
    *
    * @param futures the CompletableFutures
-   * @param <T> value type of CompletableFuture
+   * @param <T>     value type of CompletableFuture
    * @return a new CompletableFuture that is completed when all of the given CompletableFutures complete
    */
   @SuppressWarnings("unchecked")
   public static <T> CompletableFuture<Stream<T>> allOf(Stream<CompletableFuture<T>> futures) {
     CompletableFuture<T>[] futuresArray = futures.toArray(CompletableFuture[]::new);
-    return CompletableFuture.allOf(futuresArray)
-        .thenApply(v -> Stream.of(futuresArray).map(CompletableFuture::join));
+    return AtomixFuture.wrap(CompletableFuture.allOf(futuresArray)
+        .thenApply(v -> Stream.of(futuresArray).map(CompletableFuture::join)));
   }
 
   /**
@@ -216,25 +134,24 @@ public final class Futures {
    * when all of the given CompletableFuture complete.
    *
    * @param futures the CompletableFutures
-   * @param <T> value type of CompletableFuture
+   * @param <T>     value type of CompletableFuture
    * @return a new CompletableFuture that is completed when all of the given CompletableFutures complete
    */
   public static <T> CompletableFuture<List<T>> allOf(List<CompletableFuture<T>> futures) {
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]))
+    return AtomixFuture.wrap(CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]))
         .thenApply(v -> futures.stream()
             .map(CompletableFuture::join)
-            .collect(Collectors.toList())
-        );
+            .collect(Collectors.toList())));
   }
 
   /**
    * Returns a new CompletableFuture completed by reducing a list of computed values
    * when all of the given CompletableFuture complete.
    *
-   * @param futures the CompletableFutures
-   * @param reducer reducer for computing the result
+   * @param futures    the CompletableFutures
+   * @param reducer    reducer for computing the result
    * @param emptyValue zero value to be returned if the input future list is empty
-   * @param <T> value type of CompletableFuture
+   * @param <T>        value type of CompletableFuture
    * @return a new CompletableFuture that is completed when all of the given CompletableFutures complete
    */
   public static <T> CompletableFuture<T> allOf(List<CompletableFuture<T>> futures,
@@ -247,10 +164,10 @@ public final class Futures {
    * Returns a new CompletableFuture completed by with the first positive result from a list of
    * input CompletableFutures.
    *
-   * @param futures the input list of CompletableFutures
+   * @param futures               the input list of CompletableFutures
    * @param positiveResultMatcher matcher to identify a positive result
-   * @param negativeResult value to complete with if none of the futures complete with a positive result
-   * @param <T> value type of CompletableFuture
+   * @param negativeResult        value to complete with if none of the futures complete with a positive result
+   * @param <T>                   value type of CompletableFuture
    * @return a new CompletableFuture
    */
   public static <T> CompletableFuture<T> firstOf(List<CompletableFuture<T>> futures,

--- a/utils/src/main/java/io/atomix/utils/concurrent/NullThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/NullThreadContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.concurrent;
+
+import java.time.Duration;
+
+/**
+ * Null thread context.
+ */
+public class NullThreadContext implements ThreadContext {
+  @Override
+  public Scheduled schedule(Duration delay, Runnable callback) {
+    return null;
+  }
+
+  @Override
+  public Scheduled schedule(Duration initialDelay, Duration interval, Runnable callback) {
+    return null;
+  }
+
+  @Override
+  public boolean isBlocked() {
+    return false;
+  }
+
+  @Override
+  public void block() {
+
+  }
+
+  @Override
+  public void unblock() {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public void execute(Runnable command) {
+
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/concurrent/OrderedFuture.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/OrderedFuture.java
@@ -48,7 +48,7 @@ public class OrderedFuture<T> extends CompletableFuture<T> {
     if (!complete) {
       synchronized (orderedFutures) {
         if (!complete) {
-          CompletableFuture<T> future = new CompletableFuture<>();
+          CompletableFuture<T> future = new AtomixFuture<>();
           orderedFutures.add(future);
           return future;
         }
@@ -57,9 +57,9 @@ public class OrderedFuture<T> extends CompletableFuture<T> {
 
     // Completed
     if (error == null) {
-      return CompletableFuture.completedFuture(result);
+      return AtomixFuture.wrap(CompletableFuture.completedFuture(result));
     } else {
-      return Futures.exceptionalFuture(error);
+      return AtomixFuture.wrap(Futures.exceptionalFuture(error));
     }
   }
 

--- a/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
@@ -41,7 +41,7 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class SingleThreadContext implements ThreadContext {
+public class SingleThreadContext extends AbstractThreadContext {
   protected static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadContext.class);
   private final ScheduledExecutorService executor;
   private final Executor wrappedExecutor = new Executor() {
@@ -80,7 +80,7 @@ public class SingleThreadContext implements ThreadContext {
    *
    * @param executor The executor on which to schedule events. This must be a single thread scheduled executor.
    */
-  private SingleThreadContext(ScheduledExecutorService executor) {
+  protected SingleThreadContext(ScheduledExecutorService executor) {
     this(getThread(executor), executor);
   }
 

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadContext.java
@@ -72,6 +72,23 @@ public interface ThreadContext extends AutoCloseable, Executor, Scheduler {
   }
 
   /**
+   * Returns whether the thread context is currently marked blocked.
+   *
+   * @return whether the thread context is currently marked blocked
+   */
+  boolean isBlocked();
+
+  /**
+   * Marks the thread context as blocked.
+   */
+  void block();
+
+  /**
+   * Marks the thread context as unblocked.
+   */
+  void unblock();
+
+  /**
    * Closes the context.
    */
   @Override

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadModel.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadModel.java
@@ -15,9 +15,6 @@
  */
 package io.atomix.utils.concurrent;
 
-import io.atomix.utils.concurrent.SingleThreadContextFactory;
-import io.atomix.utils.concurrent.ThreadContextFactory;
-import io.atomix.utils.concurrent.ThreadPoolContextFactory;
 import org.slf4j.Logger;
 
 /**
@@ -31,7 +28,7 @@ public enum ThreadModel {
   SHARED_THREAD_POOL {
     @Override
     public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
-      return new ThreadPoolContextFactory(nameFormat, threadPoolSize, logger);
+      return new BlockingAwareThreadPoolContextFactory(nameFormat, threadPoolSize, logger);
     }
   },
 
@@ -41,7 +38,7 @@ public enum ThreadModel {
   THREAD_PER_SERVICE {
     @Override
     public ThreadContextFactory factory(String nameFormat, int threadPoolSize, Logger logger) {
-      return new SingleThreadContextFactory(nameFormat, logger);
+      return new BlockingAwareSingleThreadContextFactory(nameFormat, threadPoolSize, logger);
     }
   };
 

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContext.java
@@ -36,9 +36,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class ThreadPoolContext implements ThreadContext {
+public class ThreadPoolContext extends AbstractThreadContext {
   private static final Logger LOGGER = LoggerFactory.getLogger(ThreadPoolContext.class);
-  private final ScheduledExecutorService parent;
+  protected final ScheduledExecutorService parent;
   private final Runnable runner;
   private final LinkedList<Runnable> tasks = new LinkedList<>();
   private boolean running;


### PR DESCRIPTION
This PR improves blocked thread checking by using the Atomix `ThreadContext` to track when futures are blocking a specific thread. This has significant advantages over the previous method - which relied on a flag set on the future itself - since futures can still be obscured while thread blocking continues to work.