### PR TITLE
Refactor transaction subsystem to support failover for transactions

### DIFF
--- a/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElection.java
+++ b/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElection.java
@@ -22,6 +22,7 @@ import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEvent;
 import io.atomix.core.election.LeadershipEventListener;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.time.Duration;
 import java.util.Map;
@@ -52,8 +53,13 @@ public class TranscodingAsyncLeaderElection<V1, V2> implements AsyncLeaderElecti
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingElection.primitiveType();
+  public PrimitiveType type() {
+    return backingElection.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingElection.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
@@ -22,6 +22,7 @@ import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEvent;
 import io.atomix.core.election.LeadershipEventListener;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.time.Duration;
 import java.util.Map;
@@ -52,8 +53,13 @@ public class TranscodingAsyncLeaderElector<V1, V2> implements AsyncLeaderElector
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingElector.primitiveType();
+  public PrimitiveType type() {
+    return backingElector.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingElector.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/generator/impl/DelegatingAtomicIdGenerator.java
+++ b/core/src/main/java/io/atomix/core/generator/impl/DelegatingAtomicIdGenerator.java
@@ -19,6 +19,7 @@ import io.atomix.core.counter.AsyncAtomicCounter;
 import io.atomix.core.generator.AsyncAtomicIdGenerator;
 import io.atomix.core.generator.AtomicIdGenerator;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -52,8 +53,13 @@ public class DelegatingAtomicIdGenerator implements AsyncAtomicIdGenerator {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return counter.primitiveType();
+  public PrimitiveType type() {
+    return counter.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return counter.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveManagementService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveManagementService.java
@@ -21,7 +21,9 @@ import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveRegistry;
 import io.atomix.primitive.PrimitiveTypeRegistry;
+import io.atomix.primitive.partition.PartitionGroupTypeRegistry;
 import io.atomix.primitive.partition.PartitionService;
+import io.atomix.primitive.protocol.PrimitiveProtocolTypeRegistry;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -36,6 +38,8 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
   private final PartitionService partitionService;
   private final PrimitiveRegistry primitiveRegistry;
   private final PrimitiveTypeRegistry primitiveTypeRegistry;
+  private final PrimitiveProtocolTypeRegistry protocolTypeRegistry;
+  private final PartitionGroupTypeRegistry partitionGroupTypeRegistry;
 
   public CorePrimitiveManagementService(
       ScheduledExecutorService executorService,
@@ -44,7 +48,9 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
       ClusterEventService eventService,
       PartitionService partitionService,
       PrimitiveRegistry primitiveRegistry,
-      PrimitiveTypeRegistry primitiveTypeRegistry) {
+      PrimitiveTypeRegistry primitiveTypeRegistry,
+      PrimitiveProtocolTypeRegistry protocolTypeRegistry,
+      PartitionGroupTypeRegistry partitionGroupTypeRegistry) {
     this.executorService = executorService;
     this.membershipService = membershipService;
     this.communicationService = communicationService;
@@ -52,6 +58,8 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
     this.partitionService = partitionService;
     this.primitiveRegistry = primitiveRegistry;
     this.primitiveTypeRegistry = primitiveTypeRegistry;
+    this.protocolTypeRegistry = protocolTypeRegistry;
+    this.partitionGroupTypeRegistry = partitionGroupTypeRegistry;
   }
 
   @Override
@@ -87,5 +95,15 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
   @Override
   public PrimitiveTypeRegistry getPrimitiveTypeRegistry() {
     return primitiveTypeRegistry;
+  }
+
+  @Override
+  public PrimitiveProtocolTypeRegistry getProtocolTypeRegistry() {
+    return protocolTypeRegistry;
+  }
+
+  @Override
+  public PartitionGroupTypeRegistry getPartitionGroupTypeRegistry() {
+    return partitionGroupTypeRegistry;
   }
 }

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -23,7 +23,6 @@ import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.core.AtomixRegistry;
 import io.atomix.core.ManagedPrimitivesService;
 import io.atomix.core.PrimitivesService;
-import io.atomix.primitive.config.ConfigService;
 import io.atomix.core.counter.AtomicCounter;
 import io.atomix.core.counter.AtomicCounterType;
 import io.atomix.core.election.LeaderElection;
@@ -60,10 +59,11 @@ import io.atomix.core.value.AtomicValueType;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
 import io.atomix.primitive.ManagedPrimitiveRegistry;
-import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveInfo;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.config.ConfigService;
+import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.utils.AtomixRuntimeException;
 import org.slf4j.Logger;
@@ -109,7 +109,9 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
         eventService,
         partitionService,
         primitiveRegistry,
-        registry.primitiveTypes());
+        registry.primitiveTypes(),
+        registry.protocolTypes(),
+        registry.partitionGroupTypes());
     this.transactionService = new CoreTransactionService(managementService);
     this.configService = checkNotNull(configService);
   }

--- a/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
@@ -15,14 +15,27 @@
  */
 package io.atomix.core.impl;
 
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import io.atomix.cluster.ClusterMembershipEvent;
+import io.atomix.cluster.ClusterMembershipEventListener;
+import io.atomix.cluster.MemberId;
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.ConsistentMapConfig;
 import io.atomix.core.map.ConsistentMapType;
 import io.atomix.core.transaction.ManagedTransactionService;
+import io.atomix.core.transaction.ParticipantInfo;
+import io.atomix.core.transaction.TransactionException;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionService;
 import io.atomix.core.transaction.TransactionState;
+import io.atomix.core.transaction.Transactional;
+import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.partition.PartitionGroup;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 import io.atomix.utils.serializer.Serializer;
@@ -34,6 +47,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -45,15 +61,22 @@ public class CoreTransactionService implements ManagedTransactionService {
   private static final Logger LOGGER = LoggerFactory.getLogger(CoreTransactionService.class);
   private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
       .register(Namespaces.BASIC)
+      .register(MemberId.class)
+      .register(MemberId.Type.class)
       .register(TransactionId.class)
       .register(TransactionState.class)
+      .register(ParticipantInfo.class)
+      .register(TransactionInfo.class)
       .build());
   private final PrimitiveManagementService managementService;
-  private AsyncConsistentMap<TransactionId, TransactionState> transactions;
+  private final MemberId localMemberId;
+  private final ClusterMembershipEventListener clusterEventListener = this::onMembershipChange;
+  private AsyncConsistentMap<TransactionId, TransactionInfo> transactions;
   private final AtomicBoolean started = new AtomicBoolean();
 
   public CoreTransactionService(PrimitiveManagementService managementService) {
     this.managementService = checkNotNull(managementService);
+    this.localMemberId = managementService.getMembershipService().getLocalMember().id();
   }
 
   @Override
@@ -65,32 +88,85 @@ public class CoreTransactionService implements ManagedTransactionService {
   @Override
   public TransactionState getTransactionState(TransactionId transactionId) {
     checkState(isRunning());
-    return Versioned.valueOrNull(transactions.get(transactionId).join());
+    TransactionInfo info = Versioned.valueOrNull(transactions.get(transactionId).join());
+    return info != null ? info.state : null;
   }
 
   @Override
   public CompletableFuture<TransactionId> begin() {
     checkState(isRunning());
     TransactionId transactionId = TransactionId.from(UUID.randomUUID().toString());
-    return transactions.put(transactionId, TransactionState.ACTIVE).thenApply(v -> transactionId);
+    TransactionInfo info = new TransactionInfo(localMemberId, TransactionState.ACTIVE, ImmutableSet.of());
+    return transactions.put(transactionId, info).thenApply(v -> transactionId);
   }
 
   @Override
-  public CompletableFuture<Void> preparing(TransactionId transactionId) {
+  public CompletableFuture<Void> preparing(TransactionId transactionId, Set<ParticipantInfo> participants) {
     checkState(isRunning());
-    return transactions.put(transactionId, TransactionState.PREPARED).thenApply(v -> null);
+    return transactions.compute(transactionId, (id, info) -> {
+      if (info == null) {
+        return null;
+      } else if (info.state == TransactionState.ACTIVE) {
+        return new TransactionInfo(info.coordinator, TransactionState.PREPARING, participants);
+      } else {
+        return info;
+      }
+    }).thenCompose(value -> {
+      if (value == null || value.value() == null) {
+        return Futures.exceptionalFuture(new TransactionException("Unknown transaction " + transactionId));
+      } else if (value.value().state != TransactionState.PREPARING) {
+        return Futures.exceptionalFuture(new TransactionException("Concurrent transaction modification " + transactionId));
+      } else if (!value.value().coordinator.equals(localMemberId)) {
+        return Futures.exceptionalFuture(new TransactionException("Transaction " + transactionId + " recovered by another member"));
+      }
+      return Futures.completedFuture(null);
+    });
   }
 
   @Override
   public CompletableFuture<Void> committing(TransactionId transactionId) {
     checkState(isRunning());
-    return transactions.put(transactionId, TransactionState.COMMITTING).thenApply(v -> null);
+    return transactions.compute(transactionId, (id, info) -> {
+      if (info == null) {
+        return null;
+      } else if (info.state == TransactionState.PREPARING) {
+        return new TransactionInfo(info.coordinator, TransactionState.COMMITTING, info.participants);
+      } else {
+        return info;
+      }
+    }).thenCompose(value -> {
+      if (value == null || value.value() == null) {
+        return Futures.exceptionalFuture(new TransactionException("Unknown transaction " + transactionId));
+      } else if (value.value().state != TransactionState.COMMITTING) {
+        return Futures.exceptionalFuture(new TransactionException("Concurrent transaction modification " + transactionId));
+      } else if (!value.value().coordinator.equals(localMemberId)) {
+        return Futures.exceptionalFuture(new TransactionException("Transaction " + transactionId + " recovered by another member"));
+      }
+      return Futures.completedFuture(null);
+    });
   }
 
   @Override
   public CompletableFuture<Void> aborting(TransactionId transactionId) {
     checkState(isRunning());
-    return transactions.put(transactionId, TransactionState.ROLLING_BACK).thenApply(v -> null);
+    return transactions.compute(transactionId, (id, info) -> {
+      if (info == null) {
+        return null;
+      } else if (info.state == TransactionState.PREPARING) {
+        return new TransactionInfo(info.coordinator, TransactionState.ROLLING_BACK, info.participants);
+      } else {
+        return info;
+      }
+    }).thenCompose(value -> {
+      if (value == null || value.value() == null) {
+        return Futures.exceptionalFuture(new TransactionException("Unknown transaction " + transactionId));
+      } else if (value.value().state != TransactionState.ROLLING_BACK) {
+        return Futures.exceptionalFuture(new TransactionException("Concurrent transaction modification " + transactionId));
+      } else if (!value.value().coordinator.equals(localMemberId)) {
+        return Futures.exceptionalFuture(new TransactionException("Transaction " + transactionId + " recovered by another member"));
+      }
+      return Futures.completedFuture(null);
+    });
   }
 
   @Override
@@ -99,13 +175,190 @@ public class CoreTransactionService implements ManagedTransactionService {
     return transactions.remove(transactionId).thenApply(v -> null);
   }
 
+  /**
+   * Handles a cluster membership change event.
+   */
+  private void onMembershipChange(ClusterMembershipEvent event) {
+    if (event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED) {
+      transactions.entrySet().thenAccept(entries -> entries.stream()
+          .filter(entry -> entry.getValue().value().coordinator.equals(event.subject().id()))
+          .forEach(entry -> {
+            recoverTransaction(entry.getKey(), entry.getValue().value());
+          }));
+    }
+  }
+
+  /**
+   * Recovers and completes the given transaction.
+   *
+   * @param transactionId   the transaction identifier
+   * @param transactionInfo the transaction info
+   */
+  private void recoverTransaction(TransactionId transactionId, TransactionInfo transactionInfo) {
+    switch (transactionInfo.state) {
+      case PREPARING:
+        completePreparingTransaction(transactionId);
+        break;
+      case COMMITTING:
+        completeCommittingTransaction(transactionId);
+        break;
+      case ROLLING_BACK:
+        completeRollingBackTransaction(transactionId);
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Completes a transaction in the {@link TransactionState#PREPARING} state.
+   *
+   * @param transactionId the transaction identifier for the transaction to complete
+   */
+  private void completePreparingTransaction(TransactionId transactionId) {
+    completeTransaction(
+        transactionId,
+        TransactionState.PREPARING,
+        info -> new TransactionInfo(localMemberId, TransactionState.ROLLING_BACK, info.participants),
+        info -> info.state == TransactionState.ROLLING_BACK,
+        (id, transactional) -> transactional.rollback(id))
+        .whenComplete((result, error) -> {
+          if (error != null) {
+            error = Throwables.getRootCause(error);
+            if (error instanceof TransactionException) {
+              LOGGER.warn("Failed to complete transaction", error);
+            } else {
+              LOGGER.warn("Failed to roll back transaction " + transactionId);
+            }
+          }
+        });
+  }
+
+  /**
+   * Completes a transaction in the {@link TransactionState#PREPARING} state.
+   *
+   * @param transactionId the transaction identifier for the transaction to complete
+   */
+  private void completeCommittingTransaction(TransactionId transactionId) {
+    completeTransaction(
+        transactionId,
+        TransactionState.COMMITTING,
+        info -> new TransactionInfo(localMemberId, TransactionState.COMMITTING, info.participants),
+        info -> info.state == TransactionState.COMMITTING && info.coordinator.equals(localMemberId),
+        (id, transactional) -> transactional.commit(id))
+        .whenComplete((result, error) -> {
+          if (error != null) {
+            error = Throwables.getRootCause(error);
+            if (error instanceof TransactionException) {
+              LOGGER.warn("Failed to complete transaction", error);
+            } else {
+              LOGGER.warn("Failed to commit transaction " + transactionId);
+            }
+          }
+        });
+  }
+
+  /**
+   * Completes a transaction in the {@link TransactionState#PREPARING} state.
+   *
+   * @param transactionId the transaction identifier for the transaction to complete
+   */
+  private void completeRollingBackTransaction(TransactionId transactionId) {
+    completeTransaction(
+        transactionId,
+        TransactionState.ROLLING_BACK,
+        info -> new TransactionInfo(localMemberId, TransactionState.ROLLING_BACK, info.participants),
+        info -> info.state == TransactionState.ROLLING_BACK && info.coordinator.equals(localMemberId),
+        (id, transactional) -> transactional.rollback(id))
+        .whenComplete((result, error) -> {
+          if (error != null) {
+            error = Throwables.getRootCause(error);
+            if (error instanceof TransactionException) {
+              LOGGER.warn("Failed to complete transaction", error);
+            } else {
+              LOGGER.warn("Failed to roll back transaction " + transactionId);
+            }
+          }
+        });
+  }
+
+  /**
+   * Completes a transaction by modifying the transaction state to change ownership to this member and then completing
+   * the transaction based on the existing transaction state.
+   */
+  @SuppressWarnings("unchecked")
+  private CompletableFuture<Void> completeTransaction(
+      TransactionId transactionId,
+      TransactionState expectState,
+      Function<TransactionInfo, TransactionInfo> updateFunction,
+      Predicate<TransactionInfo> updatedPredicate,
+      BiFunction<TransactionId, Transactional<?>, CompletableFuture<Void>> completionFunction) {
+    return transactions.compute(transactionId, (id, info) -> {
+      if (info == null) {
+        return null;
+      } else if (info.state == expectState) {
+        return updateFunction.apply(info);
+      } else {
+        return info;
+      }
+    }).thenCompose(value -> {
+      if (value != null && updatedPredicate.test(value.value())) {
+        return Futures.allOf(value.value().participants.stream()
+            .map(participantInfo -> completeParticipant(participantInfo, info -> completionFunction.apply(transactionId, info))))
+            .thenApply(v -> null);
+      }
+      return Futures.exceptionalFuture(new TransactionException("Failed to acquire transaction lock"));
+    });
+  }
+
+  /**
+   * Completes an individual participant in a transaction by loading the primitive by type/protocol/partition group
+   * and applying the given completion function to it.
+   */
+  @SuppressWarnings("unchecked")
+  private CompletableFuture<Void> completeParticipant(
+      ParticipantInfo participantInfo,
+      Function<Transactional<?>, CompletableFuture<Void>> completionFunction) {
+    // Loop up the primitive type for the participant. If the primitive type is not found, return an exception.
+    PrimitiveType primitiveType = managementService.getPrimitiveTypeRegistry().getPrimitiveType(participantInfo.type());
+    if (primitiveType == null) {
+      return Futures.exceptionalFuture(new TransactionException("Failed to locate primitive type " + participantInfo.type() + " for participant " + participantInfo.name()));
+    }
+
+    // Look up the protocol type for the participant.
+    PrimitiveProtocol.Type protocolType = managementService.getProtocolTypeRegistry().getProtocolType(participantInfo.protocol());
+    if (protocolType == null) {
+      return Futures.exceptionalFuture(new TransactionException("Failed to locate protocol type for participant " + participantInfo.name()));
+    }
+
+    // Loop up the partition group in which the primitive is stored.
+    PartitionGroup partitionGroup;
+    if (participantInfo.group() == null) {
+      partitionGroup = managementService.getPartitionService().getPartitionGroup(protocolType);
+    } else {
+      partitionGroup = managementService.getPartitionService().getPartitionGroup(participantInfo.group());
+    }
+
+    // If the partition group is not found, return an exception.
+    if (partitionGroup == null) {
+      return Futures.exceptionalFuture(new TransactionException("Failed to locate partition group for participant " + participantInfo.name()));
+    }
+
+    DistributedPrimitive primitive = primitiveType.newBuilder(participantInfo.name(), primitiveType.newConfig(), managementService)
+        .withProtocol(partitionGroup.newProtocol())
+        .build();
+    return completionFunction.apply((Transactional<?>) primitive);
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<TransactionService> start() {
-    return ConsistentMapType.<TransactionId, TransactionState>instance()
+    managementService.getMembershipService().addListener(clusterEventListener);
+    return ConsistentMapType.<TransactionId, TransactionInfo>instance()
         .newBuilder("atomix-transactions", new ConsistentMapConfig(), managementService)
         .withProtocol(managementService.getPartitionService().getSystemPartitionGroup().newProtocol())
         .withSerializer(SERIALIZER)
+        .withCacheEnabled()
         .buildAsync()
         .thenApply(transactions -> {
           this.transactions = transactions.async();
@@ -123,8 +376,24 @@ public class CoreTransactionService implements ManagedTransactionService {
   @Override
   public CompletableFuture<Void> stop() {
     if (started.compareAndSet(true, false)) {
+      managementService.getMembershipService().removeListener(clusterEventListener);
       return transactions.close().exceptionally(e -> null);
     }
     return CompletableFuture.completedFuture(null);
+  }
+
+  /**
+   * Transaction info.
+   */
+  private static class TransactionInfo {
+    private final MemberId coordinator;
+    private final TransactionState state;
+    private final Set<ParticipantInfo> participants;
+
+    TransactionInfo(MemberId coordinator, TransactionState state, Set<ParticipantInfo> participants) {
+      this.coordinator = coordinator;
+      this.state = state;
+      this.participants = participants;
+    }
   }
 }

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentMapService.java
@@ -64,6 +64,8 @@ public class DefaultConsistentMapService
     super(ConsistentMapType.instance(), ConsistentMapClient.class);
     serializer = Serializer.using(Namespace.builder()
         .register(ConsistentMapType.instance().namespace())
+        .register(SessionId.class)
+        .register(TransactionId.class)
         .register(TransactionScope.class)
         .register(MapEntryValue.class)
         .register(MapEntryValue.Type.class)

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentTreeMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentTreeMap.java
@@ -22,6 +22,7 @@ import io.atomix.core.map.MapEventListener;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.DelegatingAsyncPrimitive;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
@@ -51,6 +52,11 @@ public class DelegatingAsyncConsistentTreeMap<V>
     super(delegateMap);
     this.delegateMap = checkNotNull(delegateMap,
         "delegate map cannot be null");
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return delegateMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncAtomicCounterMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncAtomicCounterMap.java
@@ -18,6 +18,7 @@ package io.atomix.core.map.impl;
 import io.atomix.core.map.AsyncAtomicCounterMap;
 import io.atomix.core.map.AtomicCounterMap;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.concurrent.Futures;
 
 import java.time.Duration;
@@ -45,8 +46,13 @@ public class TranscodingAsyncAtomicCounterMap<K1, K2> implements AsyncAtomicCoun
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingMap.primitiveType();
+  public PrimitiveType type() {
+    return backingMap.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentMap.java
@@ -26,6 +26,7 @@ import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.time.Versioned;
 
@@ -82,8 +83,13 @@ public class TranscodingAsyncConsistentMap<K1, V1, K2, V2> implements AsyncConsi
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingMap.primitiveType();
+  public PrimitiveType type() {
+    return backingMap.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentTreeMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/TranscodingAsyncConsistentTreeMap.java
@@ -24,6 +24,7 @@ import io.atomix.core.map.MapEventListener;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.time.Versioned;
 
@@ -66,8 +67,13 @@ public class TranscodingAsyncConsistentTreeMap<V1, V2> implements AsyncConsisten
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingMap.primitiveType();
+  public PrimitiveType type() {
+    return backingMap.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/TranscodingAsyncConsistentMultimap.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/TranscodingAsyncConsistentMultimap.java
@@ -25,6 +25,7 @@ import io.atomix.core.multimap.MultimapEvent;
 import io.atomix.core.multimap.MultimapEventListener;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.time.Versioned;
 
@@ -95,8 +96,13 @@ public class TranscodingAsyncConsistentMultimap<K1, V1, K2, V2> implements Async
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingMap.primitiveType();
+  public PrimitiveType type() {
+    return backingMap.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/queue/impl/TranscodingAsyncWorkQueue.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/TranscodingAsyncWorkQueue.java
@@ -20,6 +20,7 @@ import io.atomix.core.queue.Task;
 import io.atomix.core.queue.WorkQueue;
 import io.atomix.core.queue.WorkQueueStats;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -52,8 +53,13 @@ public class TranscodingAsyncWorkQueue<V1, V2> implements AsyncWorkQueue<V1> {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingQueue.primitiveType();
+  public PrimitiveType type() {
+    return backingQueue.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingQueue.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/ParticipantInfo.java
+++ b/core/src/main/java/io/atomix/core/transaction/ParticipantInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.transaction;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Transaction participant info.
+ */
+public final class ParticipantInfo {
+  private final String name;
+  private final String type;
+  private final String protocol;
+  private final String group;
+
+  public ParticipantInfo(String name, String type, String protocol, String group) {
+    this.name = checkNotNull(name);
+    this.type = checkNotNull(type);
+    this.protocol = checkNotNull(protocol);
+    this.group = group;
+  }
+
+  /**
+   * Returns the participant name.
+   *
+   * @return the participant name
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Returns the participant type.
+   *
+   * @return the participant type
+   */
+  public String type() {
+    return type;
+  }
+
+  /**
+   * Returns the protocol type used by the participant.
+   *
+   * @return the protocol type used by the participant
+   */
+  public String protocol() {
+    return protocol;
+  }
+
+  /**
+   * Returns the partition group in which the participant is stored.
+   *
+   * @return the partition group in which the participant is stored
+   */
+  public String group() {
+    return group;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object instanceof ParticipantInfo) {
+      ParticipantInfo info = (ParticipantInfo) object;
+      return name.equals(info.name)
+          && type.equals(info.type)
+          && protocol.equals(info.protocol)
+          && Objects.equals(group, info.group);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name(), type(), protocol(), group());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("name", name())
+        .add("type", type())
+        .add("protocol", protocol())
+        .add("group", group())
+        .toString();
+  }
+}

--- a/core/src/main/java/io/atomix/core/transaction/TransactionException.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.transaction;
+
+import io.atomix.primitive.PrimitiveException;
+
+/**
+ * Transaction exception.
+ */
+public class TransactionException extends PrimitiveException {
+  public TransactionException() {
+  }
+
+  public TransactionException(String message) {
+    super(message);
+  }
+
+  public TransactionException(Throwable t) {
+    super(t);
+  }
+}

--- a/core/src/main/java/io/atomix/core/transaction/TransactionParticipant.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionParticipant.java
@@ -15,12 +15,14 @@
  */
 package io.atomix.core.transaction;
 
+import io.atomix.primitive.DistributedPrimitive;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
  * Transaction participant.
  */
-public interface TransactionParticipant<T> {
+public interface TransactionParticipant<T> extends DistributedPrimitive {
 
   /**
    * Returns the participant's transaction log.
@@ -49,5 +51,12 @@ public interface TransactionParticipant<T> {
    * @return a future to be completed once the participant has been rolled back
    */
   CompletableFuture<Void> rollback();
+
+  /**
+   * Closes the participant.
+   *
+   * @return a future to be completed once the participant has been closed
+   */
+  CompletableFuture<Void> close();
 
 }

--- a/core/src/main/java/io/atomix/core/transaction/TransactionService.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionService.java
@@ -49,9 +49,10 @@ public interface TransactionService {
    * Marks the given transaction as preparing.
    *
    * @param transactionId the transaction to mark as preparing
+   * @param participants the set of participants in the transaction
    * @return a future to be completed once the transaction state has been updated
    */
-  CompletableFuture<Void> preparing(TransactionId transactionId);
+  CompletableFuture<Void> preparing(TransactionId transactionId, Set<ParticipantInfo> participants);
 
   /**
    * Marks the given transaction as committing.

--- a/core/src/main/java/io/atomix/core/transaction/impl/BlockingTransaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/BlockingTransaction.java
@@ -24,6 +24,7 @@ import io.atomix.core.transaction.TransactionalMapBuilder;
 import io.atomix.core.transaction.TransactionalSetBuilder;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -50,8 +51,13 @@ public class BlockingTransaction implements Transaction {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return asyncTransaction.primitiveType();
+  public PrimitiveType type() {
+    return asyncTransaction.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return asyncTransaction.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/BlockingTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/BlockingTransactionalMap.java
@@ -20,6 +20,7 @@ import io.atomix.core.transaction.AsyncTransactionalMap;
 import io.atomix.core.transaction.TransactionalMap;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -44,8 +45,13 @@ public class BlockingTransactionalMap<K, V> implements TransactionalMap<K, V> {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return asyncMap.primitiveType();
+  public PrimitiveType type() {
+    return asyncMap.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return asyncMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/BlockingTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/BlockingTransactionalSet.java
@@ -20,6 +20,7 @@ import io.atomix.core.transaction.AsyncTransactionalSet;
 import io.atomix.core.transaction.TransactionalSet;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -44,8 +45,13 @@ public class BlockingTransactionalSet<E> implements TransactionalSet<E> {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return asyncSet.primitiveType();
+  public PrimitiveType type() {
+    return asyncSet.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return asyncSet.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
@@ -23,6 +23,7 @@ import io.atomix.core.transaction.TransactionalMapBuilder;
 import io.atomix.core.transaction.TransactionalMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -37,6 +38,12 @@ public class DefaultTransactionalMapBuilder<K, V> extends TransactionalMapBuilde
     super(name, config, managementService);
     this.mapBuilder = ConsistentMapType.<K, V>instance().newBuilder(name, new ConsistentMapConfig(), managementService);
     this.transaction = transaction;
+  }
+
+  @Override
+  public TransactionalMapBuilder<K, V> withSerializer(Serializer serializer) {
+    mapBuilder.withSerializer(serializer);
+    return this;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSet.java
@@ -20,6 +20,7 @@ import io.atomix.core.transaction.AsyncTransactionalMap;
 import io.atomix.core.transaction.AsyncTransactionalSet;
 import io.atomix.core.transaction.TransactionalSet;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -40,8 +41,13 @@ public class DefaultTransactionalSet<E> implements AsyncTransactionalSet<E> {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
+  public PrimitiveType type() {
     return DistributedSetType.instance();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return transactionalMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
@@ -15,11 +15,15 @@
  */
 package io.atomix.core.transaction.impl;
 
-import io.atomix.core.transaction.TransactionalMapConfig;
+import io.atomix.core.map.ConsistentMapBuilder;
+import io.atomix.core.map.ConsistentMapConfig;
+import io.atomix.core.map.ConsistentMapType;
 import io.atomix.core.transaction.TransactionalSet;
 import io.atomix.core.transaction.TransactionalSetBuilder;
 import io.atomix.core.transaction.TransactionalSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -28,16 +32,43 @@ import java.util.concurrent.CompletableFuture;
  */
 public class DefaultTransactionalSetBuilder<E> extends TransactionalSetBuilder<E> {
   private final DefaultTransaction transaction;
+  private final ConsistentMapBuilder<E, Boolean> mapBuilder;
 
   public DefaultTransactionalSetBuilder(String name, TransactionalSetConfig config, PrimitiveManagementService managementService, DefaultTransaction transaction) {
     super(name, config, managementService);
     this.transaction = transaction;
+    this.mapBuilder = ConsistentMapType.<E, Boolean>instance().newBuilder(name, new ConsistentMapConfig(), managementService);
+  }
+
+  @Override
+  public TransactionalSetBuilder<E> withSerializer(Serializer serializer) {
+    mapBuilder.withSerializer(serializer);
+    return this;
+  }
+
+  @Override
+  public TransactionalSetBuilder<E> withProtocol(PrimitiveProtocol protocol) {
+    mapBuilder.withProtocol(protocol);
+    return this;
   }
 
   @Override
   public CompletableFuture<TransactionalSet<E>> buildAsync() {
-    return new DefaultTransactionalMapBuilder<E, Boolean>(name(), new TransactionalMapConfig(), managementService, transaction)
-        .buildAsync()
-        .thenApply(map -> new DefaultTransactionalSet<>(map.async()).sync());
+    return mapBuilder.buildAsync()
+        .thenApply(map -> {
+          TransactionalMapParticipant<E, Boolean> transactionalMap;
+          switch (transaction.isolation()) {
+            case READ_COMMITTED:
+              transactionalMap = new ReadCommittedTransactionalMap<>(transaction.transactionId(), map.async());
+              break;
+            case REPEATABLE_READS:
+              transactionalMap = new RepeatableReadsTransactionalMap<>(transaction.transactionId(), map.async());
+              break;
+            default:
+              throw new AssertionError();
+          }
+          transaction.addParticipants(transactionalMap);
+          return transactionalMap;
+        }).thenApply(map -> new DefaultTransactionalSet<>(map).sync());
   }
 }

--- a/core/src/main/java/io/atomix/core/transaction/impl/ReadCommittedTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/ReadCommittedTransactionalMap.java
@@ -23,6 +23,7 @@ import io.atomix.core.map.impl.MapUpdate;
 import io.atomix.core.map.impl.MapUpdate.Type;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.util.Map;
@@ -37,6 +38,11 @@ public class ReadCommittedTransactionalMap<K, V> extends TransactionalMapPartici
 
   public ReadCommittedTransactionalMap(TransactionId transactionId, AsyncConsistentMap<K, V> consistentMap) {
     super(transactionId, consistentMap);
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return consistentMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/RepeatableReadsTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/RepeatableReadsTransactionalMap.java
@@ -23,6 +23,7 @@ import io.atomix.core.map.impl.MapUpdate;
 import io.atomix.core.map.impl.MapUpdate.Type;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.util.Map;
@@ -38,6 +39,11 @@ public class RepeatableReadsTransactionalMap<K, V> extends TransactionalMapParti
 
   public RepeatableReadsTransactionalMap(TransactionId transactionId, AsyncConsistentMap<K, V> consistentMap) {
     super(transactionId, consistentMap);
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return consistentMap.protocol();
   }
 
   private CompletableFuture<Versioned<V>> read(K key) {

--- a/core/src/main/java/io/atomix/core/transaction/impl/TransactionalMapParticipant.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/TransactionalMapParticipant.java
@@ -47,8 +47,8 @@ public abstract class TransactionalMapParticipant<K, V> implements AsyncTransact
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return consistentMap.primitiveType();
+  public PrimitiveType type() {
+    return consistentMap.type();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTree.java
@@ -28,6 +28,7 @@ import io.atomix.core.tree.IllegalDocumentModificationException;
 import io.atomix.core.tree.NoSuchDocumentPathException;
 import io.atomix.primitive.Ordering;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.util.Iterator;
@@ -68,7 +69,12 @@ public class DefaultDocumentTree<V> implements DocumentTree<V> {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
+  public PrimitiveType type() {
+    return null;
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
     return null;
   }
 

--- a/core/src/main/java/io/atomix/core/tree/impl/TranscodingAsyncDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/TranscodingAsyncDocumentTree.java
@@ -22,6 +22,7 @@ import io.atomix.core.tree.DocumentTree;
 import io.atomix.core.tree.DocumentTreeEvent;
 import io.atomix.core.tree.DocumentTreeListener;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
@@ -53,8 +54,13 @@ public class TranscodingAsyncDocumentTree<V1, V2> implements AsyncDocumentTree<V
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingTree.primitiveType();
+  public PrimitiveType type() {
+    return backingTree.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingTree.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/value/impl/TranscodingAsyncAtomicValue.java
+++ b/core/src/main/java/io/atomix/core/value/impl/TranscodingAsyncAtomicValue.java
@@ -21,6 +21,7 @@ import io.atomix.core.value.AtomicValue;
 import io.atomix.core.value.AtomicValueEvent;
 import io.atomix.core.value.AtomicValueEventListener;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.time.Duration;
 import java.util.Map;
@@ -51,8 +52,13 @@ public class TranscodingAsyncAtomicValue<V1, V2> implements AsyncAtomicValue<V1>
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return backingValue.primitiveType();
+  public PrimitiveType type() {
+    return backingValue.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingValue.protocol();
   }
 
   @Override

--- a/core/src/test/java/io/atomix/core/transaction/impl/PrimaryBackupTransactionalMapTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/impl/PrimaryBackupTransactionalMapTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.transaction.impl;
+
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup transactional map test.
+ */
+public class PrimaryBackupTransactionalMapTest extends TransactionalMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/transaction/impl/RaftTransactionalMapTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/impl/RaftTransactionalMapTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.transaction.impl;
+
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.protocols.raft.MultiRaftProtocol;
+
+/**
+ * Raft transactional map test.
+ */
+public class RaftTransactionalMapTest extends TransactionalMapTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiRaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/transaction/impl/TransactionalMapTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/impl/TransactionalMapTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.transaction.impl;
+
+import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.core.transaction.CommitStatus;
+import io.atomix.core.transaction.Isolation;
+import io.atomix.core.transaction.Transaction;
+import io.atomix.core.transaction.TransactionalMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Transactional map test.
+ */
+public abstract class TransactionalMapTest extends AbstractPrimitiveTest {
+  @Test
+  public void testTransactionalMap() throws Throwable {
+    Transaction transaction1 = atomix().transactionBuilder()
+        .withIsolation(Isolation.REPEATABLE_READS)
+        .build();
+    transaction1.begin();
+
+    TransactionalMap<String, String> map1 = transaction1.<String, String>mapBuilder("test-map")
+        .withProtocol(protocol())
+        .build();
+
+    Transaction transaction2 = atomix().transactionBuilder()
+        .withIsolation(Isolation.REPEATABLE_READS)
+        .build();
+    transaction2.begin();
+
+    TransactionalMap<String, String> map2 = transaction1.<String, String>mapBuilder("test-map")
+        .withProtocol(protocol())
+        .build();
+
+    try {
+      assertNull(map1.get("foo"));
+      map1.put("foo", "bar");
+      assertEquals("bar", map1.get("foo"));
+    } finally {
+      assertEquals(CommitStatus.SUCCESS, transaction1.commit());
+    }
+
+    try {
+      assertEquals("bar", map2.get("foo"));
+    } finally {
+      assertEquals(CommitStatus.SUCCESS, transaction2.commit());
+    }
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/AbstractAsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/AbstractAsyncPrimitive.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.primitive;
 
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 
 import java.util.concurrent.CompletableFuture;
@@ -42,8 +43,13 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive, S> implem
   }
 
   @Override
-  public PrimitiveType primitiveType() {
+  public PrimitiveType type() {
     return client.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return client.protocol();
   }
 
   /**
@@ -72,7 +78,7 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive, S> implem
    */
   @SuppressWarnings("unchecked")
   public CompletableFuture<A> connect() {
-    return registry.createPrimitive(name(), primitiveType())
+    return registry.createPrimitive(name(), type())
         .thenApply(v -> (A) this);
   }
 

--- a/primitive/src/main/java/io/atomix/primitive/DelegatingAsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/DelegatingAsyncPrimitive.java
@@ -16,6 +16,7 @@
 package io.atomix.primitive;
 
 import com.google.common.base.MoreObjects;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -39,8 +40,13 @@ public abstract class DelegatingAsyncPrimitive implements AsyncPrimitive {
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return primitive.primitiveType();
+  public PrimitiveType type() {
+    return primitive.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return primitive.protocol();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/DistributedPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/DistributedPrimitive.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.primitive;
 
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+
 import java.util.function.Consumer;
 
 /**
@@ -39,7 +41,14 @@ public interface DistributedPrimitive {
    *
    * @return primitive type
    */
-  PrimitiveType primitiveType();
+  PrimitiveType type();
+
+  /**
+   * Returns the primitive protocol.
+   *
+   * @return the primitive protocol
+   */
+  PrimitiveProtocol protocol();
 
   /**
    * Registers a listener to be called when the primitive's state changes.

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveManagementService.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveManagementService.java
@@ -18,7 +18,9 @@ package io.atomix.primitive;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.cluster.messaging.ClusterEventService;
+import io.atomix.primitive.partition.PartitionGroupTypeRegistry;
 import io.atomix.primitive.partition.PartitionService;
+import io.atomix.primitive.protocol.PrimitiveProtocolTypeRegistry;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -75,5 +77,19 @@ public interface PrimitiveManagementService {
    * @return the primitive type registry
    */
   PrimitiveTypeRegistry getPrimitiveTypeRegistry();
+
+  /**
+   * Returns the primitive protocol type registry.
+   *
+   * @return the primitive protocol type registry
+   */
+  PrimitiveProtocolTypeRegistry getProtocolTypeRegistry();
+
+  /**
+   * Returns the partition group type registry.
+   *
+   * @return the partition group type registry
+   */
+  PartitionGroupTypeRegistry getPartitionGroupTypeRegistry();
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/Synchronous.java
+++ b/primitive/src/main/java/io/atomix/primitive/Synchronous.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.primitive;
 
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.AtomixRuntimeException;
 
 import java.util.concurrent.ExecutionException;
@@ -41,8 +42,13 @@ public abstract class Synchronous<T extends AsyncPrimitive> implements SyncPrimi
   }
 
   @Override
-  public PrimitiveType primitiveType() {
-    return primitive.primitiveType();
+  public PrimitiveType type() {
+    return primitive.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return primitive.protocol();
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/TransactionalPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/TransactionalPrimitive.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive;
+
+/**
+ * Transactional primitive.
+ */
+public interface TransactionalPrimitive extends DistributedPrimitive {
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
@@ -29,7 +29,7 @@ public interface PrimitiveProtocol {
   /**
    * Distributed primitive protocol type.
    */
-  interface Type<C extends PrimitiveProtocolConfig<C>> extends NamedType {
+  interface Type<C extends PrimitiveProtocolConfig<C>> extends NamedType, Comparable<Type<C>> {
 
     /**
      * Returns a new protocol configuration.
@@ -45,6 +45,11 @@ public interface PrimitiveProtocol {
      * @return the protocol instance
      */
     PrimitiveProtocol newProtocol(C config);
+
+    @Override
+    default int compareTo(Type<C> o) {
+      return name().compareTo(o.name());
+    }
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/proxy/ProxyClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/ProxyClient.java
@@ -19,6 +19,7 @@ import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.concurrent.Futures;
 
 import java.util.Collection;
@@ -45,6 +46,13 @@ public interface ProxyClient<S> {
    * @return The client proxy type.
    */
   PrimitiveType type();
+
+  /**
+   * Returns the client proxy protocol.
+   *
+   * @return the client proxy protocol
+   */
+  PrimitiveProtocol protocol();
 
   /**
    * Returns the session state.

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxyClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxyClient.java
@@ -19,11 +19,12 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.session.SessionClient;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.Partitioner;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.ProxySession;
+import io.atomix.primitive.session.SessionClient;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.serializer.Serializer;
 
@@ -45,6 +46,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class DefaultProxyClient<S> implements ProxyClient<S> {
   private final String name;
   private final PrimitiveType type;
+  private final PrimitiveProtocol protocol;
   private final Serializer serializer;
   private final List<PartitionId> partitionIds = new CopyOnWriteArrayList<>();
   private final Map<PartitionId, ProxySession<S>> partitions = Maps.newConcurrentMap();
@@ -56,11 +58,13 @@ public class DefaultProxyClient<S> implements ProxyClient<S> {
   public DefaultProxyClient(
       String name,
       PrimitiveType type,
+      PrimitiveProtocol protocol,
       Class<S> serviceType,
       Collection<SessionClient> partitions,
       Partitioner<String> partitioner) {
     this.name = checkNotNull(name, "name cannot be null");
     this.type = checkNotNull(type, "type cannot be null");
+    this.protocol = checkNotNull(protocol, "protocol cannot be null");
     this.serializer = Serializer.using(type.namespace());
     this.partitioner = checkNotNull(partitioner, "partitioner cannot be null");
     partitions.forEach(partition -> {
@@ -80,6 +84,11 @@ public class DefaultProxyClient<S> implements ProxyClient<S> {
   @Override
   public PrimitiveType type() {
     return type;
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return protocol;
   }
 
   @Override

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -113,7 +113,7 @@ public class MultiPrimaryProtocol implements PrimitiveProtocol {
             .withRetryDelay(config.getRetryDelay())
             .build())
         .collect(Collectors.toList());
-    return new DefaultProxyClient<>(primitiveName, primitiveType, serviceType, partitions, config.getPartitioner());
+    return new DefaultProxyClient<>(primitiveName, primitiveType, this, serviceType, partitions, config.getPartitioner());
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
@@ -113,7 +113,7 @@ public class MultiRaftProtocol implements PrimitiveProtocol {
             .withRetryDelay(config.getRetryDelay())
             .build())
         .collect(Collectors.toList());
-    return new DefaultProxyClient<>(primitiveName, primitiveType, serviceType, partitions, config.getPartitioner());
+    return new DefaultProxyClient<>(primitiveName, primitiveType, this, serviceType, partitions, config.getPartitioner());
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -21,14 +21,13 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.AbstractAsyncPrimitive;
 import io.atomix.primitive.AsyncPrimitive;
 import io.atomix.primitive.DistributedPrimitiveBuilder;
-import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveInfo;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveRegistry;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.SyncPrimitive;
-import io.atomix.primitive.session.SessionClient;
+import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.event.Event;
 import io.atomix.primitive.operation.Command;
 import io.atomix.primitive.operation.OperationType;
@@ -36,6 +35,7 @@ import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.operation.Query;
 import io.atomix.primitive.operation.impl.DefaultOperationId;
 import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.AbstractPrimitiveService;
@@ -44,6 +44,7 @@ import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionClient;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.primitive.session.SessionMetadata;
 import io.atomix.protocols.raft.cluster.RaftClusterEvent;
@@ -1285,6 +1286,7 @@ public class RaftTest extends ConcurrentTestCase {
     ProxyClient<TestPrimitiveService> proxy = new DefaultProxyClient<>(
         "test",
         TestPrimitiveType.INSTANCE,
+        MultiRaftProtocol.builder().build(),
         TestPrimitiveService.class,
         Collections.singletonList(partition),
         (key, partitions) -> partitions.get(0));
@@ -1425,6 +1427,11 @@ public class RaftTest extends ConcurrentTestCase {
 
     public TestPrimitiveImpl(ProxyClient<TestPrimitiveService> proxy, PrimitiveRegistry registry) {
       super(proxy, registry);
+    }
+
+    @Override
+    public PrimitiveProtocol protocol() {
+      throw new UnsupportedOperationException();
     }
 
     @Override

--- a/rest/src/main/java/io/atomix/rest/resources/PrimitivesResource.java
+++ b/rest/src/main/java/io/atomix/rest/resources/PrimitivesResource.java
@@ -41,7 +41,7 @@ public class PrimitivesResource extends AbstractRestResource {
   @SuppressWarnings("unchecked")
   public PrimitiveResource getPrimitive(@PathParam("name") String name, @Context PrimitivesService primitives) {
     DistributedPrimitive primitive = primitives.getPrimitive(name);
-    return primitive.primitiveType().newResource(primitive);
+    return primitive.type().newResource(primitive);
   }
 
   /**


### PR DESCRIPTION
* Replicate participant info in TransactionService
* When a member leaves the cluster, use atomic operations to assume control over its transactions
* Commit or roll back transactions based on transaction state

This needs a lot more testing, but I'm throwing it up here now for review.