### PR TITLE
Use proxy interface class loaders for proxy loading

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
@@ -54,7 +54,7 @@ public class DefaultProxySession<S> implements ProxySession<S> {
     this.session = session;
     this.serializer = serializer;
     ServiceProxyHandler serviceProxyHandler = new ServiceProxyHandler(serviceType);
-    S serviceProxy = (S) java.lang.reflect.Proxy.newProxyInstance(getClass().getClassLoader(), new Class[]{serviceType}, serviceProxyHandler);
+    S serviceProxy = (S) java.lang.reflect.Proxy.newProxyInstance(serviceType.getClassLoader(), new Class[]{serviceType}, serviceProxyHandler);
     proxy = new ServiceProxy<>(serviceProxy, serviceProxyHandler);
   }
 

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/ClientSession.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/ClientSession.java
@@ -93,7 +93,7 @@ public class ClientSession<C> implements Session<C> {
     @SuppressWarnings("unchecked")
     SessionProxy(Class<C> clientType) {
       proxy = clientType == null ? null : (C) java.lang.reflect.Proxy.newProxyInstance(
-          getClass().getClassLoader(),
+          clientType.getClassLoader(),
           new Class[]{clientType},
           new SessionProxyHandler(clientType));
     }


### PR DESCRIPTION
Need to use the interface class loader for proxy interfaces to ensure the interfaces are loaded by the correct class loader when `Proxy.newProxyInstance` is called.