### PR TITLE
Implement minimum/maximum thread counts for various thread pools

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -252,7 +252,7 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
     super(config.getClusterConfig());
     config.getProfiles().forEach(profile -> registry.profiles().getProfile(profile).configure(config));
     this.executorService = Executors.newScheduledThreadPool(
-        Runtime.getRuntime().availableProcessors(),
+        Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 8), 4),
         Threads.namedThreads("atomix-primitive-%d", LOGGER));
     this.registry = registry;
     this.config = new DefaultConfigService(config.getPrimitives().values());

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupClient.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupClient.java
@@ -168,7 +168,7 @@ public class PrimaryBackupClient {
     protected PrimaryElection primaryElection;
     protected SessionIdService sessionIdService;
     protected ThreadModel threadModel = ThreadModel.SHARED_THREAD_POOL;
-    protected int threadPoolSize = Runtime.getRuntime().availableProcessors();
+    protected int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
     protected ThreadContextFactory threadContextFactory;
 
     /**

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupServer.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/PrimaryBackupServer.java
@@ -111,7 +111,7 @@ public class PrimaryBackupServer implements Managed<PrimaryBackupServer> {
     protected PrimitiveTypeRegistry primitiveTypes;
     protected MemberGroupProvider memberGroupProvider;
     protected ThreadModel threadModel = ThreadModel.SHARED_THREAD_POOL;
-    protected int threadPoolSize = Runtime.getRuntime().availableProcessors();
+    protected int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
     protected ThreadContextFactory threadContextFactory;
 
     /**

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
@@ -155,7 +155,8 @@ public class PrimaryBackupPartitionGroup implements ManagedPartitionGroup {
 
   @Override
   public CompletableFuture<ManagedPartitionGroup> join(PartitionManagementService managementService) {
-    threadFactory = new BlockingAwareThreadPoolContextFactory("atomix-" + name() + "-%d", Runtime.getRuntime().availableProcessors() * 2, LOGGER);
+    int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 32), 4);
+    threadFactory = new BlockingAwareThreadPoolContextFactory("atomix-" + name() + "-%d", threadPoolSize, LOGGER);
     List<CompletableFuture<Partition>> futures = partitions.values().stream()
         .map(p -> p.join(managementService, threadFactory))
         .collect(Collectors.toList());
@@ -167,7 +168,8 @@ public class PrimaryBackupPartitionGroup implements ManagedPartitionGroup {
 
   @Override
   public CompletableFuture<ManagedPartitionGroup> connect(PartitionManagementService managementService) {
-    threadFactory = new BlockingAwareThreadPoolContextFactory("atomix-" + name() + "-%d", Runtime.getRuntime().availableProcessors() * 2, LOGGER);
+    int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 32), 4);
+    threadFactory = new BlockingAwareThreadPoolContextFactory("atomix-" + name() + "-%d", threadPoolSize, LOGGER);
     List<CompletableFuture<Partition>> futures = partitions.values().stream()
         .map(p -> p.connect(managementService, threadFactory))
         .collect(Collectors.toList());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
@@ -188,7 +188,7 @@ public interface RaftClient {
     protected MemberId memberId;
     protected RaftClientProtocol protocol;
     protected ThreadModel threadModel = ThreadModel.SHARED_THREAD_POOL;
-    protected int threadPoolSize = Runtime.getRuntime().availableProcessors();
+    protected int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
 
     protected Builder(Collection<MemberId> cluster) {
       this.cluster = checkNotNull(cluster, "cluster cannot be null");

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -551,7 +551,7 @@ public interface RaftServer {
     private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
     private static final Duration DEFAULT_SESSION_TIMEOUT = Duration.ofMillis(5000);
     private static final ThreadModel DEFAULT_THREAD_MODEL = ThreadModel.SHARED_THREAD_POOL;
-    private static final int DEFAULT_THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors();
+    private static final int DEFAULT_THREAD_POOL_SIZE = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 8), 4);
 
     protected String name;
     protected MemberId localMemberId;


### PR DESCRIPTION
This PR implements minimum and maximum default thread counts for various thread pools used in Raft/primary-backup protocols.