### PR TITLE
Implement streaming iterators and Java 8 stream API for all collections

### DIFF
--- a/core/src/main/java/io/atomix/core/collection/AsyncDistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/AsyncDistributedCollection.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection;
+
+import io.atomix.primitive.AsyncPrimitive;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Asynchronous distributed collection.
+ */
+public interface AsyncDistributedCollection<E> extends AsyncPrimitive, AsyncIterable<E> {
+
+  /**
+   * Adds the specified element to this collection if it is not already present (optional operation).
+   *
+   * @param element element to add
+   * @return {@code true} if this collection did not already contain the specified element.
+   */
+  CompletableFuture<Boolean> add(E element);
+
+  /**
+   * Removes the specified element to this collection if it is present (optional operation).
+   *
+   * @param element element to remove
+   * @return {@code true} if this collection contained the specified element
+   */
+  CompletableFuture<Boolean> remove(E element);
+
+  /**
+   * Returns the number of elements in the collection.
+   *
+   * @return size of the collection
+   */
+  CompletableFuture<Integer> size();
+
+  /**
+   * Returns if the collection is empty.
+   *
+   * @return {@code true} if this collection is empty
+   */
+  CompletableFuture<Boolean> isEmpty();
+
+  /**
+   * Removes all elements from the collection.
+   *
+   * @return CompletableFuture that is completed when the operation completes
+   */
+  CompletableFuture<Void> clear();
+
+  /**
+   * Returns if this collection contains the specified element.
+   *
+   * @param element element to check
+   * @return {@code true} if this collection contains the specified element
+   */
+  CompletableFuture<Boolean> contains(E element);
+
+  /**
+   * Adds all of the elements in the specified collection to this collection if they're not
+   * already present (optional operation).
+   *
+   * @param c collection containing elements to be added to this collection
+   * @return {@code true} if this collection contains all elements in the collection
+   */
+  CompletableFuture<Boolean> addAll(Collection<? extends E> c);
+
+  /**
+   * Returns if this collection contains all the elements in specified collection.
+   *
+   * @param c collection
+   * @return {@code true} if this collection contains all elements in the collection
+   */
+  CompletableFuture<Boolean> containsAll(Collection<? extends E> c);
+
+  /**
+   * Retains only the elements in this collection that are contained in the specified collection (optional operation).
+   *
+   * @param c collection containing elements to be retained in this collection
+   * @return {@code true} if this collection changed as a result of the call
+   */
+  CompletableFuture<Boolean> retainAll(Collection<? extends E> c);
+
+  /**
+   * Removes from this collection all of its elements that are contained in the specified collection (optional operation).
+   *
+   * @param c collection containing elements to be removed from this collection
+   * @return {@code true} if this collection changed as a result of the call
+   */
+  CompletableFuture<Boolean> removeAll(Collection<? extends E> c);
+
+  @Override
+  default DistributedCollection<E> sync() {
+    return sync(Duration.ofMillis(DEFAULT_OPERATION_TIMEOUT_MILLIS));
+  }
+
+  @Override
+  DistributedCollection<E> sync(Duration operationTimeout);
+}

--- a/core/src/main/java/io/atomix/core/collection/AsyncIterable.java
+++ b/core/src/main/java/io/atomix/core/collection/AsyncIterable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Asynchronously iterable object.
+ */
+public interface AsyncIterable<T> {
+
+  /**
+   * Returns an asynchronous iterator.
+   *
+   * @return an asynchronous iterator
+   */
+  CompletableFuture<AsyncIterator<T>> iterator();
+
+  /**
+   * Returns a stream.
+   *
+   * @return a new stream
+   */
+  default CompletableFuture<Stream<T>> stream() {
+    return iterator().thenApply(asyncIterator -> {
+      Iterator<T> iterator = asyncIterator.sync();
+      return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
+    });
+  }
+}

--- a/core/src/main/java/io/atomix/core/collection/AsyncIterator.java
+++ b/core/src/main/java/io/atomix/core/collection/AsyncIterator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection;
+
+import io.atomix.core.collection.impl.BlockingIterator;
+import io.atomix.primitive.DistributedPrimitive;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Asynchronous iterator.
+ */
+public interface AsyncIterator<T> {
+
+  /**
+   * Returns whether the iterator has a next item.
+   *
+   * @return whether a next item exists in the iterator
+   */
+  CompletableFuture<Boolean> hasNext();
+
+  /**
+   * Returns the next item in the iterator.
+   *
+   * @return the next item in the iterator
+   */
+  CompletableFuture<T> next();
+
+  /**
+   * Returns a synchronous iterator.
+   *
+   * @return the synchronous iterator
+   */
+  default Iterator<T> sync() {
+    return sync(Duration.ofMillis(DistributedPrimitive.DEFAULT_OPERATION_TIMEOUT_MILLIS));
+  }
+
+  /**
+   * Returns a synchronous iterator.
+   *
+   * @param timeout the iterator operation timeout
+   * @return the synchronous iterator
+   */
+  default Iterator<T> sync(Duration timeout) {
+    return new BlockingIterator<>(this, timeout.toMillis());
+  }
+}

--- a/core/src/main/java/io/atomix/core/collection/DistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/DistributedCollection.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection;
+
+import io.atomix.primitive.SyncPrimitive;
+
+import java.util.Collection;
+
+/**
+ * Distributed collection.
+ */
+public interface DistributedCollection<E> extends SyncPrimitive, SyncIterable<E>, Collection<E> {
+  @Override
+  SyncIterator<E> iterator();
+}

--- a/core/src/main/java/io/atomix/core/collection/DistributedCollectionType.java
+++ b/core/src/main/java/io/atomix/core/collection/DistributedCollectionType.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection;
+
+import io.atomix.core.set.DistributedSet;
+import io.atomix.core.set.DistributedSetBuilder;
+import io.atomix.core.set.DistributedSetConfig;
+import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.primitive.service.ServiceConfig;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * Distributed collection primitive type.
+ */
+public class DistributedCollectionType<E> implements PrimitiveType<DistributedSetBuilder<E>, DistributedSetConfig, DistributedSet<E>> {
+  private static final String NAME = "collection";
+  private static final DistributedCollectionType INSTANCE = new DistributedCollectionType();
+
+  /**
+   * Returns a new distributed collection type.
+   *
+   * @param <E> the collection element type
+   * @return a new distributed collection type
+   */
+  @SuppressWarnings("unchecked")
+  public static <E> DistributedCollectionType<E> instance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public PrimitiveService newService(ServiceConfig config) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DistributedSetConfig newConfig() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DistributedSetBuilder<E> newBuilder(String primitiveName, DistributedSetConfig config, PrimitiveManagementService managementService) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("name", name())
+        .toString();
+  }
+}

--- a/core/src/main/java/io/atomix/core/collection/SyncIterable.java
+++ b/core/src/main/java/io/atomix/core/collection/SyncIterable.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection;
+
+/**
+ * Synchronous iterable primitive.
+ */
+public interface SyncIterable<T> extends Iterable<T> {
+
+  /**
+   * Returns the synchronous iterator.
+   *
+   * @return the synchronous iterator
+   */
+  SyncIterator<T> iterator();
+
+}

--- a/core/src/main/java/io/atomix/core/collection/SyncIterator.java
+++ b/core/src/main/java/io/atomix/core/collection/SyncIterator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection;
+
+import java.util.Iterator;
+
+/**
+ * Synchronous iterator.
+ */
+public interface SyncIterator<T> extends Iterator<T> {
+
+  /**
+   * Returns the underlying asynchronous iterator.
+   *
+   * @return the underlying asynchronous iterator
+   */
+  AsyncIterator<T> async();
+
+}

--- a/core/src/main/java/io/atomix/core/collection/impl/BlockingDistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/BlockingDistributedCollection.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.core.set.impl;
+package io.atomix.core.collection.impl;
 
+import io.atomix.core.collection.AsyncDistributedCollection;
+import io.atomix.core.collection.DistributedCollection;
 import io.atomix.core.collection.SyncIterator;
-import io.atomix.core.collection.impl.BlockingIterator;
-import io.atomix.core.set.AsyncDistributedSet;
-import io.atomix.core.set.DistributedSet;
-import io.atomix.core.set.SetEventListener;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.Synchronous;
 
@@ -30,81 +28,81 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Implementation of {@link DistributedSet} that merely delegates to a {@link AsyncDistributedSet}
+ * Implementation of {@link DistributedCollection} that merely delegates to a {@link AsyncDistributedCollection}
  * and waits for the operation to complete.
  *
- * @param <E> set element type
+ * @param <E> collection element type
  */
-public class BlockingDistributedSet<E> extends Synchronous<AsyncDistributedSet<E>> implements DistributedSet<E> {
+public class BlockingDistributedCollection<E> extends Synchronous<AsyncDistributedCollection<E>> implements DistributedCollection<E> {
 
   private final long operationTimeoutMillis;
 
-  private final AsyncDistributedSet<E> asyncSet;
+  private final AsyncDistributedCollection<E> asyncCollection;
 
-  public BlockingDistributedSet(AsyncDistributedSet<E> asyncSet, long operationTimeoutMillis) {
-    super(asyncSet);
-    this.asyncSet = asyncSet;
+  public BlockingDistributedCollection(AsyncDistributedCollection<E> asyncCollection, long operationTimeoutMillis) {
+    super(asyncCollection);
+    this.asyncCollection = asyncCollection;
     this.operationTimeoutMillis = operationTimeoutMillis;
   }
 
   @Override
   public int size() {
-    return complete(asyncSet.size());
+    return complete(asyncCollection.size());
   }
 
   @Override
   public boolean isEmpty() {
-    return complete(asyncSet.isEmpty());
+    return complete(asyncCollection.isEmpty());
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public boolean contains(Object o) {
-    return complete(asyncSet.contains((E) o));
+    return complete(asyncCollection.contains((E) o));
   }
 
   @Override
   public boolean add(E e) {
-    return complete(asyncSet.add(e));
+    return complete(asyncCollection.add(e));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public boolean remove(Object o) {
-    return complete(asyncSet.remove((E) o));
+    return complete(asyncCollection.remove((E) o));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public boolean containsAll(Collection<?> c) {
-    return complete(asyncSet.containsAll((Collection<? extends E>) c));
+    return complete(asyncCollection.containsAll((Collection<? extends E>) c));
   }
 
   @Override
   public boolean addAll(Collection<? extends E> c) {
-    return complete(asyncSet.addAll(c));
+    return complete(asyncCollection.addAll(c));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public boolean retainAll(Collection<?> c) {
-    return complete(asyncSet.retainAll((Collection<? extends E>) c));
+    return complete(asyncCollection.retainAll((Collection<? extends E>) c));
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public boolean removeAll(Collection<?> c) {
-    return complete(asyncSet.removeAll((Collection<? extends E>) c));
+    return complete(asyncCollection.removeAll((Collection<? extends E>) c));
   }
 
   @Override
   public void clear() {
-    complete(asyncSet.clear());
+    complete(asyncCollection.clear());
   }
 
   @Override
   public SyncIterator<E> iterator() {
-    return new BlockingIterator<>(complete(asyncSet.iterator()), operationTimeoutMillis);
+    return new BlockingIterator<>(complete(asyncCollection.iterator()), operationTimeoutMillis);
   }
 
   @Override
@@ -120,18 +118,8 @@ public class BlockingDistributedSet<E> extends Synchronous<AsyncDistributedSet<E
   }
 
   @Override
-  public void addListener(SetEventListener<E> listener) {
-    complete(asyncSet.addListener(listener));
-  }
-
-  @Override
-  public void removeListener(SetEventListener<E> listener) {
-    complete(asyncSet.removeListener(listener));
-  }
-
-  @Override
-  public AsyncDistributedSet<E> async() {
-    return asyncSet;
+  public AsyncDistributedCollection<E> async() {
+    return asyncCollection;
   }
 
   private <T> T complete(CompletableFuture<T> future) {

--- a/core/src/main/java/io/atomix/core/collection/impl/BlockingIterator.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/BlockingIterator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection.impl;
+
+import io.atomix.core.collection.AsyncIterator;
+import io.atomix.core.collection.SyncIterator;
+import io.atomix.primitive.PrimitiveException;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Blocking iterator.
+ */
+public class BlockingIterator<T> implements SyncIterator<T> {
+  private final AsyncIterator<T> asyncIterator;
+  private final long operationTimeoutMillis;
+
+  public BlockingIterator(AsyncIterator<T> asyncIterator, long operationTimeoutMillis) {
+    this.asyncIterator = asyncIterator;
+    this.operationTimeoutMillis = operationTimeoutMillis;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return complete(asyncIterator.hasNext());
+  }
+
+  @Override
+  public T next() {
+    return complete(asyncIterator.next());
+  }
+
+  @Override
+  public AsyncIterator<T> async() {
+    return asyncIterator;
+  }
+
+  private <T> T complete(CompletableFuture<T> future) {
+    try {
+      return future.get(operationTimeoutMillis, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new PrimitiveException.Interrupted();
+    } catch (TimeoutException e) {
+      throw new PrimitiveException.Timeout();
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof PrimitiveException) {
+        throw (PrimitiveException) e.getCause();
+      } else {
+        throw new PrimitiveException(e.getCause());
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/atomix/core/collection/impl/TranscodingAsyncDistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/TranscodingAsyncDistributedCollection.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.atomix.core.collection.impl;
+
+import io.atomix.core.collection.AsyncDistributedCollection;
+import io.atomix.core.collection.DistributedCollection;
+import io.atomix.core.collection.AsyncIterator;
+import io.atomix.primitive.PrimitiveState;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * An {@code AsyncDistributedCollection} that maps its operations to operations on a
+ * differently typed {@code AsyncDistributedCollection} by transcoding operation inputs and outputs.
+ *
+ * @param <E2> element type of other collection
+ * @param <E1> element type of this collection
+ */
+public class TranscodingAsyncDistributedCollection<E1, E2> implements AsyncDistributedCollection<E1> {
+
+  private final AsyncDistributedCollection<E2> backingCollection;
+  private final Function<E1, E2> entryEncoder;
+  private final Function<E2, E1> entryDecoder;
+
+  public TranscodingAsyncDistributedCollection(
+      AsyncDistributedCollection<E2> backingCollection,
+      Function<E1, E2> entryEncoder,
+      Function<E2, E1> entryDecoder) {
+    this.backingCollection = backingCollection;
+    this.entryEncoder = k -> k == null ? null : entryEncoder.apply(k);
+    this.entryDecoder = k -> k == null ? null : entryDecoder.apply(k);
+  }
+
+  @Override
+  public String name() {
+    return backingCollection.name();
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return backingCollection.type();
+  }
+
+  @Override
+  public PrimitiveProtocol protocol() {
+    return backingCollection.protocol();
+  }
+
+  @Override
+  public CompletableFuture<Integer> size() {
+    return backingCollection.size();
+  }
+
+  @Override
+  public CompletableFuture<Boolean> add(E1 element) {
+    return backingCollection.add(entryEncoder.apply(element));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> remove(E1 element) {
+    return backingCollection.remove(entryEncoder.apply(element));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> isEmpty() {
+    return backingCollection.isEmpty();
+  }
+
+  @Override
+  public CompletableFuture<Void> clear() {
+    return backingCollection.clear();
+  }
+
+  @Override
+  public CompletableFuture<Boolean> contains(E1 element) {
+    return backingCollection.contains(entryEncoder.apply(element));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> addAll(Collection<? extends E1> c) {
+    return backingCollection.addAll(c.stream().map(entryEncoder).collect(Collectors.toList()));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> containsAll(Collection<? extends E1> c) {
+    return backingCollection.containsAll(c.stream().map(entryEncoder).collect(Collectors.toList()));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> retainAll(Collection<? extends E1> c) {
+    return backingCollection.retainAll(c.stream().map(entryEncoder).collect(Collectors.toList()));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> removeAll(Collection<? extends E1> c) {
+    return backingCollection.removeAll(c.stream().map(entryEncoder).collect(Collectors.toList()));
+  }
+
+  @Override
+  public CompletableFuture<AsyncIterator<E1>> iterator() {
+    return backingCollection.iterator().thenApply(iterator -> new TranscodingIterator<>(iterator, entryDecoder));
+  }
+
+  @Override
+  public void addStateChangeListener(Consumer<PrimitiveState> listener) {
+    backingCollection.addStateChangeListener(listener);
+  }
+
+  @Override
+  public void removeStateChangeListener(Consumer<PrimitiveState> listener) {
+    backingCollection.removeStateChangeListener(listener);
+  }
+
+  @Override
+  public DistributedCollection<E1> sync(Duration operationTimeout) {
+    return new BlockingDistributedCollection<>(this, operationTimeout.toMillis());
+  }
+
+  @Override
+  public CompletableFuture<Void> close() {
+    return backingCollection.close();
+  }
+}

--- a/core/src/main/java/io/atomix/core/collection/impl/TranscodingIterator.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/TranscodingIterator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.collection.impl;
+
+import io.atomix.core.collection.AsyncIterator;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Transcoding iterator.
+ */
+public class TranscodingIterator<T1, T2> implements AsyncIterator<T1> {
+  private final AsyncIterator<T2> backingIterator;
+  private final Function<T2, T1> elementDecoder;
+
+  public TranscodingIterator(AsyncIterator<T2> backingIterator, Function<T2, T1> elementDecoder) {
+    this.backingIterator = backingIterator;
+    this.elementDecoder = elementDecoder;
+  }
+
+  @Override
+  public CompletableFuture<Boolean> hasNext() {
+    return backingIterator.hasNext();
+  }
+
+  @Override
+  public CompletableFuture<T1> next() {
+    return backingIterator.next().thenApply(elementDecoder);
+  }
+}

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
@@ -78,20 +78,9 @@ public class CorePrimitiveRegistry implements ManagedPrimitiveRegistry {
 
   @Override
   public Collection<PrimitiveInfo> getPrimitives() {
-    try {
-      return primitives.entrySet()
-          .get(DistributedPrimitive.DEFAULT_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
-          .stream()
-          .map(entry -> new PrimitiveInfo(entry.getKey(), primitiveTypeRegistry.getPrimitiveType(entry.getValue().value())))
-          .collect(Collectors.toList());
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new PrimitiveException.Interrupted();
-    } catch (TimeoutException e) {
-      throw new PrimitiveException.Timeout();
-    } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
-    }
+    return primitives.sync().entrySet().stream()
+        .map(entry -> new PrimitiveInfo(entry.getKey(), primitiveTypeRegistry.getPrimitiveType(entry.getValue().value())))
+        .collect(Collectors.toList());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
@@ -82,7 +82,7 @@ public class CoreTransactionService implements ManagedTransactionService {
   @Override
   public Set<TransactionId> getActiveTransactions() {
     checkState(isRunning());
-    return transactions.keySet().join();
+    return transactions.sync().keySet();
   }
 
   @Override
@@ -180,11 +180,11 @@ public class CoreTransactionService implements ManagedTransactionService {
    */
   private void onMembershipChange(ClusterMembershipEvent event) {
     if (event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED) {
-      transactions.entrySet().thenAccept(entries -> entries.stream()
-          .filter(entry -> entry.getValue().value().coordinator.equals(event.subject().id()))
-          .forEach(entry -> {
-            recoverTransaction(entry.getKey(), entry.getValue().value());
-          }));
+      transactions.entrySet().stream()
+          .thenAccept(stream -> stream.filter(entry -> entry.getValue().value().coordinator.equals(event.subject().id()))
+              .forEach(entry -> {
+                recoverTransaction(entry.getKey(), entry.getValue().value());
+              }));
     }
   }
 

--- a/core/src/main/java/io/atomix/core/map/AsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/AsyncConsistentMap.java
@@ -17,18 +17,18 @@
 package io.atomix.core.map;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import io.atomix.core.collection.AsyncDistributedCollection;
 import io.atomix.core.map.impl.MapUpdate;
+import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.core.transaction.Transactional;
 import io.atomix.primitive.AsyncPrimitive;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
@@ -273,7 +273,7 @@ public interface AsyncConsistentMap<K, V> extends AsyncPrimitive, Transactional<
    *
    * @return a set of the keys contained in this map
    */
-  CompletableFuture<Set<K>> keySet();
+  AsyncDistributedSet<K> keySet();
 
   /**
    * Returns the collection of values (and associated versions) contained in this map.
@@ -284,7 +284,7 @@ public interface AsyncConsistentMap<K, V> extends AsyncPrimitive, Transactional<
    *
    * @return a collection of the values (and associated versions) contained in this map
    */
-  CompletableFuture<Collection<Versioned<V>>> values();
+  AsyncDistributedCollection<Versioned<V>> values();
 
   /**
    * Returns the set of entries contained in this map.
@@ -295,7 +295,7 @@ public interface AsyncConsistentMap<K, V> extends AsyncPrimitive, Transactional<
    *
    * @return set of entries contained in this map.
    */
-  CompletableFuture<Set<Entry<K, Versioned<V>>>> entrySet();
+  AsyncDistributedSet<Entry<K, Versioned<V>>> entrySet();
 
   /**
    * If the specified key is not already associated with a value associates

--- a/core/src/main/java/io/atomix/core/map/ConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentMap.java
@@ -17,14 +17,14 @@
 package io.atomix.core.map;
 
 import com.google.common.util.concurrent.MoreExecutors;
+import io.atomix.core.collection.DistributedCollection;
+import io.atomix.core.set.DistributedSet;
 import io.atomix.primitive.SyncPrimitive;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -238,7 +238,7 @@ public interface ConsistentMap<K, V> extends SyncPrimitive {
    *
    * @return a set of the keys contained in this map
    */
-  Set<K> keySet();
+  DistributedSet<K> keySet();
 
   /**
    * Returns the collection of values (and associated versions) contained in this map.
@@ -249,7 +249,7 @@ public interface ConsistentMap<K, V> extends SyncPrimitive {
    *
    * @return a collection of the values (and associated versions) contained in this map
    */
-  Collection<Versioned<V>> values();
+  DistributedCollection<Versioned<V>> values();
 
   /**
    * Returns the set of entries contained in this map.
@@ -260,7 +260,7 @@ public interface ConsistentMap<K, V> extends SyncPrimitive {
    *
    * @return set of entries contained in this map.
    */
-  Set<Entry<K, Versioned<V>>> entrySet();
+  DistributedSet<Entry<K, Versioned<V>>> entrySet();
 
   /**
    * If the specified key is not already associated with a value

--- a/core/src/main/java/io/atomix/core/map/ConsistentMapType.java
+++ b/core/src/main/java/io/atomix/core/map/ConsistentMapType.java
@@ -18,6 +18,7 @@ package io.atomix.core.map;
 import io.atomix.core.map.impl.CommitResult;
 import io.atomix.core.map.impl.ConsistentMapProxyBuilder;
 import io.atomix.core.map.impl.ConsistentMapResource;
+import io.atomix.core.map.impl.ConsistentMapService;
 import io.atomix.core.map.impl.DefaultConsistentMapService;
 import io.atomix.core.map.impl.MapEntryUpdateResult;
 import io.atomix.core.map.impl.MapUpdate;
@@ -79,6 +80,7 @@ public class ConsistentMapType<K, V> implements PrimitiveType<ConsistentMapBuild
         .register(Versioned.class)
         .register(MapEvent.class)
         .register(MapEvent.Type.class)
+        .register(ConsistentMapService.Batch.class)
         .register(byte[].class)
         .build();
   }

--- a/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentMap.java
@@ -16,10 +16,14 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.base.Throwables;
+import io.atomix.core.collection.DistributedCollection;
+import io.atomix.core.collection.impl.BlockingDistributedCollection;
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.ConsistentMap;
 import io.atomix.core.map.ConsistentMapBackedJavaMap;
 import io.atomix.core.map.MapEventListener;
+import io.atomix.core.set.DistributedSet;
+import io.atomix.core.set.impl.BlockingDistributedSet;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.Synchronous;
@@ -27,10 +31,8 @@ import io.atomix.utils.concurrent.Retries;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -144,18 +146,18 @@ public class BlockingConsistentMap<K, V> extends Synchronous<AsyncConsistentMap<
   }
 
   @Override
-  public Set<K> keySet() {
-    return complete(asyncMap.keySet());
+  public DistributedSet<K> keySet() {
+    return new BlockingDistributedSet<K>(asyncMap.keySet(), operationTimeoutMillis);
   }
 
   @Override
-  public Collection<Versioned<V>> values() {
-    return complete(asyncMap.values());
+  public DistributedCollection<Versioned<V>> values() {
+    return new BlockingDistributedCollection<>(asyncMap.values(), operationTimeoutMillis);
   }
 
   @Override
-  public Set<Map.Entry<K, Versioned<V>>> entrySet() {
-    return complete(asyncMap.entrySet());
+  public DistributedSet<Map.Entry<K, Versioned<V>>> entrySet() {
+    return new BlockingDistributedSet<>(asyncMap.entrySet(), operationTimeoutMillis);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentTreeMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/BlockingConsistentTreeMap.java
@@ -17,20 +17,22 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.base.Throwables;
+import io.atomix.core.collection.DistributedCollection;
+import io.atomix.core.collection.impl.BlockingDistributedCollection;
 import io.atomix.core.map.AsyncConsistentTreeMap;
 import io.atomix.core.map.ConsistentMapBackedJavaMap;
 import io.atomix.core.map.ConsistentTreeMap;
 import io.atomix.core.map.MapEventListener;
+import io.atomix.core.set.DistributedSet;
+import io.atomix.core.set.impl.BlockingDistributedSet;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.Synchronous;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -213,18 +215,18 @@ public class BlockingConsistentTreeMap<V>
   }
 
   @Override
-  public Set<String> keySet() {
-    return complete(treeMap.keySet());
+  public DistributedSet<String> keySet() {
+    return new BlockingDistributedSet<>(treeMap.keySet(), operationTimeoutMillis);
   }
 
   @Override
-  public Collection<Versioned<V>> values() {
-    return complete(treeMap.values());
+  public DistributedCollection<Versioned<V>> values() {
+    return new BlockingDistributedCollection<>(treeMap.values(), operationTimeoutMillis);
   }
 
   @Override
-  public Set<Map.Entry<String, Versioned<V>>> entrySet() {
-    return complete(treeMap.entrySet());
+  public DistributedSet<Map.Entry<String, Versioned<V>>> entrySet() {
+    return new BlockingDistributedSet<>(treeMap.entrySet(), operationTimeoutMillis);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/ConsistentMapResource.java
+++ b/core/src/main/java/io/atomix/core/map/impl/ConsistentMapResource.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.map.impl;
 
+import com.google.common.collect.Sets;
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.utils.time.Versioned;
@@ -93,9 +94,9 @@ public class ConsistentMapResource implements PrimitiveResource {
   @Path("/keys")
   @Produces(MediaType.APPLICATION_JSON)
   public void keys(@Suspended AsyncResponse response) {
-    map.keySet().whenComplete((result, error) -> {
+    map.keySet().iterator().whenComplete((result, error) -> {
       if (error == null) {
-        response.resume(Response.ok(result).build());
+        response.resume(Response.ok(Sets.newHashSet(result.sync())).build());
       } else {
         LOGGER.warn("{}", error);
         response.resume(Response.serverError().build());

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentTreeMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultConsistentTreeMapService.java
@@ -22,6 +22,7 @@ import io.atomix.utils.time.Versioned;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * State machine corresponding to {@link ConsistentTreeMapProxy} backed by a
@@ -33,18 +34,18 @@ public class DefaultConsistentTreeMapService extends DefaultConsistentMapService
   }
 
   @Override
-  protected TreeMap<String, MapEntryValue> createMap() {
-    return Maps.newTreeMap();
+  protected NavigableMap<String, MapEntryValue> createMap() {
+    return new ConcurrentSkipListMap<>();
   }
 
   @Override
-  protected TreeMap<String, MapEntryValue> entries() {
-    return (TreeMap<String, MapEntryValue>) super.entries();
+  protected NavigableMap<String, MapEntryValue> entries() {
+    return (NavigableMap<String, MapEntryValue>) super.entries();
   }
 
   @Override
   public NavigableMap<String, byte[]> subMap(String fromKey, boolean fromInclusive, String toKey, boolean toInclusive) {
-    TreeMap<String, byte[]> map = new TreeMap<>();
+    NavigableMap<String, byte[]> map = new TreeMap<>();
     entries().subMap(fromKey, fromInclusive, toKey, toInclusive).forEach((k, v) -> map.put(k, v.value()));
     return map;
   }

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentMap.java
@@ -17,9 +17,11 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.base.MoreObjects;
+import io.atomix.core.collection.AsyncDistributedCollection;
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.ConsistentMap;
 import io.atomix.core.map.MapEventListener;
+import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.DelegatingAsyncPrimitive;
@@ -27,10 +29,8 @@ import io.atomix.primitive.PrimitiveState;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
@@ -112,17 +112,17 @@ public class DelegatingAsyncConsistentMap<K, V>
   }
 
   @Override
-  public CompletableFuture<Set<K>> keySet() {
+  public AsyncDistributedSet<K> keySet() {
     return delegateMap.keySet();
   }
 
   @Override
-  public CompletableFuture<Collection<Versioned<V>>> values() {
+  public AsyncDistributedCollection<Versioned<V>> values() {
     return delegateMap.values();
   }
 
   @Override
-  public CompletableFuture<Set<Entry<K, Versioned<V>>>> entrySet() {
+  public AsyncDistributedSet<Entry<K, Versioned<V>>> entrySet() {
     return delegateMap.entrySet();
   }
 

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentTreeMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncConsistentTreeMap.java
@@ -16,9 +16,11 @@
 
 package io.atomix.core.map.impl;
 
+import io.atomix.core.collection.AsyncDistributedCollection;
 import io.atomix.core.map.AsyncConsistentTreeMap;
 import io.atomix.core.map.ConsistentTreeMap;
 import io.atomix.core.map.MapEventListener;
+import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
 import io.atomix.primitive.DelegatingAsyncPrimitive;
@@ -26,11 +28,9 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
@@ -194,17 +194,17 @@ public class DelegatingAsyncConsistentTreeMap<V>
   }
 
   @Override
-  public CompletableFuture<Set<String>> keySet() {
+  public AsyncDistributedSet<String> keySet() {
     return delegateMap.keySet();
   }
 
   @Override
-  public CompletableFuture<Collection<Versioned<V>>> values() {
+  public AsyncDistributedCollection<Versioned<V>> values() {
     return delegateMap.values();
   }
 
   @Override
-  public CompletableFuture<Set<Map.Entry<String, Versioned<V>>>> entrySet() {
+  public AsyncDistributedSet<Map.Entry<String, Versioned<V>>> entrySet() {
     return delegateMap.entrySet();
   }
 

--- a/core/src/main/java/io/atomix/core/map/impl/NotNullAsyncConsistentMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/NotNullAsyncConsistentMap.java
@@ -16,14 +16,11 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.collect.ImmutableMap;
-
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.utils.time.Versioned;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -52,8 +49,8 @@ public class NotNullAsyncConsistentMap<K, V> extends DelegatingAsyncConsistentMa
   @Override
   public CompletableFuture<Map<K, Versioned<V>>> getAllPresent(Iterable<K> keys) {
     return super.getAllPresent(keys).thenApply(m -> ImmutableMap.copyOf(m.entrySet()
-            .stream().filter(e -> e.getValue().value() != null)
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+        .stream().filter(e -> e.getValue().value() != null)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
   }
 
   @Override
@@ -75,20 +72,6 @@ public class NotNullAsyncConsistentMap<K, V> extends DelegatingAsyncConsistentMa
       return super.remove(key).thenApply(v -> null);
     }
     return super.putAndGet(key, value);
-  }
-
-  @Override
-  public CompletableFuture<Collection<Versioned<V>>> values() {
-    return super.values().thenApply(value -> value.stream()
-        .filter(v -> v.value() != null)
-        .collect(Collectors.toList()));
-  }
-
-  @Override
-  public CompletableFuture<Set<Map.Entry<K, Versioned<V>>>> entrySet() {
-    return super.entrySet().thenApply(entries -> entries.stream()
-        .filter(e -> e.getValue().value() != null)
-        .collect(Collectors.toSet()));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/AsyncDistributedSet.java
+++ b/core/src/main/java/io/atomix/core/set/AsyncDistributedSet.java
@@ -15,13 +15,14 @@
  */
 package io.atomix.core.set;
 
+import io.atomix.core.collection.AsyncDistributedCollection;
 import io.atomix.core.set.impl.BlockingDistributedSet;
 import io.atomix.primitive.AsyncPrimitive;
 import io.atomix.primitive.DistributedPrimitive;
+import io.atomix.primitive.PrimitiveType;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -33,7 +34,11 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <E> set entry type
  */
-public interface AsyncDistributedSet<E> extends AsyncPrimitive {
+public interface AsyncDistributedSet<E> extends AsyncDistributedCollection<E> {
+  @Override
+  default PrimitiveType type() {
+    return DistributedSetType.instance();
+  }
 
   /**
    * Registers the specified listener to be notified whenever
@@ -53,86 +58,6 @@ public interface AsyncDistributedSet<E> extends AsyncPrimitive {
   CompletableFuture<Void> removeListener(SetEventListener<E> listener);
 
   /**
-   * Adds the specified element to this set if it is not already present (optional operation).
-   *
-   * @param element element to add
-   * @return {@code true} if this set did not already contain the specified element.
-   */
-  CompletableFuture<Boolean> add(E element);
-
-  /**
-   * Removes the specified element to this set if it is present (optional operation).
-   *
-   * @param element element to remove
-   * @return {@code true} if this set contained the specified element
-   */
-  CompletableFuture<Boolean> remove(E element);
-
-  /**
-   * Returns the number of elements in the set.
-   *
-   * @return size of the set
-   */
-  CompletableFuture<Integer> size();
-
-  /**
-   * Returns if the set is empty.
-   *
-   * @return {@code true} if this set is empty
-   */
-  CompletableFuture<Boolean> isEmpty();
-
-  /**
-   * Removes all elements from the set.
-   *
-   * @return CompletableFuture that is completed when the operation completes
-   */
-  CompletableFuture<Void> clear();
-
-  /**
-   * Returns if this set contains the specified element.
-   *
-   * @param element element to check
-   * @return {@code true} if this set contains the specified element
-   */
-  CompletableFuture<Boolean> contains(E element);
-
-  /**
-   * Adds all of the elements in the specified collection to this set if they're not
-   * already present (optional operation).
-   *
-   * @param c collection containing elements to be added to this set
-   * @return {@code true} if this set contains all elements in the collection
-   */
-  CompletableFuture<Boolean> addAll(Collection<? extends E> c);
-
-  /**
-   * Returns if this set contains all the elements in specified collection.
-   *
-   * @param c collection
-   * @return {@code true} if this set contains all elements in the collection
-   */
-  CompletableFuture<Boolean> containsAll(Collection<? extends E> c);
-
-  /**
-   * Retains only the elements in this set that are contained in the specified collection (optional operation).
-   *
-   * @param c collection containing elements to be retained in this set
-   * @return {@code true} if this set changed as a result of the call
-   */
-  CompletableFuture<Boolean> retainAll(Collection<? extends E> c);
-
-  /**
-   * Removes from this set all of its elements that are contained in the specified collection (optional operation).
-   * If the specified collection is also a set, this operation effectively modifies this set so that its
-   * value is the asymmetric set difference of the two sets.
-   *
-   * @param c collection containing elements to be removed from this set
-   * @return {@code true} if this set changed as a result of the call
-   */
-  CompletableFuture<Boolean> removeAll(Collection<? extends E> c);
-
-  /**
    * Returns a new {@link DistributedSet} that is backed by this instance.
    *
    * @return new {@code DistributedSet} instance
@@ -150,14 +75,6 @@ public interface AsyncDistributedSet<E> extends AsyncPrimitive {
   default DistributedSet<E> asDistributedSet(long timeoutMillis) {
     return new BlockingDistributedSet<>(this, timeoutMillis);
   }
-
-  /**
-   * Returns the entries as a immutable set. The returned set is a snapshot and will not reflect new changes made to
-   * this AsyncDistributedSet
-   *
-   * @return immutable set copy
-   */
-  CompletableFuture<? extends Set<E>> getAsImmutableSet();
 
   @Override
   default DistributedSet<E> sync() {

--- a/core/src/main/java/io/atomix/core/set/DistributedSet.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSet.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set;
 
-import io.atomix.primitive.SyncPrimitive;
+import io.atomix.core.collection.DistributedCollection;
 
 import java.util.Set;
 
@@ -24,7 +24,7 @@ import java.util.Set;
  *
  * @param <E> set entry type
  */
-public interface DistributedSet<E> extends Set<E>, SyncPrimitive {
+public interface DistributedSet<E> extends DistributedCollection<E>, Set<E> {
 
   /**
    * Registers the specified listener to be notified whenever

--- a/core/src/main/java/io/atomix/core/set/impl/DelegatingAsyncDistributedSet.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DelegatingAsyncDistributedSet.java
@@ -15,10 +15,8 @@
  */
 package io.atomix.core.set.impl;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-
+import io.atomix.core.collection.AsyncIterator;
 import io.atomix.core.map.AsyncConsistentMap;
 import io.atomix.core.map.MapEvent;
 import io.atomix.core.map.MapEventListener;
@@ -35,7 +33,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -98,8 +95,7 @@ public class DelegatingAsyncDistributedSet<E> extends DelegatingAsyncPrimitive i
 
   @Override
   public CompletableFuture<Boolean> retainAll(Collection<? extends E> c) {
-    return backingMap.keySet().thenApply(set -> Sets.difference(set, Sets.newHashSet(c)))
-        .thenCompose(this::removeAll);
+    return Futures.exceptionalFuture(new UnsupportedOperationException());
   }
 
   @Override
@@ -109,13 +105,13 @@ public class DelegatingAsyncDistributedSet<E> extends DelegatingAsyncPrimitive i
   }
 
   @Override
-  public CompletableFuture<Void> clear() {
-    return backingMap.clear();
+  public CompletableFuture<AsyncIterator<E>> iterator() {
+    return backingMap.keySet().iterator();
   }
 
   @Override
-  public CompletableFuture<? extends Set<E>> getAsImmutableSet() {
-    return backingMap.keySet().thenApply(s -> ImmutableSet.copyOf(s));
+  public CompletableFuture<Void> clear() {
+    return backingMap.clear();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/impl/DistributedSetResource.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DistributedSetResource.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.set.impl;
 
+import com.google.common.collect.Sets;
 import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
@@ -46,9 +47,9 @@ public class DistributedSetResource implements PrimitiveResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   public void get(@Suspended AsyncResponse response) {
-    set.getAsImmutableSet().whenComplete((result, error) -> {
+    set.iterator().whenComplete((iterator, error) -> {
       if (error == null) {
-        response.resume(Response.ok(result).build());
+        response.resume(Response.ok(Sets.newHashSet(iterator.sync())).build());
       } else {
         LOGGER.warn("{}", error);
         response.resume(Response.serverError().build());

--- a/core/src/main/java/io/atomix/core/set/impl/TranscodingAsyncDistributedSet.java
+++ b/core/src/main/java/io/atomix/core/set/impl/TranscodingAsyncDistributedSet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.atomix.core.set.impl;
+
+import com.google.common.collect.Maps;
+import io.atomix.core.collection.impl.TranscodingAsyncDistributedCollection;
+import io.atomix.core.set.AsyncDistributedSet;
+import io.atomix.core.set.DistributedSet;
+import io.atomix.core.set.SetEvent;
+import io.atomix.core.set.SetEventListener;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * An {@code AsyncDistributedSet} that maps its operations to operations on a
+ * differently typed {@code AsyncDistributedSet} by transcoding operation inputs and outputs.
+ *
+ * @param <E2> key type of other map
+ * @param <E1> key type of this map
+ */
+public class TranscodingAsyncDistributedSet<E1, E2> extends TranscodingAsyncDistributedCollection<E1, E2> implements AsyncDistributedSet<E1> {
+
+  private final AsyncDistributedSet<E2> backingSet;
+  private final Function<E2, E1> entryDecoder;
+  private final Map<SetEventListener<E1>, InternalBackingSetEventListener> listeners =
+      Maps.newIdentityHashMap();
+
+  public TranscodingAsyncDistributedSet(
+      AsyncDistributedSet<E2> backingSet,
+      Function<E1, E2> entryEncoder,
+      Function<E2, E1> entryDecoder) {
+    super(backingSet, entryEncoder, entryDecoder);
+    this.backingSet = backingSet;
+    this.entryDecoder = k -> k == null ? null : entryDecoder.apply(k);
+  }
+
+  @Override
+  public CompletableFuture<Void> addListener(SetEventListener<E1> listener) {
+    synchronized (listeners) {
+      InternalBackingSetEventListener backingSetListener =
+          listeners.computeIfAbsent(listener, k -> new InternalBackingSetEventListener(listener));
+      return backingSet.addListener(backingSetListener);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Void> removeListener(SetEventListener<E1> listener) {
+    synchronized (listeners) {
+      InternalBackingSetEventListener backingMapListener = listeners.remove(listener);
+      if (backingMapListener != null) {
+        return backingSet.removeListener(backingMapListener);
+      } else {
+        return CompletableFuture.completedFuture(null);
+      }
+    }
+  }
+
+  @Override
+  public DistributedSet<E1> sync(Duration operationTimeout) {
+    return new BlockingDistributedSet<>(this, operationTimeout.toMillis());
+  }
+
+  private class InternalBackingSetEventListener implements SetEventListener<E2> {
+
+    private final SetEventListener<E1> listener;
+
+    InternalBackingSetEventListener(SetEventListener<E1> listener) {
+      this.listener = listener;
+    }
+
+    @Override
+    public void event(SetEvent<E2> event) {
+      listener.event(new SetEvent<>(
+          event.name(),
+          event.type(),
+          entryDecoder.apply(event.entry())));
+    }
+  }
+}


### PR DESCRIPTION
This PR implements support for key/value/entry views for map primitives and supports streaming iterators and the Java 8 stream API. This can be used to read very large collections efficiently.

As with all other primitive implementations, iterators have both a synchronous and asynchronous API. The asynchronous implementation fetches batches of entries from the map. Iterators have the same types of weak consistency guarantees as exist for `ConcurrentHashMap`, `ConcurrentSkipListMap`, et al.

* Add base sync/async collection primitive interfaces
* Add sync/async iterable/iterator interfaces
* Add map key/value/entry views
* Implement streaming iterators for map primitives