### PR TITLE
Add distributed set tests and ensure set primitive type is correctly assigned

### DIFF
--- a/core/src/main/java/io/atomix/core/set/impl/DelegatingAsyncDistributedSet.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DelegatingAsyncDistributedSet.java
@@ -24,9 +24,11 @@ import io.atomix.core.map.MapEvent;
 import io.atomix.core.map.MapEventListener;
 import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.core.set.DistributedSet;
+import io.atomix.core.set.DistributedSetType;
 import io.atomix.core.set.SetEvent;
 import io.atomix.core.set.SetEventListener;
 import io.atomix.primitive.DelegatingAsyncPrimitive;
+import io.atomix.primitive.PrimitiveType;
 import io.atomix.utils.concurrent.Futures;
 
 import java.time.Duration;
@@ -50,6 +52,11 @@ public class DelegatingAsyncDistributedSet<E> extends DelegatingAsyncPrimitive i
   public DelegatingAsyncDistributedSet(AsyncConsistentMap<E, Boolean> backingMap) {
     super(backingMap);
     this.backingMap = backingMap;
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return DistributedSetType.instance();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DelegatingDistributedSetBuilder.java
@@ -17,6 +17,7 @@ package io.atomix.core.set.impl;
 
 import com.google.common.io.BaseEncoding;
 import io.atomix.core.map.AsyncConsistentMap;
+import io.atomix.core.map.ConsistentMapType;
 import io.atomix.core.map.impl.CachingAsyncConsistentMap;
 import io.atomix.core.map.impl.ConsistentMapProxy;
 import io.atomix.core.map.impl.ConsistentMapService;
@@ -47,7 +48,7 @@ public class DelegatingDistributedSetBuilder<E> extends DistributedSetBuilder<E>
   public CompletableFuture<DistributedSet<E>> buildAsync() {
     ProxyClient<ConsistentMapService> proxy = protocol().newProxy(
         name(),
-        primitiveType(),
+        ConsistentMapType.instance(),
         ConsistentMapService.class,
         new ServiceConfig(),
         managementService.getPartitionService());

--- a/core/src/test/java/io/atomix/core/set/impl/DistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/impl/DistributedSetTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.set.impl;
+
+import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.core.set.DistributedSet;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Distributed set test.
+ */
+public abstract class DistributedSetTest extends AbstractPrimitiveTest {
+  @Test
+  public void testSetOperations() throws Exception {
+    DistributedSet<String> set = atomix().<String>setBuilder("test-set")
+        .withProtocol(protocol())
+        .build();
+
+    assertEquals(0, set.size());
+    assertTrue(set.isEmpty());
+    assertFalse(set.contains("foo"));
+    assertTrue(set.add("foo"));
+    assertTrue(set.contains("foo"));
+    assertFalse(set.add("foo"));
+    assertTrue(set.contains("foo"));
+    assertEquals(1, set.size());
+    assertFalse(set.isEmpty());
+    assertTrue(set.remove("foo"));
+    assertEquals(0, set.size());
+    assertFalse(set.contains("foo"));
+    assertTrue(set.isEmpty());
+    assertFalse(set.remove("foo"));
+    assertTrue(set.isEmpty());
+  }
+}

--- a/core/src/test/java/io/atomix/core/set/impl/PrimaryBackupDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/impl/PrimaryBackupDistributedSetTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.set.impl;
+
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.protocols.backup.MultiPrimaryProtocol;
+
+/**
+ * Primary-backup distributed set test.
+ */
+public class PrimaryBackupDistributedSetTest extends DistributedSetTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiPrimaryProtocol.builder()
+        .withBackups(2)
+        .withMaxRetries(5)
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/set/impl/RaftDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/impl/RaftDistributedSetTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.set.impl;
+
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.protocols.raft.MultiRaftProtocol;
+import io.atomix.protocols.raft.ReadConsistency;
+
+/**
+ * Raft distributed set test.
+ */
+public class RaftDistributedSetTest extends DistributedSetTest {
+  @Override
+  protected PrimitiveProtocol protocol() {
+    return MultiRaftProtocol.builder()
+        .withReadConsistency(ReadConsistency.LINEARIZABLE)
+        .withMaxRetries(5)
+        .build();
+  }
+}


### PR DESCRIPTION
There was a bug in `DistributedSet` due to the underlying `ConsistentMap` not using the correct serializer. This ensures the underlying map is constructed with the correct serializer and `DistributedSet` returns the `DistributedSetType` as its type. Also adds tests.