### PR TITLE
Netty 4.1.27.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <kryo.version>4.0.2</kryo.version>
     <commons.lang3.version>3.7</commons.lang3.version>
     <commons.math3.version>3.6.1</commons.math3.version>
-    <netty.version>4.1.26.Final</netty.version>
+    <netty.version>4.1.27.Final</netty.version>
     <vertx.version>3.5.0</vertx.version>
     <jaxrs.version>2.0</jaxrs.version>
     <jackson.version>2.9.6</jackson.version>
@@ -97,7 +97,7 @@
     <profile>
         <id>java11</id>
         <properties>
-          <!--argLine.common>-Xss256k -Xms2G -Xmx4G -XX:+UseShenandoahGC -XX:+AlwaysPreTouch -XX:+UseTransparentHugePages -XX:+UseNUMA -XX:-OmitStackTraceInFastThrow -Dio.atomix.scanSpec=io.atomix</argLine.common-->
+          <!--argLine.common>-Xss256k -Xms2G -Xmx4G -XX:+UseShenandoahGC -XX:+UseStringDeduplication -XX:-OmitStackTraceInFastThrow -Dio.atomix.scanSpec=io.atomix</argLine.common-->
           <!-- jacoco version 0.8.1 does not work with java 11, see https://github.com/jacoco/jacoco/issues/663 -->
           <jacoco.skip>true</jacoco.skip>
         </properties>


### PR DESCRIPTION
Netty 4.1.27.Final released
by normanmaurer 
on 11-Jul-2018

Due some possible regression that could cause an NPE during selecting the keymaterial if the alias is not known when using OpenSSL (and so signal back the wrong alert to the remote peer) we decided to cut another netty releases. While it was possible to "work around" this regression by using a KeyManagerFactory to configure SslContextBuilder we thought this deserves a fast release.

Beside fixing the above mentioned bug we also fixes a few other small things.