### PR TITLE
Refactor service Session to support a proxy-based client event API

### DIFF
--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectionService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectionService.java
@@ -102,7 +102,7 @@ public class DefaultLeaderElectionService extends AbstractPrimitiveService<Leade
   }
 
   private void notifyLeadershipChange(Leadership<byte[]> oldLeadership, Leadership<byte[]> newLeadership) {
-    listeners.forEach(id -> acceptOn(id, client -> client.onLeadershipChange(oldLeadership, newLeadership)));
+    listeners.forEach(id -> getSession(id).accept(client -> client.onLeadershipChange(oldLeadership, newLeadership)));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
@@ -91,7 +91,7 @@ public class DefaultLeaderElectorService extends AbstractPrimitiveService<Leader
   }
 
   private void notifyLeadershipChange(String topic, Leadership<byte[]> previousLeadership, Leadership<byte[]> newLeadership) {
-    listeners.forEach(id -> acceptOn(id, client -> client.onLeadershipChange(topic, previousLeadership, newLeadership)));
+    listeners.forEach(id -> getSession(id).accept(client -> client.onLeadershipChange(topic, previousLeadership, newLeadership)));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentMapService.java
@@ -778,7 +778,7 @@ public class DefaultConsistentMapService
    * @param events list of map event to publish
    */
   private void publish(List<MapEvent<String, byte[]>> events) {
-    listeners.forEach(listener -> events.forEach(event -> acceptOn(listener, client -> client.change(event))));
+    listeners.forEach(listener -> events.forEach(event -> getSession(listener).accept(client -> client.change(event))));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/DefaultConsistentSetMultimapService.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/DefaultConsistentSetMultimapService.java
@@ -320,7 +320,7 @@ public class DefaultConsistentSetMultimapService extends AbstractPrimitiveServic
    * @param newValue the new value
    */
   private void onChange(String key, byte[] oldValue, byte[] newValue) {
-    listeners.forEach(id -> acceptOn(id, client -> client.onChange(key, oldValue, newValue)));
+    listeners.forEach(id -> getSession(id).accept(client -> client.onChange(key, oldValue, newValue)));
   }
 
   private interface MapEntryValues {

--- a/core/src/main/java/io/atomix/core/queue/impl/DefaultWorkQueueService.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/DefaultWorkQueueService.java
@@ -129,7 +129,7 @@ public class DefaultWorkQueueService extends AbstractPrimitiveService<WorkQueueC
 
     // Send an event to all sessions that have expressed interest in task processing
     // and are not actively processing a task.
-    registeredWorkers.forEach(session -> acceptOn(session, client -> client.taskAvailable()));
+    registeredWorkers.forEach(session -> getSession(session).accept(client -> client.taskAvailable()));
     // FIXME: This generates a lot of event traffic.
   }
 

--- a/core/src/main/java/io/atomix/core/semaphore/impl/DefaultDistributedSemaphoreService.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/DefaultDistributedSemaphoreService.java
@@ -205,11 +205,11 @@ public class DefaultDistributedSemaphoreService extends AbstractPrimitiveService
   }
 
   private void success(SessionId sessionId, long operationId, int acquirePermits, long version) {
-    acceptOn(sessionId, client -> client.succeeded(operationId, version, acquirePermits));
+    getSession(sessionId).accept(client -> client.succeeded(operationId, version, acquirePermits));
   }
 
   private void fail(SessionId sessionId, long operationId) {
-    acceptOn(sessionId, client -> client.failed(operationId));
+    getSession(sessionId).accept(client -> client.failed(operationId));
   }
 
   private void releaseSession(Session session) {

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
@@ -266,7 +266,7 @@ public class DefaultDocumentTreeService extends AbstractPrimitiveService<Documen
     listeners.entrySet()
         .stream()
         .filter(e -> event.path().isDescendentOf(e.getValue().leastCommonAncestorPath()))
-        .forEach(e -> acceptOn(e.getKey(), client -> client.change(event)));
+        .forEach(e -> getSession(e.getKey()).accept(client -> client.change(event)));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueService.java
+++ b/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueService.java
@@ -20,45 +20,50 @@ import io.atomix.core.value.AtomicValueType;
 import io.atomix.primitive.service.AbstractPrimitiveService;
 import io.atomix.primitive.service.BackupInput;
 import io.atomix.primitive.service.BackupOutput;
-import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.utils.serializer.KryoNamespace;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Raft atomic value service.
  */
 public class DefaultAtomicValueService extends AbstractPrimitiveService<AtomicValueClient> implements AtomicValueService {
+  private static final Serializer SERIALIZER = Serializer.using(KryoNamespace.builder()
+      .register((KryoNamespace) AtomicValueType.instance().namespace())
+      .register(SessionId.class)
+      .build());
+
   private byte[] value;
-  private java.util.Set<Session> listeners = Sets.newHashSet();
+  private Set<SessionId> listeners = Sets.newHashSet();
 
   public DefaultAtomicValueService() {
     super(AtomicValueType.instance(), AtomicValueClient.class);
   }
 
   @Override
+  public Serializer serializer() {
+    return SERIALIZER;
+  }
+
+  @Override
   public void backup(BackupOutput writer) {
     writer.writeInt(value.length).writeBytes(value);
-    java.util.Set<Long> sessionIds = new HashSet<>();
-    for (Session session : listeners) {
-      sessionIds.add(session.sessionId().id());
-    }
-    writer.writeObject(sessionIds);
+    writer.writeObject(listeners);
   }
 
   @Override
   public void restore(BackupInput reader) {
     value = reader.readBytes(reader.readInt());
-    listeners = new HashSet<>();
-    for (Long sessionId : reader.<java.util.Set<Long>>readObject()) {
-      listeners.add(getSession(sessionId));
-    }
+    listeners = reader.readObject();
   }
 
   private byte[] updateAndNotify(byte[] value) {
     byte[] oldValue = this.value;
     this.value = value;
-    listeners.forEach(s -> acceptOn(s, client -> client.change(value, oldValue)));
+    listeners.forEach(session -> getSession(session).accept(client -> client.change(value, oldValue)));
     return oldValue;
   }
 
@@ -93,11 +98,11 @@ public class DefaultAtomicValueService extends AbstractPrimitiveService<AtomicVa
 
   @Override
   public void addListener() {
-    listeners.add(getCurrentSession());
+    listeners.add(getCurrentSession().sessionId());
   }
 
   @Override
   public void removeListener() {
-    listeners.remove(getCurrentSession());
+    listeners.remove(getCurrentSession().sessionId());
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/session/Session.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/Session.java
@@ -20,6 +20,8 @@ import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.event.EventType;
 import io.atomix.primitive.event.PrimitiveEvent;
 
+import java.util.function.Consumer;
+
 /**
  * Provides an interface to communicating with a client via session events.
  * <p>
@@ -43,7 +45,7 @@ import io.atomix.primitive.event.PrimitiveEvent;
  * When the message is published, it will be queued to be sent to the other side of the connection. Raft guarantees
  * that the message will eventually be received by the client unless the session itself times out or is closed.
  */
-public interface Session {
+public interface Session<C> {
 
   /**
    * Returns the session identifier.
@@ -57,14 +59,14 @@ public interface Session {
    *
    * @return The session's service name.
    */
-  String serviceName();
+  String primitiveName();
 
   /**
    * Returns the session's service type.
    *
    * @return The session's service type.
    */
-  PrimitiveType serviceType();
+  PrimitiveType primitiveType();
 
   /**
    * Returns the member identifier to which the session belongs.
@@ -104,6 +106,13 @@ public interface Session {
    * @param event the event to publish
    */
   void publish(PrimitiveEvent event);
+
+  /**
+   * Sends an event to the client via the client proxy.
+   *
+   * @param event the client proxy operation
+   */
+  void accept(Consumer<C> event);
 
   /**
    * Session state enums.

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/AbstractSession.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/AbstractSession.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.session.impl;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.event.EventType;
+import io.atomix.primitive.event.PrimitiveEvent;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.utils.serializer.Serializer;
+
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Abstract session.
+ */
+public abstract class AbstractSession implements Session {
+  private final SessionId sessionId;
+  private final String primitiveName;
+  private final PrimitiveType primitiveType;
+  private final MemberId memberId;
+  private final Serializer serializer;
+
+  @SuppressWarnings("unchecked")
+  protected AbstractSession(
+      SessionId sessionId,
+      String primitiveName,
+      PrimitiveType primitiveType,
+      MemberId memberId,
+      Serializer serializer) {
+    this.sessionId = checkNotNull(sessionId);
+    this.primitiveName = checkNotNull(primitiveName);
+    this.primitiveType = checkNotNull(primitiveType);
+    this.memberId = checkNotNull(memberId);
+    this.serializer = checkNotNull(serializer);
+  }
+
+  @Override
+  public SessionId sessionId() {
+    return sessionId;
+  }
+
+  @Override
+  public String primitiveName() {
+    return primitiveName;
+  }
+
+  @Override
+  public PrimitiveType primitiveType() {
+    return primitiveType;
+  }
+
+  @Override
+  public MemberId memberId() {
+    return memberId;
+  }
+
+  /**
+   * Encodes the given object using the configured {@link #serializer}.
+   *
+   * @param object the object to encode
+   * @param <T>    the object type
+   * @return the encoded bytes
+   */
+  protected <T> byte[] encode(T object) {
+    return object != null ? serializer.encode(object) : null;
+  }
+
+  /**
+   * Decodes the given object using the configured {@link #serializer}.
+   *
+   * @param bytes the bytes to decode
+   * @param <T>   the object type
+   * @return the decoded object
+   */
+  protected <T> T decode(byte[] bytes) {
+    return bytes != null ? serializer.decode(bytes) : null;
+  }
+
+  @Override
+  public abstract void publish(PrimitiveEvent event);
+
+  @Override
+  public void publish(EventType eventType, Object event) {
+    publish(PrimitiveEvent.event(eventType, encode(event)));
+  }
+
+  @Override
+  public void accept(Consumer event) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/ClientSession.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/ClientSession.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.session.impl;
+
+import com.google.common.collect.Maps;
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.PrimitiveException;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.event.EventType;
+import io.atomix.primitive.event.Events;
+import io.atomix.primitive.event.PrimitiveEvent;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Client session.
+ */
+public class ClientSession<C> implements Session<C> {
+  private final Session session;
+  private final SessionProxy proxy;
+
+  public ClientSession(Class<C> clientType, Session session) {
+    this.session = checkNotNull(session);
+    this.proxy = new SessionProxy(clientType);
+  }
+
+  @Override
+  public SessionId sessionId() {
+    return session.sessionId();
+  }
+
+  @Override
+  public String primitiveName() {
+    return session.primitiveName();
+  }
+
+  @Override
+  public PrimitiveType primitiveType() {
+    return session.primitiveType();
+  }
+
+  @Override
+  public MemberId memberId() {
+    return session.memberId();
+  }
+
+  @Override
+  public State getState() {
+    return session.getState();
+  }
+
+  @Override
+  public void publish(PrimitiveEvent event) {
+    session.publish(event);
+  }
+
+  @Override
+  public <T> void publish(EventType eventType, T event) {
+    session.publish(eventType, event);
+  }
+
+  @Override
+  public void accept(Consumer<C> event) {
+    proxy.accept(event);
+  }
+
+  /**
+   * Session proxy.
+   */
+  private final class SessionProxy {
+    private final C proxy;
+
+    @SuppressWarnings("unchecked")
+    SessionProxy(Class<C> clientType) {
+      proxy = clientType == null ? null : (C) java.lang.reflect.Proxy.newProxyInstance(
+          getClass().getClassLoader(),
+          new Class[]{clientType},
+          new SessionProxyHandler(clientType));
+    }
+
+    /**
+     * Publishes an event to the session.
+     *
+     * @param event the event to publish
+     */
+    void accept(Consumer<C> event) {
+      event.accept(proxy);
+    }
+  }
+
+  /**
+   * Session proxy invocation handler.
+   */
+  private final class SessionProxyHandler implements InvocationHandler {
+    private final Map<Method, EventType> events;
+
+    private SessionProxyHandler(Class<C> clientType) {
+      this.events = clientType != null ? Events.getMethodMap(clientType) : Maps.newHashMap();
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      EventType eventType = events.get(method);
+      if (eventType == null) {
+        throw new PrimitiveException.ServiceException("Cannot invoke unknown event type: " + method.getName());
+      }
+      session.publish(eventType, args);
+      return null;
+    }
+  }
+}

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -26,6 +26,7 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
+import io.atomix.protocols.backup.partition.PrimaryBackupPartition;
 
 import java.time.Duration;
 import java.util.Collection;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -705,15 +705,15 @@ public class RaftServiceManager implements AutoCloseable {
 
       Set<SessionMetadata> sessions = new HashSet<>();
       for (RaftSession s : raft.getSessions().getSessions()) {
-        if (s.serviceName().equals(session.serviceName())) {
-          sessions.add(new SessionMetadata(s.sessionId().id(), s.serviceName(), s.serviceType().name()));
+        if (s.primitiveName().equals(session.primitiveName())) {
+          sessions.add(new SessionMetadata(s.sessionId().id(), s.primitiveName(), s.primitiveType().name()));
         }
       }
       return new MetadataResult(sessions);
     } else {
       Set<SessionMetadata> sessions = new HashSet<>();
       for (RaftSession session : raft.getSessions().getSessions()) {
-        sessions.add(new SessionMetadata(session.sessionId().id(), session.serviceName(), session.serviceType().name()));
+        sessions.add(new SessionMetadata(session.sessionId().id(), session.primitiveName(), session.primitiveType().name()));
       }
       return new MetadataResult(sessions);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -18,11 +18,11 @@ package io.atomix.protocols.raft.session;
 import com.google.common.collect.Lists;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.event.EventType;
 import io.atomix.primitive.event.PrimitiveEvent;
 import io.atomix.primitive.operation.OperationType;
 import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
+import io.atomix.primitive.session.impl.AbstractSession;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.impl.OperationResult;
 import io.atomix.protocols.raft.impl.PendingCommand;
@@ -52,16 +52,11 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * Raft session.
  */
-public class RaftSession implements Session {
+public class RaftSession extends AbstractSession {
   private final Logger log;
-  private final SessionId sessionId;
-  private final MemberId member;
-  private final String name;
-  private final PrimitiveType primitiveType;
   private final ReadConsistency readConsistency;
   private final long minTimeout;
   private final long maxTimeout;
-  private final Serializer serializer;
   private final RaftServerProtocol protocol;
   private final RaftServiceContext context;
   private final RaftContext server;
@@ -94,10 +89,7 @@ public class RaftSession implements Session {
       RaftServiceContext context,
       RaftContext server,
       ThreadContextFactory threadContextFactory) {
-    this.sessionId = sessionId;
-    this.member = member;
-    this.name = name;
-    this.primitiveType = primitiveType;
+    super(sessionId, name, primitiveType, member, serializer);
     this.readConsistency = readConsistency;
     this.minTimeout = minTimeout;
     this.maxTimeout = maxTimeout;
@@ -106,7 +98,6 @@ public class RaftSession implements Session {
     this.completeIndex = sessionId.id();
     this.lastApplied = sessionId.id();
     this.protocol = server.getProtocol();
-    this.serializer = serializer;
     this.context = context;
     this.server = server;
     this.eventExecutor = threadContextFactory.createContext();
@@ -115,26 +106,6 @@ public class RaftSession implements Session {
         .add("type", context.serviceType())
         .add("name", context.serviceName())
         .build());
-  }
-
-  @Override
-  public SessionId sessionId() {
-    return sessionId;
-  }
-
-  @Override
-  public String serviceName() {
-    return name;
-  }
-
-  @Override
-  public PrimitiveType serviceType() {
-    return primitiveType;
-  }
-
-  @Override
-  public MemberId memberId() {
-    return member;
   }
 
   /**
@@ -461,11 +432,6 @@ public class RaftSession implements Session {
   }
 
   @Override
-  public <T> void publish(EventType eventType, T event) {
-    publish(PrimitiveEvent.event(eventType, serializer.encode(event)));
-  }
-
-  @Override
   public void publish(PrimitiveEvent event) {
     // Store volatile state in a local variable.
     State state = this.state;
@@ -570,7 +536,7 @@ public class RaftSession implements Session {
             .build();
 
         log.trace("Sending {}", request);
-        protocol.publish(member, request);
+        protocol.publish(memberId(), request);
       });
     }
   }
@@ -580,7 +546,7 @@ public class RaftSession implements Session {
    */
   public void open() {
     setState(State.OPEN);
-    protocol.registerResetListener(sessionId, request -> resendEvents(request.index()), server.getServiceManager().executor());
+    protocol.registerResetListener(sessionId(), request -> resendEvents(request.index()), server.getServiceManager().executor());
   }
 
   /**
@@ -588,7 +554,7 @@ public class RaftSession implements Session {
    */
   public void expire() {
     setState(State.EXPIRED);
-    protocol.unregisterResetListener(sessionId);
+    protocol.unregisterResetListener(sessionId());
   }
 
   /**
@@ -596,24 +562,24 @@ public class RaftSession implements Session {
    */
   public void close() {
     setState(State.CLOSED);
-    protocol.unregisterResetListener(sessionId);
+    protocol.unregisterResetListener(sessionId());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), sessionId);
+    return Objects.hash(getClass(), sessionId());
   }
 
   @Override
   public boolean equals(Object object) {
-    return object instanceof Session && ((Session) object).sessionId() == sessionId;
+    return object instanceof Session && ((Session) object).sessionId() == sessionId();
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
         .addValue(context)
-        .add("session", sessionId)
+        .add("session", sessionId())
         .add("timestamp", TimestampPrinter.of(lastUpdated))
         .toString();
   }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1505,14 +1505,14 @@ public class RaftTest extends ConcurrentTestCase {
     @Override
     public void onExpire(Session session) {
       if (expire != null) {
-        acceptOn(expire, client -> client.expire("Hello world!"));
+        getSession(expire).accept(client -> client.expire("Hello world!"));
       }
     }
 
     @Override
     public void onClose(Session session) {
       if (close != null && !session.sessionId().equals(close)) {
-        acceptOn(close, client -> client.close("Hello world!"));
+        getSession(close).accept(client -> client.close("Hello world!"));
       }
     }
 
@@ -1539,10 +1539,10 @@ public class RaftTest extends ConcurrentTestCase {
     @Override
     public long sendEvent(boolean sender) {
       if (sender) {
-        acceptOn(getCurrentSession().sessionId(), service -> service.event(getCurrentIndex()));
+        getCurrentSession().accept(service -> service.event(getCurrentIndex()));
       } else {
-        for (Session session : getSessions()) {
-          acceptOn(session.sessionId(), service -> service.event(getCurrentIndex()));
+        for (Session<TestPrimitiveClient> session : getSessions()) {
+          session.accept(service -> service.event(getCurrentIndex()));
         }
       }
       return getCurrentIndex();


### PR DESCRIPTION
This PR allows primitive services to use `Session` objects for client proxies:

```java
SessionId sessionId = SessionId.from(1);
getSession(sessionId).accept(client -> client.onEvent(someEvent));
```