### PR TITLE
Handle exceptions to avoid breaking stop CF chain.

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
@@ -331,12 +331,12 @@ public class DefaultClusterMembershipService
   public CompletableFuture<Void> stop() {
     if (started.compareAndSet(true, false)) {
       heartbeatScheduler.shutdownNow();
-      heartbeatExecutor.shutdownNow();
       LOGGER.info("{} - Member deactivated: {}", localMember.id(), localMember);
       localMember.setState(State.INACTIVE);
       members.clear();
       heartbeatFuture.cancel(true);
       messagingService.unregisterHandler(HEARTBEAT_MESSAGE);
+      heartbeatExecutor.shutdownNow();
       LOGGER.info("Stopped");
     }
     return CompletableFuture.completedFuture(null);

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
@@ -149,9 +149,8 @@ public class CorePrimitiveRegistry implements ManagedPrimitiveRegistry {
 
   @Override
   public CompletableFuture<Void> stop() {
-    if (started.get()) {
-      primitives.close();
-      started.set(false);
+    if (started.compareAndSet(true, false)) {
+      return primitives.close().exceptionally(e -> null);
     }
     return CompletableFuture.completedFuture(null);
   }

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -279,11 +279,15 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
 
   @Override
   public CompletableFuture<Void> stop() {
-    return transactionService.stop()
-        .thenCompose(v -> primitiveRegistry.stop())
-        .whenComplete((r, e) -> {
-          started.set(false);
-          LOGGER.info("Stopped");
-        });
+    return transactionService.stop().exceptionally(throwable -> {
+      LOGGER.error("Failed stopping transaction service", throwable);
+      return null;
+    }).thenCompose(v -> primitiveRegistry.stop()).exceptionally(throwable -> {
+      LOGGER.error("Failed stopping primitive registry", throwable);
+      return null;
+    }).whenComplete((r, e) -> {
+      started.set(false);
+      LOGGER.info("Stopped");
+    });
   }
 }

--- a/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
@@ -122,7 +122,9 @@ public class CoreTransactionService implements ManagedTransactionService {
 
   @Override
   public CompletableFuture<Void> stop() {
-    started.set(false);
+    if (started.compareAndSet(true, false)) {
+      return transactions.close().exceptionally(e -> null);
+    }
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionServer.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/impl/PrimaryBackupPartitionServer.java
@@ -88,7 +88,10 @@ public class PrimaryBackupPartitionServer implements Managed<PrimaryBackupPartit
   public CompletableFuture<Void> stop() {
     PrimaryBackupServer server = this.server;
     if (server != null) {
-      return server.stop().thenRun(() -> started.set(false));
+      return server.stop().exceptionally(throwable -> {
+        log.error("Failed stopping server for {}", partition.id(), throwable);
+        return null;
+      }).thenRun(() -> started.set(false));
     }
     started.set(false);
     return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
@kuujo still seeing some weird behaviour where a node goes down but the other nodes don't know about it, or detect it..

```
4:27:37.126 [atomix-system-13] TRACE i.a.p.backup.roles.PrimaryRole - PrimaryRole{system-partition-1}{role=PRIMARY} - Sending RestoreResponse{status=OK, index=2, timestamp=1528547257121, data=byte[]{length=116, hash=718750111}}
14:27:37.127 [atomix-system-8] TRACE i.a.p.b.s.PrimaryBackupSessionClient - SessionClient{system-partition-1}{type=consistent-map, name=primitives} - Received ExecuteResponse{status=OK, result=byte[]{length=56, hash=642793866}}
14:27:37.128 [atomix-system-8] INFO  i.a.core.impl.CoreTransactionService - Started
14:27:37.128 [atomix-system-8] INFO  i.a.core.impl.CorePrimitivesService - Started
14:27:37.128 [atomix-cluster-0] INFO  io.atomix.cluster.AtomixCluster - Started
14:27:37.129 [atomix-system-13] WARN  i.a.utils.event.ListenerRegistry - Listener io.atomix.protocols.backup.session.PrimaryBackupSessionClient$$Lambda$928/557495955@ab661d5 not registered
14:27:37.130 [atomix-system-13] INFO  i.a.core.impl.CorePrimitivesService - Stopped
14:27:37.130 [atomix-0] INFO  i.a.p.b.p.PrimaryBackupPartitionGroup - Stopped
14:27:37.130 [atomix-0] INFO  i.a.p.b.p.PrimaryBackupPartitionGroup - Stopped
14:27:37.130 [atomix-0] INFO  i.a.p.p.i.DefaultPartitionGroupMembershipService - Stopped
14:27:37.130 [atomix-0] INFO  i.a.p.p.impl.DefaultPartitionService - Stopped
14:27:37.131 [atomix-0] INFO  i.a.c.m.i.DefaultClusterCommunicationService - Stopped
14:27:37.131 [atomix-cluster-0] INFO  i.a.c.m.i.DefaultClusterEventService - Stopped
14:27:37.131 [atomix-cluster-0] INFO  i.a.c.i.DefaultClusterMembershipService - 1 - Member deactivated: StatefulMember{id=1, address=localhost:5001, metadata={}}
14:27:37.131 [atomix-cluster-0] INFO  i.a.c.i.DefaultClusterMembershipService - Stopped
14:27:37.139 [netty-messaging-event-epoll-server-0] INFO  i.a.c.m.impl.NettyMessagingService - Stopped
14:27:37.139 [atomix-cluster-0] INFO  io.atomix.cluster.AtomixCluster - Stopped
14:27:37.210 [atomix-system-5] TRACE i.a.p.backup.roles.PrimaryRole - PrimaryRole{system-partition-1}{role=PRIMARY} - Sending BackupRequest{primary=2, term=6, index=142, primitive=PrimitiveDescriptor{name=atomix-primary-elector, type=PRIMARY_ELECTOR, backups=1, replication=ASYNCHRONOUS}, operations=[ExecuteOperation{index=72, timestamp=1528547257087, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850685}}}, ExecuteOperation{index=73, timestamp=1528547257088, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850759}}}, ExecuteOperation{index=74, timestamp=1528547257088, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850693}}}, ExecuteOperation{index=75, timestamp=1528547257088, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491564}}}, ExecuteOperation{index=76, timestamp=1528547257088, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850767}}}, ExecuteOperation{index=77, timestamp=1528547257088, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850701}}}, ExecuteOperation{index=78, timestamp=1528547257089, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491316}}}, ExecuteOperation{index=79, timestamp=1528547257089, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850709}}}, ExecuteOperation{index=80, timestamp=1528547257089, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850651}}}, ExecuteOperation{index=81, timestamp=1528547257089, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850751}}}, ExecuteOperation{index=82, timestamp=1528547257089, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850683}}}, ExecuteOperation{index=83, timestamp=1528547257089, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850741}}}, ExecuteOperation{index=84, timestamp=1528547257090, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850675}}}, ExecuteOperation{index=85, timestamp=1528547257090, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850733}}}, ExecuteOperation{index=86, timestamp=1528547257090, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850667}}}, ExecuteOperation{index=87, timestamp=1528547257090, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850725}}}, ExecuteOperation{index=88, timestamp=1528547257090, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850659}}}, ExecuteOperation{index=89, timestamp=1528547257090, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850717}}}, ExecuteOperation{index=90, timestamp=1528547257090, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850645}}}, ExecuteOperation{index=91, timestamp=1528547257091, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850711}}}, ExecuteOperation{index=92, timestamp=1528547257091, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850769}}}, ExecuteOperation{index=93, timestamp=1528547257091, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491502}}}, ExecuteOperation{index=94, timestamp=1528547257091, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850703}}}, ExecuteOperation{index=95, timestamp=1528547257091, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850761}}}, ExecuteOperation{index=96, timestamp=1528547257091, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491750}}}, ExecuteOperation{index=97, timestamp=1528547257091, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850695}}}, ExecuteOperation{index=98, timestamp=1528547257100, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850753}}}, ExecuteOperation{index=99, timestamp=1528547257100, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850687}}}, ExecuteOperation{index=100, timestamp=1528547257100, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850677}}}, ExecuteOperation{index=101, timestamp=1528547257100, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850743}}}, ExecuteOperation{index=102, timestamp=1528547257100, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850669}}}, ExecuteOperation{index=103, timestamp=1528547257100, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850735}}}, ExecuteOperation{index=104, timestamp=1528547257100, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850661}}}, ExecuteOperation{index=105, timestamp=1528547257101, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850727}}}, ExecuteOperation{index=106, timestamp=1528547257101, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850653}}}, ExecuteOperation{index=107, timestamp=1528547257101, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850719}}}, ExecuteOperation{index=108, timestamp=1528547257101, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850713}}}, ExecuteOperation{index=109, timestamp=1528547257101, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850647}}}, ExecuteOperation{index=110, timestamp=1528547257101, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850705}}}, ExecuteOperation{index=111, timestamp=1528547257102, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491440}}}, ExecuteOperation{index=112, timestamp=1528547257102, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850697}}}, ExecuteOperation{index=113, timestamp=1528547257102, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850763}}}, ExecuteOperation{index=114, timestamp=1528547257102, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491688}}}, ExecuteOperation{index=115, timestamp=1528547257102, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850689}}}, ExecuteOperation{index=116, timestamp=1528547257102, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850755}}}, ExecuteOperation{index=117, timestamp=1528547257103, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850745}}}, ExecuteOperation{index=118, timestamp=1528547257103, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850679}}}, ExecuteOperation{index=119, timestamp=1528547257103, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850737}}}, ExecuteOperation{index=120, timestamp=1528547257103, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850671}}}, ExecuteOperation{index=121, timestamp=1528547257103, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850729}}}, ExecuteOperation{index=122, timestamp=1528547257103, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850663}}}, ExecuteOperation{index=123, timestamp=1528547257104, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850721}}}, ExecuteOperation{index=124, timestamp=1528547257104, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850655}}}, ExecuteOperation{index=125, timestamp=1528547257104, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850649}}}, ExecuteOperation{index=126, timestamp=1528547257104, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850715}}}, ExecuteOperation{index=127, timestamp=1528547257104, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491378}}}, ExecuteOperation{index=128, timestamp=1528547257104, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850707}}}, ExecuteOperation{index=129, timestamp=1528547257105, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850765}}}, ExecuteOperation{index=130, timestamp=1528547257105, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=29, hash=382491626}}}, ExecuteOperation{index=131, timestamp=1528547257105, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850699}}}, ExecuteOperation{index=132, timestamp=1528547257105, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850757}}}, ExecuteOperation{index=133, timestamp=1528547257105, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850691}}}, ExecuteOperation{index=134, timestamp=1528547257105, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850749}}}, ExecuteOperation{index=135, timestamp=1528547257106, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850681}}}, ExecuteOperation{index=136, timestamp=1528547257106, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850747}}}, ExecuteOperation{index=137, timestamp=1528547257106, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850673}}}, ExecuteOperation{index=138, timestamp=1528547257106, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850739}}}, ExecuteOperation{index=139, timestamp=1528547257106, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850665}}}, ExecuteOperation{index=140, timestamp=1528547257106, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850731}}}, ExecuteOperation{index=141, timestamp=1528547257107, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850657}}}, ExecuteOperation{index=142, timestamp=1528547257107, session=-1895162640358661666, node=3, operation=PrimitiveOperation{id=DefaultOperationId{id=ENTER, type=COMMAND}, value=byte[]{length=28, hash=-541850723}}}]} to 1
14:27:38.010 [atomix-system-7] TRACE i.a.p.backup.roles.PrimaryRole - PrimaryRole{system-partition-1}{role=PRIMARY} - Sending BackupRequest{primary=2, term=6, index=142, primitive=PrimitiveDescriptor{name=atomix-primary-elector, type=PRIMARY_ELECTOR, backups=1, replication=ASYNCHRONOUS}, operations=[HeartbeatOperation{index=143, timestamp=1528547257998}]} to 1
14:27:38.043 [atomix-system-1] TRACE i.a.p.backup.roles.PrimaryRole - PrimaryRole{system-partition-1}{role=PRIMARY} - Sending BackupRequest{primary=2, term=6, index=2, primitive=PrimitiveDescriptor{name=primitives, type=consistent-map, backups=2, replication=SYNCHRONOUS}, operations=[HeartbeatOperation{index=3, timestamp=1528547258043}]} to 1
14:27:38.043 [atomix-system-1] TRACE i.a.p.backup.roles.PrimaryRole - PrimaryRole{system-partition-1}{role=PRIMARY} - Sending BackupRequest{primary=2, term=6, index=2, primitive=PrimitiveDescriptor{name=primitives, type=consistent-map, backups=2, replication=SYNCHRONOUS}, operations=[HeartbeatOperation{index=3, timestamp=1528547258043}]} to 3
14:27:38.044 [atomix-system-4] TRACE i.a.p.backup.roles.BackupRole - BackupRole{system-partition-1}{role=BACKUP} - Received BackupRequest{primary=2, term=6, index=2, primitive=PrimitiveDescriptor{name=primitives, type=consistent-map, backups=2, replication=SYNCHRONOUS}, operations=[HeartbeatOperation{index=3, timestamp=1528547258043}]}
14:27:38.044 [atomix-system-4] TRACE i.a.p.backup.roles.BackupRole - BackupRole{system-partition-1}{role=BACKUP} - Sending BackupResponse{status=OK}
14:27:38.046 [atomix-system-15] TRACE i.a.p.backup.roles.PrimaryRole - PrimaryRole{system-partition-1}{role=PRIMARY} - Replication to 1 failed! {}
java.util.concurrent.CompletionException: io.netty.channel.AbstractChannel$AnnotatedConnectException: syscall:getsockopt(..) failed: Connection refused: localhost/127.0.0.1:5001
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[na:1.8.0_131]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[na:1.8.0_131]
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:593) ~[na:1.8.0_131]
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:577) ~[na:1.8.0_131]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[na:1.8.0_131]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[na:1.8.0_131]
	at io.atomix.cluster.messaging.impl.NettyMessagingService.lambda$null$15(NettyMessagingService.java:503) ~[atomix-cluster-3.0.1-SNAPSHOT.jar:na]
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399) ~[guava-22.0.jar:na]
```