### PR TITLE
Move primitive serializers into protocol configuration

### DIFF
--- a/core/src/main/java/io/atomix/core/barrier/impl/DefaultDistributedCyclicBarrierBuilder.java
+++ b/core/src/main/java/io/atomix/core/barrier/impl/DefaultDistributedCyclicBarrierBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.barrier.DistributedCyclicBarrier;
 import io.atomix.core.barrier.DistributedCyclicBarrierBuilder;
 import io.atomix.core.barrier.DistributedCyclicBarrierConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -36,9 +37,10 @@ public class DefaultDistributedCyclicBarrierBuilder extends DistributedCyclicBar
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedCyclicBarrier> buildAsync() {
-    ProxyClient<DistributedCyclicBarrierService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient<DistributedCyclicBarrierService> proxy = protocol.newProxy(
+        name,
+        type,
         DistributedCyclicBarrierService.class,
         new ServiceConfig(),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/counter/impl/DefaultAtomicCounterBuilder.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/DefaultAtomicCounterBuilder.java
@@ -15,10 +15,11 @@
  */
 package io.atomix.core.counter.impl;
 
-import io.atomix.core.counter.AtomicCounterConfig;
 import io.atomix.core.counter.AtomicCounter;
 import io.atomix.core.counter.AtomicCounterBuilder;
+import io.atomix.core.counter.AtomicCounterConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -35,9 +36,10 @@ public class DefaultAtomicCounterBuilder extends AtomicCounterBuilder {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicCounter> buildAsync() {
-    ProxyClient<AtomicCounterService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient<AtomicCounterService> proxy = protocol.newProxy(
+        name,
+        type,
         AtomicCounterService.class,
         new ServiceConfig(),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/election/LeaderElectionBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectionBuilder.java
@@ -15,42 +15,15 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.cluster.MemberId;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.NamespaceConfig;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 
 /**
  * Builder for constructing new {@link AsyncLeaderElection} instances.
  */
 public abstract class LeaderElectionBuilder<T>
     extends PrimitiveBuilder<LeaderElectionBuilder<T>, LeaderElectionConfig, LeaderElection<T>> {
-
-  public LeaderElectionBuilder(String name, LeaderElectionConfig config, PrimitiveManagementService managementService) {
+  protected LeaderElectionBuilder(String name, LeaderElectionConfig config, PrimitiveManagementService managementService) {
     super(LeaderElectionType.instance(), name, config, managementService);
-  }
-
-  @Override
-  public Serializer serializer() {
-    Serializer serializer = this.serializer;
-    if (serializer == null) {
-      NamespaceConfig config = this.config.getNamespaceConfig();
-      if (config == null) {
-        serializer = Serializer.using(Namespace.builder()
-            .register(Namespaces.BASIC)
-            .register(MemberId.class)
-            .build());
-      } else {
-        serializer = Serializer.using(Namespace.builder()
-            .register(Namespaces.BASIC)
-            .register(MemberId.class)
-            .register(new Namespace(config))
-            .build());
-      }
-    }
-    return serializer;
   }
 }

--- a/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
@@ -15,41 +15,15 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.cluster.MemberId;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.NamespaceConfig;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 
 /**
  * Builder for constructing new {@link AsyncLeaderElector} instances.
  */
 public abstract class LeaderElectorBuilder<T>
     extends PrimitiveBuilder<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>> {
-  public LeaderElectorBuilder(String name, LeaderElectorConfig config, PrimitiveManagementService managementService) {
+  protected LeaderElectorBuilder(String name, LeaderElectorConfig config, PrimitiveManagementService managementService) {
     super(LeaderElectorType.instance(), name, config, managementService);
-  }
-
-  @Override
-  public Serializer serializer() {
-    Serializer serializer = this.serializer;
-    if (serializer == null) {
-      NamespaceConfig config = this.config.getNamespaceConfig();
-      if (config == null) {
-        serializer = Serializer.using(Namespace.builder()
-            .register(Namespaces.BASIC)
-            .register(MemberId.class)
-            .build());
-      } else {
-        serializer = Serializer.using(Namespace.builder()
-            .register(Namespaces.BASIC)
-            .register(MemberId.class)
-            .register(new Namespace(config))
-            .build());
-      }
-    }
-    return serializer;
   }
 }

--- a/core/src/main/java/io/atomix/core/idgenerator/impl/DelegatingAtomicIdGeneratorBuilder.java
+++ b/core/src/main/java/io/atomix/core/idgenerator/impl/DelegatingAtomicIdGeneratorBuilder.java
@@ -38,8 +38,8 @@ public class DelegatingAtomicIdGeneratorBuilder extends AtomicIdGeneratorBuilder
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicIdGenerator> buildAsync() {
     ProxyClient<AtomicCounterService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         AtomicCounterService.class,
         new ServiceConfig(),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListBuilder.java
+++ b/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.list.DistributedList;
 import io.atomix.core.list.DistributedListBuilder;
 import io.atomix.core.list.DistributedListConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -40,16 +41,17 @@ public class DefaultDistributedListBuilder<E> extends DistributedListBuilder<E> 
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedList<E>> buildAsync() {
-    ProxyClient<DistributedListService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient<DistributedListService> proxy = protocol.newProxy(
+        name,
+        type,
         DistributedListService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new DistributedListProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(rawList -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           AsyncDistributedList<E> list = new TranscodingAsyncDistributedList<>(
               rawList,
               element -> BaseEncoding.base16().encode(serializer.encode(element)),

--- a/core/src/main/java/io/atomix/core/lock/impl/DefaultAtomicLockBuilder.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DefaultAtomicLockBuilder.java
@@ -37,8 +37,8 @@ public class DefaultAtomicLockBuilder extends AtomicLockBuilder {
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicLock> buildAsync() {
     ProxyClient<AtomicLockService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         AtomicLockService.class,
         new ServiceConfig(),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/lock/impl/DefaultDistributedLockBuilder.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DefaultDistributedLockBuilder.java
@@ -36,8 +36,8 @@ public class DefaultDistributedLockBuilder extends DistributedLockBuilder {
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedLock> buildAsync() {
     ProxyClient<AtomicLockService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         AtomicLockService.class,
         new ServiceConfig(),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicMapBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.map.AtomicMap;
 import io.atomix.core.map.AtomicMapBuilder;
 import io.atomix.core.map.AtomicMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -41,16 +42,17 @@ public class DefaultAtomicMapBuilder<K, V> extends AtomicMapBuilder<K, V> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicMap<K, V>> buildAsync() {
+    PrimitiveProtocol protocol = protocol();
     ProxyClient proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         AtomicMapService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicMapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(rawMap -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           AsyncAtomicMap<K, V> map = new TranscodingAsyncAtomicMap<K, V, String, byte[]>(
               rawMap,
               key -> BaseEncoding.base16().encode(serializer.encode(key)),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicTreeMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicTreeMapBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.map.AtomicTreeMap;
 import io.atomix.core.map.AtomicTreeMapBuilder;
 import io.atomix.core.map.AtomicTreeMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -39,16 +40,17 @@ public class DefaultAtomicTreeMapBuilder<K extends Comparable<K>, V> extends Ato
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicTreeMap<K, V>> buildAsync() {
+    PrimitiveProtocol protocol = protocol();
     ProxyClient<AtomicTreeMapService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         AtomicTreeMapService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicTreeMapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(map -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           return new TranscodingAsyncAtomicTreeMap<K, V, byte[]>(
               (AsyncAtomicTreeMap) map,
               value -> serializer.encode(value),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedTreeMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedTreeMapBuilder.java
@@ -19,6 +19,7 @@ import io.atomix.core.map.DistributedTreeMap;
 import io.atomix.core.map.DistributedTreeMapBuilder;
 import io.atomix.core.map.DistributedTreeMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -36,16 +37,17 @@ public class DefaultDistributedTreeMapBuilder<K extends Comparable<K>, V> extend
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedTreeMap<K, V>> buildAsync() {
-    ProxyClient proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient proxy = protocol.newProxy(
+        name,
+        type,
         AtomicTreeMapService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicTreeMapProxy<K>(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(map -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           return new TranscodingAsyncAtomicTreeMap<K, V, byte[]>(
               map,
               value -> serializer.encode(value),

--- a/core/src/main/java/io/atomix/core/multimap/impl/DefaultDistributedMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/DefaultDistributedMultimapBuilder.java
@@ -25,6 +25,7 @@ import io.atomix.core.multimap.DistributedMultimap;
 import io.atomix.core.multimap.DistributedMultimapBuilder;
 import io.atomix.core.multimap.DistributedMultimapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -42,16 +43,17 @@ public class DefaultDistributedMultimapBuilder<K, V> extends DistributedMultimap
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedMultimap<K, V>> buildAsync() {
-    ProxyClient<AtomicMultimapService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient<AtomicMultimapService> proxy = protocol.newProxy(
+        name,
+        type,
         AtomicMultimapService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicMultimapProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(rawMultimap -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           AsyncAtomicMultimap<K, V> multimap = new TranscodingAsyncAtomicMultimap<>(
               rawMultimap,
               key -> BaseEncoding.base16().encode(serializer.encode(key)),

--- a/core/src/main/java/io/atomix/core/queue/impl/DefaultDistributedQueueBuilder.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/DefaultDistributedQueueBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.queue.DistributedQueue;
 import io.atomix.core.queue.DistributedQueueBuilder;
 import io.atomix.core.queue.DistributedQueueConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -40,16 +41,17 @@ public class DefaultDistributedQueueBuilder<E> extends DistributedQueueBuilder<E
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedQueue<E>> buildAsync() {
-    ProxyClient<DistributedQueueService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient<DistributedQueueService> proxy = protocol.newProxy(
+        name,
+        type,
         DistributedQueueService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new DistributedQueueProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(rawQueue -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           AsyncDistributedQueue<E> queue = new TranscodingAsyncDistributedQueue<>(
               rawQueue,
               element -> BaseEncoding.base16().encode(serializer.encode(element)),

--- a/core/src/main/java/io/atomix/core/semaphore/impl/DefaultAtomicSemaphoreBuilder.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/DefaultAtomicSemaphoreBuilder.java
@@ -33,8 +33,8 @@ public class DefaultAtomicSemaphoreBuilder extends AtomicSemaphoreBuilder {
   @Override
   public CompletableFuture<AtomicSemaphore> buildAsync() {
     ProxyClient<AtomicSemaphoreService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         AtomicSemaphoreService.class,
         new AtomicSemaphoreServiceConfig().setInitialCapacity(config.initialCapacity()),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/semaphore/impl/DefaultDistributedSemaphoreBuilder.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/DefaultDistributedSemaphoreBuilder.java
@@ -35,8 +35,8 @@ public class DefaultDistributedSemaphoreBuilder extends DistributedSemaphoreBuil
   @Override
   public CompletableFuture<DistributedSemaphore> buildAsync() {
     ProxyClient<AtomicSemaphoreService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         AtomicSemaphoreService.class,
         new AtomicSemaphoreServiceConfig().setInitialCapacity(config.initialCapacity()),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetBuilder.java
@@ -21,6 +21,7 @@ import io.atomix.core.set.DistributedSet;
 import io.atomix.core.set.DistributedSetBuilder;
 import io.atomix.core.set.DistributedSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -40,16 +41,17 @@ public class DefaultDistributedSetBuilder<E> extends DistributedSetBuilder<E> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedSet<E>> buildAsync() {
-    ProxyClient proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient proxy = protocol.newProxy(
+        name,
+        type,
         DistributedSetService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new DistributedSetProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(rawSet -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           AsyncDistributedSet<E> set = new TranscodingAsyncDistributedSet<>(
               rawSet,
               element -> BaseEncoding.base16().encode(serializer.encode(element)),

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedTreeSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedTreeSetBuilder.java
@@ -38,8 +38,8 @@ public class DefaultDistributedTreeSetBuilder<E extends Comparable<E>> extends D
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedTreeSet<E>> buildAsync() {
     ProxyClient proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+        name,
+        type,
         DistributedTreeSetService.class,
         new ServiceConfig(),
         managementService.getPartitionService());

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
@@ -23,7 +23,6 @@ import io.atomix.core.transaction.TransactionalMapBuilder;
 import io.atomix.core.transaction.TransactionalMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -38,12 +37,6 @@ public class DefaultTransactionalMapBuilder<K, V> extends TransactionalMapBuilde
     super(name, config, managementService);
     this.mapBuilder = AtomicMapType.<K, V>instance().newBuilder(name, new AtomicMapConfig(), managementService);
     this.transaction = transaction;
-  }
-
-  @Override
-  public TransactionalMapBuilder<K, V> withSerializer(Serializer serializer) {
-    mapBuilder.withSerializer(serializer);
-    return this;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
@@ -23,7 +23,6 @@ import io.atomix.core.transaction.TransactionalSetBuilder;
 import io.atomix.core.transaction.TransactionalSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.utils.serializer.Serializer;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -38,12 +37,6 @@ public class DefaultTransactionalSetBuilder<E> extends TransactionalSetBuilder<E
     super(name, config, managementService);
     this.setBuilder = DistributedSetType.<E>instance().newBuilder(name, new DistributedSetConfig(), managementService);
     this.transaction = transaction;
-  }
-
-  @Override
-  public TransactionalSetBuilder<E> withSerializer(Serializer serializer) {
-    setBuilder.withSerializer(serializer);
-    return this;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTreeBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTreeBuilder.java
@@ -20,6 +20,7 @@ import io.atomix.core.tree.AtomicDocumentTree;
 import io.atomix.core.tree.AtomicDocumentTreeBuilder;
 import io.atomix.core.tree.AtomicDocumentTreeConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -39,16 +40,17 @@ public class DefaultAtomicDocumentTreeBuilder<V> extends AtomicDocumentTreeBuild
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicDocumentTree<V>> buildAsync() {
-    ProxyClient<DocumentTreeService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient<DocumentTreeService> proxy = protocol.newProxy(
+        name,
+        type,
         DocumentTreeService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicDocumentTreeProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(tree -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           return new TranscodingAsyncAtomicDocumentTree<V, byte[]>(
               tree,
               key -> serializer.encode(key),

--- a/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueBuilder.java
@@ -19,6 +19,7 @@ import io.atomix.core.value.AtomicValue;
 import io.atomix.core.value.AtomicValueBuilder;
 import io.atomix.core.value.AtomicValueConfig;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -38,16 +39,17 @@ public class DefaultAtomicValueBuilder<V> extends AtomicValueBuilder<V> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicValue<V>> buildAsync() {
-    ProxyClient<AtomicValueService> proxy = protocol().newProxy(
-        name(),
-        primitiveType(),
+    PrimitiveProtocol protocol = protocol();
+    ProxyClient<AtomicValueService> proxy = protocol.newProxy(
+        name,
+        type,
         AtomicValueService.class,
         new ServiceConfig(),
         managementService.getPartitionService());
     return new AtomicValueProxy(proxy, managementService.getPrimitiveRegistry())
         .connect()
         .thenApply(elector -> {
-          Serializer serializer = serializer();
+          Serializer serializer = protocol.serializer();
           return new TranscodingAsyncAtomicValue<V, byte[]>(
               elector,
               key -> serializer.encode(key),

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
@@ -22,10 +22,6 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocolConfig;
 import io.atomix.utils.Builder;
 import io.atomix.utils.config.ConfigurationException;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.NamespaceConfig;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +39,6 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
   protected final PrimitiveType type;
   protected final String name;
   protected final C config;
-  protected Serializer serializer;
   protected PrimitiveProtocol protocol;
   protected final PrimitiveManagementService managementService;
 
@@ -52,18 +47,6 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
     this.name = checkNotNull(name, "name cannot be null");
     this.config = checkNotNull(config, "config cannot be null");
     this.managementService = checkNotNull(managementService, "managementService cannot be null");
-  }
-
-  /**
-   * Sets the serializer to use for transcoding info held in the primitive.
-   *
-   * @param serializer serializer
-   * @return this builder
-   */
-  @SuppressWarnings("unchecked")
-  public B withSerializer(Serializer serializer) {
-    this.serializer = serializer;
-    return (B) this;
   }
 
   /**
@@ -102,29 +85,11 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
   }
 
   /**
-   * Returns the name of the primitive.
-   *
-   * @return primitive name
-   */
-  public String name() {
-    return name;
-  }
-
-  /**
-   * Returns the primitive type.
-   *
-   * @return primitive type
-   */
-  public PrimitiveType primitiveType() {
-    return type;
-  }
-
-  /**
    * Returns the primitive protocol.
    *
    * @return the primitive protocol
    */
-  public PrimitiveProtocol protocol() {
+  protected PrimitiveProtocol protocol() {
     PrimitiveProtocol protocol = this.protocol;
     if (protocol == null) {
       PrimitiveProtocolConfig<?> protocolConfig = config.getProtocolConfig();
@@ -143,27 +108,6 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
       }
     }
     return protocol;
-  }
-
-  /**
-   * Returns the serializer.
-   *
-   * @return serializer
-   */
-  public Serializer serializer() {
-    Serializer serializer = this.serializer;
-    if (serializer == null) {
-      NamespaceConfig config = this.config.getNamespaceConfig();
-      if (config == null) {
-        serializer = Serializer.using(Namespaces.BASIC);
-      } else {
-        serializer = Serializer.using(Namespace.builder()
-            .register(Namespaces.BASIC)
-            .register(new Namespace(config))
-            .build());
-      }
-    }
-    return serializer;
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
@@ -20,6 +20,7 @@ import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.ConfiguredType;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Primitive protocol.
@@ -58,6 +59,13 @@ public interface PrimitiveProtocol {
    * @return the protocol group name
    */
   String group();
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  Serializer serializer();
 
   /**
    * Returns a new primitive proxy for the given partition group.

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolBuilder.java
@@ -16,16 +16,29 @@
 package io.atomix.primitive.protocol;
 
 import io.atomix.utils.Builder;
+import io.atomix.utils.serializer.Serializer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Primitive protocol builder.
  */
-public abstract class PrimitiveProtocolBuilder<C extends PrimitiveProtocolConfig<C>, P extends PrimitiveProtocol> implements Builder<P> {
+public abstract class PrimitiveProtocolBuilder<B extends PrimitiveProtocolBuilder<B, C, P>, C extends PrimitiveProtocolConfig<C>, P extends PrimitiveProtocol> implements Builder<P> {
   protected final C config;
 
   protected PrimitiveProtocolBuilder(C config) {
     this.config = checkNotNull(config);
+  }
+
+  /**
+   * Sets the protocol serializer.
+   *
+   * @param serializer the protocol serializer
+   * @return the protocol builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withSerializer(Serializer serializer) {
+    config.setSerializer(serializer);
+    return (B) this;
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolConfig.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolConfig.java
@@ -16,12 +16,18 @@
 package io.atomix.primitive.protocol;
 
 import io.atomix.utils.config.TypedConfig;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Namespaces;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Primitive protocol configuration.
  */
 public abstract class PrimitiveProtocolConfig<C extends PrimitiveProtocolConfig<C>> implements TypedConfig<PrimitiveProtocol.Type> {
   private String group;
+  private volatile Serializer serializer;
+  private NamespaceConfig namespaceConfig;
 
   /**
    * Returns the protocol group.
@@ -41,6 +47,66 @@ public abstract class PrimitiveProtocolConfig<C extends PrimitiveProtocolConfig<
   @SuppressWarnings("unchecked")
   public C setGroup(String group) {
     this.group = group;
+    return (C) this;
+  }
+
+  /**
+   * Sets the protocol serializer.
+   *
+   * @param serializer the protocol serializer
+   * @return the protocol configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setSerializer(Serializer serializer) {
+    this.serializer = serializer;
+    return (C) this;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  public Serializer getSerializer() {
+    Serializer serializer = this.serializer;
+    if (serializer == null) {
+      synchronized (this) {
+        serializer = this.serializer;
+        if (serializer == null) {
+          NamespaceConfig config = getNamespaceConfig();
+          if (config == null) {
+            serializer = Serializer.using(Namespaces.BASIC);
+          } else {
+            serializer = Serializer.using(Namespace.builder()
+                .register(Namespaces.BASIC)
+                .register(new Namespace(config))
+                .build());
+          }
+          this.serializer = serializer;
+        }
+      }
+    }
+    return serializer;
+  }
+
+  /**
+   * Returns the namespace configuration.
+   *
+   * @return the namespace configuration
+   */
+  public NamespaceConfig getNamespaceConfig() {
+    return namespaceConfig;
+  }
+
+  /**
+   * Sets the namespace configuration.
+   *
+   * @param namespaceConfig the namespace configuration
+   * @return the protocol serializer
+   */
+  @SuppressWarnings("unchecked")
+  public C setNamespaceConfig(NamespaceConfig namespaceConfig) {
+    this.namespaceConfig = namespaceConfig;
     return (C) this;
   }
 }

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -23,6 +23,7 @@ import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionClient;
 import io.atomix.protocols.backup.partition.PrimaryBackupPartition;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -90,6 +91,11 @@ public class MultiPrimaryProtocol implements PrimitiveProtocol {
   @Override
   public String group() {
     return config.getGroup();
+  }
+
+  @Override
+  public Serializer serializer() {
+    return config.getSerializer();
   }
 
   @Override

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocolBuilder.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocolBuilder.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Multi-primary protocol builder.
  */
-public class MultiPrimaryProtocolBuilder extends PrimitiveProtocolBuilder<MultiPrimaryProtocolConfig, MultiPrimaryProtocol> {
+public class MultiPrimaryProtocolBuilder extends PrimitiveProtocolBuilder<MultiPrimaryProtocolBuilder, MultiPrimaryProtocolConfig, MultiPrimaryProtocol> {
   protected MultiPrimaryProtocolBuilder(MultiPrimaryProtocolConfig config) {
     super(config);
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
@@ -23,6 +23,7 @@ import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionClient;
 import io.atomix.protocols.raft.partition.RaftPartition;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -90,6 +91,11 @@ public class MultiRaftProtocol implements PrimitiveProtocol {
   @Override
   public String group() {
     return config.getGroup();
+  }
+
+  @Override
+  public Serializer serializer() {
+    return config.getSerializer();
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocolBuilder.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocolBuilder.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Multi-Raft protocol builder.
  */
-public class MultiRaftProtocolBuilder extends PrimitiveProtocolBuilder<MultiRaftProtocolConfig, MultiRaftProtocol> {
+public class MultiRaftProtocolBuilder extends PrimitiveProtocolBuilder<MultiRaftProtocolBuilder, MultiRaftProtocolConfig, MultiRaftProtocol> {
   protected MultiRaftProtocolBuilder(MultiRaftProtocolConfig config) {
     super(config);
   }


### PR DESCRIPTION
This PR moves user-provided `Serializer`s into the protocol configurations rather than the primitive configurations. This allows the serializers to be accessible to protocol implementations, which is necessary for some eventually consistent protocol implementations.