### PR TITLE
Make primitive builders type safe with respect to supported protocols

### DIFF
--- a/core/src/main/java/io/atomix/core/PrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/PrimitivesService.java
@@ -105,7 +105,6 @@ import io.atomix.primitive.PrimitiveInfo;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.SyncPrimitive;
 import io.atomix.primitive.config.PrimitiveConfig;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.utils.AtomixRuntimeException;
 
 import java.util.Collection;
@@ -135,38 +134,12 @@ public interface PrimitivesService {
    * Creates a new AtomicMapBuilder.
    *
    * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a distributed map
-   */
-  default <K, V> DistributedMapBuilder<K, V> mapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedMapType.instance(), protocol);
-  }
-
-  /**
-   * Creates a new AtomicMapBuilder.
-   *
-   * @param name the primitive name
    * @param <K> key type
    * @param <V> value type
    * @return builder for a tree map
    */
   default <K extends Comparable<K>, V> DistributedSortedMapBuilder<K, V> sortedMapBuilder(String name) {
     return primitiveBuilder(name, DistributedSortedMapType.instance());
-  }
-
-  /**
-   * Creates a new AtomicMapBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a tree map
-   */
-  default <K extends Comparable<K>, V> DistributedSortedMapBuilder<K, V> sortedMapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedSortedMapType.instance(), protocol);
   }
 
   /**
@@ -182,19 +155,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new AtomicMapBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a tree map
-   */
-  default <K extends Comparable<K>, V> DistributedNavigableMapBuilder<K, V> navigableMapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedNavigableMapType.instance(), protocol);
-  }
-
-  /**
    * Creates a new AtomicMultimapBuilder.
    *
    * @param name the primitive name
@@ -204,19 +164,6 @@ public interface PrimitivesService {
    */
   default <K, V> DistributedMultimapBuilder<K, V> multimapBuilder(String name) {
     return primitiveBuilder(name, DistributedMultimapType.instance());
-  }
-
-  /**
-   * Creates a new AtomicMultimapBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a multimap
-   */
-  default <K, V> DistributedMultimapBuilder<K, V> multimapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedMultimapType.instance(), protocol);
   }
 
   /**
@@ -232,19 +179,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new AtomicMapBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a atomic map
-   */
-  default <K, V> AtomicMapBuilder<K, V> atomicMapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicMapType.instance(), protocol);
-  }
-
-  /**
    * Creates a new AtomicDocumentTreeBuilder.
    *
    * @param name the primitive name
@@ -253,18 +187,6 @@ public interface PrimitivesService {
    */
   default <V> AtomicDocumentTreeBuilder<V> atomicDocumentTreeBuilder(String name) {
     return primitiveBuilder(name, AtomicDocumentTreeType.instance());
-  }
-
-  /**
-   * Creates a new AtomicDocumentTreeBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <V> value type
-   * @return builder for a atomic document tree
-   */
-  default <V> AtomicDocumentTreeBuilder<V> atomicDocumentTreeBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicDocumentTreeType.instance(), protocol);
   }
 
   /**
@@ -280,19 +202,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new {@code AtomicSortedMapBuilder}.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a async atomic tree map
-   */
-  default <K extends Comparable<K>, V> AtomicSortedMapBuilder<K, V> atomicSortedMapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicSortedMapType.instance(), protocol);
-  }
-
-  /**
    * Creates a new {@code AtomicNavigableMapBuilder}.
    *
    * @param name the primitive name
@@ -302,19 +211,6 @@ public interface PrimitivesService {
    */
   default <K extends Comparable<K>, V> AtomicNavigableMapBuilder<K, V> atomicNavigableMapBuilder(String name) {
     return primitiveBuilder(name, AtomicNavigableMapType.instance());
-  }
-
-  /**
-   * Creates a new {@code AtomicNavigableMapBuilder}.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a async atomic tree map
-   */
-  default <K extends Comparable<K>, V> AtomicNavigableMapBuilder<K, V> atomicNavigableMapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicNavigableMapType.instance(), protocol);
   }
 
   /**
@@ -330,19 +226,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new {@code AtomicMultimapBuilder}.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @param <V> value type
-   * @return builder for a set based async atomic multimap
-   */
-  default <K, V> AtomicMultimapBuilder<K, V> atomicMultimapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicMultimapType.instance(), protocol);
-  }
-
-  /**
    * Creates a new {@code AtomicCounterMapBuilder}.
    *
    * @param name the primitive name
@@ -351,18 +234,6 @@ public interface PrimitivesService {
    */
   default <K> AtomicCounterMapBuilder<K> atomicCounterMapBuilder(String name) {
     return primitiveBuilder(name, AtomicCounterMapType.instance());
-  }
-
-  /**
-   * Creates a new {@code AtomicCounterMapBuilder}.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <K> key type
-   * @return builder for an atomic counter map
-   */
-  default <K> AtomicCounterMapBuilder<K> atomicCounterMapBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicCounterMapType.instance(), protocol);
   }
 
   /**
@@ -377,18 +248,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new DistributedSetBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <E> set element type
-   * @return builder for an distributed set
-   */
-  default <E> DistributedSetBuilder<E> setBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedSetType.instance(), protocol);
-  }
-
-  /**
    * Creates a new DistributedSortedSetBuilder.
    *
    * @param name the primitive name
@@ -397,18 +256,6 @@ public interface PrimitivesService {
    */
   default <E extends Comparable<E>> DistributedSortedSetBuilder<E> sortedSetBuilder(String name) {
     return primitiveBuilder(name, DistributedSortedSetType.instance());
-  }
-
-  /**
-   * Creates a new DistributedSortedSetBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <E> set element type
-   * @return builder for a distributed set
-   */
-  default <E extends Comparable<E>> DistributedSortedSetBuilder<E> sortedSetBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedSortedSetType.instance(), protocol);
   }
 
   /**
@@ -423,18 +270,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new DistributedNavigableSetBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <E> set element type
-   * @return builder for a distributed set
-   */
-  default <E extends Comparable<E>> DistributedNavigableSetBuilder<E> navigableSetBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedNavigableSetType.instance(), protocol);
-  }
-
-  /**
    * Creates a new DistributedQueueBuilder.
    *
    * @param name the primitive name
@@ -443,18 +278,6 @@ public interface PrimitivesService {
    */
   default <E> DistributedQueueBuilder<E> queueBuilder(String name) {
     return primitiveBuilder(name, DistributedQueueType.instance());
-  }
-
-  /**
-   * Creates a new DistributedQueueBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <E> queue element type
-   * @return builder for a distributed queue
-   */
-  default <E> DistributedQueueBuilder<E> queueBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedQueueType.instance(), protocol);
   }
 
   /**
@@ -469,18 +292,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new DistributedQueueBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <E> list element type
-   * @return builder for a distributed list
-   */
-  default <E> DistributedListBuilder<E> listBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedListType.instance(), protocol);
-  }
-
-  /**
    * Creates a new DistributedMultisetBuilder.
    *
    * @param name the primitive name
@@ -489,18 +300,6 @@ public interface PrimitivesService {
    */
   default <E> DistributedMultisetBuilder<E> multisetBuilder(String name) {
     return primitiveBuilder(name, DistributedMultisetType.instance());
-  }
-
-  /**
-   * Creates a new DistributedMultisetBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <E> multiset element type
-   * @return builder for a distributed multiset
-   */
-  default <E> DistributedMultisetBuilder<E> multisetBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedMultisetType.instance(), protocol);
   }
 
   /**
@@ -514,17 +313,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new DistributedCounterBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return distributed counter builder
-   */
-  default DistributedCounterBuilder counterBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedCounterType.instance(), protocol);
-  }
-
-  /**
    * Creates a new AtomicCounterBuilder.
    *
    * @param name the primitive name
@@ -535,17 +323,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new AtomicCounterBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return atomic counter builder
-   */
-  default AtomicCounterBuilder atomicCounterBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicCounterType.instance(), protocol);
-  }
-
-  /**
    * Creates a new AtomicIdGeneratorBuilder.
    *
    * @param name the primitive name
@@ -553,17 +330,6 @@ public interface PrimitivesService {
    */
   default AtomicIdGeneratorBuilder atomicIdGeneratorBuilder(String name) {
     return primitiveBuilder(name, AtomicIdGeneratorType.instance());
-  }
-
-  /**
-   * Creates a new AtomicIdGeneratorBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return atomic ID generator builder
-   */
-  default AtomicIdGeneratorBuilder atomicIdGeneratorBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicIdGeneratorType.instance(), protocol);
   }
 
   /**
@@ -578,18 +344,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new AtomicValueBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <V> atomic value type
-   * @return atomic value builder
-   */
-  default <V> AtomicValueBuilder<V> atomicValueBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicValueType.instance(), protocol);
-  }
-
-  /**
    * Creates a new LeaderElectionBuilder.
    *
    * @param name the primitive name
@@ -600,17 +354,6 @@ public interface PrimitivesService {
   }
 
   /**
-   * Creates a new LeaderElectionBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return leader election builder
-   */
-  default <T> LeaderElectionBuilder<T> leaderElectionBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, LeaderElectionType.instance(), protocol);
-  }
-
-  /**
    * Creates a new LeaderElectorBuilder.
    *
    * @param name the primitive name
@@ -618,17 +361,6 @@ public interface PrimitivesService {
    */
   default <T> LeaderElectorBuilder<T> leaderElectorBuilder(String name) {
     return primitiveBuilder(name, LeaderElectorType.instance());
-  }
-
-  /**
-   * Creates a new LeaderElectorBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return leader elector builder
-   */
-  default <T> LeaderElectorBuilder<T> leaderElectorBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, LeaderElectorType.instance(), protocol);
   }
 
   /**
@@ -645,32 +377,10 @@ public interface PrimitivesService {
    * Creates a new DistributedLockBuilder.
    *
    * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return distributed lock builder
-   */
-  default DistributedLockBuilder lockBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedLockType.instance(), protocol);
-  }
-
-  /**
-   * Creates a new DistributedLockBuilder.
-   *
-   * @param name the primitive name
    * @return distributed lock builder
    */
   default AtomicLockBuilder atomicLockBuilder(String name) {
     return primitiveBuilder(name, AtomicLockType.instance());
-  }
-
-  /**
-   * Creates a new DistributedLockBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return distributed lock builder
-   */
-  default AtomicLockBuilder atomicLockBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicLockType.instance(), protocol);
   }
 
   /**
@@ -681,17 +391,6 @@ public interface PrimitivesService {
    */
   default DistributedCyclicBarrierBuilder cyclicBarrierBuilder(String name) {
     return primitiveBuilder(name, DistributedCyclicBarrierType.instance());
-  }
-
-  /**
-   * Creates a new DistributedCyclicBarrierBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return distributed cyclic barrier builder
-   */
-  default DistributedCyclicBarrierBuilder cyclicBarrierBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedCyclicBarrierType.instance(), protocol);
   }
 
   /**
@@ -708,32 +407,10 @@ public interface PrimitivesService {
    * Creates a new DistributedSemaphoreBuilder.
    *
    * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return distributed semaphore builder
-   */
-  default DistributedSemaphoreBuilder semaphoreBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, DistributedSemaphoreType.instance(), protocol);
-  }
-
-  /**
-   * Creates a new DistributedSemaphoreBuilder.
-   *
-   * @param name the primitive name
    * @return distributed semaphore builder
    */
   default AtomicSemaphoreBuilder atomicSemaphoreBuilder(String name) {
     return primitiveBuilder(name, AtomicSemaphoreType.instance());
-  }
-
-  /**
-   * Creates a new DistributedSemaphoreBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @return distributed semaphore builder
-   */
-  default AtomicSemaphoreBuilder atomicSemaphoreBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, AtomicSemaphoreType.instance(), protocol);
   }
 
   /**
@@ -745,18 +422,6 @@ public interface PrimitivesService {
    */
   default <E> WorkQueueBuilder<E> workQueueBuilder(String name) {
     return primitiveBuilder(name, WorkQueueType.instance());
-  }
-
-  /**
-   * Creates a new WorkQueueBuilder.
-   *
-   * @param name the primitive name
-   * @param protocol the primitive protocol
-   * @param <E> work queue element type
-   * @return work queue builder
-   */
-  default <E> WorkQueueBuilder<E> workQueueBuilder(String name, PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, WorkQueueType.instance(), protocol);
   }
 
   /**
@@ -1122,23 +787,6 @@ public interface PrimitivesService {
   <B extends PrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends SyncPrimitive> B primitiveBuilder(
       String name,
       PrimitiveType<B, C, P> primitiveType);
-
-  /**
-   * Returns a primitive builder of the given type.
-   *
-   * @param name the primitive name
-   * @param primitiveType the primitive type
-   * @param protocol the primitive protocol
-   * @param <B> the primitive builder type
-   * @param <P> the primitive type
-   * @return the primitive builder
-   */
-  default <B extends PrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends SyncPrimitive> B primitiveBuilder(
-      String name,
-      PrimitiveType<B, C, P> primitiveType,
-      PrimitiveProtocol protocol) {
-    return primitiveBuilder(name, primitiveType).withProtocol(protocol);
-  }
 
   /**
    * Returns a collection of open primitives.

--- a/core/src/main/java/io/atomix/core/barrier/DistributedCyclicBarrierBuilder.java
+++ b/core/src/main/java/io/atomix/core/barrier/DistributedCyclicBarrierBuilder.java
@@ -17,6 +17,9 @@ package io.atomix.core.barrier;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -24,12 +27,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Distributed cyclic barrier builder.
  */
 public abstract class DistributedCyclicBarrierBuilder
-    extends PrimitiveBuilder<DistributedCyclicBarrierBuilder, DistributedCyclicBarrierConfig, DistributedCyclicBarrier> {
+    extends PrimitiveBuilder<DistributedCyclicBarrierBuilder, DistributedCyclicBarrierConfig, DistributedCyclicBarrier>
+    implements ProxyCompatibleBuilder<DistributedCyclicBarrierBuilder> {
 
   protected Runnable barrierAction = () -> {};
 
-  public DistributedCyclicBarrierBuilder(String name, DistributedCyclicBarrierConfig config, PrimitiveManagementService managementService) {
+  protected DistributedCyclicBarrierBuilder(String name, DistributedCyclicBarrierConfig config, PrimitiveManagementService managementService) {
     super(DistributedCyclicBarrierType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedCyclicBarrierBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 
   /**

--- a/core/src/main/java/io/atomix/core/counter/AtomicCounterBuilder.java
+++ b/core/src/main/java/io/atomix/core/counter/AtomicCounterBuilder.java
@@ -17,13 +17,23 @@ package io.atomix.core.counter;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for AtomicCounter.
  */
 public abstract class AtomicCounterBuilder
-    extends PrimitiveBuilder<AtomicCounterBuilder, AtomicCounterConfig, AtomicCounter> {
-  public AtomicCounterBuilder(String name, AtomicCounterConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<AtomicCounterBuilder, AtomicCounterConfig, AtomicCounter>
+    implements ProxyCompatibleBuilder<AtomicCounterBuilder> {
+
+  protected AtomicCounterBuilder(String name, AtomicCounterConfig config, PrimitiveManagementService managementService) {
     super(AtomicCounterType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicCounterBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/counter/DistributedCounterBuilder.java
+++ b/core/src/main/java/io/atomix/core/counter/DistributedCounterBuilder.java
@@ -17,13 +17,30 @@ package io.atomix.core.counter;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.primitive.protocol.counter.CounterCompatibleBuilder;
+import io.atomix.primitive.protocol.counter.CounterProtocol;
 
 /**
  * Builder for DistributedCounter.
  */
 public abstract class DistributedCounterBuilder
-    extends PrimitiveBuilder<DistributedCounterBuilder, DistributedCounterConfig, DistributedCounter> {
-  public DistributedCounterBuilder(String name, DistributedCounterConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<DistributedCounterBuilder, DistributedCounterConfig, DistributedCounter>
+    implements ProxyCompatibleBuilder<DistributedCounterBuilder>, CounterCompatibleBuilder<DistributedCounterBuilder> {
+
+  protected DistributedCounterBuilder(String name, DistributedCounterConfig config, PrimitiveManagementService managementService) {
     super(DistributedCounterType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedCounterBuilder withProtocol(CounterProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedCounterBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/counter/impl/GossipDistributedCounter.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/GossipDistributedCounter.java
@@ -21,7 +21,7 @@ import io.atomix.core.counter.DistributedCounterType;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.counter.CounterProtocol;
+import io.atomix.primitive.protocol.counter.CounterDelegate;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -32,9 +32,9 @@ import java.util.concurrent.CompletableFuture;
 public class GossipDistributedCounter implements AsyncDistributedCounter {
   private final String name;
   private final GossipProtocol protocol;
-  private final CounterProtocol counter;
+  private final CounterDelegate counter;
 
-  public GossipDistributedCounter(String name, GossipProtocol protocol, CounterProtocol counter) {
+  public GossipDistributedCounter(String name, GossipProtocol protocol, CounterDelegate counter) {
     this.name = name;
     this.protocol = protocol;
     this.counter = counter;

--- a/core/src/main/java/io/atomix/core/election/LeaderElectionBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectionBuilder.java
@@ -17,13 +17,23 @@ package io.atomix.core.election;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for constructing new {@link AsyncLeaderElection} instances.
  */
 public abstract class LeaderElectionBuilder<T>
-    extends PrimitiveBuilder<LeaderElectionBuilder<T>, LeaderElectionConfig, LeaderElection<T>> {
+    extends PrimitiveBuilder<LeaderElectionBuilder<T>, LeaderElectionConfig, LeaderElection<T>>
+    implements ProxyCompatibleBuilder<LeaderElectionBuilder<T>> {
+
   protected LeaderElectionBuilder(String name, LeaderElectionConfig config, PrimitiveManagementService managementService) {
     super(LeaderElectionType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public LeaderElectionBuilder<T> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
@@ -17,13 +17,23 @@ package io.atomix.core.election;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for constructing new {@link AsyncLeaderElector} instances.
  */
 public abstract class LeaderElectorBuilder<T>
-    extends PrimitiveBuilder<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>> {
+    extends PrimitiveBuilder<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>>
+    implements ProxyCompatibleBuilder<LeaderElectorBuilder<T>> {
+
   protected LeaderElectorBuilder(String name, LeaderElectorConfig config, PrimitiveManagementService managementService) {
     super(LeaderElectorType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public LeaderElectorBuilder<T> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/idgenerator/AtomicIdGeneratorBuilder.java
+++ b/core/src/main/java/io/atomix/core/idgenerator/AtomicIdGeneratorBuilder.java
@@ -17,13 +17,23 @@ package io.atomix.core.idgenerator;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for AtomicIdGenerator.
  */
 public abstract class AtomicIdGeneratorBuilder
-    extends PrimitiveBuilder<AtomicIdGeneratorBuilder, AtomicIdGeneratorConfig, AtomicIdGenerator> {
+    extends PrimitiveBuilder<AtomicIdGeneratorBuilder, AtomicIdGeneratorConfig, AtomicIdGenerator>
+    implements ProxyCompatibleBuilder<AtomicIdGeneratorBuilder> {
+
   protected AtomicIdGeneratorBuilder(String name, AtomicIdGeneratorConfig config, PrimitiveManagementService managementService) {
     super(AtomicIdGeneratorType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicIdGeneratorBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
@@ -28,7 +28,7 @@ import io.atomix.primitive.PrimitiveRegistry;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.PartitionService;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespaces;
@@ -110,7 +110,7 @@ public class CorePrimitiveRegistry implements ManagedPrimitiveRegistry {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<PrimitiveRegistry> start() {
-    StateMachineReplicationProtocol protocol = partitionService.getSystemPartitionGroup().newProtocol();
+    ProxyProtocol protocol = partitionService.getSystemPartitionGroup().newProtocol();
     ProxyClient proxy = protocol.newProxy(
         "primitives",
         AtomicMapType.instance(),

--- a/core/src/main/java/io/atomix/core/list/DistributedListBuilder.java
+++ b/core/src/main/java/io/atomix/core/list/DistributedListBuilder.java
@@ -17,14 +17,25 @@ package io.atomix.core.list;
 
 import io.atomix.core.collection.DistributedCollectionBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for distributed queue.
  *
  * @param <E> queue element type
  */
-public abstract class DistributedListBuilder<E> extends DistributedCollectionBuilder<DistributedListBuilder<E>, DistributedListConfig, DistributedList<E>, E> {
-  public DistributedListBuilder(String name, DistributedListConfig config, PrimitiveManagementService managementService) {
+public abstract class DistributedListBuilder<E>
+    extends DistributedCollectionBuilder<DistributedListBuilder<E>, DistributedListConfig, DistributedList<E>, E>
+    implements ProxyCompatibleBuilder<DistributedListBuilder<E>> {
+
+  protected DistributedListBuilder(String name, DistributedListConfig config, PrimitiveManagementService managementService) {
     super(DistributedListType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedListBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/lock/AtomicLockBuilder.java
+++ b/core/src/main/java/io/atomix/core/lock/AtomicLockBuilder.java
@@ -17,13 +17,23 @@ package io.atomix.core.lock;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for AtomicIdGenerator.
  */
 public abstract class AtomicLockBuilder
-    extends PrimitiveBuilder<AtomicLockBuilder, AtomicLockConfig, AtomicLock> {
-  public AtomicLockBuilder(String name, AtomicLockConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<AtomicLockBuilder, AtomicLockConfig, AtomicLock>
+    implements ProxyCompatibleBuilder<AtomicLockBuilder> {
+
+  protected AtomicLockBuilder(String name, AtomicLockConfig config, PrimitiveManagementService managementService) {
     super(AtomicLockType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicLockBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/lock/DistributedLockBuilder.java
+++ b/core/src/main/java/io/atomix/core/lock/DistributedLockBuilder.java
@@ -17,13 +17,23 @@ package io.atomix.core.lock;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for DistributedLock.
  */
 public abstract class DistributedLockBuilder
-    extends PrimitiveBuilder<DistributedLockBuilder, DistributedLockConfig, DistributedLock> {
-  public DistributedLockBuilder(String name, DistributedLockConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<DistributedLockBuilder, DistributedLockConfig, DistributedLock>
+    implements ProxyCompatibleBuilder<DistributedLockBuilder> {
+
+  protected DistributedLockBuilder(String name, DistributedLockConfig config, PrimitiveManagementService managementService) {
     super(DistributedLockType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedLockBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/AtomicCounterMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicCounterMapBuilder.java
@@ -17,13 +17,23 @@ package io.atomix.core.map;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for AtomicCounterMap.
  */
 public abstract class AtomicCounterMapBuilder<K>
-    extends PrimitiveBuilder<AtomicCounterMapBuilder<K>, AtomicCounterMapConfig, AtomicCounterMap<K>> {
-  public AtomicCounterMapBuilder(String name, AtomicCounterMapConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<AtomicCounterMapBuilder<K>, AtomicCounterMapConfig, AtomicCounterMap<K>>
+    implements ProxyCompatibleBuilder<AtomicCounterMapBuilder<K>> {
+
+  protected AtomicCounterMapBuilder(String name, AtomicCounterMapConfig config, PrimitiveManagementService managementService) {
     super(AtomicCounterMapType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicCounterMapBuilder<K> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/AtomicMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicMapBuilder.java
@@ -17,6 +17,9 @@ package io.atomix.core.map;
 
 import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for {@link AtomicMap} instances.
@@ -25,9 +28,10 @@ import io.atomix.primitive.PrimitiveManagementService;
  * @param <V> type for map value
  */
 public abstract class AtomicMapBuilder<K, V>
-    extends CachedPrimitiveBuilder<AtomicMapBuilder<K, V>, AtomicMapConfig, AtomicMap<K, V>> {
+    extends CachedPrimitiveBuilder<AtomicMapBuilder<K, V>, AtomicMapConfig, AtomicMap<K, V>>
+    implements ProxyCompatibleBuilder<AtomicMapBuilder<K, V>> {
 
-  public AtomicMapBuilder(String name, AtomicMapConfig config, PrimitiveManagementService managementService) {
+  protected AtomicMapBuilder(String name, AtomicMapConfig config, PrimitiveManagementService managementService) {
     super(AtomicMapType.instance(), name, config, managementService);
   }
 
@@ -50,5 +54,10 @@ public abstract class AtomicMapBuilder<K, V>
   public AtomicMapBuilder<K, V> withNullValues(boolean nullValues) {
     config.setNullValues(nullValues);
     return this;
+  }
+
+  @Override
+  public AtomicMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/AtomicNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicNavigableMapBuilder.java
@@ -18,13 +18,23 @@ package io.atomix.core.map;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for {@link AtomicNavigableMap}.
  */
 public abstract class AtomicNavigableMapBuilder<K extends Comparable<K>, V>
-    extends PrimitiveBuilder<AtomicNavigableMapBuilder<K, V>, AtomicNavigableMapConfig, AtomicNavigableMap<K, V>> {
-  public AtomicNavigableMapBuilder(String name, AtomicNavigableMapConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<AtomicNavigableMapBuilder<K, V>, AtomicNavigableMapConfig, AtomicNavigableMap<K, V>>
+    implements ProxyCompatibleBuilder<AtomicNavigableMapBuilder<K, V>> {
+
+  protected AtomicNavigableMapBuilder(String name, AtomicNavigableMapConfig config, PrimitiveManagementService managementService) {
     super(AtomicNavigableMapType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicNavigableMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/AtomicSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicSortedMapBuilder.java
@@ -18,13 +18,23 @@ package io.atomix.core.map;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for {@link AtomicSortedMap}.
  */
 public abstract class AtomicSortedMapBuilder<K extends Comparable<K>, V>
-    extends PrimitiveBuilder<AtomicSortedMapBuilder<K, V>, AtomicSortedMapConfig, AtomicSortedMap<K, V>> {
-  public AtomicSortedMapBuilder(String name, AtomicSortedMapConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<AtomicSortedMapBuilder<K, V>, AtomicSortedMapConfig, AtomicSortedMap<K, V>>
+    implements ProxyCompatibleBuilder<AtomicSortedMapBuilder<K, V>> {
+
+  protected AtomicSortedMapBuilder(String name, AtomicSortedMapConfig config, PrimitiveManagementService managementService) {
     super(AtomicSortedMapType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicSortedMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/DistributedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedMapBuilder.java
@@ -17,6 +17,15 @@ package io.atomix.core.map;
 
 import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.primitive.protocol.map.MapProtocol;
+import io.atomix.primitive.protocol.map.MapCompatibleBuilder;
+import io.atomix.primitive.protocol.map.NavigableMapProtocol;
+import io.atomix.primitive.protocol.map.NavigableMapCompatibleBuilder;
+import io.atomix.primitive.protocol.map.SortedMapProtocol;
+import io.atomix.primitive.protocol.map.SortedMapCompatibleBuilder;
 
 /**
  * Builder for {@link DistributedMap} instances.
@@ -25,9 +34,13 @@ import io.atomix.primitive.PrimitiveManagementService;
  * @param <V> type for map value
  */
 public abstract class DistributedMapBuilder<K, V>
-    extends CachedPrimitiveBuilder<DistributedMapBuilder<K, V>, DistributedMapConfig, DistributedMap<K, V>> {
+    extends CachedPrimitiveBuilder<DistributedMapBuilder<K, V>, DistributedMapConfig, DistributedMap<K, V>>
+    implements ProxyCompatibleBuilder<DistributedMapBuilder<K, V>>,
+    MapCompatibleBuilder<DistributedMapBuilder<K, V>>,
+    SortedMapCompatibleBuilder<DistributedMapBuilder<K, V>>,
+    NavigableMapCompatibleBuilder<DistributedMapBuilder<K, V>> {
 
-  public DistributedMapBuilder(String name, DistributedMapConfig config, PrimitiveManagementService managementService) {
+  protected DistributedMapBuilder(String name, DistributedMapConfig config, PrimitiveManagementService managementService) {
     super(DistributedMapType.instance(), name, config, managementService);
   }
 
@@ -50,5 +63,25 @@ public abstract class DistributedMapBuilder<K, V>
   public DistributedMapBuilder<K, V> withNullValues(boolean nullValues) {
     config.setNullValues(nullValues);
     return this;
+  }
+
+  @Override
+  public DistributedMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedMapBuilder<K, V> withProtocol(MapProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedMapBuilder<K, V> withProtocol(SortedMapProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedMapBuilder<K, V> withProtocol(NavigableMapProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/DistributedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedMapBuilder.java
@@ -20,12 +20,8 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.primitive.protocol.map.MapProtocol;
 import io.atomix.primitive.protocol.map.MapCompatibleBuilder;
-import io.atomix.primitive.protocol.map.NavigableMapProtocol;
-import io.atomix.primitive.protocol.map.NavigableMapCompatibleBuilder;
-import io.atomix.primitive.protocol.map.SortedMapProtocol;
-import io.atomix.primitive.protocol.map.SortedMapCompatibleBuilder;
+import io.atomix.primitive.protocol.map.MapProtocol;
 
 /**
  * Builder for {@link DistributedMap} instances.
@@ -35,10 +31,7 @@ import io.atomix.primitive.protocol.map.SortedMapCompatibleBuilder;
  */
 public abstract class DistributedMapBuilder<K, V>
     extends CachedPrimitiveBuilder<DistributedMapBuilder<K, V>, DistributedMapConfig, DistributedMap<K, V>>
-    implements ProxyCompatibleBuilder<DistributedMapBuilder<K, V>>,
-    MapCompatibleBuilder<DistributedMapBuilder<K, V>>,
-    SortedMapCompatibleBuilder<DistributedMapBuilder<K, V>>,
-    NavigableMapCompatibleBuilder<DistributedMapBuilder<K, V>> {
+    implements ProxyCompatibleBuilder<DistributedMapBuilder<K, V>>, MapCompatibleBuilder<DistributedMapBuilder<K, V>> {
 
   protected DistributedMapBuilder(String name, DistributedMapConfig config, PrimitiveManagementService managementService) {
     super(DistributedMapType.instance(), name, config, managementService);
@@ -72,16 +65,6 @@ public abstract class DistributedMapBuilder<K, V>
 
   @Override
   public DistributedMapBuilder<K, V> withProtocol(MapProtocol protocol) {
-    return withProtocol((PrimitiveProtocol) protocol);
-  }
-
-  @Override
-  public DistributedMapBuilder<K, V> withProtocol(SortedMapProtocol protocol) {
-    return withProtocol((PrimitiveProtocol) protocol);
-  }
-
-  @Override
-  public DistributedMapBuilder<K, V> withProtocol(NavigableMapProtocol protocol) {
     return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/DistributedNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedNavigableMapBuilder.java
@@ -20,8 +20,8 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.primitive.protocol.map.NavigableMapProtocol;
 import io.atomix.primitive.protocol.map.NavigableMapCompatibleBuilder;
+import io.atomix.primitive.protocol.map.NavigableMapProtocol;
 
 /**
  * Builder for {@link DistributedNavigableMap} instances.
@@ -31,8 +31,7 @@ import io.atomix.primitive.protocol.map.NavigableMapCompatibleBuilder;
  */
 public abstract class DistributedNavigableMapBuilder<K extends Comparable<K>, V>
     extends CachedPrimitiveBuilder<DistributedNavigableMapBuilder<K, V>, DistributedNavigableMapConfig, DistributedNavigableMap<K, V>>
-    implements ProxyCompatibleBuilder<DistributedNavigableMapBuilder<K, V>>,
-    NavigableMapCompatibleBuilder<DistributedNavigableMapBuilder<K, V>> {
+    implements ProxyCompatibleBuilder<DistributedNavigableMapBuilder<K, V>>, NavigableMapCompatibleBuilder<DistributedNavigableMapBuilder<K, V>> {
 
   public DistributedNavigableMapBuilder(String name, DistributedNavigableMapConfig config, PrimitiveManagementService managementService) {
     super(DistributedNavigableMapType.instance(), name, config, managementService);

--- a/core/src/main/java/io/atomix/core/map/DistributedNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedNavigableMapBuilder.java
@@ -17,6 +17,11 @@ package io.atomix.core.map;
 
 import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.primitive.protocol.map.NavigableMapProtocol;
+import io.atomix.primitive.protocol.map.NavigableMapCompatibleBuilder;
 
 /**
  * Builder for {@link DistributedNavigableMap} instances.
@@ -25,7 +30,9 @@ import io.atomix.primitive.PrimitiveManagementService;
  * @param <V> type for map value
  */
 public abstract class DistributedNavigableMapBuilder<K extends Comparable<K>, V>
-    extends CachedPrimitiveBuilder<DistributedNavigableMapBuilder<K, V>, DistributedNavigableMapConfig, DistributedNavigableMap<K, V>> {
+    extends CachedPrimitiveBuilder<DistributedNavigableMapBuilder<K, V>, DistributedNavigableMapConfig, DistributedNavigableMap<K, V>>
+    implements ProxyCompatibleBuilder<DistributedNavigableMapBuilder<K, V>>,
+    NavigableMapCompatibleBuilder<DistributedNavigableMapBuilder<K, V>> {
 
   public DistributedNavigableMapBuilder(String name, DistributedNavigableMapConfig config, PrimitiveManagementService managementService) {
     super(DistributedNavigableMapType.instance(), name, config, managementService);
@@ -50,5 +57,15 @@ public abstract class DistributedNavigableMapBuilder<K extends Comparable<K>, V>
   public DistributedNavigableMapBuilder<K, V> withNullValues(boolean nullValues) {
     config.setNullValues(nullValues);
     return this;
+  }
+
+  @Override
+  public DistributedNavigableMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedNavigableMapBuilder<K, V> withProtocol(NavigableMapProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/DistributedSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedSortedMapBuilder.java
@@ -20,10 +20,8 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.primitive.protocol.map.NavigableMapProtocol;
-import io.atomix.primitive.protocol.map.NavigableMapCompatibleBuilder;
-import io.atomix.primitive.protocol.map.SortedMapProtocol;
 import io.atomix.primitive.protocol.map.SortedMapCompatibleBuilder;
+import io.atomix.primitive.protocol.map.SortedMapProtocol;
 
 /**
  * Builder for {@link DistributedSortedMap} instances.
@@ -33,9 +31,7 @@ import io.atomix.primitive.protocol.map.SortedMapCompatibleBuilder;
  */
 public abstract class DistributedSortedMapBuilder<K extends Comparable<K>, V>
     extends CachedPrimitiveBuilder<DistributedSortedMapBuilder<K, V>, DistributedSortedMapConfig, DistributedSortedMap<K, V>>
-    implements ProxyCompatibleBuilder<DistributedSortedMapBuilder<K, V>>,
-    SortedMapCompatibleBuilder<DistributedSortedMapBuilder<K, V>>,
-    NavigableMapCompatibleBuilder<DistributedSortedMapBuilder<K, V>> {
+    implements ProxyCompatibleBuilder<DistributedSortedMapBuilder<K, V>>, SortedMapCompatibleBuilder<DistributedSortedMapBuilder<K, V>>{
 
   public DistributedSortedMapBuilder(String name, DistributedSortedMapConfig config, PrimitiveManagementService managementService) {
     super(DistributedSortedMapType.instance(), name, config, managementService);
@@ -69,11 +65,6 @@ public abstract class DistributedSortedMapBuilder<K extends Comparable<K>, V>
 
   @Override
   public DistributedSortedMapBuilder<K, V> withProtocol(SortedMapProtocol protocol) {
-    return withProtocol((PrimitiveProtocol) protocol);
-  }
-
-  @Override
-  public DistributedSortedMapBuilder<K, V> withProtocol(NavigableMapProtocol protocol) {
     return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/DistributedSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedSortedMapBuilder.java
@@ -17,6 +17,13 @@ package io.atomix.core.map;
 
 import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.primitive.protocol.map.NavigableMapProtocol;
+import io.atomix.primitive.protocol.map.NavigableMapCompatibleBuilder;
+import io.atomix.primitive.protocol.map.SortedMapProtocol;
+import io.atomix.primitive.protocol.map.SortedMapCompatibleBuilder;
 
 /**
  * Builder for {@link DistributedSortedMap} instances.
@@ -25,7 +32,10 @@ import io.atomix.primitive.PrimitiveManagementService;
  * @param <V> type for map value
  */
 public abstract class DistributedSortedMapBuilder<K extends Comparable<K>, V>
-    extends CachedPrimitiveBuilder<DistributedSortedMapBuilder<K, V>, DistributedSortedMapConfig, DistributedSortedMap<K, V>> {
+    extends CachedPrimitiveBuilder<DistributedSortedMapBuilder<K, V>, DistributedSortedMapConfig, DistributedSortedMap<K, V>>
+    implements ProxyCompatibleBuilder<DistributedSortedMapBuilder<K, V>>,
+    SortedMapCompatibleBuilder<DistributedSortedMapBuilder<K, V>>,
+    NavigableMapCompatibleBuilder<DistributedSortedMapBuilder<K, V>> {
 
   public DistributedSortedMapBuilder(String name, DistributedSortedMapConfig config, PrimitiveManagementService managementService) {
     super(DistributedSortedMapType.instance(), name, config, managementService);
@@ -50,5 +60,20 @@ public abstract class DistributedSortedMapBuilder<K extends Comparable<K>, V>
   public DistributedSortedMapBuilder<K, V> withNullValues(boolean nullValues) {
     config.setNullValues(nullValues);
     return this;
+  }
+
+  @Override
+  public DistributedSortedMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedSortedMapBuilder<K, V> withProtocol(SortedMapProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedSortedMapBuilder<K, V> withProtocol(NavigableMapProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
@@ -24,7 +24,7 @@ import io.atomix.core.map.DistributedMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.map.MapProtocolProvider;
+import io.atomix.primitive.protocol.map.MapProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.concurrent.Futures;
@@ -45,9 +45,9 @@ public class DefaultDistributedMapBuilder<K, V> extends DistributedMapBuilder<K,
   public CompletableFuture<DistributedMap<K, V>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
     if (protocol instanceof GossipProtocol) {
-      if (protocol instanceof MapProtocolProvider) {
+      if (protocol instanceof MapProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((MapProtocolProvider) protocol).<K, V>newMapProtocol(name, managementService))
+            CompletableFuture.completedFuture(((MapProtocol) protocol).<K, V>newMapDelegate(name, managementService))
                 .thenApply(map -> new GossipDistributedMap<>(name, protocol, map)))
             .thenApply(AsyncDistributedMap::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedNavigableMapBuilder.java
@@ -22,7 +22,7 @@ import io.atomix.core.map.DistributedNavigableMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.map.NavigableMapProtocolProvider;
+import io.atomix.primitive.protocol.map.NavigableMapProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.concurrent.Futures;
@@ -43,9 +43,9 @@ public class DefaultDistributedNavigableMapBuilder<K extends Comparable<K>, V> e
   public CompletableFuture<DistributedNavigableMap<K, V>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
     if (protocol instanceof GossipProtocol) {
-      if (protocol instanceof NavigableMapProtocolProvider) {
+      if (protocol instanceof NavigableMapProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((NavigableMapProtocolProvider) protocol).<K, V>newNavigableMapProtocol(name, managementService))
+            CompletableFuture.completedFuture(((NavigableMapProtocol) protocol).<K, V>newNavigableMapDelegate(name, managementService))
                 .thenApply(set -> new GossipDistributedNavigableMap<>(name, protocol, set)))
             .thenApply(AsyncDistributedNavigableMap::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedSortedMapBuilder.java
@@ -22,7 +22,7 @@ import io.atomix.core.map.DistributedSortedMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.map.SortedMapProtocolProvider;
+import io.atomix.primitive.protocol.map.SortedMapProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.concurrent.Futures;
@@ -43,9 +43,9 @@ public class DefaultDistributedSortedMapBuilder<K extends Comparable<K>, V> exte
   public CompletableFuture<DistributedSortedMap<K, V>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
     if (protocol instanceof GossipProtocol) {
-      if (protocol instanceof SortedMapProtocolProvider) {
+      if (protocol instanceof SortedMapProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((SortedMapProtocolProvider) protocol).<K, V>newSortedMapProtocol(name, managementService))
+            CompletableFuture.completedFuture(((SortedMapProtocol) protocol).<K, V>newSortedMapDelegate(name, managementService))
                 .thenApply(set -> new GossipDistributedSortedMap<>(name, protocol, set)))
             .thenApply(AsyncDistributedSortedMap::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/map/impl/GossipDistributedMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/GossipDistributedMap.java
@@ -19,8 +19,8 @@ import com.google.common.collect.Maps;
 import io.atomix.core.map.MapEvent;
 import io.atomix.core.map.MapEventListener;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.map.MapProtocol;
-import io.atomix.primitive.protocol.map.MapProtocolEventListener;
+import io.atomix.primitive.protocol.map.MapDelegate;
+import io.atomix.primitive.protocol.map.MapDelegateEventListener;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -30,17 +30,17 @@ import java.util.concurrent.Executor;
  * Gossip-based distributed map.
  */
 public class GossipDistributedMap<K, V> extends AsyncDistributedJavaMap<K, V> {
-  private final MapProtocol<K, V> map;
-  private final Map<MapEventListener<K, V>, MapProtocolEventListener<K, V>> listenerMap = Maps.newConcurrentMap();
+  private final MapDelegate<K, V> map;
+  private final Map<MapEventListener<K, V>, MapDelegateEventListener<K, V>> listenerMap = Maps.newConcurrentMap();
 
-  public GossipDistributedMap(String name, PrimitiveProtocol protocol, MapProtocol<K, V> map) {
+  public GossipDistributedMap(String name, PrimitiveProtocol protocol, MapDelegate<K, V> map) {
     super(name, protocol, map);
     this.map = map;
   }
 
   @Override
   public CompletableFuture<Void> addListener(MapEventListener<K, V> listener, Executor executor) {
-    MapProtocolEventListener<K, V> eventListener = event -> executor.execute(() -> {
+    MapDelegateEventListener<K, V> eventListener = event -> executor.execute(() -> {
       switch (event.type()) {
         case INSERT:
           listener.event(new MapEvent<>(MapEvent.Type.INSERT, event.key(), event.value(), null));
@@ -63,7 +63,7 @@ public class GossipDistributedMap<K, V> extends AsyncDistributedJavaMap<K, V> {
 
   @Override
   public CompletableFuture<Void> removeListener(MapEventListener<K, V> listener) {
-    MapProtocolEventListener<K, V> eventListener = listenerMap.remove(listener);
+    MapDelegateEventListener<K, V> eventListener = listenerMap.remove(listener);
     if (eventListener != null) {
       return complete(() -> map.removeListener(eventListener));
     }

--- a/core/src/main/java/io/atomix/core/map/impl/GossipDistributedSortedMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/GossipDistributedSortedMap.java
@@ -19,8 +19,8 @@ import com.google.common.collect.Maps;
 import io.atomix.core.map.MapEvent;
 import io.atomix.core.map.MapEventListener;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.map.MapProtocolEventListener;
-import io.atomix.primitive.protocol.map.SortedMapProtocol;
+import io.atomix.primitive.protocol.map.MapDelegateEventListener;
+import io.atomix.primitive.protocol.map.SortedMapDelegate;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -30,17 +30,17 @@ import java.util.concurrent.Executor;
  * Gossip-based distributed sorted map.
  */
 public class GossipDistributedSortedMap<K extends Comparable<K>, V> extends AsyncDistributedSortedJavaMap<K, V> {
-  private final SortedMapProtocol<K, V> map;
-  private final Map<MapEventListener<K, V>, MapProtocolEventListener<K, V>> listenerMap = Maps.newConcurrentMap();
+  private final SortedMapDelegate<K, V> map;
+  private final Map<MapEventListener<K, V>, MapDelegateEventListener<K, V>> listenerMap = Maps.newConcurrentMap();
 
-  public GossipDistributedSortedMap(String name, PrimitiveProtocol protocol, SortedMapProtocol<K, V> map) {
+  public GossipDistributedSortedMap(String name, PrimitiveProtocol protocol, SortedMapDelegate<K, V> map) {
     super(name, protocol, map);
     this.map = map;
   }
 
   @Override
   public CompletableFuture<Void> addListener(MapEventListener<K, V> listener, Executor executor) {
-    MapProtocolEventListener<K, V> eventListener = event -> executor.execute(() -> {
+    MapDelegateEventListener<K, V> eventListener = event -> executor.execute(() -> {
       switch (event.type()) {
         case INSERT:
           listener.event(new MapEvent<>(MapEvent.Type.INSERT, event.key(), event.value(), null));
@@ -63,7 +63,7 @@ public class GossipDistributedSortedMap<K extends Comparable<K>, V> extends Asyn
 
   @Override
   public CompletableFuture<Void> removeListener(MapEventListener<K, V> listener) {
-    MapProtocolEventListener<K, V> eventListener = listenerMap.remove(listener);
+    MapDelegateEventListener<K, V> eventListener = listenerMap.remove(listener);
     if (eventListener != null) {
       return complete(() -> map.removeListener(eventListener));
     }

--- a/core/src/main/java/io/atomix/core/multimap/AtomicMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/AtomicMultimapBuilder.java
@@ -18,13 +18,23 @@ package io.atomix.core.multimap;
 
 import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * A builder class for {@code AsyncConsistentMultimap}.
  */
 public abstract class AtomicMultimapBuilder<K, V>
-    extends CachedPrimitiveBuilder<AtomicMultimapBuilder<K, V>, AtomicMultimapConfig, AtomicMultimap<K, V>> {
-  public AtomicMultimapBuilder(String name, AtomicMultimapConfig config, PrimitiveManagementService managementService) {
+    extends CachedPrimitiveBuilder<AtomicMultimapBuilder<K, V>, AtomicMultimapConfig, AtomicMultimap<K, V>>
+    implements ProxyCompatibleBuilder<AtomicMultimapBuilder<K, V>> {
+
+  protected AtomicMultimapBuilder(String name, AtomicMultimapConfig config, PrimitiveManagementService managementService) {
     super(AtomicMultimapType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicMultimapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/multimap/DistributedMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/DistributedMultimapBuilder.java
@@ -18,13 +18,23 @@ package io.atomix.core.multimap;
 
 import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * A builder class for {@code AsyncConsistentMultimap}.
  */
 public abstract class DistributedMultimapBuilder<K, V>
-    extends CachedPrimitiveBuilder<DistributedMultimapBuilder<K, V>, DistributedMultimapConfig, DistributedMultimap<K, V>> {
-  public DistributedMultimapBuilder(String name, DistributedMultimapConfig config, PrimitiveManagementService managementService) {
+    extends CachedPrimitiveBuilder<DistributedMultimapBuilder<K, V>, DistributedMultimapConfig, DistributedMultimap<K, V>>
+    implements ProxyCompatibleBuilder<DistributedMultimapBuilder<K, V>> {
+
+  protected DistributedMultimapBuilder(String name, DistributedMultimapConfig config, PrimitiveManagementService managementService) {
     super(DistributedMultimapType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedMultimapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/multiset/DistributedMultisetBuilder.java
+++ b/core/src/main/java/io/atomix/core/multiset/DistributedMultisetBuilder.java
@@ -17,14 +17,25 @@ package io.atomix.core.multiset;
 
 import io.atomix.core.collection.DistributedCollectionBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for distributed multiset.
  *
  * @param <E> multiset element type
  */
-public abstract class DistributedMultisetBuilder<E> extends DistributedCollectionBuilder<DistributedMultisetBuilder<E>, DistributedMultisetConfig, DistributedMultiset<E>, E> {
-  public DistributedMultisetBuilder(String name, DistributedMultisetConfig config, PrimitiveManagementService managementService) {
+public abstract class DistributedMultisetBuilder<E>
+    extends DistributedCollectionBuilder<DistributedMultisetBuilder<E>, DistributedMultisetConfig, DistributedMultiset<E>, E>
+    implements ProxyCompatibleBuilder<DistributedMultisetBuilder<E>> {
+
+  protected DistributedMultisetBuilder(String name, DistributedMultisetConfig config, PrimitiveManagementService managementService) {
     super(DistributedMultisetType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedMultisetBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/queue/DistributedQueueBuilder.java
+++ b/core/src/main/java/io/atomix/core/queue/DistributedQueueBuilder.java
@@ -17,14 +17,25 @@ package io.atomix.core.queue;
 
 import io.atomix.core.collection.DistributedCollectionBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for distributed queue.
  *
  * @param <E> queue element type
  */
-public abstract class DistributedQueueBuilder<E> extends DistributedCollectionBuilder<DistributedQueueBuilder<E>, DistributedQueueConfig, DistributedQueue<E>, E> {
-  public DistributedQueueBuilder(String name, DistributedQueueConfig config, PrimitiveManagementService managementService) {
+public abstract class DistributedQueueBuilder<E>
+    extends DistributedCollectionBuilder<DistributedQueueBuilder<E>, DistributedQueueConfig, DistributedQueue<E>, E>
+    implements ProxyCompatibleBuilder<DistributedQueueBuilder<E>> {
+
+  protected DistributedQueueBuilder(String name, DistributedQueueConfig config, PrimitiveManagementService managementService) {
     super(DistributedQueueType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedQueueBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/semaphore/AtomicSemaphoreBuilder.java
+++ b/core/src/main/java/io/atomix/core/semaphore/AtomicSemaphoreBuilder.java
@@ -17,15 +17,34 @@ package io.atomix.core.semaphore;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
+/**
+ * Atomic semaphore builder.
+ */
 public abstract class AtomicSemaphoreBuilder
-        extends PrimitiveBuilder<AtomicSemaphoreBuilder, AtomicSemaphoreConfig, AtomicSemaphore> {
-  public AtomicSemaphoreBuilder(String name, AtomicSemaphoreConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<AtomicSemaphoreBuilder, AtomicSemaphoreConfig, AtomicSemaphore>
+    implements ProxyCompatibleBuilder<AtomicSemaphoreBuilder> {
+
+  protected AtomicSemaphoreBuilder(String name, AtomicSemaphoreConfig config, PrimitiveManagementService managementService) {
     super(AtomicSemaphoreType.instance(), name, config, managementService);
   }
 
+  /**
+   * Sets the semaphore's initial capacity.
+   *
+   * @param permits the initial number of permits
+   * @return the semaphore builder
+   */
   public AtomicSemaphoreBuilder withInitialCapacity(int permits) {
     config.setInitialCapacity(permits);
     return this;
+  }
+
+  @Override
+  public AtomicSemaphoreBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/semaphore/DistributedSemaphoreBuilder.java
+++ b/core/src/main/java/io/atomix/core/semaphore/DistributedSemaphoreBuilder.java
@@ -17,15 +17,34 @@ package io.atomix.core.semaphore;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
+/**
+ * Distributed semaphore builder.
+ */
 public abstract class DistributedSemaphoreBuilder
-        extends PrimitiveBuilder<DistributedSemaphoreBuilder, DistributedSemaphoreConfig, DistributedSemaphore> {
-  public DistributedSemaphoreBuilder(String name, DistributedSemaphoreConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<DistributedSemaphoreBuilder, DistributedSemaphoreConfig, DistributedSemaphore>
+    implements ProxyCompatibleBuilder<DistributedSemaphoreBuilder> {
+
+  protected DistributedSemaphoreBuilder(String name, DistributedSemaphoreConfig config, PrimitiveManagementService managementService) {
     super(DistributedSemaphoreType.instance(), name, config, managementService);
   }
 
+  /**
+   * Sets the semaphore's initial capacity.
+   *
+   * @param permits the initial number of permits
+   * @return the semaphore builder
+   */
   public DistributedSemaphoreBuilder withInitialCapacity(int permits) {
     config.setInitialCapacity(permits);
     return this;
+  }
+
+  @Override
+  public DistributedSemaphoreBuilder withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/set/DistributedNavigableSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedNavigableSetBuilder.java
@@ -17,6 +17,11 @@ package io.atomix.core.set;
 
 import io.atomix.core.collection.DistributedCollectionBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetCompatibleBuilder;
 
 /**
  * Builder for distributed navigable set.
@@ -24,8 +29,21 @@ import io.atomix.primitive.PrimitiveManagementService;
  * @param <E> type set elements.
  */
 public abstract class DistributedNavigableSetBuilder<E extends Comparable<E>>
-    extends DistributedCollectionBuilder<DistributedNavigableSetBuilder<E>, DistributedNavigableSetConfig, DistributedNavigableSet<E>, E> {
-  public DistributedNavigableSetBuilder(String name, DistributedNavigableSetConfig config, PrimitiveManagementService managementService) {
+    extends DistributedCollectionBuilder<DistributedNavigableSetBuilder<E>, DistributedNavigableSetConfig, DistributedNavigableSet<E>, E>
+    implements ProxyCompatibleBuilder<DistributedNavigableSetBuilder<E>>,
+    NavigableSetCompatibleBuilder<DistributedNavigableSetBuilder<E>> {
+
+  protected DistributedNavigableSetBuilder(String name, DistributedNavigableSetConfig config, PrimitiveManagementService managementService) {
     super(DistributedNavigableSetType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedNavigableSetBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedNavigableSetBuilder<E> withProtocol(NavigableSetProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/set/DistributedNavigableSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedNavigableSetBuilder.java
@@ -20,8 +20,8 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.primitive.protocol.set.NavigableSetProtocol;
 import io.atomix.primitive.protocol.set.NavigableSetCompatibleBuilder;
+import io.atomix.primitive.protocol.set.NavigableSetProtocol;
 
 /**
  * Builder for distributed navigable set.
@@ -30,8 +30,7 @@ import io.atomix.primitive.protocol.set.NavigableSetCompatibleBuilder;
  */
 public abstract class DistributedNavigableSetBuilder<E extends Comparable<E>>
     extends DistributedCollectionBuilder<DistributedNavigableSetBuilder<E>, DistributedNavigableSetConfig, DistributedNavigableSet<E>, E>
-    implements ProxyCompatibleBuilder<DistributedNavigableSetBuilder<E>>,
-    NavigableSetCompatibleBuilder<DistributedNavigableSetBuilder<E>> {
+    implements ProxyCompatibleBuilder<DistributedNavigableSetBuilder<E>>, NavigableSetCompatibleBuilder<DistributedNavigableSetBuilder<E>> {
 
   protected DistributedNavigableSetBuilder(String name, DistributedNavigableSetConfig config, PrimitiveManagementService managementService) {
     super(DistributedNavigableSetType.instance(), name, config, managementService);

--- a/core/src/main/java/io/atomix/core/set/DistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSetBuilder.java
@@ -17,14 +17,49 @@ package io.atomix.core.set;
 
 import io.atomix.core.collection.DistributedCollectionBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetCompatibleBuilder;
+import io.atomix.primitive.protocol.set.SetProtocol;
+import io.atomix.primitive.protocol.set.SetCompatibleBuilder;
+import io.atomix.primitive.protocol.set.SortedSetProtocol;
+import io.atomix.primitive.protocol.set.SortedSetCompatibleBuilder;
 
 /**
  * Builder for distributed set.
  *
  * @param <E> type set elements.
  */
-public abstract class DistributedSetBuilder<E> extends DistributedCollectionBuilder<DistributedSetBuilder<E>, DistributedSetConfig, DistributedSet<E>, E> {
-  public DistributedSetBuilder(String name, DistributedSetConfig config, PrimitiveManagementService managementService) {
+public abstract class DistributedSetBuilder<E>
+    extends DistributedCollectionBuilder<DistributedSetBuilder<E>, DistributedSetConfig, DistributedSet<E>, E>
+    implements ProxyCompatibleBuilder<DistributedSetBuilder<E>>,
+    SetCompatibleBuilder<DistributedSetBuilder<E>>,
+    SortedSetCompatibleBuilder<DistributedSetBuilder<E>>,
+    NavigableSetCompatibleBuilder<DistributedSetBuilder<E>> {
+
+  protected DistributedSetBuilder(String name, DistributedSetConfig config, PrimitiveManagementService managementService) {
     super(DistributedSetType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedSetBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedSetBuilder<E> withProtocol(SetProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedSetBuilder<E> withProtocol(SortedSetProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedSetBuilder<E> withProtocol(NavigableSetProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/set/DistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSetBuilder.java
@@ -20,12 +20,8 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.primitive.protocol.set.NavigableSetProtocol;
-import io.atomix.primitive.protocol.set.NavigableSetCompatibleBuilder;
-import io.atomix.primitive.protocol.set.SetProtocol;
 import io.atomix.primitive.protocol.set.SetCompatibleBuilder;
-import io.atomix.primitive.protocol.set.SortedSetProtocol;
-import io.atomix.primitive.protocol.set.SortedSetCompatibleBuilder;
+import io.atomix.primitive.protocol.set.SetProtocol;
 
 /**
  * Builder for distributed set.
@@ -34,10 +30,7 @@ import io.atomix.primitive.protocol.set.SortedSetCompatibleBuilder;
  */
 public abstract class DistributedSetBuilder<E>
     extends DistributedCollectionBuilder<DistributedSetBuilder<E>, DistributedSetConfig, DistributedSet<E>, E>
-    implements ProxyCompatibleBuilder<DistributedSetBuilder<E>>,
-    SetCompatibleBuilder<DistributedSetBuilder<E>>,
-    SortedSetCompatibleBuilder<DistributedSetBuilder<E>>,
-    NavigableSetCompatibleBuilder<DistributedSetBuilder<E>> {
+    implements ProxyCompatibleBuilder<DistributedSetBuilder<E>>, SetCompatibleBuilder<DistributedSetBuilder<E>> {
 
   protected DistributedSetBuilder(String name, DistributedSetConfig config, PrimitiveManagementService managementService) {
     super(DistributedSetType.instance(), name, config, managementService);
@@ -50,16 +43,6 @@ public abstract class DistributedSetBuilder<E>
 
   @Override
   public DistributedSetBuilder<E> withProtocol(SetProtocol protocol) {
-    return withProtocol((PrimitiveProtocol) protocol);
-  }
-
-  @Override
-  public DistributedSetBuilder<E> withProtocol(SortedSetProtocol protocol) {
-    return withProtocol((PrimitiveProtocol) protocol);
-  }
-
-  @Override
-  public DistributedSetBuilder<E> withProtocol(NavigableSetProtocol protocol) {
     return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/set/DistributedSortedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSortedSetBuilder.java
@@ -17,6 +17,13 @@ package io.atomix.core.set;
 
 import io.atomix.core.collection.DistributedCollectionBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetCompatibleBuilder;
+import io.atomix.primitive.protocol.set.SortedSetProtocol;
+import io.atomix.primitive.protocol.set.SortedSetCompatibleBuilder;
 
 /**
  * Builder for distributed sorted set.
@@ -24,8 +31,27 @@ import io.atomix.primitive.PrimitiveManagementService;
  * @param <E> type set elements.
  */
 public abstract class DistributedSortedSetBuilder<E extends Comparable<E>>
-    extends DistributedCollectionBuilder<DistributedSortedSetBuilder<E>, DistributedSortedSetConfig, DistributedSortedSet<E>, E> {
-  public DistributedSortedSetBuilder(String name, DistributedSortedSetConfig config, PrimitiveManagementService managementService) {
+    extends DistributedCollectionBuilder<DistributedSortedSetBuilder<E>, DistributedSortedSetConfig, DistributedSortedSet<E>, E>
+    implements ProxyCompatibleBuilder<DistributedSortedSetBuilder<E>>,
+    SortedSetCompatibleBuilder<DistributedSortedSetBuilder<E>>,
+    NavigableSetCompatibleBuilder<DistributedSortedSetBuilder<E>> {
+
+  protected DistributedSortedSetBuilder(String name, DistributedSortedSetConfig config, PrimitiveManagementService managementService) {
     super(DistributedSortedSetType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public DistributedSortedSetBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedSortedSetBuilder<E> withProtocol(SortedSetProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  @Override
+  public DistributedSortedSetBuilder<E> withProtocol(NavigableSetProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/set/DistributedSortedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSortedSetBuilder.java
@@ -20,10 +20,8 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.primitive.protocol.set.NavigableSetProtocol;
-import io.atomix.primitive.protocol.set.NavigableSetCompatibleBuilder;
-import io.atomix.primitive.protocol.set.SortedSetProtocol;
 import io.atomix.primitive.protocol.set.SortedSetCompatibleBuilder;
+import io.atomix.primitive.protocol.set.SortedSetProtocol;
 
 /**
  * Builder for distributed sorted set.
@@ -33,8 +31,7 @@ import io.atomix.primitive.protocol.set.SortedSetCompatibleBuilder;
 public abstract class DistributedSortedSetBuilder<E extends Comparable<E>>
     extends DistributedCollectionBuilder<DistributedSortedSetBuilder<E>, DistributedSortedSetConfig, DistributedSortedSet<E>, E>
     implements ProxyCompatibleBuilder<DistributedSortedSetBuilder<E>>,
-    SortedSetCompatibleBuilder<DistributedSortedSetBuilder<E>>,
-    NavigableSetCompatibleBuilder<DistributedSortedSetBuilder<E>> {
+    SortedSetCompatibleBuilder<DistributedSortedSetBuilder<E>> {
 
   protected DistributedSortedSetBuilder(String name, DistributedSortedSetConfig config, PrimitiveManagementService managementService) {
     super(DistributedSortedSetType.instance(), name, config, managementService);
@@ -47,11 +44,6 @@ public abstract class DistributedSortedSetBuilder<E extends Comparable<E>>
 
   @Override
   public DistributedSortedSetBuilder<E> withProtocol(SortedSetProtocol protocol) {
-    return withProtocol((PrimitiveProtocol) protocol);
-  }
-
-  @Override
-  public DistributedSortedSetBuilder<E> withProtocol(NavigableSetProtocol protocol) {
     return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetBuilder.java
@@ -22,7 +22,7 @@ import io.atomix.core.set.DistributedNavigableSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.set.NavigableSetProtocolProvider;
+import io.atomix.primitive.protocol.set.NavigableSetProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.concurrent.Futures;
@@ -44,9 +44,9 @@ public class DefaultDistributedNavigableSetBuilder<E extends Comparable<E>> exte
   public CompletableFuture<DistributedNavigableSet<E>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
     if (protocol instanceof GossipProtocol) {
-      if (protocol instanceof NavigableSetProtocolProvider) {
+      if (protocol instanceof NavigableSetProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((NavigableSetProtocolProvider) protocol).<E>newNavigableSetProtocol(name, managementService))
+            CompletableFuture.completedFuture(((NavigableSetProtocol) protocol).<E>newNavigableSetDelegate(name, managementService))
                 .thenApply(set -> new GossipDistributedNavigableSet<>(name, protocol, set)))
             .thenApply(AsyncDistributedNavigableSet::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetBuilder.java
@@ -23,7 +23,7 @@ import io.atomix.core.set.DistributedSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.set.SetProtocolProvider;
+import io.atomix.primitive.protocol.set.SetProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.concurrent.Futures;
@@ -46,9 +46,9 @@ public class DefaultDistributedSetBuilder<E> extends DistributedSetBuilder<E> {
   public CompletableFuture<DistributedSet<E>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
     if (protocol instanceof GossipProtocol) {
-      if (protocol instanceof SetProtocolProvider) {
+      if (protocol instanceof SetProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((SetProtocolProvider) protocol).<E>newSetProtocol(name, managementService))
+            CompletableFuture.completedFuture(((SetProtocol) protocol).<E>newSetDelegate(name, managementService))
                 .thenApply(set -> new GossipDistributedSet<>(name, protocol, set)))
             .thenApply(AsyncDistributedSet::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSortedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSortedSetBuilder.java
@@ -22,7 +22,7 @@ import io.atomix.core.set.DistributedSortedSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.set.SortedSetProtocolProvider;
+import io.atomix.primitive.protocol.set.SortedSetProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.concurrent.Futures;
@@ -44,9 +44,9 @@ public class DefaultDistributedSortedSetBuilder<E extends Comparable<E>> extends
   public CompletableFuture<DistributedSortedSet<E>> buildAsync() {
     PrimitiveProtocol protocol = protocol();
     if (protocol instanceof GossipProtocol) {
-      if (protocol instanceof SortedSetProtocolProvider) {
+      if (protocol instanceof SortedSetProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((SortedSetProtocolProvider) protocol).<E>newSortedSetProtocol(name, managementService))
+            CompletableFuture.completedFuture(((SortedSetProtocol) protocol).<E>newSortedSetDelegate(name, managementService))
                 .thenApply(set -> new GossipDistributedSortedSet<>(name, protocol, set)))
             .thenApply(AsyncDistributedSortedSet::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/set/impl/GossipDistributedNavigableSet.java
+++ b/core/src/main/java/io/atomix/core/set/impl/GossipDistributedNavigableSet.java
@@ -19,9 +19,9 @@ import com.google.common.collect.Maps;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.set.SetProtocol;
-import io.atomix.primitive.protocol.set.SetProtocolEventListener;
-import io.atomix.primitive.protocol.set.NavigableSetProtocol;
+import io.atomix.primitive.protocol.set.SetDelegate;
+import io.atomix.primitive.protocol.set.SetDelegateEventListener;
+import io.atomix.primitive.protocol.set.NavigableSetDelegate;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -30,17 +30,17 @@ import java.util.concurrent.CompletableFuture;
  * Gossip-based distributed set.
  */
 public class GossipDistributedNavigableSet<E extends Comparable<E>> extends AsyncDistributedNavigableJavaSet<E> {
-  private final SetProtocol<E> set;
-  private final Map<CollectionEventListener<E>, SetProtocolEventListener<E>> listenerMap = Maps.newConcurrentMap();
+  private final SetDelegate<E> set;
+  private final Map<CollectionEventListener<E>, SetDelegateEventListener<E>> listenerMap = Maps.newConcurrentMap();
 
-  public GossipDistributedNavigableSet(String name, PrimitiveProtocol protocol, NavigableSetProtocol<E> set) {
+  public GossipDistributedNavigableSet(String name, PrimitiveProtocol protocol, NavigableSetDelegate<E> set) {
     super(name, protocol, set);
     this.set = set;
   }
 
   @Override
   public CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
-    SetProtocolEventListener<E> eventListener = event -> {
+    SetDelegateEventListener<E> eventListener = event -> {
       switch (event.type()) {
         case ADD:
           listener.event(new CollectionEvent<>(CollectionEvent.Type.ADD, event.element()));
@@ -60,7 +60,7 @@ public class GossipDistributedNavigableSet<E extends Comparable<E>> extends Asyn
 
   @Override
   public CompletableFuture<Void> removeListener(CollectionEventListener<E> listener) {
-    SetProtocolEventListener<E> eventListener = listenerMap.remove(listener);
+    SetDelegateEventListener<E> eventListener = listenerMap.remove(listener);
     if (eventListener != null) {
       set.removeListener(eventListener);
     }

--- a/core/src/main/java/io/atomix/core/set/impl/GossipDistributedSet.java
+++ b/core/src/main/java/io/atomix/core/set/impl/GossipDistributedSet.java
@@ -19,8 +19,8 @@ import com.google.common.collect.Maps;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.set.SetProtocol;
-import io.atomix.primitive.protocol.set.SetProtocolEventListener;
+import io.atomix.primitive.protocol.set.SetDelegate;
+import io.atomix.primitive.protocol.set.SetDelegateEventListener;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -29,17 +29,17 @@ import java.util.concurrent.CompletableFuture;
  * Gossip-based distributed set.
  */
 public class GossipDistributedSet<E> extends AsyncDistributedJavaSet<E> {
-  private final SetProtocol<E> set;
-  private final Map<CollectionEventListener<E>, SetProtocolEventListener<E>> listenerMap = Maps.newConcurrentMap();
+  private final SetDelegate<E> set;
+  private final Map<CollectionEventListener<E>, SetDelegateEventListener<E>> listenerMap = Maps.newConcurrentMap();
 
-  public GossipDistributedSet(String name, PrimitiveProtocol protocol, SetProtocol<E> set) {
+  public GossipDistributedSet(String name, PrimitiveProtocol protocol, SetDelegate<E> set) {
     super(name, protocol, set);
     this.set = set;
   }
 
   @Override
   public CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
-    SetProtocolEventListener<E> eventListener = event -> {
+    SetDelegateEventListener<E> eventListener = event -> {
       switch (event.type()) {
         case ADD:
           listener.event(new CollectionEvent<>(CollectionEvent.Type.ADD, event.element()));
@@ -59,7 +59,7 @@ public class GossipDistributedSet<E> extends AsyncDistributedJavaSet<E> {
 
   @Override
   public CompletableFuture<Void> removeListener(CollectionEventListener<E> listener) {
-    SetProtocolEventListener<E> eventListener = listenerMap.remove(listener);
+    SetDelegateEventListener<E> eventListener = listenerMap.remove(listener);
     if (eventListener != null) {
       set.removeListener(eventListener);
     }

--- a/core/src/main/java/io/atomix/core/set/impl/GossipDistributedSortedSet.java
+++ b/core/src/main/java/io/atomix/core/set/impl/GossipDistributedSortedSet.java
@@ -19,8 +19,8 @@ import com.google.common.collect.Maps;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.set.SetProtocolEventListener;
-import io.atomix.primitive.protocol.set.SortedSetProtocol;
+import io.atomix.primitive.protocol.set.SetDelegateEventListener;
+import io.atomix.primitive.protocol.set.SortedSetDelegate;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -29,17 +29,17 @@ import java.util.concurrent.CompletableFuture;
  * Gossip-based distributed set.
  */
 public class GossipDistributedSortedSet<E extends Comparable<E>> extends AsyncDistributedSortedJavaSet<E> {
-  private final SortedSetProtocol<E> set;
-  private final Map<CollectionEventListener<E>, SetProtocolEventListener<E>> listenerMap = Maps.newConcurrentMap();
+  private final SortedSetDelegate<E> set;
+  private final Map<CollectionEventListener<E>, SetDelegateEventListener<E>> listenerMap = Maps.newConcurrentMap();
 
-  public GossipDistributedSortedSet(String name, PrimitiveProtocol protocol, SortedSetProtocol<E> set) {
+  public GossipDistributedSortedSet(String name, PrimitiveProtocol protocol, SortedSetDelegate<E> set) {
     super(name, protocol, set);
     this.set = set;
   }
 
   @Override
   public CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
-    SetProtocolEventListener<E> eventListener = event -> {
+    SetDelegateEventListener<E> eventListener = event -> {
       switch (event.type()) {
         case ADD:
           listener.event(new CollectionEvent<>(CollectionEvent.Type.ADD, event.element()));
@@ -59,7 +59,7 @@ public class GossipDistributedSortedSet<E extends Comparable<E>> extends AsyncDi
 
   @Override
   public CompletableFuture<Void> removeListener(CollectionEventListener<E> listener) {
-    SetProtocolEventListener<E> eventListener = listenerMap.remove(listener);
+    SetDelegateEventListener<E> eventListener = listenerMap.remove(listener);
     if (eventListener != null) {
       set.removeListener(eventListener);
     }

--- a/core/src/main/java/io/atomix/core/transaction/AsyncTransaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/AsyncTransaction.java
@@ -17,7 +17,7 @@ package io.atomix.core.transaction;
 
 import io.atomix.primitive.AsyncPrimitive;
 import io.atomix.primitive.DistributedPrimitive;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -89,7 +89,7 @@ public interface AsyncTransaction extends AsyncPrimitive {
    * @param <V>  the value type
    * @return the transactional map builder
    */
-  default <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name, PrimitiveProtocol protocol) {
+  default <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name, ProxyProtocol protocol) {
     return this.<K, V>mapBuilder(name).withProtocol(protocol);
   }
 
@@ -110,7 +110,7 @@ public interface AsyncTransaction extends AsyncPrimitive {
    * @param <E>  the set element type
    * @return the transactional set builder
    */
-  default <E> TransactionalSetBuilder<E> setBuilder(String name, PrimitiveProtocol protocol) {
+  default <E> TransactionalSetBuilder<E> setBuilder(String name, ProxyProtocol protocol) {
     return this.<E>setBuilder(name).withProtocol(protocol);
   }
 

--- a/core/src/main/java/io/atomix/core/transaction/Transaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/Transaction.java
@@ -16,7 +16,6 @@
 package io.atomix.core.transaction;
 
 import io.atomix.primitive.SyncPrimitive;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 /**
  * Transaction primitive.
@@ -73,19 +72,6 @@ public interface Transaction extends SyncPrimitive {
   <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name);
 
   /**
-   * Returns a new transactional map builder.
-   *
-   * @param name     the map name
-   * @param protocol the primitive protocol
-   * @param <K>      the key type
-   * @param <V>      the value type
-   * @return the transactional map builder
-   */
-  default <K, V> TransactionalMapBuilder<K, V> mapBuilder(String name, PrimitiveProtocol protocol) {
-    return this.<K, V>mapBuilder(name).withProtocol(protocol);
-  }
-
-  /**
    * Returns a new transactional set builder.
    *
    * @param name the set name
@@ -93,18 +79,6 @@ public interface Transaction extends SyncPrimitive {
    * @return the transactional set builder
    */
   <E> TransactionalSetBuilder<E> setBuilder(String name);
-
-  /**
-   * Returns a new transactional set builder.
-   *
-   * @param name     the set name
-   * @param protocol the primitive protocol
-   * @param <E>      the set element type
-   * @return the transactional set builder
-   */
-  default <E> TransactionalSetBuilder<E> setBuilder(String name, PrimitiveProtocol protocol) {
-    return this.<E>setBuilder(name).withProtocol(protocol);
-  }
 
   @Override
   AsyncTransaction async();

--- a/core/src/main/java/io/atomix/core/transaction/TransactionParticipant.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionParticipant.java
@@ -16,7 +16,7 @@
 package io.atomix.core.transaction;
 
 import io.atomix.primitive.DistributedPrimitive;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface TransactionParticipant<T> extends DistributedPrimitive {
   @Override
-  StateMachineReplicationProtocol protocol();
+  ProxyProtocol protocol();
 
   /**
    * Returns the participant's transaction log.

--- a/core/src/main/java/io/atomix/core/transaction/TransactionalMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionalMapBuilder.java
@@ -18,13 +18,23 @@ package io.atomix.core.transaction;
 import io.atomix.core.map.AtomicMapType;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Transactional map builder.
  */
 public abstract class TransactionalMapBuilder<K, V>
-    extends PrimitiveBuilder<TransactionalMapBuilder<K, V>, TransactionalMapConfig, TransactionalMap<K, V>> {
+    extends PrimitiveBuilder<TransactionalMapBuilder<K, V>, TransactionalMapConfig, TransactionalMap<K, V>>
+    implements ProxyCompatibleBuilder<TransactionalMapBuilder<K, V>> {
+
   protected TransactionalMapBuilder(String name, TransactionalMapConfig config, PrimitiveManagementService managementService) {
     super(AtomicMapType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public TransactionalMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/transaction/TransactionalSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionalSetBuilder.java
@@ -18,13 +18,23 @@ package io.atomix.core.transaction;
 import io.atomix.core.set.DistributedSetType;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Transactional set builder.
  */
 public abstract class TransactionalSetBuilder<E>
-    extends PrimitiveBuilder<TransactionalSetBuilder<E>, TransactionalSetConfig, TransactionalSet<E>> {
+    extends PrimitiveBuilder<TransactionalSetBuilder<E>, TransactionalSetConfig, TransactionalSet<E>>
+    implements ProxyCompatibleBuilder<TransactionalSetBuilder<E>> {
+
   protected TransactionalSetBuilder(String name, TransactionalSetConfig config, PrimitiveManagementService managementService) {
     super(DistributedSetType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public TransactionalSetBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalMapBuilder.java
@@ -22,7 +22,7 @@ import io.atomix.core.transaction.TransactionalMap;
 import io.atomix.core.transaction.TransactionalMapBuilder;
 import io.atomix.core.transaction.TransactionalMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -40,7 +40,7 @@ public class DefaultTransactionalMapBuilder<K, V> extends TransactionalMapBuilde
   }
 
   @Override
-  public TransactionalMapBuilder<K, V> withProtocol(PrimitiveProtocol protocol) {
+  public TransactionalMapBuilder<K, V> withProtocol(ProxyProtocol protocol) {
     mapBuilder.withProtocol(protocol);
     return this;
   }

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransactionalSetBuilder.java
@@ -22,7 +22,7 @@ import io.atomix.core.transaction.TransactionalSet;
 import io.atomix.core.transaction.TransactionalSetBuilder;
 import io.atomix.core.transaction.TransactionalSetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -40,7 +40,7 @@ public class DefaultTransactionalSetBuilder<E> extends TransactionalSetBuilder<E
   }
 
   @Override
-  public TransactionalSetBuilder<E> withProtocol(PrimitiveProtocol protocol) {
+  public TransactionalSetBuilder<E> withProtocol(ProxyProtocol protocol) {
     setBuilder.withProtocol(protocol);
     return this;
   }

--- a/core/src/main/java/io/atomix/core/transaction/impl/ReadCommittedTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/ReadCommittedTransactionalMap.java
@@ -23,8 +23,7 @@ import io.atomix.core.map.impl.MapUpdate;
 import io.atomix.core.map.impl.MapUpdate.Type;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.util.Map;
@@ -42,8 +41,8 @@ public class ReadCommittedTransactionalMap<K, V> extends TransactionalMapPartici
   }
 
   @Override
-  public StateMachineReplicationProtocol protocol() {
-    return (StateMachineReplicationProtocol) consistentMap.protocol();
+  public ProxyProtocol protocol() {
+    return (ProxyProtocol) consistentMap.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/ReadCommittedTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/ReadCommittedTransactionalSet.java
@@ -21,8 +21,7 @@ import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.core.set.impl.SetUpdate;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -38,8 +37,8 @@ public class ReadCommittedTransactionalSet<E> extends TransactionalSetParticipan
   }
 
   @Override
-  public StateMachineReplicationProtocol protocol() {
-    return (StateMachineReplicationProtocol) set.protocol();
+  public ProxyProtocol protocol() {
+    return (ProxyProtocol) set.protocol();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/transaction/impl/RepeatableReadsTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/RepeatableReadsTransactionalMap.java
@@ -22,7 +22,7 @@ import io.atomix.core.map.impl.MapUpdate;
 import io.atomix.core.map.impl.MapUpdate.Type;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.time.Versioned;
 
 import java.util.Map;
@@ -41,8 +41,8 @@ public class RepeatableReadsTransactionalMap<K, V> extends TransactionalMapParti
   }
 
   @Override
-  public StateMachineReplicationProtocol protocol() {
-    return (StateMachineReplicationProtocol) consistentMap.protocol();
+  public ProxyProtocol protocol() {
+    return (ProxyProtocol) consistentMap.protocol();
   }
 
   private CompletableFuture<Versioned<V>> read(K key) {

--- a/core/src/main/java/io/atomix/core/transaction/impl/RepeatableReadsTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/RepeatableReadsTransactionalSet.java
@@ -21,7 +21,7 @@ import io.atomix.core.set.AsyncDistributedSet;
 import io.atomix.core.set.impl.SetUpdate;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -38,8 +38,8 @@ public class RepeatableReadsTransactionalSet<E> extends TransactionalSetParticip
   }
 
   @Override
-  public StateMachineReplicationProtocol protocol() {
-    return (StateMachineReplicationProtocol) set.protocol();
+  public ProxyProtocol protocol() {
+    return (ProxyProtocol) set.protocol();
   }
 
   private CompletableFuture<Boolean> read(E element) {

--- a/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeBuilder.java
@@ -18,13 +18,23 @@ package io.atomix.core.tree;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for {@link AtomicDocumentTree}.
  */
 public abstract class AtomicDocumentTreeBuilder<V>
-    extends PrimitiveBuilder<AtomicDocumentTreeBuilder<V>, AtomicDocumentTreeConfig, AtomicDocumentTree<V>> {
+    extends PrimitiveBuilder<AtomicDocumentTreeBuilder<V>, AtomicDocumentTreeConfig, AtomicDocumentTree<V>>
+    implements ProxyCompatibleBuilder<AtomicDocumentTreeBuilder<V>> {
+
   protected AtomicDocumentTreeBuilder(String name, AtomicDocumentTreeConfig config, PrimitiveManagementService managementService) {
     super(AtomicDocumentTreeType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicDocumentTreeBuilder<V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/value/AtomicValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/AtomicValueBuilder.java
@@ -17,6 +17,9 @@ package io.atomix.core.value;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Builder for constructing new AtomicValue instances.
@@ -24,8 +27,15 @@ import io.atomix.primitive.PrimitiveManagementService;
  * @param <V> atomic value type
  */
 public abstract class AtomicValueBuilder<V>
-    extends PrimitiveBuilder<AtomicValueBuilder<V>, AtomicValueConfig, AtomicValue<V>> {
-  public AtomicValueBuilder(String name, AtomicValueConfig config, PrimitiveManagementService managementService) {
+    extends PrimitiveBuilder<AtomicValueBuilder<V>, AtomicValueConfig, AtomicValue<V>>
+    implements ProxyCompatibleBuilder<AtomicValueBuilder<V>> {
+
+  protected AtomicValueBuilder(String name, AtomicValueConfig config, PrimitiveManagementService managementService) {
     super(AtomicValueType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public AtomicValueBuilder<V> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/main/java/io/atomix/core/workqueue/WorkQueueBuilder.java
+++ b/core/src/main/java/io/atomix/core/workqueue/WorkQueueBuilder.java
@@ -17,12 +17,23 @@ package io.atomix.core.workqueue;
 
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
+import io.atomix.primitive.protocol.ProxyProtocol;
 
 /**
  * Work queue builder.
  */
-public abstract class WorkQueueBuilder<E> extends PrimitiveBuilder<WorkQueueBuilder<E>, WorkQueueConfig, WorkQueue<E>> {
-  public WorkQueueBuilder(String name, WorkQueueConfig config, PrimitiveManagementService managementService) {
+public abstract class WorkQueueBuilder<E>
+    extends PrimitiveBuilder<WorkQueueBuilder<E>, WorkQueueConfig, WorkQueue<E>>
+    implements ProxyCompatibleBuilder<WorkQueueBuilder<E>> {
+
+  protected WorkQueueBuilder(String name, WorkQueueConfig config, PrimitiveManagementService managementService) {
     super(WorkQueueType.instance(), name, config, managementService);
+  }
+
+  @Override
+  public WorkQueueBuilder<E> withProtocol(ProxyProtocol protocol) {
+    return withProtocol((PrimitiveProtocol) protocol);
   }
 }

--- a/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractPrimitiveTest.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 /**
  * Base Atomix test.
  */
-public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
+public abstract class AbstractPrimitiveTest<P extends PrimitiveProtocol> extends AbstractAtomixTest {
   private static List<Atomix> servers;
   private static List<Atomix> clients;
   private static int id = 10;
@@ -44,7 +44,7 @@ public abstract class AbstractPrimitiveTest extends AbstractAtomixTest {
    *
    * @return the protocol with which to test
    */
-  protected abstract PrimitiveProtocol protocol();
+  protected abstract P protocol();
 
   /**
    * Returns a new Atomix instance.

--- a/core/src/test/java/io/atomix/core/barrier/DistributedCyclicBarrierTest.java
+++ b/core/src/test/java/io/atomix/core/barrier/DistributedCyclicBarrierTest.java
@@ -16,6 +16,7 @@
 package io.atomix.core.barrier;
 
 import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ import static org.junit.Assert.fail;
 /**
  * Distributed cyclic barrier test.
  */
-public abstract class DistributedCyclicBarrierTest extends AbstractPrimitiveTest {
+public abstract class DistributedCyclicBarrierTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Ignore
   @Test
   public void testBarrier() throws Exception {

--- a/core/src/test/java/io/atomix/core/barrier/PrimaryBackupDistributedCyclicBarrierTest.java
+++ b/core/src/test/java/io/atomix/core/barrier/PrimaryBackupDistributedCyclicBarrierTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.barrier;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedCyclicBarrierTest extends DistributedCyclicBarrierTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/barrier/RaftDistributedCyclicBarrierTest.java
+++ b/core/src/test/java/io/atomix/core/barrier/RaftDistributedCyclicBarrierTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.barrier;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 import java.time.Duration;
@@ -25,7 +25,7 @@ import java.time.Duration;
  */
 public class RaftDistributedCyclicBarrierTest extends DistributedCyclicBarrierTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMinTimeout(Duration.ofSeconds(1))
         .withMaxTimeout(Duration.ofSeconds(1))

--- a/core/src/test/java/io/atomix/core/counter/AtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/AtomicCounterTest.java
@@ -16,8 +16,8 @@
 package io.atomix.core.counter;
 
 import io.atomix.core.AbstractPrimitiveTest;
-
 import io.atomix.core.counter.impl.AtomicCounterProxy;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -29,10 +29,13 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link AtomicCounterProxy}.
  */
-public abstract class AtomicCounterTest extends AbstractPrimitiveTest {
+public abstract class AtomicCounterTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testBasicOperations() throws Throwable {
-    AsyncAtomicCounter along = atomix().atomicCounterBuilder("test-counter-basic-operations", protocol()).build().async();
+    AsyncAtomicCounter along = atomix().atomicCounterBuilder("test-counter-basic-operations")
+        .withProtocol(protocol())
+        .build()
+        .async();
     assertEquals(0, along.get().get(30, TimeUnit.SECONDS).longValue());
     assertEquals(1, along.incrementAndGet().get(30, TimeUnit.SECONDS).longValue());
     along.set(100).get(30, TimeUnit.SECONDS);

--- a/core/src/test/java/io/atomix/core/counter/CrdtCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/CrdtCounterTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.counter;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.counter.CounterProtocol;
 import io.atomix.protocols.gossip.CrdtProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.gossip.CrdtProtocol;
  */
 public class CrdtCounterTest extends DistributedCounterTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected CounterProtocol protocol() {
     return CrdtProtocol.builder().build();
   }
 }

--- a/core/src/test/java/io/atomix/core/counter/DistributedCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/DistributedCounterTest.java
@@ -16,23 +16,24 @@
 package io.atomix.core.counter;
 
 import io.atomix.core.AbstractPrimitiveTest;
-import io.atomix.core.counter.impl.AtomicCounterProxy;
+import io.atomix.primitive.protocol.counter.CounterProtocol;
 import org.junit.Test;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link DistributedCounter}.
  */
-public abstract class DistributedCounterTest extends AbstractPrimitiveTest {
+public abstract class DistributedCounterTest extends AbstractPrimitiveTest<CounterProtocol> {
   @Test
   public void testBasicOperations() throws Throwable {
-    DistributedCounter counter1 = atomix().counterBuilder("testBasicOperations", protocol()).build();
-    DistributedCounter counter2 = atomix().counterBuilder("testBasicOperations", protocol()).build();
+    DistributedCounter counter1 = atomix().counterBuilder("testBasicOperations")
+        .withProtocol(protocol())
+        .build();
+    DistributedCounter counter2 = atomix().counterBuilder("testBasicOperations")
+        .withProtocol(protocol())
+        .build();
 
     assertEquals(1, counter1.incrementAndGet());
     assertEquals(2, counter1.incrementAndGet());

--- a/core/src/test/java/io/atomix/core/counter/PrimaryBackupAtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/PrimaryBackupAtomicCounterTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.counter;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicCounterTest extends AtomicCounterTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/counter/RaftAtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/RaftAtomicCounterTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.counter;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftAtomicCounterTest extends AtomicCounterTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/election/LeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/LeaderElectionTest.java
@@ -17,8 +17,8 @@ package io.atomix.core.election;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.core.AbstractPrimitiveTest;
-
 import io.atomix.core.election.impl.LeaderElectionProxy;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link LeaderElectionProxy}.
  */
-public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
+public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   MemberId node1 = MemberId.from("node1");
   MemberId node2 = MemberId.from("node2");
@@ -42,7 +42,10 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testRun() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-run", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-run")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election1.run(node1).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -50,7 +53,10 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
       assertEquals(node1, result.candidates().get(0));
     }).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-run", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-run")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election2.run(node2).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -62,9 +68,15 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testWithdraw() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-withdraw", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-withdraw")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-withdraw", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-withdraw")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election2.run(node2).get(30, TimeUnit.SECONDS);
 
     LeaderEventListener listener1 = new LeaderEventListener();
@@ -100,9 +112,18 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testAnoint() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint", protocol()).build().async();
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint", protocol()).build().async();
-    AsyncLeaderElection<MemberId> election3 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElection<MemberId> election3 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
     election2.run(node2).get(30, TimeUnit.SECONDS);
 
@@ -146,9 +167,18 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testPromote() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-promote", protocol()).build().async();
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-promote", protocol()).build().async();
-    AsyncLeaderElection<MemberId> election3 = atomix().<MemberId>leaderElectionBuilder("test-election-promote", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-promote")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-promote")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElection<MemberId> election3 = atomix().<MemberId>leaderElectionBuilder("test-election-promote")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
     election2.run(node2).get(30, TimeUnit.SECONDS);
 
@@ -196,9 +226,15 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testLeaderSessionClose() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-leader-session-close", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-leader-session-close", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     LeaderEventListener listener = new LeaderEventListener();
     election2.run(node2).get(30, TimeUnit.SECONDS);
     election2.addListener(listener).get(30, TimeUnit.SECONDS);
@@ -212,9 +248,15 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testNonLeaderSessionClose() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-non-leader-session-close", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-non-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-non-leader-session-close", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-non-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     LeaderEventListener listener = new LeaderEventListener();
     election2.run(node2).get(30, TimeUnit.SECONDS);
     election1.addListener(listener).get(30, TimeUnit.SECONDS);
@@ -228,8 +270,14 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest {
 
   @Test
   public void testQueries() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-query", protocol()).build().async();
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-query", protocol()).build().async();
+    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-query")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-query")
+        .withProtocol(protocol())
+        .build()
+        .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
     election2.run(node2).get(30, TimeUnit.SECONDS);
     election2.run(node2).get(30, TimeUnit.SECONDS);

--- a/core/src/test/java/io/atomix/core/election/LeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/LeaderElectorTest.java
@@ -17,6 +17,7 @@ package io.atomix.core.election;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Leader elector test.
  */
-public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
+public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   MemberId node1 = MemberId.from("4");
   MemberId node2 = MemberId.from("5");
@@ -41,7 +42,10 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testRun() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-run", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-run")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -56,7 +60,10 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
       assertEquals(node1, result.candidates().get(0));
     }).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-run", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-run")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector2.run("bar", node2).thenAccept(result -> {
       assertEquals(node1, result.leader().id());
       assertEquals(1, result.leader().term());
@@ -68,9 +75,15 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testWithdraw() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-withdraw", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-withdraw")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-withdraw", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-withdraw")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
 
     LeaderEventListener listener1 = new LeaderEventListener();
@@ -112,9 +125,18 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testAnoint() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint", protocol()).build().async();
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint", protocol()).build().async();
-    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
 
@@ -158,9 +180,18 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testPromote() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote", protocol()).build().async();
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote", protocol()).build().async();
-    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
 
@@ -208,9 +239,15 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testLeaderSessionClose() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-session-close", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-session-close", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     LeaderEventListener listener = new LeaderEventListener();
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
     elector2.addListener("foo", listener).get(30, TimeUnit.SECONDS);
@@ -224,9 +261,15 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testNonLeaderSessionClose() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-non-leader-session-close", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-non-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-non-leader-session-close", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-non-leader-session-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     LeaderEventListener listener = new LeaderEventListener();
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
     elector1.addListener(listener).get(30, TimeUnit.SECONDS);
@@ -241,17 +284,23 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
   @Test
   @Ignore // Leader balancing is currently not deterministic in this test
   public void testLeaderBalance() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
     elector1.run("bar", node1).get(30, TimeUnit.SECONDS);
     elector1.run("baz", node1).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance").build().async();
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
     elector2.run("bar", node2).get(30, TimeUnit.SECONDS);
     elector2.run("baz", node2).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector3.run("foo", node3).get(30, TimeUnit.SECONDS);
     elector3.run("bar", node3).get(30, TimeUnit.SECONDS);
     elector3.run("baz", node3).get(30, TimeUnit.SECONDS);
@@ -285,8 +334,14 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest {
 
   @Test
   public void testQueries() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-query", protocol()).build().async();
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-query", protocol()).build().async();
+    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-query")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-query")
+        .withProtocol(protocol())
+        .build()
+        .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
     elector2.run("bar", node2).get(30, TimeUnit.SECONDS);

--- a/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectionTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupLeaderElectionTest extends LeaderElectionTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectorTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupLeaderElectorTest extends LeaderElectorTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftLeaderElectionTest extends LeaderElectionTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/election/RaftLeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/RaftLeaderElectorTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftLeaderElectorTest extends LeaderElectorTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/idgenerator/IdGeneratorTest.java
+++ b/core/src/test/java/io/atomix/core/idgenerator/IdGeneratorTest.java
@@ -16,8 +16,8 @@
 package io.atomix.core.idgenerator;
 
 import io.atomix.core.AbstractPrimitiveTest;
-
 import io.atomix.core.idgenerator.impl.DelegatingAtomicIdGenerator;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
@@ -28,15 +28,21 @@ import static org.junit.Assert.assertEquals;
 /**
  * Unit test for {@code AtomixIdGenerator}.
  */
-public abstract class IdGeneratorTest extends AbstractPrimitiveTest {
+public abstract class IdGeneratorTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   /**
    * Tests generating IDs.
    */
   @Test
   public void testNextId() throws Throwable {
-    AsyncAtomicIdGenerator idGenerator1 = atomix().atomicIdGeneratorBuilder("testNextId", protocol()).build().async();
-    AsyncAtomicIdGenerator idGenerator2 = atomix().atomicIdGeneratorBuilder("testNextId", protocol()).build().async();
+    AsyncAtomicIdGenerator idGenerator1 = atomix().atomicIdGeneratorBuilder("testNextId")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncAtomicIdGenerator idGenerator2 = atomix().atomicIdGeneratorBuilder("testNextId")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     CompletableFuture<Long> future11 = idGenerator1.nextId();
     CompletableFuture<Long> future12 = idGenerator1.nextId();
@@ -66,9 +72,15 @@ public abstract class IdGeneratorTest extends AbstractPrimitiveTest {
   @Test
   public void testNextIdBatchRollover() throws Throwable {
     DelegatingAtomicIdGenerator idGenerator1 = new DelegatingAtomicIdGenerator(
-        atomix().atomicCounterBuilder("testNextIdBatchRollover", protocol()).build().async(), 2);
+        atomix().atomicCounterBuilder("testNextIdBatchRollover")
+            .withProtocol(protocol())
+            .build()
+            .async(), 2);
     DelegatingAtomicIdGenerator idGenerator2 = new DelegatingAtomicIdGenerator(
-        atomix().atomicCounterBuilder("testNextIdBatchRollover", protocol()).build().async(), 2);
+        atomix().atomicCounterBuilder("testNextIdBatchRollover")
+            .withProtocol(protocol())
+            .build()
+            .async(), 2);
 
     CompletableFuture<Long> future11 = idGenerator1.nextId();
     CompletableFuture<Long> future12 = idGenerator1.nextId();

--- a/core/src/test/java/io/atomix/core/idgenerator/PrimaryBackupIdGeneratorTest.java
+++ b/core/src/test/java/io/atomix/core/idgenerator/PrimaryBackupIdGeneratorTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.idgenerator;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupIdGeneratorTest extends IdGeneratorTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/idgenerator/RaftIdGeneratorTest.java
+++ b/core/src/test/java/io/atomix/core/idgenerator/RaftIdGeneratorTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.idgenerator;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftIdGeneratorTest extends IdGeneratorTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/list/DistributedListTest.java
+++ b/core/src/test/java/io/atomix/core/list/DistributedListTest.java
@@ -18,6 +18,7 @@ package io.atomix.core.list;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -27,14 +28,12 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Distributed list test.
  */
-public abstract class DistributedListTest extends AbstractPrimitiveTest {
+public abstract class DistributedListTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testListOperations() throws Exception {
     DistributedList<String> list = atomix().<String>listBuilder("test-list")

--- a/core/src/test/java/io/atomix/core/list/PrimaryBackupDistributedListTest.java
+++ b/core/src/test/java/io/atomix/core/list/PrimaryBackupDistributedListTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.list;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedListTest extends DistributedListTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/list/RaftDistributedListTest.java
+++ b/core/src/test/java/io/atomix/core/list/RaftDistributedListTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.list;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 
@@ -24,7 +24,7 @@ import io.atomix.protocols.raft.ReadConsistency;
  */
 public class RaftDistributedListTest extends DistributedListTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/lock/AtomicLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/AtomicLockTest.java
@@ -16,6 +16,7 @@
 package io.atomix.core.lock;
 
 import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.time.Version;
 import org.junit.Test;
@@ -31,14 +32,17 @@ import static org.junit.Assert.assertTrue;
 /**
  * Raft lock test.
  */
-public abstract class AtomicLockTest extends AbstractPrimitiveTest {
+public abstract class AtomicLockTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   /**
    * Tests locking and unlocking a lock.
    */
   @Test
   public void testLockUnlock() throws Throwable {
-    AsyncAtomicLock lock = atomix().atomicLockBuilder("test-lock-unlock", protocol()).build().async();
+    AsyncAtomicLock lock = atomix().atomicLockBuilder("test-lock-unlock")
+        .withProtocol(protocol())
+        .build()
+        .async();
     lock.lock().get(30, TimeUnit.SECONDS);
     lock.unlock().get(30, TimeUnit.SECONDS);
   }
@@ -48,8 +52,14 @@ public abstract class AtomicLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testReleaseOnClose() throws Throwable {
-    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-lock-on-close", protocol()).build().async();
-    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-lock-on-close", protocol()).build().async();
+    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-lock-on-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-lock-on-close")
+        .withProtocol(protocol())
+        .build()
+        .async();
     lock1.lock().get(30, TimeUnit.SECONDS);
     CompletableFuture<Version> future = lock2.lock();
     lock1.close();
@@ -61,8 +71,14 @@ public abstract class AtomicLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockFail() throws Throwable {
-    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-try-lock-fail", protocol()).build().async();
-    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-try-lock-fail", protocol()).build().async();
+    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-try-lock-fail")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-try-lock-fail")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     lock1.lock().get(30, TimeUnit.SECONDS);
 
@@ -74,7 +90,10 @@ public abstract class AtomicLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockSucceed() throws Throwable {
-    AsyncAtomicLock lock = atomix().atomicLockBuilder("test-try-lock-succeed", protocol()).build().async();
+    AsyncAtomicLock lock = atomix().atomicLockBuilder("test-try-lock-succeed")
+        .withProtocol(protocol())
+        .build()
+        .async();
     assertTrue(lock.tryLock().get(30, TimeUnit.SECONDS).isPresent());
   }
 
@@ -83,8 +102,14 @@ public abstract class AtomicLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockFailWithTimeout() throws Throwable {
-    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-try-lock-fail-with-timeout", protocol()).build().async();
-    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-try-lock-fail-with-timeout", protocol()).build().async();
+    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-try-lock-fail-with-timeout")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-try-lock-fail-with-timeout")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     lock1.lock().get(30, TimeUnit.SECONDS);
 
@@ -96,8 +121,14 @@ public abstract class AtomicLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testTryLockSucceedWithTimeout() throws Throwable {
-    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-try-lock-succeed-with-timeout", protocol()).build().async();
-    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-try-lock-succeed-with-timeout", protocol()).build().async();
+    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-try-lock-succeed-with-timeout")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-try-lock-succeed-with-timeout")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     lock1.lock().get(30, TimeUnit.SECONDS);
 
@@ -111,8 +142,14 @@ public abstract class AtomicLockTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testBlockingUnlock() throws Throwable {
-    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-blocking-unlock", protocol()).build().async();
-    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-blocking-unlock", protocol()).build().async();
+    AsyncAtomicLock lock1 = atomix().atomicLockBuilder("test-blocking-unlock")
+        .withProtocol(protocol())
+        .build()
+        .async();
+    AsyncAtomicLock lock2 = atomix().atomicLockBuilder("test-blocking-unlock")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     lock1.lock().thenRun(() -> {
       Futures.get(lock1.unlock());

--- a/core/src/test/java/io/atomix/core/lock/PrimaryBackupAtomicLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/PrimaryBackupAtomicLockTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.lock;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicLockTest extends AtomicLockTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/lock/RaftAtomicLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/RaftAtomicLockTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.lock;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftAtomicLockTest extends AtomicLockTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/map/AntiEntropyDistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/AntiEntropyDistributedMapTest.java
@@ -16,10 +16,9 @@
 package io.atomix.core.map;
 
 import io.atomix.core.AbstractPrimitiveTest;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.map.MapProtocol;
 import io.atomix.protocols.gossip.AntiEntropyProtocol;
 import io.atomix.utils.time.LogicalTimestamp;
-import io.atomix.utils.time.WallClockTimestamp;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -41,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Anti-entropy based distributed map test.
  */
-public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
+public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest<MapProtocol> {
 
   private final AtomicLong timestamp = new AtomicLong();
 
@@ -51,7 +50,7 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
   private static final String VALUE2 = "twoValue";
 
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected MapProtocol protocol() {
     return AntiEntropyProtocol.builder()
         .withTimestampProvider(e -> new LogicalTimestamp(timestamp.incrementAndGet()))
         .build();
@@ -59,8 +58,12 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testReplication() throws Exception {
-    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapReplication", protocol()).build();
-    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapReplication", protocol()).build();
+    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapReplication")
+        .withProtocol(protocol())
+        .build();
+    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapReplication")
+        .withProtocol(protocol())
+        .build();
 
     TestMapEventListener listener1 = new TestMapEventListener();
     map1.addListener(listener1);
@@ -118,7 +121,9 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testSize() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapSize", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapSize")
+        .withProtocol(protocol())
+        .build();
 
     assertEquals(0, map.size());
     map.put(KEY1, VALUE1);
@@ -139,7 +144,9 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testIsEmpty() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapIsEmpty", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapIsEmpty")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.isEmpty());
     map.put(KEY1, VALUE1);
@@ -150,7 +157,9 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testContainsKey() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapContainsKey", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapContainsKey")
+        .withProtocol(protocol())
+        .build();
 
     assertFalse(map.containsKey(KEY1));
     map.put(KEY1, VALUE1);
@@ -162,7 +171,9 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testContainsValue() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapContainsValue", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapContainsValue")
+        .withProtocol(protocol())
+        .build();
 
     assertFalse(map.containsValue(VALUE1));
     map.put(KEY1, VALUE1);
@@ -177,8 +188,12 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testGet() throws Exception {
-    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapGet", protocol()).build();
-    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapGet", protocol()).build();
+    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapGet")
+        .withProtocol(protocol())
+        .build();
+    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapGet")
+        .withProtocol(protocol())
+        .build();
 
     // Create a latch so we know when the put operation has finished
     TestMapEventListener listener = new TestMapEventListener();
@@ -209,8 +224,12 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testPut() throws Exception {
-    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapPut", protocol()).build();
-    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapPut", protocol()).build();
+    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapPut")
+        .withProtocol(protocol())
+        .build();
+    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapPut")
+        .withProtocol(protocol())
+        .build();
 
     TestMapEventListener listener = new TestMapEventListener();
     MapEvent event;
@@ -242,8 +261,12 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testRemove() throws Exception {
-    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapRemove", protocol()).build();
-    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapRemove", protocol()).build();
+    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapRemove")
+        .withProtocol(protocol())
+        .build();
+    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapRemove")
+        .withProtocol(protocol())
+        .build();
 
     TestMapEventListener listener = new TestMapEventListener();
     map2.addListener(listener);
@@ -284,8 +307,12 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testCompute() throws Exception {
-    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapCompute", protocol()).build();
-    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapCompute", protocol()).build();
+    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapCompute")
+        .withProtocol(protocol())
+        .build();
+    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapCompute")
+        .withProtocol(protocol())
+        .build();
 
     TestMapEventListener listener = new TestMapEventListener();
     map2.addListener(listener);
@@ -333,8 +360,12 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testPutAll() throws Exception {
-    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapPutAll", protocol()).build();
-    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapPutAll", protocol()).build();
+    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapPutAll")
+        .withProtocol(protocol())
+        .build();
+    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapPutAll")
+        .withProtocol(protocol())
+        .build();
 
     map1.putAll(new HashMap<>());
 
@@ -364,8 +395,12 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testClear() throws Exception {
-    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapClear", protocol()).build();
-    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapClear", protocol()).build();
+    DistributedMap<String, String> map1 = atomix().<String, String>mapBuilder("testAntiEntropyMapClear")
+        .withProtocol(protocol())
+        .build();
+    DistributedMap<String, String> map2 = atomix().<String, String>mapBuilder("testAntiEntropyMapClear")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map1.isEmpty());
     map1.clear();
@@ -398,7 +433,9 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testKeySet() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapKeySet", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapKeySet")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.keySet().isEmpty());
 
@@ -431,7 +468,9 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testValues() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapValues", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapValues")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.values().isEmpty());
 
@@ -469,7 +508,9 @@ public class AntiEntropyDistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testEntrySet() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapEntrySet", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testAntiEntropyMapEntrySet")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.entrySet().isEmpty());
 

--- a/core/src/test/java/io/atomix/core/map/AtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/AtomicCounterMapTest.java
@@ -16,8 +16,7 @@
 package io.atomix.core.map;
 
 import io.atomix.core.AbstractPrimitiveTest;
-
-import io.atomix.core.map.AsyncAtomicCounterMap;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -28,14 +27,17 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit test for {@code AtomixCounterMap}.
  */
-public abstract class AtomicCounterMapTest extends AbstractPrimitiveTest {
+public abstract class AtomicCounterMapTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   /**
    * Tests basic counter map operations.
    */
   @Test
   public void testBasicCounterMapOperations() throws Throwable {
-    AsyncAtomicCounterMap<String> map = atomix().<String>atomicCounterMapBuilder("testBasicCounterMapOperationMap", protocol()).build().async();
+    AsyncAtomicCounterMap<String> map = atomix().<String>atomicCounterMapBuilder("testBasicCounterMapOperationMap")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     map.isEmpty().thenAccept(isEmpty -> {
       assertTrue(isEmpty);

--- a/core/src/test/java/io/atomix/core/map/AtomicMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/AtomicMapTest.java
@@ -22,6 +22,7 @@ import io.atomix.core.transaction.CommitStatus;
 import io.atomix.core.transaction.Isolation;
 import io.atomix.core.transaction.Transaction;
 import io.atomix.core.transaction.TransactionalMap;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.time.Versioned;
 import org.junit.Test;
 
@@ -46,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link AtomicMap}.
  */
-public abstract class AtomicMapTest extends AbstractPrimitiveTest {
+public abstract class AtomicMapTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   /**
    * Tests null values.
@@ -57,7 +58,8 @@ public abstract class AtomicMapTest extends AbstractPrimitiveTest {
     final String barValue = "Hello bar!";
 
     AsyncAtomicMap<String, String> map = atomix()
-        .<String, String>atomicMapBuilder("testNullValues", protocol())
+        .<String, String>atomicMapBuilder("testNullValues")
+        .withProtocol(protocol())
         .withNullValues()
         .build().async();
 
@@ -94,7 +96,10 @@ public abstract class AtomicMapTest extends AbstractPrimitiveTest {
     final String fooValue = "Hello foo!";
     final String barValue = "Hello bar!";
 
-    AsyncAtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap", protocol()).build().async();
+    AsyncAtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     map.isEmpty().thenAccept(result -> {
       assertTrue(result);
@@ -270,7 +275,10 @@ public abstract class AtomicMapTest extends AbstractPrimitiveTest {
     final String value2 = "value2";
     final String value3 = "value3";
 
-    AsyncAtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testMapComputeOperationsMap", protocol()).build().async();
+    AsyncAtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testMapComputeOperationsMap")
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     map.computeIfAbsent("foo", k -> value1).thenAccept(result -> {
       assertEquals(Versioned.valueOrElse(result, null), value1);
@@ -307,7 +315,10 @@ public abstract class AtomicMapTest extends AbstractPrimitiveTest {
     final String value2 = "value2";
     final String value3 = "value3";
 
-    AsyncAtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testMapListenerMap", protocol()).build().async();
+    AsyncAtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testMapListenerMap")
+        .withProtocol(protocol())
+        .build()
+        .async();
     TestAtomicMapEventListener listener = new TestAtomicMapEventListener();
 
     // add listener; insert new value into map and verify an INSERT event is received.
@@ -374,7 +385,9 @@ public abstract class AtomicMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testMapViews() throws Exception {
-    AtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testMapViews", protocol()).build();
+    AtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testMapViews")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.isEmpty());
     assertTrue(map.keySet().isEmpty());
@@ -449,13 +462,17 @@ public abstract class AtomicMapTest extends AbstractPrimitiveTest {
         .withIsolation(Isolation.READ_COMMITTED)
         .build();
     transaction1.begin();
-    TransactionalMap<String, String> map1 = transaction1.<String, String>mapBuilder("test-transactional-map", protocol()).build();
+    TransactionalMap<String, String> map1 = transaction1.<String, String>mapBuilder("test-transactional-map")
+        .withProtocol(protocol())
+        .build();
 
     Transaction transaction2 = atomix().transactionBuilder()
         .withIsolation(Isolation.REPEATABLE_READS)
         .build();
     transaction2.begin();
-    TransactionalMap<String, String> map2 = transaction2.<String, String>mapBuilder("test-transactional-map", protocol()).build();
+    TransactionalMap<String, String> map2 = transaction2.<String, String>mapBuilder("test-transactional-map")
+        .withProtocol(protocol())
+        .build();
 
     assertNull(map1.get("foo"));
     assertFalse(map1.containsKey("foo"));
@@ -480,13 +497,17 @@ public abstract class AtomicMapTest extends AbstractPrimitiveTest {
         .withIsolation(Isolation.REPEATABLE_READS)
         .build();
     transaction3.begin();
-    TransactionalMap<String, String> map3 = transaction3.<String, String>mapBuilder("test-transactional-map", protocol()).build();
+    TransactionalMap<String, String> map3 = transaction3.<String, String>mapBuilder("test-transactional-map")
+        .withProtocol(protocol())
+        .build();
     assertEquals(map3.get("foo"), "bar");
     map3.put("foo", "baz");
     assertEquals(map3.get("foo"), "baz");
     assertEquals(transaction3.commit(), CommitStatus.SUCCESS);
 
-    AtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("test-transactional-map", protocol()).build();
+    AtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("test-transactional-map")
+        .withProtocol(protocol())
+        .build();
     assertEquals(map.get("foo").value(), "baz");
     assertEquals(map.get("bar").value(), "baz");
 

--- a/core/src/test/java/io/atomix/core/map/AtomicNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/AtomicNavigableMapTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.map.impl.AtomicNavigableMapProxy;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.time.Versioned;
 import org.junit.Test;
 
@@ -45,7 +46,7 @@ import static org.junit.Assert.fail;
 /**
  * Unit tests for {@link AtomicNavigableMapProxy}.
  */
-public abstract class AtomicNavigableMapTest extends AbstractPrimitiveTest {
+public abstract class AtomicNavigableMapTest extends AbstractPrimitiveTest<ProxyProtocol> {
   private final String four = "hello";
   private final String three = "goodbye";
   private final String two = "foo";
@@ -852,7 +853,10 @@ public abstract class AtomicNavigableMapTest extends AbstractPrimitiveTest {
 
   private AsyncAtomicNavigableMap<String, String> createResource(String mapName) {
     try {
-      return atomix().<String, String>atomicNavigableMapBuilder(mapName, protocol()).build().async();
+      return atomix().<String, String>atomicNavigableMapBuilder(mapName)
+          .withProtocol(protocol())
+          .build()
+          .async();
     } catch (Throwable e) {
       throw new RuntimeException(e.toString());
     }

--- a/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
@@ -18,6 +18,7 @@ package io.atomix.core.map;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link DistributedMap}.
  */
-public abstract class DistributedMapTest extends AbstractPrimitiveTest {
+public abstract class DistributedMapTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   /**
    * Tests null values.
@@ -49,7 +50,8 @@ public abstract class DistributedMapTest extends AbstractPrimitiveTest {
     final String barValue = "Hello bar!";
 
     DistributedMap<String, String> map = atomix()
-        .<String, String>mapBuilder("testNullValues", protocol())
+        .<String, String>mapBuilder("testNullValues")
+        .withProtocol(protocol())
         .withNullValues()
         .build();
 
@@ -69,7 +71,9 @@ public abstract class DistributedMapTest extends AbstractPrimitiveTest {
     final String fooValue = "Hello foo!";
     final String barValue = "Hello bar!";
 
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testBasicMapOperationMap", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.isEmpty());
     assertNull(map.put("foo", fooValue));
@@ -115,7 +119,9 @@ public abstract class DistributedMapTest extends AbstractPrimitiveTest {
     final String value2 = "value2";
     final String value3 = "value3";
 
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testMapComputeOperationsMap", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testMapComputeOperationsMap")
+        .withProtocol(protocol())
+        .build();
     assertEquals(value1, map.computeIfAbsent("foo", k -> value1));
     assertEquals(value1, map.computeIfAbsent("foo", k -> value2));
     assertNull(map.computeIfPresent("bar", (k, v) -> value2));
@@ -130,7 +136,9 @@ public abstract class DistributedMapTest extends AbstractPrimitiveTest {
     final String value2 = "value2";
     final String value3 = "value3";
 
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testMapListenerMap", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testMapListenerMap")
+        .withProtocol(protocol())
+        .build();
     TestMapEventListener listener = new TestMapEventListener();
 
     // add listener; insert new value into map and verify an INSERT event is received.
@@ -190,7 +198,9 @@ public abstract class DistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testMapViews() throws Exception {
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testMapViews", protocol()).build();
+    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testMapViews")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.isEmpty());
     assertTrue(map.keySet().isEmpty());

--- a/core/src/test/java/io/atomix/core/map/DistributedNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/DistributedNavigableMapTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.map.impl.AtomicNavigableMapProxy;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -39,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link AtomicNavigableMapProxy}.
  */
-public abstract class DistributedNavigableMapTest extends AbstractPrimitiveTest {
+public abstract class DistributedNavigableMapTest extends AbstractPrimitiveTest<ProxyProtocol> {
   private final String four = "hello";
   private final String three = "goodbye";
   private final String two = "foo";
@@ -57,7 +58,9 @@ public abstract class DistributedNavigableMapTest extends AbstractPrimitiveTest 
     //make sure that the previous section has been cleaned up, they serve
     //the secondary purpose of testing isEmpty but that is not their
     //primary purpose.
-    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("basicTestMap", protocol()).build();
+    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("basicTestMap")
+        .withProtocol(protocol())
+        .build();
 
     assertEquals(0, map.size());
     assertTrue(map.isEmpty());
@@ -115,7 +118,9 @@ public abstract class DistributedNavigableMapTest extends AbstractPrimitiveTest 
     final String value2 = "value2";
     final String value3 = "value3";
 
-    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("treeMapListenerTestMap", protocol()).build();
+    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("treeMapListenerTestMap")
+        .withProtocol(protocol())
+        .build();
     TestMapEventListener listener = new TestMapEventListener();
 
     // add listener; insert new value into map and verify an INSERT event
@@ -166,7 +171,9 @@ public abstract class DistributedNavigableMapTest extends AbstractPrimitiveTest 
 
   @Test
   public void treeMapFunctionsTest() throws Throwable {
-    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("treeMapFunctionTestMap", protocol()).build();
+    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("treeMapFunctionTestMap")
+        .withProtocol(protocol())
+        .build();
     //Tests on empty map
 
     assertNull(map.firstKey());
@@ -224,7 +231,9 @@ public abstract class DistributedNavigableMapTest extends AbstractPrimitiveTest 
 
   @Test
   public void testTreeMapViews() throws Throwable {
-    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("testTreeMapViews", protocol()).build();
+    DistributedNavigableMap<String, String> map = atomix().<String, String>navigableMapBuilder("testTreeMapViews")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.isEmpty());
     assertTrue(map.keySet().isEmpty());

--- a/core/src/test/java/io/atomix/core/map/PrimaryBackupAtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/PrimaryBackupAtomicCounterMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicCounterMapTest extends AtomicCounterMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/map/PrimaryBackupAtomicMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/PrimaryBackupAtomicMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicMapTest extends AtomicMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/map/PrimaryBackupAtomicNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/PrimaryBackupAtomicNavigableMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicNavigableMapTest extends AtomicNavigableMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/map/PrimaryBackupDistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/PrimaryBackupDistributedMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedMapTest extends DistributedMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/map/PrimaryBackupDistributedNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/PrimaryBackupDistributedNavigableMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedNavigableMapTest extends DistributedNavigableMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicCounterMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftAtomicCounterMapTest extends AtomicCounterMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 
@@ -26,7 +26,7 @@ import java.time.Duration;
  */
 public class RaftAtomicMapTest extends AtomicMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxTimeout(Duration.ofSeconds(1))
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicNavigableMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftAtomicNavigableMapTest extends AtomicNavigableMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/map/RaftDistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftDistributedMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 
@@ -26,7 +26,7 @@ import java.time.Duration;
  */
 public class RaftDistributedMapTest extends DistributedMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxTimeout(Duration.ofSeconds(1))
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/map/RaftDistributedNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftDistributedNavigableMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftDistributedNavigableMapTest extends DistributedNavigableMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/multimap/AtomicMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/AtomicMultimapTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.multimap.impl.AtomicMultimapProxy;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -39,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the {@link AtomicMultimapProxy}.
  */
-public abstract class AtomicMultimapTest extends AbstractPrimitiveTest {
+public abstract class AtomicMultimapTest extends AbstractPrimitiveTest<ProxyProtocol> {
   private final String one = "hello";
   private final String two = "goodbye";
   private final String three = "foo";
@@ -336,7 +337,9 @@ public abstract class AtomicMultimapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testMultimapViews() throws Exception {
-    AtomicMultimap<String, String> map = atomix().<String, String>atomicMultimapBuilder("testMultimapViews", protocol()).build();
+    AtomicMultimap<String, String> map = atomix().<String, String>atomicMultimapBuilder("testMultimapViews")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.isEmpty());
     assertTrue(map.keySet().isEmpty());
@@ -432,7 +435,11 @@ public abstract class AtomicMultimapTest extends AbstractPrimitiveTest {
 
   private AsyncAtomicMultimap<String, String> createMultimap(String mapName) {
     try {
-      return atomix().<String, String>atomicMultimapBuilder(mapName, protocol()).withCacheEnabled().build().async();
+      return atomix().<String, String>atomicMultimapBuilder(mapName)
+          .withCacheEnabled()
+          .withProtocol(protocol())
+          .build()
+          .async();
     } catch (Throwable e) {
       throw new RuntimeException(e.toString());
     }

--- a/core/src/test/java/io/atomix/core/multimap/DistributedMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/DistributedMultimapTest.java
@@ -19,6 +19,7 @@ package io.atomix.core.multimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -36,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests the {@link DistributedMultimap}.
  */
-public abstract class DistributedMultimapTest extends AbstractPrimitiveTest {
+public abstract class DistributedMultimapTest extends AbstractPrimitiveTest<ProxyProtocol> {
   private final String one = "hello";
   private final String two = "goodbye";
   private final String three = "foo";
@@ -48,7 +49,9 @@ public abstract class DistributedMultimapTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testSize() throws Throwable {
-    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testOneMap", protocol()).build();
+    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testOneMap")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(multimap.isEmpty());
     assertEquals(0, multimap.size());
@@ -76,7 +79,9 @@ public abstract class DistributedMultimapTest extends AbstractPrimitiveTest {
    */
   @Test
   public void containsTest() throws Throwable {
-    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testTwoMap", protocol()).build();
+    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testTwoMap")
+        .withProtocol(protocol())
+        .build();
 
     all.forEach(key -> assertTrue(multimap.putAll(key, all)));
     assertEquals(16, multimap.size());
@@ -105,7 +110,9 @@ public abstract class DistributedMultimapTest extends AbstractPrimitiveTest {
    */
   @Test
   public void addAndRemoveTest() throws Exception {
-    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testThreeMap", protocol()).build();
+    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testThreeMap")
+        .withProtocol(protocol())
+        .build();
 
     all.forEach(key -> all.forEach(value -> {
       assertTrue(multimap.put(key, value));
@@ -163,7 +170,9 @@ public abstract class DistributedMultimapTest extends AbstractPrimitiveTest {
    */
   @Test
   public void testAccessors() throws Exception {
-    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testFourMap", protocol()).build();
+    DistributedMultimap<String, String> multimap = atomix().<String, String>multimapBuilder("testFourMap")
+        .withProtocol(protocol())
+        .build();
 
     all.forEach(key -> assertTrue(multimap.putAll(key, all)));
     assertEquals(16, multimap.size());
@@ -177,7 +186,9 @@ public abstract class DistributedMultimapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testMultimapViews() throws Exception {
-    DistributedMultimap<String, String> map = atomix().<String, String>multimapBuilder("testMultimapViews", protocol()).build();
+    DistributedMultimap<String, String> map = atomix().<String, String>multimapBuilder("testMultimapViews")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(map.isEmpty());
     assertTrue(map.keySet().isEmpty());

--- a/core/src/test/java/io/atomix/core/multimap/PrimaryBackupAtomicMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/PrimaryBackupAtomicMultimapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.multimap;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicMultimapTest extends AtomicMultimapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/multimap/PrimaryBackupDistributedMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/PrimaryBackupDistributedMultimapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.multimap;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedMultimapTest extends DistributedMultimapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/multimap/RaftAtomicMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/RaftAtomicMultimapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.multimap;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftAtomicMultimapTest extends AtomicMultimapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/multimap/RaftDistributedMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/RaftDistributedMultimapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.multimap;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftDistributedMultimapTest extends DistributedMultimapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/multiset/DistributedMultisetTest.java
+++ b/core/src/test/java/io/atomix/core/multiset/DistributedMultisetTest.java
@@ -18,6 +18,7 @@ package io.atomix.core.multiset;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Distributed multiset test.
  */
-public abstract class DistributedMultisetTest extends AbstractPrimitiveTest {
+public abstract class DistributedMultisetTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testMultisetOperations() throws Exception {
     DistributedMultiset<String> multiset = atomix().<String>multisetBuilder("test-multiset")

--- a/core/src/test/java/io/atomix/core/multiset/PrimaryBackupDistributedMultisetTest.java
+++ b/core/src/test/java/io/atomix/core/multiset/PrimaryBackupDistributedMultisetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.multiset;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedMultisetTest extends DistributedMultisetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/multiset/RaftDistributedMultisetTest.java
+++ b/core/src/test/java/io/atomix/core/multiset/RaftDistributedMultisetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.multiset;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 
@@ -24,7 +24,7 @@ import io.atomix.protocols.raft.ReadConsistency;
  */
 public class RaftDistributedMultisetTest extends DistributedMultisetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/queue/DistributedQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/DistributedQueueTest.java
@@ -18,6 +18,7 @@ package io.atomix.core.queue;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -35,7 +36,7 @@ import static org.junit.Assert.fail;
 /**
  * Distributed queue test.
  */
-public abstract class DistributedQueueTest extends AbstractPrimitiveTest {
+public abstract class DistributedQueueTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testQueueOperations() throws Exception {
     DistributedQueue<String> queue = atomix().<String>queueBuilder("test-queue")

--- a/core/src/test/java/io/atomix/core/queue/PrimaryBackupDistributedQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/PrimaryBackupDistributedQueueTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.queue;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedQueueTest extends DistributedQueueTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/queue/RaftDistributedQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/RaftDistributedQueueTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.queue;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 
@@ -24,7 +24,7 @@ import io.atomix.protocols.raft.ReadConsistency;
  */
 public class RaftDistributedQueueTest extends DistributedQueueTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/semaphore/PrimaryBackupSemaphoreTest.java
+++ b/core/src/test/java/io/atomix/core/semaphore/PrimaryBackupSemaphoreTest.java
@@ -15,12 +15,12 @@
  */
 package io.atomix.core.semaphore;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 public class PrimaryBackupSemaphoreTest extends SemaphoreTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
             .withBackups(2)
             .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/semaphore/RaftSemaphoreTest.java
+++ b/core/src/test/java/io/atomix/core/semaphore/RaftSemaphoreTest.java
@@ -16,7 +16,7 @@
 package io.atomix.core.semaphore;
 
 import io.atomix.core.Atomix;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.utils.time.Version;
@@ -29,21 +29,22 @@ import static org.junit.Assert.assertEquals;
 
 public class RaftSemaphoreTest extends SemaphoreTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
-            .withReadConsistency(ReadConsistency.LINEARIZABLE)
-            .withMaxRetries(5)
-            .build();
+        .withReadConsistency(ReadConsistency.LINEARIZABLE)
+        .withMaxRetries(5)
+        .build();
   }
 
   // Needs linearizable read consistency
   @Test(timeout = 10000)
   public void testQueueStatus() throws Exception {
     Atomix atomix = atomix();
-    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-status", protocol())
-            .withInitialCapacity(10)
-            .build()
-            .async();
+    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-status")
+        .withProtocol(protocol())
+        .withInitialCapacity(10)
+        .build()
+        .async();
 
     semaphore.acquire(5).get(30, TimeUnit.SECONDS);
 

--- a/core/src/test/java/io/atomix/core/semaphore/SemaphoreTest.java
+++ b/core/src/test/java/io/atomix/core/semaphore/SemaphoreTest.java
@@ -22,6 +22,7 @@ import io.atomix.core.semaphore.impl.AtomicSemaphoreProxy;
 import io.atomix.core.semaphore.impl.AtomicSemaphoreServiceConfig;
 import io.atomix.core.semaphore.impl.DefaultAtomicSemaphoreService;
 import io.atomix.primitive.PrimitiveException;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.service.impl.DefaultBackupInput;
 import io.atomix.primitive.service.impl.DefaultBackupOutput;
 import io.atomix.storage.buffer.Buffer;
@@ -52,22 +53,25 @@ import static org.junit.Assert.assertTrue;
 /**
  * Semaphore test.
  */
-public abstract class SemaphoreTest extends AbstractPrimitiveTest {
+public abstract class SemaphoreTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   @Test
   public void testInit() throws Exception {
     Atomix atomix = atomix();
-    AsyncAtomicSemaphore semaphore100 = atomix.atomicSemaphoreBuilder("test-semaphore-init-100", protocol())
+    AsyncAtomicSemaphore semaphore100 = atomix.atomicSemaphoreBuilder("test-semaphore-init-100")
+        .withProtocol(protocol())
         .withInitialCapacity(100)
         .build()
         .async();
-    AsyncAtomicSemaphore semaphore0 = atomix.atomicSemaphoreBuilder("test-semaphore-init-0", protocol())
+    AsyncAtomicSemaphore semaphore0 = atomix.atomicSemaphoreBuilder("test-semaphore-init-0")
+        .withProtocol(protocol())
         .build()
         .async();
     assertEquals(100, semaphore100.availablePermits().get().intValue());
     assertEquals(0, semaphore0.availablePermits().get().intValue());
 
-    AsyncAtomicSemaphore semaphoreNoInit = atomix.atomicSemaphoreBuilder("test-semaphore-init-100", protocol())
+    AsyncAtomicSemaphore semaphoreNoInit = atomix.atomicSemaphoreBuilder("test-semaphore-init-100")
+        .withProtocol(protocol())
         .build()
         .async();
     assertEquals(100, semaphoreNoInit.availablePermits().get().intValue());
@@ -76,7 +80,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   @Test
   public void testAcquireRelease() throws Exception {
     Atomix atomix = atomix();
-    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-base", protocol())
+    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-base")
+        .withProtocol(protocol())
         .withInitialCapacity(10)
         .build()
         .async();
@@ -96,7 +101,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   @Test
   public void testIncreaseReduceDrain() throws Exception {
     Atomix atomix = atomix();
-    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-ird", protocol())
+    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-ird")
+        .withProtocol(protocol())
         .withInitialCapacity(-10)
         .build()
         .async();
@@ -111,7 +117,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   @Test
   public void testOverflow() throws Exception {
     Atomix atomix = atomix();
-    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-overflow", protocol())
+    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-overflow")
+        .withProtocol(protocol())
         .withInitialCapacity(Integer.MAX_VALUE)
         .build()
         .async();
@@ -129,7 +136,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   @Test(timeout = 10000)
   public void testTimeout() throws Exception {
     Atomix atomix = atomix();
-    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-timeout", protocol())
+    AsyncAtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-timeout")
+        .withProtocol(protocol())
         .withInitialCapacity(10)
         .build()
         .async();
@@ -159,13 +167,15 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   public void testReleaseSession() throws Exception {
     Atomix atomix = atomix();
     AtomicSemaphoreProxy semaphore =
-        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-releaseSession", protocol())
+        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-releaseSession")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build()
             .async());
 
     AtomicSemaphoreProxy semaphore2 =
-        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-releaseSession", protocol())
+        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-releaseSession")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build()
             .async());
@@ -188,13 +198,15 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   public void testHolderStatus() throws Exception {
     Atomix atomix = atomix();
     AtomicSemaphoreProxy semaphore =
-        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-holders", protocol())
+        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-holders")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build()
             .async());
 
     AtomicSemaphoreProxy semaphore2 =
-        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-holders", protocol())
+        (AtomicSemaphoreProxy) (atomix.atomicSemaphoreBuilder("test-semaphore-holders")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build()
             .async());
@@ -224,7 +236,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   public void testBlocking() throws Exception {
     Atomix atomix = atomix();
     AtomicSemaphore semaphore =
-        atomix.atomicSemaphoreBuilder("test-semaphore-blocking", protocol())
+        atomix.atomicSemaphoreBuilder("test-semaphore-blocking")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build();
 
@@ -247,7 +260,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
     assertEquals(5, semaphore.drainPermits());
 
     AtomicSemaphore semaphore2 =
-        atomix.atomicSemaphoreBuilder("test-semaphore-blocking", protocol())
+        atomix.atomicSemaphoreBuilder("test-semaphore-blocking")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build();
 
@@ -260,7 +274,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   public void testQueue() throws Exception {
     Atomix atomix = atomix();
     AsyncAtomicSemaphore semaphore =
-        atomix.atomicSemaphoreBuilder("test-semaphore-queue", protocol())
+        atomix.atomicSemaphoreBuilder("test-semaphore-queue")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build()
             .async();
@@ -287,7 +302,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   public void testExpire() throws Exception {
     Atomix atomix = atomix();
     AsyncAtomicSemaphore semaphore =
-        atomix.atomicSemaphoreBuilder("test-semaphore-expire", protocol())
+        atomix.atomicSemaphoreBuilder("test-semaphore-expire")
+            .withProtocol(protocol())
             .withInitialCapacity(10)
             .build()
             .async();
@@ -303,11 +319,13 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   @Test(timeout = 10000)
   public void testInterrupt() throws Exception {
     Atomix atomix = atomix();
-    AtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-interrupt", protocol())
+    AtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-interrupt")
+        .withProtocol(protocol())
         .withInitialCapacity(10)
         .build();
 
-    AtomicSemaphore semaphore2 = atomix.atomicSemaphoreBuilder("test-semaphore-interrupt", protocol())
+    AtomicSemaphore semaphore2 = atomix.atomicSemaphoreBuilder("test-semaphore-interrupt")
+        .withProtocol(protocol())
         .withInitialCapacity(10)
         .build();
 
@@ -340,11 +358,13 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
   @Test(timeout = 30000)
   public void testBlockTimeout() throws Exception {
     Atomix atomix = atomix();
-    AtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-block-timeout", protocol())
+    AtomicSemaphore semaphore = atomix.atomicSemaphoreBuilder("test-semaphore-block-timeout")
+        .withProtocol(protocol())
         .withInitialCapacity(10)
         .build();
 
-    AtomicSemaphore semaphore2 = atomix.atomicSemaphoreBuilder("test-semaphore-block-timeout", protocol())
+    AtomicSemaphore semaphore2 = atomix.atomicSemaphoreBuilder("test-semaphore-block-timeout")
+        .withProtocol(protocol())
         .withInitialCapacity(10)
         .build();
 
@@ -388,7 +408,8 @@ public abstract class SemaphoreTest extends AbstractPrimitiveTest {
     for (int i = 0; i < threads; i++) {
       taskFuture.add(executorService.submit(() -> {
         AsyncAtomicSemaphore semaphore =
-            atomix.atomicSemaphoreBuilder("test-semaphore-race", protocol())
+            atomix.atomicSemaphoreBuilder("test-semaphore-race")
+                .withProtocol(protocol())
                 .withInitialCapacity(TEST_COUNT)
                 .build()
                 .async();

--- a/core/src/test/java/io/atomix/core/set/AntiEntropyDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/AntiEntropyDistributedSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.set.SetProtocol;
 import io.atomix.protocols.gossip.AntiEntropyProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.gossip.AntiEntropyProtocol;
  */
 public class AntiEntropyDistributedSetTest extends GossipDistributedSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected SetProtocol protocol() {
     return AntiEntropyProtocol.builder()
         .withTimestampProvider(timestampProvider)
         .build();

--- a/core/src/test/java/io/atomix/core/set/CrdtDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/CrdtDistributedSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.set.SetProtocol;
 import io.atomix.protocols.gossip.CrdtProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.gossip.CrdtProtocol;
  */
 public class CrdtDistributedSetTest extends GossipDistributedSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected SetProtocol protocol() {
     return CrdtProtocol.builder()
         .withTimestampProvider(timestampProvider)
         .build();

--- a/core/src/test/java/io/atomix/core/set/DistributedNavigableSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/DistributedNavigableSetTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -36,7 +37,7 @@ import static org.junit.Assert.fail;
 /**
  * Distributed tree set test.
  */
-public abstract class DistributedNavigableSetTest extends AbstractPrimitiveTest {
+public abstract class DistributedNavigableSetTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testSetOperations() throws Exception {
     DistributedNavigableSet<String> set = atomix().<String>navigableSetBuilder("test-set")

--- a/core/src/test/java/io/atomix/core/set/DistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/DistributedSetTest.java
@@ -18,6 +18,7 @@ package io.atomix.core.set;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Distributed set test.
  */
-public abstract class DistributedSetTest extends AbstractPrimitiveTest {
+public abstract class DistributedSetTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testSetOperations() throws Exception {
     DistributedSet<String> set = atomix().<String>setBuilder("test-set")

--- a/core/src/test/java/io/atomix/core/set/GossipDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/GossipDistributedSetTest.java
@@ -18,6 +18,7 @@ package io.atomix.core.set;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
+import io.atomix.primitive.protocol.set.SetProtocol;
 import io.atomix.protocols.gossip.TimestampProvider;
 import io.atomix.utils.time.LogicalTimestamp;
 import org.junit.Test;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Gossip based distributed set test.
  */
-public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
+public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest<SetProtocol> {
 
   private final AtomicLong timestamp = new AtomicLong();
   protected final TimestampProvider<String> timestampProvider = e -> new LogicalTimestamp(timestamp.incrementAndGet());
@@ -47,8 +48,12 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testReplication() throws Exception {
-    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetReplication", protocol()).build();
-    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetReplication", protocol()).build();
+    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetReplication")
+        .withProtocol(protocol())
+        .build();
+    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetReplication")
+        .withProtocol(protocol())
+        .build();
 
     TestSetEventListener listener1 = new TestSetEventListener();
     set1.addListener(listener1);
@@ -102,7 +107,9 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testSize() throws Exception {
-    DistributedSet<String> set = atomix().<String>setBuilder("testAntiEntropySetSize", protocol()).build();
+    DistributedSet<String> set = atomix().<String>setBuilder("testAntiEntropySetSize")
+        .withProtocol(protocol())
+        .build();
 
     assertEquals(0, set.size());
     assertTrue(set.add(KEY1));
@@ -123,7 +130,9 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testIsEmpty() throws Exception {
-    DistributedSet<String> set = atomix().<String>setBuilder("testAntiEntropySetIsEmpty", protocol()).build();
+    DistributedSet<String> set = atomix().<String>setBuilder("testAntiEntropySetIsEmpty")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(set.isEmpty());
     assertTrue(set.add(KEY1));
@@ -134,7 +143,9 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testContains() throws Exception {
-    DistributedSet<String> set = atomix().<String>setBuilder("testAntiEntropySetContains", protocol()).build();
+    DistributedSet<String> set = atomix().<String>setBuilder("testAntiEntropySetContains")
+        .withProtocol(protocol())
+        .build();
 
     assertFalse(set.contains(KEY1));
     assertTrue(set.add(KEY1));
@@ -146,8 +157,12 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testGet() throws Exception {
-    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetGet", protocol()).build();
-    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetGet", protocol()).build();
+    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetGet")
+        .withProtocol(protocol())
+        .build();
+    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetGet")
+        .withProtocol(protocol())
+        .build();
 
     // Create a latch so we know when the put operation has finished
     TestSetEventListener listener = new TestSetEventListener();
@@ -178,8 +193,12 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testAdd() throws Exception {
-    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetPut", protocol()).build();
-    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetPut", protocol()).build();
+    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetPut")
+        .withProtocol(protocol())
+        .build();
+    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetPut")
+        .withProtocol(protocol())
+        .build();
 
     TestSetEventListener listener = new TestSetEventListener();
     CollectionEvent<String> event;
@@ -212,8 +231,12 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testRemove() throws Exception {
-    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetRemove", protocol()).build();
-    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetRemove", protocol()).build();
+    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetRemove")
+        .withProtocol(protocol())
+        .build();
+    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetRemove")
+        .withProtocol(protocol())
+        .build();
 
     TestSetEventListener listener = new TestSetEventListener();
     set2.addListener(listener);
@@ -252,8 +275,12 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testPutAll() throws Exception {
-    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetPutAll", protocol()).build();
-    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetPutAll", protocol()).build();
+    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetPutAll")
+        .withProtocol(protocol())
+        .build();
+    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetPutAll")
+        .withProtocol(protocol())
+        .build();
 
     set1.addAll(new HashSet<>());
 
@@ -278,8 +305,12 @@ public abstract class GossipDistributedSetTest extends AbstractPrimitiveTest {
 
   @Test
   public void testClear() throws Exception {
-    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetClear", protocol()).build();
-    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetClear", protocol()).build();
+    DistributedSet<String> set1 = atomix().<String>setBuilder("testAntiEntropySetClear")
+        .withProtocol(protocol())
+        .build();
+    DistributedSet<String> set2 = atomix().<String>setBuilder("testAntiEntropySetClear")
+        .withProtocol(protocol())
+        .build();
 
     assertTrue(set1.isEmpty());
     set1.clear();

--- a/core/src/test/java/io/atomix/core/set/PrimaryBackupDistributedNavigableSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/PrimaryBackupDistributedNavigableSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedNavigableSetTest extends DistributedNavigableSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/set/PrimaryBackupDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/PrimaryBackupDistributedSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupDistributedSetTest extends DistributedSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/set/RaftDistributedNavigableSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/RaftDistributedNavigableSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 
@@ -24,7 +24,7 @@ import io.atomix.protocols.raft.ReadConsistency;
  */
 public class RaftDistributedNavigableSetTest extends DistributedNavigableSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/set/RaftDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/RaftDistributedSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.set;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 
@@ -24,7 +24,7 @@ import io.atomix.protocols.raft.ReadConsistency;
  */
 public class RaftDistributedSetTest extends DistributedSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/transaction/PrimaryBackupTransactionalMapTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/PrimaryBackupTransactionalMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.transaction;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupTransactionalMapTest extends TransactionalMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/transaction/PrimaryBackupTransactionalSetTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/PrimaryBackupTransactionalSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.transaction;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupTransactionalSetTest extends TransactionalSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/transaction/RaftTransactionalMapTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/RaftTransactionalMapTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.transaction;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftTransactionalMapTest extends TransactionalMapTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/transaction/RaftTransactionalSetTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/RaftTransactionalSetTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.transaction;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftTransactionalSetTest extends TransactionalSetTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/transaction/TransactionalMapTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/TransactionalMapTest.java
@@ -16,10 +16,7 @@
 package io.atomix.core.transaction;
 
 import io.atomix.core.AbstractPrimitiveTest;
-import io.atomix.core.transaction.CommitStatus;
-import io.atomix.core.transaction.Isolation;
-import io.atomix.core.transaction.Transaction;
-import io.atomix.core.transaction.TransactionalMap;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -28,7 +25,7 @@ import static org.junit.Assert.assertNull;
 /**
  * Transactional map test.
  */
-public abstract class TransactionalMapTest extends AbstractPrimitiveTest {
+public abstract class TransactionalMapTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testTransactionalMap() throws Throwable {
     Transaction transaction1 = atomix().transactionBuilder()

--- a/core/src/test/java/io/atomix/core/transaction/TransactionalSetTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/TransactionalSetTest.java
@@ -17,21 +17,17 @@ package io.atomix.core.transaction;
 
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.set.DistributedSet;
-import io.atomix.core.transaction.CommitStatus;
-import io.atomix.core.transaction.Isolation;
-import io.atomix.core.transaction.Transaction;
-import io.atomix.core.transaction.TransactionalSet;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Transactional set test.
  */
-public abstract class TransactionalSetTest extends AbstractPrimitiveTest {
+public abstract class TransactionalSetTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testTransactionalSet() throws Throwable {
     Transaction transaction1 = atomix().transactionBuilder()

--- a/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
@@ -18,6 +18,7 @@ package io.atomix.core.tree;
 
 import com.google.common.base.Throwables;
 import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.time.Versioned;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -35,12 +36,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Unit tests for {@link AtomicDocumentTreeProxy}.
+ * Unit tests for {@link io.atomix.core.tree.impl.AtomicDocumentTreeProxy}.
  */
-public abstract class DocumentTreeTest extends AbstractPrimitiveTest {
+public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtocol> {
 
   protected AsyncAtomicDocumentTree<String> newTree(String name) throws Exception {
-    return atomix().<String>atomicDocumentTreeBuilder(name, protocol())
+    return atomix().<String>atomicDocumentTreeBuilder(name)
+        .withProtocol(protocol())
         .build()
         .async();
   }

--- a/core/src/test/java/io/atomix/core/tree/PrimaryBackupAtomicDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/PrimaryBackupAtomicDocumentTreeTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.tree;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicDocumentTreeTest extends DocumentTreeTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/tree/RaftAtomicDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/RaftAtomicDocumentTreeTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.tree;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftAtomicDocumentTreeTest extends DocumentTreeTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/value/AtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/AtomicValueTest.java
@@ -16,6 +16,7 @@
 package io.atomix.core.value;
 
 import io.atomix.core.AbstractPrimitiveTest;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.util.concurrent.BlockingQueue;
@@ -30,10 +31,13 @@ import static org.junit.Assert.assertTrue;
 /**
  * Raft atomic value test.
  */
-public abstract class AtomicValueTest extends AbstractPrimitiveTest {
+public abstract class AtomicValueTest extends AbstractPrimitiveTest<ProxyProtocol> {
   @Test
   public void testValue() throws Exception {
-    AsyncAtomicValue<String> value = atomix().<String>atomicValueBuilder("test-value", protocol()).build().async();
+    AsyncAtomicValue<String> value = atomix().<String>atomicValueBuilder("test-value")
+        .withProtocol(protocol())
+        .build()
+        .async();
     assertNull(value.get().get(30, TimeUnit.SECONDS));
     value.set("a").get(30, TimeUnit.SECONDS);
     assertEquals("a", value.get().get(30, TimeUnit.SECONDS));
@@ -46,8 +50,12 @@ public abstract class AtomicValueTest extends AbstractPrimitiveTest {
 
   @Test
   public void testEvents() throws Exception {
-    AtomicValue<String> value1 = atomix().<String>atomicValueBuilder("test-value-events", protocol()).build();
-    AtomicValue<String> value2 = atomix().<String>atomicValueBuilder("test-value-events", protocol()).build();
+    AtomicValue<String> value1 = atomix().<String>atomicValueBuilder("test-value-events")
+        .withProtocol(protocol())
+        .build();
+    AtomicValue<String> value2 = atomix().<String>atomicValueBuilder("test-value-events")
+        .withProtocol(protocol())
+        .build();
 
     BlockingAtomicValueListener<String> listener1 = new BlockingAtomicValueListener<>();
     BlockingAtomicValueListener<String> listener2 = new BlockingAtomicValueListener<>();

--- a/core/src/test/java/io/atomix/core/value/PrimaryBackupAtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/PrimaryBackupAtomicValueTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.value;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupAtomicValueTest extends AtomicValueTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/value/RaftAtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/RaftAtomicValueTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.value;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftAtomicValueTest extends AtomicValueTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/workqueue/PrimaryBackupWorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/workqueue/PrimaryBackupWorkQueueTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.workqueue;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.backup.MultiPrimaryProtocol;
  */
 public class PrimaryBackupWorkQueueTest extends WorkQueueTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
         .withBackups(2)
         .withMaxRetries(5)

--- a/core/src/test/java/io/atomix/core/workqueue/RaftWorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/workqueue/RaftWorkQueueTest.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.workqueue;
 
-import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 
 /**
@@ -23,7 +23,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
  */
 public class RaftWorkQueueTest extends WorkQueueTest {
   @Override
-  protected PrimitiveProtocol protocol() {
+  protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/workqueue/WorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/workqueue/WorkQueueTest.java
@@ -16,10 +16,9 @@
 package io.atomix.core.workqueue;
 
 import com.google.common.util.concurrent.Uninterruptibles;
-
 import io.atomix.core.AbstractPrimitiveTest;
-
 import io.atomix.core.workqueue.impl.WorkQueueProxy;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -37,18 +36,24 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link WorkQueueProxy}.
  */
-public abstract class WorkQueueTest extends AbstractPrimitiveTest {
+public abstract class WorkQueueTest extends AbstractPrimitiveTest<ProxyProtocol> {
   private static final Duration DEFAULT_PROCESSING_TIME = Duration.ofMillis(100);
   private static final String DEFAULT_PAYLOAD = "hello world";
 
   @Test
   public void testAdd() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String item = DEFAULT_PAYLOAD;
     queue1.addOne(item).get(30, TimeUnit.SECONDS);
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String task2 = DEFAULT_PAYLOAD;
     queue2.addOne(task2).get(30, TimeUnit.SECONDS);
 
@@ -61,7 +66,10 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testAddMultiple() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String item1 = DEFAULT_PAYLOAD;
     String item2 = DEFAULT_PAYLOAD;
     queue1.addMultiple(Arrays.asList(item1, item2)).get(30, TimeUnit.SECONDS);
@@ -75,11 +83,17 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testTakeAndComplete() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String item1 = DEFAULT_PAYLOAD;
     queue1.addOne(item1).get(30, TimeUnit.SECONDS);
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     Task<String> removedTask = queue2.take().get(30, TimeUnit.SECONDS);
 
     WorkQueueStats stats = queue2.stats().get(30, TimeUnit.SECONDS);
@@ -102,11 +116,17 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testUnexpectedClientClose() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String item1 = DEFAULT_PAYLOAD;
     queue1.addOne(item1).get(30, TimeUnit.SECONDS);
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     queue2.take().get(30, TimeUnit.SECONDS);
 
     WorkQueueStats stats = queue1.stats().get(30, TimeUnit.SECONDS);
@@ -125,13 +145,19 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testAutomaticTaskProcessing() throws Throwable {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     Executor executor = Executors.newSingleThreadExecutor();
 
     CountDownLatch latch1 = new CountDownLatch(1);
     queue1.registerTaskProcessor(s -> latch1.countDown(), 2, executor);
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String item1 = DEFAULT_PAYLOAD;
     queue2.addOne(item1).get(30, TimeUnit.SECONDS);
 
@@ -159,11 +185,17 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testDestroy() throws Exception {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String item = DEFAULT_PAYLOAD;
     queue1.addOne(item).get(30, TimeUnit.SECONDS);
 
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String task2 = DEFAULT_PAYLOAD;
     queue2.addOne(task2).get(30, TimeUnit.SECONDS);
 
@@ -183,7 +215,10 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest {
   @Test
   public void testCompleteAttemptWithIncorrectSession() throws Exception {
     String queueName = UUID.randomUUID().toString();
-    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
     String item = DEFAULT_PAYLOAD;
     queue1.addOne(item).get(30, TimeUnit.SECONDS);
 
@@ -191,7 +226,10 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest {
     String taskId = task.taskId();
 
     // Create another client and get a handle to the same queue.
-    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName, protocol()).build().async();
+    AsyncWorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build()
+        .async();
 
     // Attempt completing the task with new client and verify task is not completed
     queue2.complete(taskId).get(30, TimeUnit.SECONDS);

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
@@ -20,7 +20,7 @@ import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocolConfig;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.Builder;
@@ -60,7 +60,7 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
    * @return the primitive builder
    */
   @SuppressWarnings("unchecked")
-  public B withProtocol(PrimitiveProtocol protocol) {
+  protected B withProtocol(PrimitiveProtocol protocol) {
     this.protocol = protocol;
     return (B) this;
   }
@@ -116,8 +116,8 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
 
   protected <S> CompletableFuture<ProxyClient<S>> newProxy(Class<S> serviceType, ServiceConfig config) {
     PrimitiveProtocol protocol = protocol();
-    if (protocol instanceof StateMachineReplicationProtocol) {
-      return CompletableFuture.completedFuture(((StateMachineReplicationProtocol) protocol)
+    if (protocol instanceof ProxyProtocol) {
+      return CompletableFuture.completedFuture(((ProxyProtocol) protocol)
           .newProxy(name, type, serviceType, config, managementService.getPartitionService()));
     }
     return Futures.exceptionalFuture(new UnsupportedOperationException());

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionGroup.java
@@ -17,7 +17,7 @@ package io.atomix.primitive.partition;
 
 import com.google.common.hash.Hashing;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.ConfiguredType;
 import io.atomix.utils.config.Configured;
 
@@ -70,7 +70,7 @@ public interface PartitionGroup extends Configured<PartitionGroupConfig> {
    *
    * @return a new primitive protocol
    */
-  StateMachineReplicationProtocol newProtocol();
+  ProxyProtocol newProtocol();
 
   /**
    * Returns a partition by ID.

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.primitive.partition;
 
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 
 import java.util.Collection;
@@ -61,7 +61,7 @@ public interface PartitionService {
    * @return the first partition group that matches the given primitive protocol
    */
   @SuppressWarnings("unchecked")
-  default PartitionGroup getPartitionGroup(StateMachineReplicationProtocol protocol) {
+  default PartitionGroup getPartitionGroup(ProxyProtocol protocol) {
     if (protocol.group() != null) {
       PartitionGroup group = getPartitionGroup(protocol.group());
       if (group != null) {

--- a/primitive/src/main/java/io/atomix/primitive/protocol/ProxyCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/ProxyCompatibleBuilder.java
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.map;
-
-import io.atomix.utils.event.EventListener;
+package io.atomix.primitive.protocol;
 
 /**
- * Map protocol event listener.
+ * State machine replication compatible primitive.
  */
-public interface MapProtocolEventListener<K, V> extends EventListener<MapProtocolEvent<K, V>> {
+public interface ProxyCompatibleBuilder<B extends ProxyCompatibleBuilder<B>> {
+
+  /**
+   * Configures the builder with a state machine replication protocol.
+   *
+   * @param protocol the state machine replication protocol
+   * @return the primitive builder
+   */
+  B withProtocol(ProxyProtocol protocol);
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/ProxyProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/ProxyProtocol.java
@@ -23,7 +23,7 @@ import io.atomix.primitive.service.ServiceConfig;
 /**
  * State machine replication-based primitive protocol.
  */
-public interface StateMachineReplicationProtocol extends PrimitiveProtocol {
+public interface ProxyProtocol extends PrimitiveProtocol {
 
   /**
    * Returns the protocol partition group name.

--- a/primitive/src/main/java/io/atomix/primitive/protocol/counter/CounterCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/counter/CounterCompatibleBuilder.java
@@ -13,12 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.set;
-
-import io.atomix.utils.event.EventListener;
+package io.atomix.primitive.protocol.counter;
 
 /**
- * Set protocol event listener.
+ * Counter builder.
  */
-public interface SetProtocolEventListener<E> extends EventListener<SetProtocolEvent<E>> {
+public interface CounterCompatibleBuilder<B extends CounterCompatibleBuilder<B>> {
+
+  /**
+   * Configures the builder with a counter compatible gossip protocol.
+   *
+   * @param protocol the counter protocol
+   * @return the primitive builder
+   */
+  B withProtocol(CounterProtocol protocol);
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/counter/CounterDelegate.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/counter/CounterDelegate.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.counter;
+
+/**
+ * Gossip-based counter service.
+ */
+public interface CounterDelegate {
+
+  /**
+   * Atomically increment by one and return the updated value.
+   *
+   * @return updated value
+   */
+  long incrementAndGet();
+
+  /**
+   * Atomically decrement by one and return the updated value.
+   *
+   * @return updated value
+   */
+  long decrementAndGet();
+
+  /**
+   * Atomically increment by one and return the previous value.
+   *
+   * @return previous value
+   */
+  long getAndIncrement();
+
+  /**
+   * Atomically decrement by one and return the previous value.
+   *
+   * @return previous value
+   */
+  long getAndDecrement();
+
+  /**
+   * Atomically adds the given value to the current value.
+   *
+   * @param delta the value to add
+   * @return previous value
+   */
+  long getAndAdd(long delta);
+
+  /**
+   * Atomically adds the given value to the current value.
+   *
+   * @param delta the value to add
+   * @return updated value
+   */
+  long addAndGet(long delta);
+
+  /**
+   * Returns the counter value.
+   *
+   * @return the counter value
+   */
+  long get();
+
+  /**
+   * Closes the counter.
+   */
+  void close();
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/counter/CounterProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/counter/CounterProtocol.java
@@ -15,64 +15,21 @@
  */
 package io.atomix.primitive.protocol.counter;
 
+import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.GossipProtocol;
+
 /**
- * Gossip-based counter service.
+ * Counter protocol.
  */
-public interface CounterProtocol {
+public interface CounterProtocol extends GossipProtocol {
 
   /**
-   * Atomically increment by one and return the updated value.
+   * Returns a new counter delegate.
    *
-   * @return updated value
+   * @param name the counter name
+   * @param managementService the primitive management service
+   * @return a new counter delegate
    */
-  long incrementAndGet();
+  CounterDelegate newCounterDelegate(String name, PrimitiveManagementService managementService);
 
-  /**
-   * Atomically decrement by one and return the updated value.
-   *
-   * @return updated value
-   */
-  long decrementAndGet();
-
-  /**
-   * Atomically increment by one and return the previous value.
-   *
-   * @return previous value
-   */
-  long getAndIncrement();
-
-  /**
-   * Atomically decrement by one and return the previous value.
-   *
-   * @return previous value
-   */
-  long getAndDecrement();
-
-  /**
-   * Atomically adds the given value to the current value.
-   *
-   * @param delta the value to add
-   * @return previous value
-   */
-  long getAndAdd(long delta);
-
-  /**
-   * Atomically adds the given value to the current value.
-   *
-   * @param delta the value to add
-   * @return updated value
-   */
-  long addAndGet(long delta);
-
-  /**
-   * Returns the counter value.
-   *
-   * @return the counter value
-   */
-  long get();
-
-  /**
-   * Closes the counter.
-   */
-  void close();
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/counter/package-info.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/counter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interfaces for counter-compatible gossip protocols and delegates.
+ */
+package io.atomix.primitive.protocol.counter;

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/MapCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/MapCompatibleBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.map;
+
+/**
+ * Map builder.
+ */
+public interface MapCompatibleBuilder<B extends MapCompatibleBuilder<B>> {
+
+  /**
+   * Configures the builder with a map compatible gossip protocol.
+   *
+   * @param protocol the map protocol
+   * @return the primitive builder
+   */
+  B withProtocol(MapProtocol protocol);
+
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/MapDelegate.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/MapDelegate.java
@@ -13,44 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.set;
+package io.atomix.primitive.protocol.map;
 
-import io.atomix.utils.event.AbstractEvent;
+import java.util.Map;
 
 /**
- * Set protocol event.
+ * Gossip-based map service.
  */
-public class SetProtocolEvent<E> extends AbstractEvent<SetProtocolEvent.Type, E> {
+public interface MapDelegate<K, V> extends Map<K, V> {
 
   /**
-   * Set protocol event type.
-   */
-  public enum Type {
-    /**
-     * Element added to set.
-     */
-    ADD,
-
-    /**
-     * Element removed from the set.
-     */
-    REMOVE,
-  }
-
-  public SetProtocolEvent(Type type, E element) {
-    super(type, element);
-  }
-
-  public SetProtocolEvent(Type type, E element, long time) {
-    super(type, element, time);
-  }
-
-  /**
-   * Returns the set element.
+   * Adds the specified listener to the map which will be notified whenever the mappings in the map are changed.
    *
-   * @return the set element
+   * @param listener listener to register for events
    */
-  public E element() {
-    return subject();
-  }
+  void addListener(MapDelegateEventListener<K, V> listener);
+
+  /**
+   * Removes the specified listener from the map such that it will no longer receive change notifications.
+   *
+   * @param listener listener to deregister for events
+   */
+  void removeListener(MapDelegateEventListener<K, V> listener);
+
+  /**
+   * Closes the map.
+   */
+  void close();
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/MapDelegateEvent.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/MapDelegateEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.map;
+
+import io.atomix.utils.event.AbstractEvent;
+
+/**
+ * Map protocol event.
+ */
+public class MapDelegateEvent<K, V> extends AbstractEvent<MapDelegateEvent.Type, K> {
+
+  /**
+   * Map protocol event type.
+   */
+  public enum Type {
+    /**
+     * Entry added to map.
+     */
+    INSERT,
+
+    /**
+     * Existing entry updated.
+     */
+    UPDATE,
+
+    /**
+     * Entry removed from map.
+     */
+    REMOVE
+  }
+
+  private final V value;
+
+  public MapDelegateEvent(Type type, K key, V value) {
+    super(type, key);
+    this.value = value;
+  }
+
+  public MapDelegateEvent(Type type, K key, V value, long time) {
+    super(type, key, time);
+    this.value = value;
+  }
+
+  /**
+   * Returns the map entry key.
+   *
+   * @return the map entry key
+   */
+  public K key() {
+    return subject();
+  }
+
+  /**
+   * Returns the map entry value.
+   *
+   * @return the map entry value
+   */
+  public V value() {
+    return value;
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/MapDelegateEventListener.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/MapDelegateEventListener.java
@@ -15,21 +15,10 @@
  */
 package io.atomix.primitive.protocol.map;
 
-import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.GossipProtocol;
+import io.atomix.utils.event.EventListener;
 
 /**
- * Map protocol provider.
+ * Map protocol event listener.
  */
-public interface MapProtocolProvider extends GossipProtocol {
-
-  /**
-   * Returns a new map protocol.
-   *
-   * @param name the map name
-   * @param managementService the primitive management service
-   * @return a new map protocol
-   */
-  <K, V> MapProtocol<K, V> newMapProtocol(String name, PrimitiveManagementService managementService);
-
+public interface MapDelegateEventListener<K, V> extends EventListener<MapDelegateEvent<K, V>> {
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/MapProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/MapProtocol.java
@@ -15,29 +15,21 @@
  */
 package io.atomix.primitive.protocol.map;
 
-import java.util.Map;
+import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.GossipProtocol;
 
 /**
- * Gossip-based map service.
+ * Map protocol.
  */
-public interface MapProtocol<K, V> extends Map<K, V> {
+public interface MapProtocol extends GossipProtocol {
 
   /**
-   * Adds the specified listener to the map which will be notified whenever the mappings in the map are changed.
+   * Returns a new map delegate.
    *
-   * @param listener listener to register for events
+   * @param name the map name
+   * @param managementService the primitive management service
+   * @return a new map delegate
    */
-  void addListener(MapProtocolEventListener<K, V> listener);
+  <K, V> MapDelegate<K, V> newMapDelegate(String name, PrimitiveManagementService managementService);
 
-  /**
-   * Removes the specified listener from the map such that it will no longer receive change notifications.
-   *
-   * @param listener listener to deregister for events
-   */
-  void removeListener(MapProtocolEventListener<K, V> listener);
-
-  /**
-   * Closes the map.
-   */
-  void close();
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapCompatibleBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.map;
+
+/**
+ * Map builder.
+ */
+public interface NavigableMapCompatibleBuilder<B extends NavigableMapCompatibleBuilder<B>> {
+
+  /**
+   * Configures the builder with a map compatible gossip protocol.
+   *
+   * @param protocol the map protocol
+   * @return the primitive builder
+   */
+  B withProtocol(NavigableMapProtocol protocol);
+
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapDelegate.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapDelegate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.map;
+
+import java.util.NavigableMap;
+
+/**
+ * Navigable map protocol.
+ */
+public interface NavigableMapDelegate<K, V> extends SortedMapDelegate<K, V>, NavigableMap<K, V> {
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapProtocol.java
@@ -15,10 +15,20 @@
  */
 package io.atomix.primitive.protocol.map;
 
-import java.util.NavigableMap;
+import io.atomix.primitive.PrimitiveManagementService;
 
 /**
  * Navigable map protocol.
  */
-public interface NavigableMapProtocol<K, V> extends SortedMapProtocol<K, V>, NavigableMap<K, V> {
+public interface NavigableMapProtocol extends SortedMapProtocol {
+
+  /**
+   * Returns a new navigable map delegate.
+   *
+   * @param name the map name
+   * @param managementService the primitive management service
+   * @return a new map delegate
+   */
+  <K, V> NavigableMapDelegate<K, V> newNavigableMapDelegate(String name, PrimitiveManagementService managementService);
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapCompatibleBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.map;
+
+/**
+ * Map builder.
+ */
+public interface SortedMapCompatibleBuilder<B extends SortedMapCompatibleBuilder<B>> {
+
+  /**
+   * Configures the builder with a map compatible gossip protocol.
+   *
+   * @param protocol the map protocol
+   * @return the primitive builder
+   */
+  B withProtocol(SortedMapProtocol protocol);
+
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapDelegate.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapDelegate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.map;
+
+import java.util.SortedMap;
+
+/**
+ * Sorted map protocol.
+ */
+public interface SortedMapDelegate<K, V> extends MapDelegate<K, V>, SortedMap<K, V> {
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapProtocol.java
@@ -15,10 +15,20 @@
  */
 package io.atomix.primitive.protocol.map;
 
-import java.util.SortedMap;
+import io.atomix.primitive.PrimitiveManagementService;
 
 /**
  * Sorted map protocol.
  */
-public interface SortedMapProtocol<K, V> extends MapProtocol<K, V>, SortedMap<K, V> {
+public interface SortedMapProtocol extends MapProtocol {
+
+  /**
+   * Returns a new sorted map delegate.
+   *
+   * @param name the map name
+   * @param managementService the primitive management service
+   * @return a new map delegate
+   */
+  <K, V> NavigableMapDelegate<K, V> newSortedMapDelegate(String name, PrimitiveManagementService managementService);
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/package-info.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/package-info.java
@@ -13,23 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.map;
-
-import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.GossipProtocol;
 
 /**
- * Sorted map protocol provider.
+ * Interfaces for map-compatible gossip protocols and delegates.
  */
-public interface SortedMapProtocolProvider extends GossipProtocol {
-
-  /**
-   * Returns a new sorted map protocol.
-   *
-   * @param name the map name
-   * @param managementService the primitive management service
-   * @return a new map protocol
-   */
-  <K, V> NavigableMapProtocol<K, V> newSortedMapProtocol(String name, PrimitiveManagementService managementService);
-
-}
+package io.atomix.primitive.protocol.map;

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetCompatibleBuilder.java
@@ -15,22 +15,17 @@
  */
 package io.atomix.primitive.protocol.set;
 
-import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.GossipProtocol;
-
 /**
- * Set protocol provider.
+ * Set builder.
  */
-public interface SetProtocolProvider extends GossipProtocol {
+public interface NavigableSetCompatibleBuilder<B extends NavigableSetCompatibleBuilder<B>> {
 
   /**
-   * Returns a new set protocol.
+   * Configures the builder with a set compatible gossip protocol.
    *
-   * @param name the set name
-   * @param managementService the primitive management service
-   * @param <E> the set element type
-   * @return a new set protocol
+   * @param protocol the set protocol
+   * @return the primitive builder
    */
-  <E> SetProtocol<E> newSetProtocol(String name, PrimitiveManagementService managementService);
+  B withProtocol(NavigableSetProtocol protocol);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetDelegate.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetDelegate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.set;
+
+import java.util.NavigableSet;
+
+/**
+ * Navigable set protocol.
+ */
+public interface NavigableSetDelegate<E> extends SortedSetDelegate<E>, NavigableSet<E> {
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetProtocol.java
@@ -15,10 +15,21 @@
  */
 package io.atomix.primitive.protocol.set;
 
-import java.util.NavigableSet;
+import io.atomix.primitive.PrimitiveManagementService;
 
 /**
  * Navigable set protocol.
  */
-public interface NavigableSetProtocol<E> extends SortedSetProtocol<E>, NavigableSet<E> {
+public interface NavigableSetProtocol extends SortedSetProtocol {
+
+  /**
+   * Returns a new set delegate.
+   *
+   * @param name the set name
+   * @param managementService the primitive management service
+   * @param <E> the set element type
+   * @return a new set delegate
+   */
+  <E> NavigableSetDelegate<E> newNavigableSetDelegate(String name, PrimitiveManagementService managementService);
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SetCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SetCompatibleBuilder.java
@@ -13,23 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.counter;
-
-import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.GossipProtocol;
+package io.atomix.primitive.protocol.set;
 
 /**
- * Counter protocol provider.
+ * Set builder.
  */
-public interface CounterProtocolProvider extends GossipProtocol {
+public interface SetCompatibleBuilder<B extends SetCompatibleBuilder<B>> {
 
   /**
-   * Returns a new counter protocol.
+   * Configures the builder with a set compatible gossip protocol.
    *
-   * @param name the counter name
-   * @param managementService the primitive management service
-   * @return a new counter protocol
+   * @param protocol the set protocol
+   * @return the primitive builder
    */
-  CounterProtocol newCounterProtocol(String name, PrimitiveManagementService managementService);
+  B withProtocol(SetProtocol protocol);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SetDelegate.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SetDelegate.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.set;
+
+import java.util.Set;
+
+/**
+ * Gossip-based set service.
+ */
+public interface SetDelegate<E> extends Set<E> {
+
+  /**
+   * Adds the specified listener to the set which will be notified whenever the entries in the set are changed.
+   *
+   * @param listener listener to register for events
+   */
+  void addListener(SetDelegateEventListener<E> listener);
+
+  /**
+   * Removes the specified listener from the set such that it will no longer receive change notifications.
+   *
+   * @param listener listener to deregister for events
+   */
+  void removeListener(SetDelegateEventListener<E> listener);
+
+  /**
+   * Closes the set.
+   */
+  void close();
+
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SetDelegateEvent.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SetDelegateEvent.java
@@ -13,62 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.map;
+package io.atomix.primitive.protocol.set;
 
 import io.atomix.utils.event.AbstractEvent;
 
 /**
- * Map protocol event.
+ * Set protocol event.
  */
-public class MapProtocolEvent<K, V> extends AbstractEvent<MapProtocolEvent.Type, K> {
+public class SetDelegateEvent<E> extends AbstractEvent<SetDelegateEvent.Type, E> {
 
   /**
-   * Map protocol event type.
+   * Set protocol event type.
    */
   public enum Type {
     /**
-     * Entry added to map.
+     * Element added to set.
      */
-    INSERT,
+    ADD,
 
     /**
-     * Existing entry updated.
+     * Element removed from the set.
      */
-    UPDATE,
-
-    /**
-     * Entry removed from map.
-     */
-    REMOVE
+    REMOVE,
   }
 
-  private final V value;
-
-  public MapProtocolEvent(Type type, K key, V value) {
-    super(type, key);
-    this.value = value;
+  public SetDelegateEvent(Type type, E element) {
+    super(type, element);
   }
 
-  public MapProtocolEvent(Type type, K key, V value, long time) {
-    super(type, key, time);
-    this.value = value;
+  public SetDelegateEvent(Type type, E element, long time) {
+    super(type, element, time);
   }
 
   /**
-   * Returns the map entry key.
+   * Returns the set element.
    *
-   * @return the map entry key
+   * @return the set element
    */
-  public K key() {
+  public E element() {
     return subject();
-  }
-
-  /**
-   * Returns the map entry value.
-   *
-   * @return the map entry value
-   */
-  public V value() {
-    return value;
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SetDelegateEventListener.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SetDelegateEventListener.java
@@ -13,23 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.map;
+package io.atomix.primitive.protocol.set;
 
-import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.GossipProtocol;
+import io.atomix.utils.event.EventListener;
 
 /**
- * Navigable map protocol provider.
+ * Set protocol event listener.
  */
-public interface NavigableMapProtocolProvider extends GossipProtocol {
-
-  /**
-   * Returns a new navigable map protocol.
-   *
-   * @param name the map name
-   * @param managementService the primitive management service
-   * @return a new map protocol
-   */
-  <K, V> NavigableMapProtocol<K, V> newNavigableMapProtocol(String name, PrimitiveManagementService managementService);
-
+public interface SetDelegateEventListener<E> extends EventListener<SetDelegateEvent<E>> {
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SetProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SetProtocol.java
@@ -15,30 +15,22 @@
  */
 package io.atomix.primitive.protocol.set;
 
-import java.util.Set;
+import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.protocol.GossipProtocol;
 
 /**
- * Gossip-based set service.
+ * Set protocol.
  */
-public interface SetProtocol<E> extends Set<E> {
+public interface SetProtocol extends GossipProtocol {
 
   /**
-   * Adds the specified listener to the set which will be notified whenever the entries in the set are changed.
+   * Returns a new set delegate.
    *
-   * @param listener listener to register for events
+   * @param name the set name
+   * @param managementService the primitive management service
+   * @param <E> the set element type
+   * @return a new set delegate
    */
-  void addListener(SetProtocolEventListener<E> listener);
-
-  /**
-   * Removes the specified listener from the set such that it will no longer receive change notifications.
-   *
-   * @param listener listener to deregister for events
-   */
-  void removeListener(SetProtocolEventListener<E> listener);
-
-  /**
-   * Closes the set.
-   */
-  void close();
+  <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetCompatibleBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetCompatibleBuilder.java
@@ -15,22 +15,17 @@
  */
 package io.atomix.primitive.protocol.set;
 
-import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.GossipProtocol;
-
 /**
- * Sorted set protocol provider.
+ * Set builder.
  */
-public interface SortedSetProtocolProvider extends GossipProtocol {
+public interface SortedSetCompatibleBuilder<B extends SortedSetCompatibleBuilder<B>> {
 
   /**
-   * Returns a new set protocol.
+   * Configures the builder with a set compatible gossip protocol.
    *
-   * @param name the set name
-   * @param managementService the primitive management service
-   * @param <E> the set element type
-   * @return a new set protocol
+   * @param protocol the set protocol
+   * @return the primitive builder
    */
-  <E> SortedSetProtocol<E> newSortedSetProtocol(String name, PrimitiveManagementService managementService);
+  B withProtocol(SortedSetProtocol protocol);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetDelegate.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetDelegate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.protocol.set;
+
+import java.util.SortedSet;
+
+/**
+ * Sorted set protocol.
+ */
+public interface SortedSetDelegate<E> extends SetDelegate<E>, SortedSet<E> {
+}

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetProtocol.java
@@ -15,10 +15,21 @@
  */
 package io.atomix.primitive.protocol.set;
 
-import java.util.SortedSet;
+import io.atomix.primitive.PrimitiveManagementService;
 
 /**
  * Sorted set protocol.
  */
-public interface SortedSetProtocol<E> extends SetProtocol<E>, SortedSet<E> {
+public interface SortedSetProtocol extends SetProtocol {
+
+  /**
+   * Returns a new set delegate.
+   *
+   * @param name the set name
+   * @param managementService the primitive management service
+   * @param <E> the set element type
+   * @return a new set delegate
+   */
+  <E> SortedSetDelegate<E> newSortedSetDelegate(String name, PrimitiveManagementService managementService);
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/package-info.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/package-info.java
@@ -13,24 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.primitive.protocol.set;
-
-import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.GossipProtocol;
 
 /**
- * Navigable set protocol provider.
+ * Interfaces for set-compatible gossip protocols and delegates.
  */
-public interface NavigableSetProtocolProvider extends GossipProtocol {
-
-  /**
-   * Returns a new set protocol.
-   *
-   * @param name the set name
-   * @param managementService the primitive management service
-   * @param <E> the set element type
-   * @return a new set protocol
-   */
-  <E> NavigableSetProtocol<E> newNavigableSetProtocol(String name, PrimitiveManagementService managementService);
-
-}
+package io.atomix.primitive.protocol.set;

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/AntiEntropyProtocol.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/AntiEntropyProtocol.java
@@ -18,10 +18,10 @@ package io.atomix.protocols.gossip;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.map.MapDelegate;
 import io.atomix.primitive.protocol.map.MapProtocol;
-import io.atomix.primitive.protocol.map.MapProtocolProvider;
+import io.atomix.primitive.protocol.set.SetDelegate;
 import io.atomix.primitive.protocol.set.SetProtocol;
-import io.atomix.primitive.protocol.set.SetProtocolProvider;
 import io.atomix.protocols.gossip.map.AntiEntropyMap;
 import io.atomix.protocols.gossip.set.AntiEntropySet;
 import io.atomix.utils.serializer.Serializer;
@@ -29,7 +29,7 @@ import io.atomix.utils.serializer.Serializer;
 /**
  * Anti-entropy protocol.
  */
-public class AntiEntropyProtocol implements GossipProtocol, MapProtocolProvider, SetProtocolProvider {
+public class AntiEntropyProtocol implements GossipProtocol, MapProtocol, SetProtocol {
   public static final Type TYPE = new Type();
 
   /**
@@ -80,12 +80,12 @@ public class AntiEntropyProtocol implements GossipProtocol, MapProtocolProvider,
   }
 
   @Override
-  public <K, V> MapProtocol<K, V> newMapProtocol(String name, PrimitiveManagementService managementService) {
+  public <K, V> MapDelegate<K, V> newMapDelegate(String name, PrimitiveManagementService managementService) {
     return new AntiEntropyMap<>(name, config, managementService);
   }
 
   @Override
-  public <E> SetProtocol<E> newSetProtocol(String name, PrimitiveManagementService managementService) {
+  public <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService) {
     return new AntiEntropySet<>(name, config, managementService);
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/AntiEntropyProtocol.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/AntiEntropyProtocol.java
@@ -22,8 +22,8 @@ import io.atomix.primitive.protocol.map.MapDelegate;
 import io.atomix.primitive.protocol.map.MapProtocol;
 import io.atomix.primitive.protocol.set.SetDelegate;
 import io.atomix.primitive.protocol.set.SetProtocol;
-import io.atomix.protocols.gossip.map.AntiEntropyMap;
-import io.atomix.protocols.gossip.set.AntiEntropySet;
+import io.atomix.protocols.gossip.map.AntiEntropyMapDelegate;
+import io.atomix.protocols.gossip.set.AntiEntropySetDelegate;
 import io.atomix.utils.serializer.Serializer;
 
 /**
@@ -31,6 +31,15 @@ import io.atomix.utils.serializer.Serializer;
  */
 public class AntiEntropyProtocol implements GossipProtocol, MapProtocol, SetProtocol {
   public static final Type TYPE = new Type();
+
+  /**
+   * Returns an instance of the anti-entropy protocol with the default configuration.
+   *
+   * @return an instance of the anti-entropy protocol with the default configuration
+   */
+  public AntiEntropyProtocol instance() {
+    return new AntiEntropyProtocol(new AntiEntropyProtocolConfig());
+  }
 
   /**
    * Returns a new gossip protocol builder.
@@ -81,11 +90,11 @@ public class AntiEntropyProtocol implements GossipProtocol, MapProtocol, SetProt
 
   @Override
   public <K, V> MapDelegate<K, V> newMapDelegate(String name, PrimitiveManagementService managementService) {
-    return new AntiEntropyMap<>(name, config, managementService);
+    return new AntiEntropyMapDelegate<>(name, config, managementService);
   }
 
   @Override
   public <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService) {
-    return new AntiEntropySet<>(name, config, managementService);
+    return new AntiEntropySetDelegate<>(name, config, managementService);
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
@@ -22,8 +22,8 @@ import io.atomix.primitive.protocol.counter.CounterDelegate;
 import io.atomix.primitive.protocol.counter.CounterProtocol;
 import io.atomix.primitive.protocol.set.SetDelegate;
 import io.atomix.primitive.protocol.set.SetProtocol;
-import io.atomix.protocols.gossip.counter.CrdtCounter;
-import io.atomix.protocols.gossip.set.CrdtSet;
+import io.atomix.protocols.gossip.counter.CrdtCounterDelegate;
+import io.atomix.protocols.gossip.set.CrdtSetDelegate;
 import io.atomix.utils.serializer.Serializer;
 
 /**
@@ -31,6 +31,15 @@ import io.atomix.utils.serializer.Serializer;
  */
 public class CrdtProtocol implements GossipProtocol, CounterProtocol, SetProtocol {
   public static final Type TYPE = new Type();
+
+  /**
+   * Returns an instance of the CRDT protocol with the default configuration.
+   *
+   * @return an instance of the CRDT protocol with the default configuration
+   */
+  public CrdtProtocol instance() {
+    return new CrdtProtocol(new CrdtProtocolConfig());
+  }
 
   /**
    * Returns a new CRDT protocol builder.
@@ -81,11 +90,11 @@ public class CrdtProtocol implements GossipProtocol, CounterProtocol, SetProtoco
 
   @Override
   public CounterDelegate newCounterDelegate(String name, PrimitiveManagementService managementService) {
-    return new CrdtCounter(name, config, managementService);
+    return new CrdtCounterDelegate(name, config, managementService);
   }
 
   @Override
   public <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService) {
-    return new CrdtSet<>(name, config, managementService);
+    return new CrdtSetDelegate<>(name, config, managementService);
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
@@ -18,10 +18,10 @@ package io.atomix.protocols.gossip;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.counter.CounterDelegate;
 import io.atomix.primitive.protocol.counter.CounterProtocol;
-import io.atomix.primitive.protocol.counter.CounterProtocolProvider;
+import io.atomix.primitive.protocol.set.SetDelegate;
 import io.atomix.primitive.protocol.set.SetProtocol;
-import io.atomix.primitive.protocol.set.SetProtocolProvider;
 import io.atomix.protocols.gossip.counter.CrdtCounter;
 import io.atomix.protocols.gossip.set.CrdtSet;
 import io.atomix.utils.serializer.Serializer;
@@ -29,7 +29,7 @@ import io.atomix.utils.serializer.Serializer;
 /**
  * Conflict-free Replicated Data Types (CRDT) protocol.
  */
-public class CrdtProtocol implements GossipProtocol, CounterProtocolProvider, SetProtocolProvider {
+public class CrdtProtocol implements GossipProtocol, CounterProtocol, SetProtocol {
   public static final Type TYPE = new Type();
 
   /**
@@ -80,12 +80,12 @@ public class CrdtProtocol implements GossipProtocol, CounterProtocolProvider, Se
   }
 
   @Override
-  public CounterProtocol newCounterProtocol(String name, PrimitiveManagementService managementService) {
+  public CounterDelegate newCounterDelegate(String name, PrimitiveManagementService managementService) {
     return new CrdtCounter(name, config, managementService);
   }
 
   @Override
-  public <E> SetProtocol<E> newSetProtocol(String name, PrimitiveManagementService managementService) {
+  public <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService) {
     return new CrdtSet<>(name, config, managementService);
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
@@ -20,16 +20,19 @@ import io.atomix.primitive.protocol.GossipProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.counter.CounterDelegate;
 import io.atomix.primitive.protocol.counter.CounterProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetDelegate;
+import io.atomix.primitive.protocol.set.NavigableSetProtocol;
 import io.atomix.primitive.protocol.set.SetDelegate;
-import io.atomix.primitive.protocol.set.SetProtocol;
+import io.atomix.primitive.protocol.set.SortedSetDelegate;
 import io.atomix.protocols.gossip.counter.CrdtCounterDelegate;
+import io.atomix.protocols.gossip.set.CrdtNavigableSetDelegate;
 import io.atomix.protocols.gossip.set.CrdtSetDelegate;
 import io.atomix.utils.serializer.Serializer;
 
 /**
  * Conflict-free Replicated Data Types (CRDT) protocol.
  */
-public class CrdtProtocol implements GossipProtocol, CounterProtocol, SetProtocol {
+public class CrdtProtocol implements GossipProtocol, CounterProtocol, NavigableSetProtocol {
   public static final Type TYPE = new Type();
 
   /**
@@ -96,5 +99,15 @@ public class CrdtProtocol implements GossipProtocol, CounterProtocol, SetProtoco
   @Override
   public <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService) {
     return new CrdtSetDelegate<>(name, config, managementService);
+  }
+
+  @Override
+  public <E> SortedSetDelegate<E> newSortedSetDelegate(String name, PrimitiveManagementService managementService) {
+    return new CrdtNavigableSetDelegate<>(name, config, managementService);
+  }
+
+  @Override
+  public <E> NavigableSetDelegate<E> newNavigableSetDelegate(String name, PrimitiveManagementService managementService) {
+    return new CrdtNavigableSetDelegate<>(name, config, managementService);
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/counter/CrdtCounter.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/counter/CrdtCounter.java
@@ -21,7 +21,7 @@ import com.google.common.util.concurrent.AtomicLongMap;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.counter.CounterProtocol;
+import io.atomix.primitive.protocol.counter.CounterDelegate;
 import io.atomix.protocols.gossip.CrdtProtocolConfig;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * CRDT based counter implementation.
  */
-public class CrdtCounter implements CounterProtocol {
+public class CrdtCounter implements CounterDelegate {
   private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
       .register(Namespaces.BASIC)
       .register(MemberId.class)

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/counter/CrdtCounterDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/counter/CrdtCounterDelegate.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * CRDT based counter implementation.
  */
-public class CrdtCounter implements CounterDelegate {
+public class CrdtCounterDelegate implements CounterDelegate {
   private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
       .register(Namespaces.BASIC)
       .register(MemberId.class)
@@ -50,7 +50,7 @@ public class CrdtCounter implements CounterDelegate {
   private final AtomicLongMap<MemberId> increments = AtomicLongMap.create();
   private final AtomicLongMap<MemberId> decrements = AtomicLongMap.create();
 
-  public CrdtCounter(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
+  public CrdtCounterDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
     this.localMemberId = managementService.getMembershipService().getLocalMember().id();
     this.clusterCommunicator = managementService.getCommunicationService();
     this.executorService = managementService.getExecutorService();

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/map/AntiEntropyMapDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/map/AntiEntropyMapDelegate.java
@@ -80,9 +80,9 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
-public class AntiEntropyMap<K, V> implements MapDelegate<K, V> {
+public class AntiEntropyMapDelegate<K, V> implements MapDelegate<K, V> {
 
-  private static final Logger log = LoggerFactory.getLogger(AntiEntropyMap.class);
+  private static final Logger log = LoggerFactory.getLogger(AntiEntropyMapDelegate.class);
   private static final String ERROR_DESTROYED = " map is already destroyed";
   private static final String ERROR_NULL_KEY = "Key cannot be null";
   private static final String ERROR_NULL_VALUE = "Null values are not allowed";
@@ -119,7 +119,7 @@ public class AntiEntropyMap<K, V> implements MapDelegate<K, V> {
   private volatile boolean closed = false;
   private SlidingWindowCounter counter = new SlidingWindowCounter(WINDOW_SIZE);
 
-  public AntiEntropyMap(String name, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
+  public AntiEntropyMapDelegate(String name, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
     this.localMemberId = managementService.getMembershipService().getLocalMember().id();
     this.mapName = name;
     this.entrySerializer = config.getSerializer();

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/AntiEntropySet.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/AntiEntropySet.java
@@ -17,11 +17,11 @@ package io.atomix.protocols.gossip.set;
 
 import com.google.common.collect.Maps;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.map.MapProtocol;
-import io.atomix.primitive.protocol.map.MapProtocolEventListener;
-import io.atomix.primitive.protocol.set.SetProtocol;
-import io.atomix.primitive.protocol.set.SetProtocolEvent;
-import io.atomix.primitive.protocol.set.SetProtocolEventListener;
+import io.atomix.primitive.protocol.map.MapDelegate;
+import io.atomix.primitive.protocol.map.MapDelegateEventListener;
+import io.atomix.primitive.protocol.set.SetDelegate;
+import io.atomix.primitive.protocol.set.SetDelegateEvent;
+import io.atomix.primitive.protocol.set.SetDelegateEventListener;
 import io.atomix.protocols.gossip.AntiEntropyProtocolConfig;
 import io.atomix.protocols.gossip.map.AntiEntropyMap;
 
@@ -32,9 +32,9 @@ import java.util.Map;
 /**
  * Anti entropy set.
  */
-public class AntiEntropySet<E> implements SetProtocol<E> {
-  private final MapProtocol<E, Boolean> map;
-  private final Map<SetProtocolEventListener<E>, MapProtocolEventListener<E, Boolean>> listenerMap = Maps.newConcurrentMap();
+public class AntiEntropySet<E> implements SetDelegate<E> {
+  private final MapDelegate<E, Boolean> map;
+  private final Map<SetDelegateEventListener<E>, MapDelegateEventListener<E, Boolean>> listenerMap = Maps.newConcurrentMap();
 
   public AntiEntropySet(String name, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
     this.map = new AntiEntropyMap<>(name, config, managementService);
@@ -115,14 +115,14 @@ public class AntiEntropySet<E> implements SetProtocol<E> {
   }
 
   @Override
-  public void addListener(SetProtocolEventListener<E> listener) {
-    MapProtocolEventListener<E, Boolean> eventListener = event -> {
+  public void addListener(SetDelegateEventListener<E> listener) {
+    MapDelegateEventListener<E, Boolean> eventListener = event -> {
       switch (event.type()) {
         case INSERT:
-          listener.event(new SetProtocolEvent<>(SetProtocolEvent.Type.ADD, event.key()));
+          listener.event(new SetDelegateEvent<>(SetDelegateEvent.Type.ADD, event.key()));
           break;
         case REMOVE:
-          listener.event(new SetProtocolEvent<>(SetProtocolEvent.Type.REMOVE, event.key()));
+          listener.event(new SetDelegateEvent<>(SetDelegateEvent.Type.REMOVE, event.key()));
           break;
         default:
           break;
@@ -134,8 +134,8 @@ public class AntiEntropySet<E> implements SetProtocol<E> {
   }
 
   @Override
-  public void removeListener(SetProtocolEventListener<E> listener) {
-    MapProtocolEventListener<E, Boolean> eventListener = listenerMap.remove(listener);
+  public void removeListener(SetDelegateEventListener<E> listener) {
+    MapDelegateEventListener<E, Boolean> eventListener = listenerMap.remove(listener);
     if (eventListener != null) {
       map.removeListener(eventListener);
     }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/AntiEntropySetDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/AntiEntropySetDelegate.java
@@ -23,7 +23,7 @@ import io.atomix.primitive.protocol.set.SetDelegate;
 import io.atomix.primitive.protocol.set.SetDelegateEvent;
 import io.atomix.primitive.protocol.set.SetDelegateEventListener;
 import io.atomix.protocols.gossip.AntiEntropyProtocolConfig;
-import io.atomix.protocols.gossip.map.AntiEntropyMap;
+import io.atomix.protocols.gossip.map.AntiEntropyMapDelegate;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -32,12 +32,12 @@ import java.util.Map;
 /**
  * Anti entropy set.
  */
-public class AntiEntropySet<E> implements SetDelegate<E> {
+public class AntiEntropySetDelegate<E> implements SetDelegate<E> {
   private final MapDelegate<E, Boolean> map;
   private final Map<SetDelegateEventListener<E>, MapDelegateEventListener<E, Boolean>> listenerMap = Maps.newConcurrentMap();
 
-  public AntiEntropySet(String name, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
-    this.map = new AntiEntropyMap<>(name, config, managementService);
+  public AntiEntropySetDelegate(String name, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
+    this.map = new AntiEntropyMapDelegate<>(name, config, managementService);
   }
 
   @Override

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSet.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSet.java
@@ -16,7 +16,7 @@
 package io.atomix.protocols.gossip.set;
 
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.set.NavigableSetProtocol;
+import io.atomix.primitive.protocol.set.NavigableSetDelegate;
 import io.atomix.protocols.gossip.CrdtProtocolConfig;
 
 import java.util.Comparator;
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 /**
  * CRDT tree set.
  */
-public class CrdtNavigableSet<E> extends CrdtSet<E> implements NavigableSetProtocol<E> {
+public class CrdtNavigableSet<E> extends CrdtSet<E> implements NavigableSetDelegate<E> {
   private final Comparator<? super E> comparator;
 
   public CrdtNavigableSet(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService, Comparator<? super E> comparator) {

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSetDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSetDelegate.java
@@ -29,10 +29,10 @@ import java.util.stream.Collectors;
 /**
  * CRDT tree set.
  */
-public class CrdtNavigableSet<E> extends CrdtSet<E> implements NavigableSetDelegate<E> {
+public class CrdtNavigableSetDelegate<E> extends CrdtSetDelegate<E> implements NavigableSetDelegate<E> {
   private final Comparator<? super E> comparator;
 
-  public CrdtNavigableSet(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService, Comparator<? super E> comparator) {
+  public CrdtNavigableSetDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService, Comparator<? super E> comparator) {
     super(name, config, managementService);
     this.comparator = comparator;
   }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSetDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSetDelegate.java
@@ -30,16 +30,13 @@ import java.util.stream.Collectors;
  * CRDT tree set.
  */
 public class CrdtNavigableSetDelegate<E> extends CrdtSetDelegate<E> implements NavigableSetDelegate<E> {
-  private final Comparator<? super E> comparator;
-
-  public CrdtNavigableSetDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService, Comparator<? super E> comparator) {
+  public CrdtNavigableSetDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
     super(name, config, managementService);
-    this.comparator = comparator;
   }
 
   @Override
   public Comparator<? super E> comparator() {
-    return comparator;
+    return null;
   }
 
   @Override
@@ -128,7 +125,7 @@ public class CrdtNavigableSetDelegate<E> extends CrdtSetDelegate<E> implements N
         .stream()
         .filter(entry -> !entry.getValue().isTombstone())
         .map(entry -> decode(entry.getKey()))
-        .sorted(comparator)
-        .collect(Collectors.toCollection(() -> new TreeSet<>()));
+        .sorted()
+        .collect(Collectors.toCollection(TreeSet::new));
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtSetDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtSetDelegate.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 /**
  * Last-write wins set.
  */
-public class CrdtSet<E> implements SetDelegate<E> {
+public class CrdtSetDelegate<E> implements SetDelegate<E> {
   private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
       .register(Namespaces.BASIC)
       .register(SetElement.class)
@@ -57,7 +57,7 @@ public class CrdtSet<E> implements SetDelegate<E> {
   protected final Map<String, SetElement> elements = Maps.newConcurrentMap();
   private final Set<SetDelegateEventListener<E>> eventListeners = Sets.newCopyOnWriteArraySet();
 
-  public CrdtSet(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
+  public CrdtSetDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
     this.clusterCommunicator = managementService.getCommunicationService();
     this.executorService = managementService.getExecutorService();
     this.elementSerializer = config.getSerializer();

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -17,7 +17,7 @@ package io.atomix.protocols.backup;
 
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionService;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.DefaultProxyClient;
@@ -34,7 +34,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 /**
  * Multi-primary protocol.
  */
-public class MultiPrimaryProtocol implements StateMachineReplicationProtocol {
+public class MultiPrimaryProtocol implements ProxyProtocol {
   public static final Type TYPE = new Type();
 
   /**

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -17,8 +17,8 @@ package io.atomix.protocols.backup;
 
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionService;
-import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
@@ -36,6 +36,15 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  */
 public class MultiPrimaryProtocol implements ProxyProtocol {
   public static final Type TYPE = new Type();
+
+  /**
+   * Returns an instance of the multi-primary protocol with the default configuration.
+   *
+   * @return an instance of the multi-primary protocol with the default configuration
+   */
+  public MultiPrimaryProtocol instance() {
+    return new MultiPrimaryProtocol(new MultiPrimaryProtocolConfig());
+  }
 
   /**
    * Returns a new multi-primary protocol builder.

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartitionGroup.java
@@ -27,7 +27,7 @@ import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 import io.atomix.utils.concurrent.BlockingAwareThreadPoolContextFactory;
 import io.atomix.utils.concurrent.ThreadContextFactory;
@@ -130,7 +130,7 @@ public class PrimaryBackupPartitionGroup implements ManagedPartitionGroup {
   }
 
   @Override
-  public StateMachineReplicationProtocol newProtocol() {
+  public ProxyProtocol newProtocol() {
     return MultiPrimaryProtocol.builder(name)
         .withRecovery(Recovery.RECOVER)
         .withBackups(2)

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
@@ -17,7 +17,7 @@ package io.atomix.protocols.raft;
 
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionService;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.DefaultProxyClient;
@@ -34,7 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Multi-Raft protocol.
  */
-public class MultiRaftProtocol implements StateMachineReplicationProtocol {
+public class MultiRaftProtocol implements ProxyProtocol {
   public static final Type TYPE = new Type();
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
@@ -17,8 +17,8 @@ package io.atomix.protocols.raft;
 
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionService;
-import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
@@ -36,6 +36,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class MultiRaftProtocol implements ProxyProtocol {
   public static final Type TYPE = new Type();
+
+  /**
+   * Returns an instance of the multi-Raft protocol with the default configuration.
+   *
+   * @return an instance of the multi-Raft protocol with the default configuration
+   */
+  public MultiRaftProtocol instance() {
+    return new MultiRaftProtocol(new MultiRaftProtocolConfig());
+  }
 
   /**
    * Returns a new multi-Raft protocol builder.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
@@ -29,7 +29,7 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.StateMachineReplicationProtocol;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.storage.StorageLevel;
 import org.slf4j.Logger;
@@ -144,7 +144,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   }
 
   @Override
-  public StateMachineReplicationProtocol newProtocol() {
+  public ProxyProtocol newProtocol() {
     return MultiRaftProtocol.builder(name)
         .withRecoveryStrategy(Recovery.RECOVER)
         .withMaxRetries(5)


### PR DESCRIPTION
This PR modifies primitive builder interfaces for type safety with respect to primitive protocols. Builders now implement interfaces to indicate the types of protocols they support. This will ensure that users cannot configure primitives with an unsupported protocol.

For primitives that support partition proxies, builders should implement the `ProxyCompatibleBuilder` interface:

```java
B withProtocol(ProxyProtocol protocol)
```

For primitives that support gossip protocols, builders should implement one of the gossip protocol interfaces, e.g. `DistributedMapBuilder` implements `MapCompatibleBuilder`:

```java
B withProtocol(MapProtocol protocol)
```