### PR TITLE
Avoid blocking Netty event loop threads in reaction to cluster membership events

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
+++ b/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
@@ -172,7 +172,7 @@ public class BootstrapDiscoveryProvider
    * Sends a heartbeat to the given peer.
    */
   private CompletableFuture<Void> sendHeartbeat(Node localNode, Address address) {
-    return bootstrap.getMessagingService().sendAndReceive(address, HEARTBEAT_MESSAGE, SERIALIZER.encode(localNode)).whenComplete((response, error) -> {
+    return bootstrap.getMessagingService().sendAndReceive(address, HEARTBEAT_MESSAGE, SERIALIZER.encode(localNode)).whenCompleteAsync((response, error) -> {
       if (error == null) {
         Collection<Node> nodes = SERIALIZER.decode(response);
         for (Node node : nodes) {
@@ -202,7 +202,7 @@ public class BootstrapDiscoveryProvider
           }
         }
       }
-    }).exceptionally(e -> null)
+    }, heartbeatExecutor).exceptionally(e -> null)
         .thenApply(v -> null);
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/discovery/MulticastDiscoveryProvider.java
+++ b/cluster/src/main/java/io/atomix/cluster/discovery/MulticastDiscoveryProvider.java
@@ -105,7 +105,7 @@ public class MulticastDiscoveryProvider
   private final ScheduledExecutorService broadcastScheduler = Executors.newSingleThreadScheduledExecutor(
       namedThreads("atomix-cluster-broadcast", LOGGER));
   private volatile ScheduledFuture<?> broadcastFuture;
-  private final Consumer<byte[]> broadcastListener = this::handleBroadcastMessage;
+  private final Consumer<byte[]> broadcastListener = message -> broadcastScheduler.execute(() -> handleBroadcastMessage(message));
 
   private final Map<Address, Node> nodes = Maps.newConcurrentMap();
 

--- a/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.MemberId;
+import io.atomix.core.iterator.AsyncIterator;
 import io.atomix.core.map.AsyncAtomicMap;
 import io.atomix.core.map.AtomicMapConfig;
 import io.atomix.core.map.AtomicMapType;
@@ -47,6 +48,7 @@ import io.atomix.utils.time.Versioned;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -183,11 +185,23 @@ public class CoreTransactionService implements ManagedTransactionService {
    */
   private void onMembershipChange(ClusterMembershipEvent event) {
     if (event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED) {
-      transactions.entrySet().stream().filter(entry -> entry.getValue().value().coordinator.equals(event.subject().id()))
-          .forEach(entry -> {
-            recoverTransaction(entry.getKey(), entry.getValue().value());
-          });
+      recoverTransactions(transactions.entrySet().iterator(), event.subject().id());
     }
+  }
+
+  /**
+   * Recursively recovers transactions using the given iterator.
+   *
+   * @param iterator the asynchronous iterator from which to recover transactions
+   * @param memberId the transaction member ID
+   */
+  private void recoverTransactions(AsyncIterator<Map.Entry<TransactionId, Versioned<TransactionInfo>>> iterator, MemberId memberId) {
+    iterator.next().thenAccept(entry -> {
+      if (entry.getValue().value().coordinator.equals(memberId)) {
+        recoverTransaction(entry.getKey(), entry.getValue().value());
+      }
+      recoverTransactions(iterator, memberId);
+    });
   }
 
   /**


### PR DESCRIPTION
This PR is a series of commits that fix thread issues with cluster membership. The core problem is that the `CoreTransactionService` receives an event on a Netty thread and then makes a blocking call to a primitive to recover transactions. This PR ensures membership events are posted on a dedicated event thread, and recovers transactions using an asynchronous iterator. The last fix is unnecessary, but it will further ensure the event thread is not blocked without requiring another dedicated thread.