### PR TITLE
Use ordered futures in SessionClient wrapper connect()/close() methods

### DIFF
--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
@@ -27,7 +27,6 @@ import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.protocols.backup.partition.impl.PrimaryBackupPartitionClient;
 import io.atomix.protocols.backup.partition.impl.PrimaryBackupPartitionServer;
 import io.atomix.protocols.backup.proxy.PrimaryBackupSessionClient;
-import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 
 import java.util.Collection;
@@ -140,7 +139,7 @@ public class PrimaryBackupPartition implements Partition {
       return CompletableFuture.completedFuture(null);
     }
 
-    CompletableFuture<Void> future = new AtomixFuture<>();
+    CompletableFuture<Void> future = new CompletableFuture<>();
     client.stop().whenComplete((clientResult, clientError) -> {
       if (server != null) {
         server.stop().whenComplete((serverResult, serverError) -> {

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupSessionClient.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/proxy/PrimaryBackupSessionClient.java
@@ -41,7 +41,6 @@ import io.atomix.protocols.backup.protocol.ExecuteRequest;
 import io.atomix.protocols.backup.protocol.PrimaryBackupClientProtocol;
 import io.atomix.protocols.backup.protocol.PrimaryBackupResponse.Status;
 import io.atomix.protocols.backup.protocol.PrimitiveDescriptor;
-import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ComposableFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.ContextualLoggerFactory;
@@ -270,7 +269,7 @@ public class PrimaryBackupSessionClient implements SessionClient {
 
   @Override
   public CompletableFuture<SessionClient> connect() {
-    CompletableFuture<SessionClient> future = new AtomixFuture<>();
+    CompletableFuture<SessionClient> future = new CompletableFuture<>();
     threadContext.execute(() -> {
       connect(1, future);
     });
@@ -308,7 +307,7 @@ public class PrimaryBackupSessionClient implements SessionClient {
 
   @Override
   public CompletableFuture<Void> close() {
-    CompletableFuture<Void> future = new AtomixFuture<>();
+    CompletableFuture<Void> future = new CompletableFuture<>();
     PrimaryTerm term = this.term;
     if (term.primary() != null) {
       protocol.close(term.primary().memberId(), new CloseRequest(descriptor, sessionId.id()))

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
@@ -31,7 +31,6 @@ import io.atomix.protocols.raft.proxy.RaftSessionClient;
 import io.atomix.protocols.raft.proxy.impl.DefaultRaftSessionClient;
 import io.atomix.protocols.raft.proxy.impl.MemberSelectorManager;
 import io.atomix.protocols.raft.proxy.impl.RaftProxyManager;
-import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.logging.ContextualLoggerFactory;
@@ -98,7 +97,7 @@ public class DefaultRaftClient implements RaftClient {
 
   @Override
   public synchronized CompletableFuture<RaftClient> connect(Collection<MemberId> cluster) {
-    CompletableFuture<RaftClient> future = new AtomixFuture<>();
+    CompletableFuture<RaftClient> future = new CompletableFuture<>();
 
     // If the provided cluster list is null or empty, use the default list.
     if (cluster == null || cluster.isEmpty()) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftMetadataClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftMetadataClient.java
@@ -27,7 +27,6 @@ import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
 import io.atomix.protocols.raft.proxy.impl.MemberSelectorManager;
 import io.atomix.protocols.raft.proxy.impl.RaftProxyConnection;
-import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.LoggerContext;
 
@@ -72,7 +71,7 @@ public class DefaultRaftMetadataClient implements RaftMetadataClient {
    * @return A completable future to be completed with cluster metadata.
    */
   private CompletableFuture<MetadataResponse> getMetadata() {
-    CompletableFuture<MetadataResponse> future = new AtomixFuture<>();
+    CompletableFuture<MetadataResponse> future = new CompletableFuture<>();
     connection.metadata(MetadataRequest.builder().build()).whenComplete((response, error) -> {
       if (error == null) {
         if (response.status() == RaftResponse.Status.OK) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyConnection.java
@@ -32,7 +32,6 @@ import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.protocol.RaftRequest;
 import io.atomix.protocols.raft.protocol.RaftResponse;
-import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
@@ -119,7 +118,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<OpenSessionResponse> openSession(OpenSessionRequest request) {
-    CompletableFuture<OpenSessionResponse> future = new AtomixFuture<>();
+    CompletableFuture<OpenSessionResponse> future = new CompletableFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::openSession, future);
     } else {
@@ -135,7 +134,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<CloseSessionResponse> closeSession(CloseSessionRequest request) {
-    CompletableFuture<CloseSessionResponse> future = new AtomixFuture<>();
+    CompletableFuture<CloseSessionResponse> future = new CompletableFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::closeSession, future);
     } else {
@@ -151,7 +150,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<KeepAliveResponse> keepAlive(KeepAliveRequest request) {
-    CompletableFuture<KeepAliveResponse> future = new AtomixFuture<>();
+    CompletableFuture<KeepAliveResponse> future = new CompletableFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::keepAlive, future);
     } else {
@@ -167,7 +166,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<QueryResponse> query(QueryRequest request) {
-    CompletableFuture<QueryResponse> future = new AtomixFuture<>();
+    CompletableFuture<QueryResponse> future = new CompletableFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::query, future);
     } else {
@@ -183,7 +182,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<CommandResponse> command(CommandRequest request) {
-    CompletableFuture<CommandResponse> future = new AtomixFuture<>();
+    CompletableFuture<CommandResponse> future = new CompletableFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::command, future);
     } else {
@@ -199,7 +198,7 @@ public class RaftProxyConnection {
    * @return a future to be completed with the response
    */
   public CompletableFuture<MetadataResponse> metadata(MetadataRequest request) {
-    CompletableFuture<MetadataResponse> future = new AtomixFuture<>();
+    CompletableFuture<MetadataResponse> future = new CompletableFuture<>();
     if (context.isCurrentContext()) {
       sendRequest(request, protocol::metadata, future);
     } else {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyInvoker.java
@@ -27,7 +27,6 @@ import io.atomix.protocols.raft.protocol.OperationResponse;
 import io.atomix.protocols.raft.protocol.QueryRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftResponse;
-import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.ThreadContext;
 
 import java.net.ConnectException;
@@ -89,7 +88,7 @@ final class RaftProxyInvoker {
    * @return A completable future to be completed once the command has been submitted.
    */
   public CompletableFuture<byte[]> invoke(PrimitiveOperation operation) {
-    CompletableFuture<byte[]> future = new AtomixFuture<>();
+    CompletableFuture<byte[]> future = new CompletableFuture<>();
     switch (operation.id().type()) {
       case COMMAND:
         context.execute(() -> invokeCommand(operation, future));

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/proxy/impl/RaftProxyManager.java
@@ -34,7 +34,6 @@ import io.atomix.protocols.raft.protocol.OpenSessionRequest;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.protocols.raft.proxy.CommunicationStrategy;
-import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -147,7 +146,7 @@ public class RaftProxyManager {
    * Opens a new session.
    *
    * @param serviceName           The session name.
-   * @param primitiveType           The session type.
+   * @param primitiveType         The session type.
    * @param communicationStrategy The strategy with which to communicate with servers.
    * @param minTimeout            The minimum session timeout.
    * @param maxTimeout            The maximum session timeout.
@@ -177,7 +176,7 @@ public class RaftProxyManager {
         .withMaxTimeout(maxTimeout.toMillis())
         .build();
 
-    CompletableFuture<RaftProxyState> future = new AtomixFuture<>();
+    CompletableFuture<RaftProxyState> future = new CompletableFuture<>();
     ThreadContext proxyContext = threadContextFactory.createContext();
     connection.openSession(request).whenCompleteAsync((response, error) -> {
       if (error == null) {
@@ -228,7 +227,7 @@ public class RaftProxyManager {
         .withSession(sessionId.id())
         .build();
 
-    CompletableFuture<Void> future = new AtomixFuture<>();
+    CompletableFuture<Void> future = new CompletableFuture<>();
     connection.closeSession(request).whenComplete((response, error) -> {
       if (error == null) {
         if (response.status() == RaftResponse.Status.OK) {
@@ -286,7 +285,7 @@ public class RaftProxyManager {
       return Futures.exceptionalFuture(new IllegalArgumentException("Unknown session: " + sessionId));
     }
 
-    CompletableFuture<Void> future = new AtomixFuture<>();
+    CompletableFuture<Void> future = new CompletableFuture<>();
 
     KeepAliveRequest request = KeepAliveRequest.builder()
         .withSessionIds(new long[]{sessionId.id()})
@@ -404,7 +403,7 @@ public class RaftProxyManager {
     }
 
     // Schedule the keep alive for 3/4 the timeout minus the delta from the last keep-alive request.
-    keepAliveTimers.put(timeout, threadContext.schedule(Duration.ofMillis(Math.max(Math.max((long)(timeout * TIMEOUT_FACTOR) - delta, timeout - MIN_TIMEOUT_DELTA - delta), 0)), () -> {
+    keepAliveTimers.put(timeout, threadContext.schedule(Duration.ofMillis(Math.max(Math.max((long) (timeout * TIMEOUT_FACTOR) - delta, timeout - MIN_TIMEOUT_DELTA - delta), 0)), () -> {
       if (open.get()) {
         keepAliveSessions(lastKeepAliveTime, timeout);
       }
@@ -435,7 +434,7 @@ public class RaftProxyManager {
    */
   public CompletableFuture<Void> close() {
     if (open.compareAndSet(true, false)) {
-      CompletableFuture<Void> future = new AtomixFuture<>();
+      CompletableFuture<Void> future = new CompletableFuture<>();
       threadContext.execute(() -> {
         synchronized (this) {
           for (Scheduled keepAliveFuture : keepAliveTimers.values()) {


### PR DESCRIPTION
When primitive clients lazily connect to a partition prior to invoking an operation, stages added to `connect()` futures can be completed in reverse order, thus:

```java
proxy.apply(service -> service.foo());
proxy.apply(service -> service.bar());
```

The `foo()` operation may be submitted prior to the `bar()` operation, but so too may the `bar()` operation be submitted before the `foo()` operation.

This PR resolves this problem by appropriately using `OrderedFuture` in all client proxy `connect()` calls to ensure subsequent asynchronous calls occur in the order in which the initial call was made.