### PR TITLE
Support key type/value type/element type registrations for primitives

### DIFF
--- a/core/src/main/java/io/atomix/core/collection/DistributedCollectionBuilder.java
+++ b/core/src/main/java/io/atomix/core/collection/DistributedCollectionBuilder.java
@@ -15,9 +15,14 @@
  */
 package io.atomix.core.collection;
 
+import com.google.common.collect.Lists;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Namespaces;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Distributed collection builder.
@@ -29,5 +34,118 @@ public abstract class DistributedCollectionBuilder<
     extends PrimitiveBuilder<B, C, P> {
   protected DistributedCollectionBuilder(PrimitiveType type, String name, C config, PrimitiveManagementService managementService) {
     super(type, name, config, managementService);
+  }
+
+  /**
+   * Sets the element type.
+   *
+   * @param elementType the element type
+   * @return the collection builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withElementType(Class<?> elementType) {
+    config.setElementType(elementType);
+    return (B) this;
+  }
+
+  /**
+   * Sets extra serializable types on the map.
+   *
+   * @param extraTypes the types to set
+   * @return the collection builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withExtraTypes(Class<?>... extraTypes) {
+    config.setExtraTypes(Lists.newArrayList(extraTypes));
+    return (B) this;
+  }
+
+  /**
+   * Adds an extra serializable type to the map.
+   *
+   * @param extraType the type to add
+   * @return the collection builder
+   */
+  @SuppressWarnings("unchecked")
+  public B addExtraType(Class<?> extraType) {
+    config.addExtraType(extraType);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @return the collection configuration
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired() {
+    return withRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the collection builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired(boolean registrationRequired) {
+    config.setRegistrationRequired(registrationRequired);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @return the collection builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the collection builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization(boolean compatibleSerialization) {
+    config.setCompatibleSerialization(compatibleSerialization);
+    return (B) this;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  protected Serializer serializer() {
+    if (serializer == null) {
+      NamespaceConfig namespaceConfig = this.config.getNamespaceConfig();
+      if (namespaceConfig == null) {
+        namespaceConfig = new NamespaceConfig();
+      }
+
+      Namespace.Builder namespaceBuilder = Namespace.builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(new Namespace(namespaceConfig))
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100);
+
+      namespaceBuilder.setRegistrationRequired(config.isRegistrationRequired());
+      namespaceBuilder.setCompatible(config.isCompatibleSerialization());
+
+      if (config.getElementType() != null) {
+        namespaceBuilder.registerSubTypes(config.getElementType());
+      }
+      if (!config.getExtraTypes().isEmpty()) {
+        namespaceBuilder.register(config.getExtraTypes().toArray(new Class<?>[config.getExtraTypes().size()]));
+      }
+
+      serializer = Serializer.using(namespaceBuilder.build());
+    }
+    return serializer;
   }
 }

--- a/core/src/main/java/io/atomix/core/collection/DistributedCollectionConfig.java
+++ b/core/src/main/java/io/atomix/core/collection/DistributedCollectionConfig.java
@@ -17,8 +17,111 @@ package io.atomix.core.collection;
 
 import io.atomix.core.cache.CachedPrimitiveConfig;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Distributed collection configuration.
  */
 public abstract class DistributedCollectionConfig<C extends DistributedCollectionConfig<C>> extends CachedPrimitiveConfig<C> {
+  private Class<?> elementType;
+  private List<Class<?>> extraTypes = new ArrayList<>();
+  private boolean registrationRequired = false;
+  private boolean compatibleSerialization = false;
+
+  /**
+   * Returns the element type.
+   *
+   * @return the collection element type
+   */
+  public Class<?> getElementType() {
+    return elementType;
+  }
+
+  /**
+   * Sets the collection element type.
+   *
+   * @param elementType the collection element type
+   * @return the collection configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setElementType(Class<?> elementType) {
+    this.elementType = elementType;
+    return (C) this;
+  }
+
+  /**
+   * Returns the extra serializable types.
+   *
+   * @return the extra serializable types
+   */
+  public List<Class<?>> getExtraTypes() {
+    return extraTypes;
+  }
+
+  /**
+   * Sets the extra serializable types.
+   *
+   * @param extraTypes the extra serializable types
+   * @return the collection configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setExtraTypes(List<Class<?>> extraTypes) {
+    this.extraTypes = extraTypes;
+    return (C) this;
+  }
+
+  /**
+   * Adds an extra serializable type.
+   *
+   * @param extraType the extra type to add
+   * @return the collection configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C addExtraType(Class<?> extraType) {
+    extraTypes.add(extraType);
+    return (C) this;
+  }
+
+  /**
+   * Returns whether registration is required for serializable types.
+   *
+   * @return whether registration is required for serializable types
+   */
+  public boolean isRegistrationRequired() {
+    return registrationRequired;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the collection configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setRegistrationRequired(boolean registrationRequired) {
+    this.registrationRequired = registrationRequired;
+    return (C) this;
+  }
+
+  /**
+   * Returns whether compatible serialization is enabled.
+   *
+   * @return whether compatible serialization is enabled
+   */
+  public boolean isCompatibleSerialization() {
+    return compatibleSerialization;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the collection configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setCompatibleSerialization(boolean compatibleSerialization) {
+    this.compatibleSerialization = compatibleSerialization;
+    return (C) this;
+  }
 }

--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectionBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectionBuilder.java
@@ -19,7 +19,6 @@ import io.atomix.core.election.LeaderElection;
 import io.atomix.core.election.LeaderElectionBuilder;
 import io.atomix.core.election.LeaderElectionConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -36,11 +35,10 @@ public class DefaultLeaderElectionBuilder<T> extends LeaderElectionBuilder<T> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<LeaderElection<T>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(LeaderElectionService.class, new ServiceConfig())
         .thenCompose(proxy -> new LeaderElectionProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(election -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncLeaderElection<T, byte[]>(
               election,
               key -> serializer.encode(key),

--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorBuilder.java
@@ -19,7 +19,6 @@ import io.atomix.core.election.LeaderElector;
 import io.atomix.core.election.LeaderElectorBuilder;
 import io.atomix.core.election.LeaderElectorConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -36,11 +35,10 @@ public class DefaultLeaderElectorBuilder<T> extends LeaderElectorBuilder<T> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<LeaderElector<T>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(LeaderElectorService.class, new ServiceConfig())
         .thenCompose(proxy -> new LeaderElectorProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(elector -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncLeaderElector<T, byte[]>(
               elector,
               key -> serializer.encode(key),

--- a/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreTransactionService.java
@@ -37,7 +37,6 @@ import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
-import io.atomix.primitive.protocol.PrimitiveProtocolConfig;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.concurrent.Futures;
@@ -372,10 +371,10 @@ public class CoreTransactionService implements ManagedTransactionService {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<TransactionService> start() {
-    PrimitiveProtocol.Type protocolType = managementService.getPartitionService().getSystemPartitionGroup().protocol();
-    PrimitiveProtocol protocol = protocolType.newProtocol(((PrimitiveProtocolConfig) protocolType.newConfig()).setSerializer(SERIALIZER));
+    PrimitiveProtocol protocol = managementService.getPartitionService().getSystemPartitionGroup().newProtocol();
     return AtomicMapType.<TransactionId, TransactionInfo>instance()
         .newBuilder("atomix-transactions", new AtomicMapConfig(), managementService)
+        .withSerializer(SERIALIZER)
         .withProtocol((ProxyProtocol) protocol)
         .withCacheEnabled()
         .buildAsync()

--- a/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListBuilder.java
+++ b/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListBuilder.java
@@ -21,7 +21,6 @@ import io.atomix.core.list.DistributedList;
 import io.atomix.core.list.DistributedListBuilder;
 import io.atomix.core.list.DistributedListConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -40,11 +39,10 @@ public class DefaultDistributedListBuilder<E> extends DistributedListBuilder<E> 
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedList<E>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(DistributedListService.class, new ServiceConfig())
         .thenCompose(proxy -> new DistributedListProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(rawList -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           AsyncDistributedList<E> list = new TranscodingAsyncDistributedList<>(
               rawList,
               element -> BaseEncoding.base16().encode(serializer.encode(element)),

--- a/core/src/main/java/io/atomix/core/map/AtomicMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicMapBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -28,7 +27,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
  * @param <V> type for map value
  */
 public abstract class AtomicMapBuilder<K, V>
-    extends CachedPrimitiveBuilder<AtomicMapBuilder<K, V>, AtomicMapConfig, AtomicMap<K, V>>
+    extends MapBuilder<AtomicMapBuilder<K, V>, AtomicMapConfig, AtomicMap<K, V>, K, V>
     implements ProxyCompatibleBuilder<AtomicMapBuilder<K, V>> {
 
   protected AtomicMapBuilder(String name, AtomicMapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/map/AtomicMapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicMapConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Consistent map configuration.
  */
-public class AtomicMapConfig extends CachedPrimitiveConfig<AtomicMapConfig> {
+public class AtomicMapConfig extends MapConfig<AtomicMapConfig> {
   private boolean nullValues = false;
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/AtomicNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicNavigableMapBuilder.java
@@ -16,7 +16,6 @@
 
 package io.atomix.core.map;
 
-import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -26,7 +25,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
  * Builder for {@link AtomicNavigableMap}.
  */
 public abstract class AtomicNavigableMapBuilder<K extends Comparable<K>, V>
-    extends PrimitiveBuilder<AtomicNavigableMapBuilder<K, V>, AtomicNavigableMapConfig, AtomicNavigableMap<K, V>>
+    extends MapBuilder<AtomicNavigableMapBuilder<K, V>, AtomicNavigableMapConfig, AtomicNavigableMap<K, V>, K, V>
     implements ProxyCompatibleBuilder<AtomicNavigableMapBuilder<K, V>> {
 
   protected AtomicNavigableMapBuilder(String name, AtomicNavigableMapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/map/AtomicNavigableMapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicNavigableMapConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Consistent tree-map configuration.
  */
-public class AtomicNavigableMapConfig extends PrimitiveConfig<AtomicNavigableMapConfig> {
+public class AtomicNavigableMapConfig extends MapConfig<AtomicNavigableMapConfig> {
   @Override
   public PrimitiveType getType() {
     return AtomicNavigableMapType.instance();

--- a/core/src/main/java/io/atomix/core/map/AtomicSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicSortedMapBuilder.java
@@ -16,7 +16,6 @@
 
 package io.atomix.core.map;
 
-import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -26,7 +25,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
  * Builder for {@link AtomicSortedMap}.
  */
 public abstract class AtomicSortedMapBuilder<K extends Comparable<K>, V>
-    extends PrimitiveBuilder<AtomicSortedMapBuilder<K, V>, AtomicSortedMapConfig, AtomicSortedMap<K, V>>
+    extends MapBuilder<AtomicSortedMapBuilder<K, V>, AtomicSortedMapConfig, AtomicSortedMap<K, V>, K, V>
     implements ProxyCompatibleBuilder<AtomicSortedMapBuilder<K, V>> {
 
   protected AtomicSortedMapBuilder(String name, AtomicSortedMapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/map/AtomicSortedMapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicSortedMapConfig.java
@@ -16,12 +16,11 @@
 package io.atomix.core.map;
 
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.config.PrimitiveConfig;
 
 /**
  * Consistent sorted map configuration.
  */
-public class AtomicSortedMapConfig extends PrimitiveConfig<AtomicSortedMapConfig> {
+public class AtomicSortedMapConfig extends MapConfig<AtomicSortedMapConfig> {
   @Override
   public PrimitiveType getType() {
     return AtomicSortedMapType.instance();

--- a/core/src/main/java/io/atomix/core/map/DistributedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedMapBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -30,7 +29,7 @@ import io.atomix.primitive.protocol.map.MapProtocol;
  * @param <V> type for map value
  */
 public abstract class DistributedMapBuilder<K, V>
-    extends CachedPrimitiveBuilder<DistributedMapBuilder<K, V>, DistributedMapConfig, DistributedMap<K, V>>
+    extends MapBuilder<DistributedMapBuilder<K, V>, DistributedMapConfig, DistributedMap<K, V>, K, V>
     implements ProxyCompatibleBuilder<DistributedMapBuilder<K, V>>, MapCompatibleBuilder<DistributedMapBuilder<K, V>> {
 
   protected DistributedMapBuilder(String name, DistributedMapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/map/DistributedMapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedMapConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Distributed map configuration.
  */
-public class DistributedMapConfig extends CachedPrimitiveConfig<DistributedMapConfig> {
+public class DistributedMapConfig extends MapConfig<DistributedMapConfig> {
   private boolean nullValues = false;
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/DistributedNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedNavigableMapBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -30,7 +29,7 @@ import io.atomix.primitive.protocol.map.NavigableMapProtocol;
  * @param <V> type for map value
  */
 public abstract class DistributedNavigableMapBuilder<K extends Comparable<K>, V>
-    extends CachedPrimitiveBuilder<DistributedNavigableMapBuilder<K, V>, DistributedNavigableMapConfig, DistributedNavigableMap<K, V>>
+    extends MapBuilder<DistributedNavigableMapBuilder<K, V>, DistributedNavigableMapConfig, DistributedNavigableMap<K, V>, K, V>
     implements ProxyCompatibleBuilder<DistributedNavigableMapBuilder<K, V>>, NavigableMapCompatibleBuilder<DistributedNavigableMapBuilder<K, V>> {
 
   public DistributedNavigableMapBuilder(String name, DistributedNavigableMapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/map/DistributedNavigableMapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedNavigableMapConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Distributed tree map configuration.
  */
-public class DistributedNavigableMapConfig extends CachedPrimitiveConfig<DistributedNavigableMapConfig> {
+public class DistributedNavigableMapConfig extends MapConfig<DistributedNavigableMapConfig> {
   private boolean nullValues = false;
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/DistributedSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedSortedMapBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -30,7 +29,7 @@ import io.atomix.primitive.protocol.map.SortedMapProtocol;
  * @param <V> type for map value
  */
 public abstract class DistributedSortedMapBuilder<K extends Comparable<K>, V>
-    extends CachedPrimitiveBuilder<DistributedSortedMapBuilder<K, V>, DistributedSortedMapConfig, DistributedSortedMap<K, V>>
+    extends MapBuilder<DistributedSortedMapBuilder<K, V>, DistributedSortedMapConfig, DistributedSortedMap<K, V>, K, V>
     implements ProxyCompatibleBuilder<DistributedSortedMapBuilder<K, V>>, SortedMapCompatibleBuilder<DistributedSortedMapBuilder<K, V>>{
 
   public DistributedSortedMapBuilder(String name, DistributedSortedMapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/map/DistributedSortedMapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/DistributedSortedMapConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.core.cache.CachedPrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Distributed sorted map configuration.
  */
-public class DistributedSortedMapConfig extends CachedPrimitiveConfig<DistributedSortedMapConfig> {
+public class DistributedSortedMapConfig extends MapConfig<DistributedSortedMapConfig> {
   private boolean nullValues = false;
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/MapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/MapBuilder.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map;
+
+import com.google.common.collect.Lists;
+import io.atomix.core.cache.CachedPrimitiveBuilder;
+import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.SyncPrimitive;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Namespaces;
+import io.atomix.utils.serializer.Serializer;
+
+/**
+ * Base map builder.
+ */
+public abstract class MapBuilder<B extends MapBuilder<B, C, P, K, V>, C extends MapConfig<C>, P extends SyncPrimitive, K, V> extends CachedPrimitiveBuilder<B, C, P> {
+  protected MapBuilder(PrimitiveType type, String name, C config, PrimitiveManagementService managementService) {
+    super(type, name, config, managementService);
+  }
+
+  /**
+   * Sets the key type.
+   *
+   * @param keyType the key type
+   * @return the map builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withKeyType(Class<?> keyType) {
+    config.setKeyType(keyType);
+    return (B) this;
+  }
+
+  /**
+   * Sets the value type.
+   *
+   * @param valueType the value type
+   * @return the map builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withValueType(Class<?> valueType) {
+    config.setValueType(valueType);
+    return (B) this;
+  }
+
+  /**
+   * Sets extra serializable types on the map.
+   *
+   * @param extraTypes the types to set
+   * @return the map builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withExtraTypes(Class<?>... extraTypes) {
+    config.setExtraTypes(Lists.newArrayList(extraTypes));
+    return (B) this;
+  }
+
+  /**
+   * Adds an extra serializable type to the map.
+   *
+   * @param extraType the type to add
+   * @return the map builder
+   */
+  @SuppressWarnings("unchecked")
+  public B addExtraType(Class<?> extraType) {
+    config.addExtraType(extraType);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired() {
+    return withRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired(boolean registrationRequired) {
+    config.setRegistrationRequired(registrationRequired);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization(boolean compatibleSerialization) {
+    config.setCompatibleSerialization(compatibleSerialization);
+    return (B) this;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  protected Serializer serializer() {
+    if (serializer == null) {
+      NamespaceConfig namespaceConfig = this.config.getNamespaceConfig();
+      if (namespaceConfig == null) {
+        namespaceConfig = new NamespaceConfig();
+      }
+
+      Namespace.Builder namespaceBuilder = Namespace.builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(new Namespace(namespaceConfig))
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100);
+
+      namespaceBuilder.setRegistrationRequired(config.isRegistrationRequired());
+      namespaceBuilder.setCompatible(config.isCompatibleSerialization());
+
+      if (config.getKeyType() != null) {
+        namespaceBuilder.registerSubTypes(config.getKeyType());
+      }
+      if (config.getValueType() != null) {
+        namespaceBuilder.registerSubTypes(config.getValueType());
+      }
+      if (!config.getExtraTypes().isEmpty()) {
+        namespaceBuilder.register(config.getExtraTypes().toArray(new Class<?>[config.getExtraTypes().size()]));
+      }
+
+      serializer = Serializer.using(namespaceBuilder.build());
+    }
+    return serializer;
+  }
+}

--- a/core/src/main/java/io/atomix/core/map/MapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/MapConfig.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map;
+
+import io.atomix.core.cache.CachedPrimitiveConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Map configuration.
+ */
+public abstract class MapConfig<C extends MapConfig<C>> extends CachedPrimitiveConfig<C> {
+  private Class<?> keyType;
+  private Class<?> valueType;
+  private List<Class<?>> extraTypes = new ArrayList<>();
+  private boolean registrationRequired = false;
+  private boolean compatibleSerialization = false;
+
+  /**
+   * Returns the key type.
+   *
+   * @return the map key type
+   */
+  public Class<?> getKeyType() {
+    return keyType;
+  }
+
+  /**
+   * Sets the map key type.
+   *
+   * @param keyType the map key type
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setKeyType(Class<?> keyType) {
+    this.keyType = keyType;
+    return (C) this;
+  }
+
+  /**
+   * Returns the value type.
+   *
+   * @return the map value type
+   */
+  public Class<?> getValueType() {
+    return valueType;
+  }
+
+  /**
+   * Sets the map value type.
+   *
+   * @param valueType the map value type
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setValueType(Class<?> valueType) {
+    this.valueType = valueType;
+    return (C) this;
+  }
+
+  /**
+   * Returns the extra serializable types.
+   *
+   * @return the extra serializable types
+   */
+  public List<Class<?>> getExtraTypes() {
+    return extraTypes;
+  }
+
+  /**
+   * Sets the extra serializable types.
+   *
+   * @param extraTypes the extra serializable types
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setExtraTypes(List<Class<?>> extraTypes) {
+    this.extraTypes = extraTypes;
+    return (C) this;
+  }
+
+  /**
+   * Adds an extra serializable type.
+   *
+   * @param extraType the extra type to add
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C addExtraType(Class<?> extraType) {
+    extraTypes.add(extraType);
+    return (C) this;
+  }
+
+  /**
+   * Returns whether registration is required for serializable types.
+   *
+   * @return whether registration is required for serializable types
+   */
+  public boolean isRegistrationRequired() {
+    return registrationRequired;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setRegistrationRequired(boolean registrationRequired) {
+    this.registrationRequired = registrationRequired;
+    return (C) this;
+  }
+
+  /**
+   * Returns whether compatible serialization is enabled.
+   *
+   * @return whether compatible serialization is enabled
+   */
+  public boolean isCompatibleSerialization() {
+    return compatibleSerialization;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setCompatibleSerialization(boolean compatibleSerialization) {
+    this.compatibleSerialization = compatibleSerialization;
+    return (C) this;
+  }
+}

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicCounterMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicCounterMapBuilder.java
@@ -20,7 +20,6 @@ import io.atomix.core.map.AtomicCounterMap;
 import io.atomix.core.map.AtomicCounterMapBuilder;
 import io.atomix.core.map.AtomicCounterMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -37,11 +36,10 @@ public class DefaultAtomicCounterMapBuilder<K> extends AtomicCounterMapBuilder<K
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicCounterMap<K>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(AtomicCounterMapService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicCounterMapProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(map -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncAtomicCounterMap<K, String>(
               map,
               key -> BaseEncoding.base16().encode(serializer.encode(key)),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicMapBuilder.java
@@ -21,7 +21,6 @@ import io.atomix.core.map.AtomicMap;
 import io.atomix.core.map.AtomicMapBuilder;
 import io.atomix.core.map.AtomicMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
@@ -42,11 +41,10 @@ public class DefaultAtomicMapBuilder<K, V> extends AtomicMapBuilder<K, V> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicMap<K, V>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(AtomicMapService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicMapProxy((ProxyClient) proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(rawMap -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           AsyncAtomicMap<K, V> map = new TranscodingAsyncAtomicMap<>(
               rawMap,
               key -> BaseEncoding.base16().encode(serializer.encode(key)),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicNavigableMapBuilder.java
@@ -20,7 +20,6 @@ import io.atomix.core.map.AtomicNavigableMap;
 import io.atomix.core.map.AtomicNavigableMapBuilder;
 import io.atomix.core.map.AtomicNavigableMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -39,11 +38,10 @@ public class DefaultAtomicNavigableMapBuilder<K extends Comparable<K>, V> extend
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicNavigableMap<K, V>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(AtomicTreeMapService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicNavigableMapProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(map -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncAtomicNavigableMap<K, V, byte[]>(
               (AsyncAtomicNavigableMap) map,
               value -> serializer.encode(value),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultAtomicSortedMapBuilder.java
@@ -20,7 +20,6 @@ import io.atomix.core.map.AtomicSortedMap;
 import io.atomix.core.map.AtomicSortedMapBuilder;
 import io.atomix.core.map.AtomicSortedMapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -39,11 +38,10 @@ public class DefaultAtomicSortedMapBuilder<K extends Comparable<K>, V> extends A
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicSortedMap<K, V>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(AtomicTreeMapService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicNavigableMapProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(map -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncAtomicSortedMap<K, V, byte[]>(
               (AsyncAtomicSortedMap) map,
               value -> serializer.encode(value),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
@@ -47,7 +47,7 @@ public class DefaultDistributedMapBuilder<K, V> extends DistributedMapBuilder<K,
     if (protocol instanceof GossipProtocol) {
       if (protocol instanceof MapProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((MapProtocol) protocol).<K, V>newMapDelegate(name, managementService))
+            CompletableFuture.completedFuture(((MapProtocol) protocol).<K, V>newMapDelegate(name, serializer(), managementService))
                 .thenApply(map -> new GossipDistributedMap<>(name, protocol, map)))
             .thenApply(AsyncDistributedMap::sync);
       } else {
@@ -57,7 +57,7 @@ public class DefaultDistributedMapBuilder<K, V> extends DistributedMapBuilder<K,
       return newProxy(AtomicMapService.class, new ServiceConfig())
           .thenCompose(proxy -> new AtomicMapProxy((ProxyClient) proxy, managementService.getPrimitiveRegistry()).connect())
           .thenApply(rawMap -> {
-            Serializer serializer = protocol.serializer();
+            Serializer serializer = serializer();
             AsyncAtomicMap<K, V> map = new TranscodingAsyncAtomicMap<K, V, String, byte[]>(
                 rawMap,
                 key -> BaseEncoding.base16().encode(serializer.encode(key)),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedNavigableMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedNavigableMapBuilder.java
@@ -45,7 +45,7 @@ public class DefaultDistributedNavigableMapBuilder<K extends Comparable<K>, V> e
     if (protocol instanceof GossipProtocol) {
       if (protocol instanceof NavigableMapProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((NavigableMapProtocol) protocol).<K, V>newNavigableMapDelegate(name, managementService))
+            CompletableFuture.completedFuture(((NavigableMapProtocol) protocol).<K, V>newNavigableMapDelegate(name, serializer(), managementService))
                 .thenApply(set -> new GossipDistributedNavigableMap<>(name, protocol, set)))
             .thenApply(AsyncDistributedNavigableMap::sync);
       } else {
@@ -55,7 +55,7 @@ public class DefaultDistributedNavigableMapBuilder<K extends Comparable<K>, V> e
       return newProxy(AtomicTreeMapService.class, new ServiceConfig())
           .thenCompose(proxy -> new AtomicNavigableMapProxy<K>((ProxyClient) proxy, managementService.getPrimitiveRegistry()).connect())
           .thenApply(map -> {
-            Serializer serializer = protocol.serializer();
+            Serializer serializer = serializer();
             return new TranscodingAsyncAtomicNavigableMap<K, V, byte[]>(
                 map,
                 value -> serializer.encode(value),

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedSortedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedSortedMapBuilder.java
@@ -45,7 +45,7 @@ public class DefaultDistributedSortedMapBuilder<K extends Comparable<K>, V> exte
     if (protocol instanceof GossipProtocol) {
       if (protocol instanceof SortedMapProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((SortedMapProtocol) protocol).<K, V>newSortedMapDelegate(name, managementService))
+            CompletableFuture.completedFuture(((SortedMapProtocol) protocol).<K, V>newSortedMapDelegate(name, serializer(), managementService))
                 .thenApply(set -> new GossipDistributedSortedMap<>(name, protocol, set)))
             .thenApply(AsyncDistributedSortedMap::sync);
       } else {
@@ -55,7 +55,7 @@ public class DefaultDistributedSortedMapBuilder<K extends Comparable<K>, V> exte
       return newProxy(AtomicTreeMapService.class, new ServiceConfig())
           .thenCompose(proxy -> new AtomicNavigableMapProxy<K>((ProxyClient) proxy, managementService.getPrimitiveRegistry()).connect())
           .thenApply(map -> {
-            Serializer serializer = protocol.serializer();
+            Serializer serializer = serializer();
             return new TranscodingAsyncAtomicNavigableMap<K, V, byte[]>(
                 map,
                 value -> serializer.encode(value),

--- a/core/src/main/java/io/atomix/core/multimap/impl/DefaultAtomicMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/DefaultAtomicMultimapBuilder.java
@@ -22,7 +22,6 @@ import io.atomix.core.multimap.AtomicMultimap;
 import io.atomix.core.multimap.AtomicMultimapBuilder;
 import io.atomix.core.multimap.AtomicMultimapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -39,11 +38,10 @@ public class DefaultAtomicMultimapBuilder<K, V> extends AtomicMultimapBuilder<K,
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicMultimap<K, V>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(AtomicMultimapService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicMultimapProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(rawMultimap -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           AsyncAtomicMultimap<K, V> multimap = new TranscodingAsyncAtomicMultimap<>(
               rawMultimap,
               key -> BaseEncoding.base16().encode(serializer.encode(key)),

--- a/core/src/main/java/io/atomix/core/multimap/impl/DefaultDistributedMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/DefaultDistributedMultimapBuilder.java
@@ -22,7 +22,6 @@ import io.atomix.core.multimap.DistributedMultimap;
 import io.atomix.core.multimap.DistributedMultimapBuilder;
 import io.atomix.core.multimap.DistributedMultimapConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -39,11 +38,10 @@ public class DefaultDistributedMultimapBuilder<K, V> extends DistributedMultimap
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedMultimap<K, V>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(AtomicMultimapService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicMultimapProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(rawMultimap -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           AsyncAtomicMultimap<K, V> multimap = new TranscodingAsyncAtomicMultimap<>(
               rawMultimap,
               key -> BaseEncoding.base16().encode(serializer.encode(key)),

--- a/core/src/main/java/io/atomix/core/multiset/impl/DefaultDistributedMultisetBuilder.java
+++ b/core/src/main/java/io/atomix/core/multiset/impl/DefaultDistributedMultisetBuilder.java
@@ -21,7 +21,6 @@ import io.atomix.core.multiset.DistributedMultiset;
 import io.atomix.core.multiset.DistributedMultisetBuilder;
 import io.atomix.core.multiset.DistributedMultisetConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -40,11 +39,10 @@ public class DefaultDistributedMultisetBuilder<E> extends DistributedMultisetBui
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedMultiset<E>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(DistributedMultisetService.class, new ServiceConfig())
         .thenCompose(proxy -> new DistributedMultisetProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(rawList -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           AsyncDistributedMultiset<E> list = new TranscodingAsyncDistributedMultiset<>(
               rawList,
               element -> BaseEncoding.base16().encode(serializer.encode(element)),

--- a/core/src/main/java/io/atomix/core/queue/impl/DefaultDistributedQueueBuilder.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/DefaultDistributedQueueBuilder.java
@@ -21,7 +21,6 @@ import io.atomix.core.queue.DistributedQueue;
 import io.atomix.core.queue.DistributedQueueBuilder;
 import io.atomix.core.queue.DistributedQueueConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -40,11 +39,10 @@ public class DefaultDistributedQueueBuilder<E> extends DistributedQueueBuilder<E
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<DistributedQueue<E>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(DistributedQueueService.class, new ServiceConfig())
         .thenCompose(proxy -> new DistributedQueueProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(rawQueue -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           AsyncDistributedQueue<E> queue = new TranscodingAsyncDistributedQueue<>(
               rawQueue,
               element -> BaseEncoding.base16().encode(serializer.encode(element)),

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetBuilder.java
@@ -46,7 +46,7 @@ public class DefaultDistributedNavigableSetBuilder<E extends Comparable<E>> exte
     if (protocol instanceof GossipProtocol) {
       if (protocol instanceof NavigableSetProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((NavigableSetProtocol) protocol).<E>newNavigableSetDelegate(name, managementService))
+            CompletableFuture.completedFuture(((NavigableSetProtocol) protocol).<E>newNavigableSetDelegate(name, serializer(), managementService))
                 .thenApply(set -> new GossipDistributedNavigableSet<>(name, protocol, set)))
             .thenApply(AsyncDistributedNavigableSet::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetBuilder.java
@@ -48,7 +48,7 @@ public class DefaultDistributedSetBuilder<E> extends DistributedSetBuilder<E> {
     if (protocol instanceof GossipProtocol) {
       if (protocol instanceof SetProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((SetProtocol) protocol).<E>newSetDelegate(name, managementService))
+            CompletableFuture.completedFuture(((SetProtocol) protocol).<E>newSetDelegate(name, serializer(), managementService))
                 .thenApply(set -> new GossipDistributedSet<>(name, protocol, set)))
             .thenApply(AsyncDistributedSet::sync);
       } else {
@@ -58,7 +58,7 @@ public class DefaultDistributedSetBuilder<E> extends DistributedSetBuilder<E> {
       return newProxy(DistributedSetService.class, new ServiceConfig())
           .thenCompose(proxy -> new DistributedSetProxy((ProxyClient) proxy, managementService.getPrimitiveRegistry()).connect())
           .thenApply(rawSet -> {
-            Serializer serializer = protocol.serializer();
+            Serializer serializer = serializer();
             AsyncDistributedSet<E> set = new TranscodingAsyncDistributedSet<>(
                 rawSet,
                 element -> BaseEncoding.base16().encode(serializer.encode(element)),

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSortedSetBuilder.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSortedSetBuilder.java
@@ -46,7 +46,7 @@ public class DefaultDistributedSortedSetBuilder<E extends Comparable<E>> extends
     if (protocol instanceof GossipProtocol) {
       if (protocol instanceof SortedSetProtocol) {
         return managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((SortedSetProtocol) protocol).<E>newSortedSetDelegate(name, managementService))
+            CompletableFuture.completedFuture(((SortedSetProtocol) protocol).<E>newSortedSetDelegate(name, serializer(), managementService))
                 .thenApply(set -> new GossipDistributedSortedSet<>(name, protocol, set)))
             .thenApply(AsyncDistributedSortedSet::sync);
       } else {

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTreeBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTreeBuilder.java
@@ -20,7 +20,6 @@ import io.atomix.core.tree.AtomicDocumentTree;
 import io.atomix.core.tree.AtomicDocumentTreeBuilder;
 import io.atomix.core.tree.AtomicDocumentTreeConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -39,11 +38,10 @@ public class DefaultAtomicDocumentTreeBuilder<V> extends AtomicDocumentTreeBuild
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicDocumentTree<V>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(DocumentTreeService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicDocumentTreeProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(tree -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncAtomicDocumentTree<V, byte[]>(
               tree,
               key -> serializer.encode(key),

--- a/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/impl/DefaultAtomicValueBuilder.java
@@ -19,7 +19,6 @@ import io.atomix.core.value.AtomicValue;
 import io.atomix.core.value.AtomicValueBuilder;
 import io.atomix.core.value.AtomicValueConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -38,11 +37,10 @@ public class DefaultAtomicValueBuilder<V> extends AtomicValueBuilder<V> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<AtomicValue<V>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(AtomicValueService.class, new ServiceConfig())
         .thenCompose(proxy -> new AtomicValueProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(elector -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncAtomicValue<V, byte[]>(
               elector,
               key -> serializer.encode(key),

--- a/core/src/main/java/io/atomix/core/value/impl/DefaultDistributedValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/impl/DefaultDistributedValueBuilder.java
@@ -46,7 +46,7 @@ public class DefaultDistributedValueBuilder<V> extends DistributedValueBuilder<V
     if (protocol instanceof GossipProtocol) {
       if (protocol instanceof ValueProtocol) {
         CompletableFuture<AsyncDistributedValue<V>> future = managementService.getPrimitiveCache().getPrimitive(name, () ->
-            CompletableFuture.completedFuture(((ValueProtocol) protocol).<V>newValueDelegate(name, managementService))
+            CompletableFuture.completedFuture(((ValueProtocol) protocol).<V>newValueDelegate(name, serializer(), managementService))
                 .thenApply(map -> new GossipDistributedValue<>(name, protocol, map)));
         return future.thenApply(AsyncDistributedValue::sync);
       } else {
@@ -56,7 +56,7 @@ public class DefaultDistributedValueBuilder<V> extends DistributedValueBuilder<V
       return newProxy(AtomicValueService.class, new ServiceConfig())
           .thenCompose(proxy -> new AtomicValueProxy(proxy, managementService.getPrimitiveRegistry()).connect())
           .thenApply(elector -> {
-            Serializer serializer = protocol.serializer();
+            Serializer serializer = serializer();
             return new TranscodingAsyncAtomicValue<V, byte[]>(
                 elector,
                 key -> serializer.encode(key),

--- a/core/src/main/java/io/atomix/core/workqueue/impl/DefaultWorkQueueBuilder.java
+++ b/core/src/main/java/io/atomix/core/workqueue/impl/DefaultWorkQueueBuilder.java
@@ -19,7 +19,6 @@ import io.atomix.core.workqueue.WorkQueue;
 import io.atomix.core.workqueue.WorkQueueBuilder;
 import io.atomix.core.workqueue.WorkQueueConfig;
 import io.atomix.primitive.PrimitiveManagementService;
-import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Serializer;
 
@@ -36,11 +35,10 @@ public class DefaultWorkQueueBuilder<E> extends WorkQueueBuilder<E> {
   @Override
   @SuppressWarnings("unchecked")
   public CompletableFuture<WorkQueue<E>> buildAsync() {
-    PrimitiveProtocol protocol = protocol();
     return newProxy(WorkQueueService.class, new ServiceConfig())
         .thenCompose(proxy -> new WorkQueueProxy(proxy, managementService.getPrimitiveRegistry()).connect())
         .thenApply(queue -> {
-          Serializer serializer = protocol.serializer();
+          Serializer serializer = serializer();
           return new TranscodingAsyncWorkQueue<E, byte[]>(
               queue,
               item -> serializer.encode(item),

--- a/core/src/test/java/io/atomix/core/election/LeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/LeaderElectionTest.java
@@ -15,13 +15,9 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.cluster.MemberId;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.election.impl.LeaderElectionProxy;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,19 +34,13 @@ import static org.junit.Assert.assertTrue;
  * Unit tests for {@link LeaderElectionProxy}.
  */
 public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProtocol> {
-  protected static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
-      .register(Namespaces.BASIC)
-      .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-      .register(MemberId.class)
-      .build());
-
-  MemberId node1 = MemberId.from("node1");
-  MemberId node2 = MemberId.from("node2");
-  MemberId node3 = MemberId.from("node3");
+  String node1 = "node1";
+  String node2 = "node2";
+  String node3 = "node3";
 
   @Test
   public void testRun() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-run")
+    AsyncLeaderElection<String> election1 = atomix().<String>leaderElectionBuilder("test-election-run")
         .withProtocol(protocol())
         .build()
         .async();
@@ -61,7 +51,7 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
       assertEquals(node1, result.candidates().get(0));
     }).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-run")
+    AsyncLeaderElection<String> election2 = atomix().<String>leaderElectionBuilder("test-election-run")
         .withProtocol(protocol())
         .build()
         .async();
@@ -76,12 +66,12 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
 
   @Test
   public void testWithdraw() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-withdraw")
+    AsyncLeaderElection<String> election1 = atomix().<String>leaderElectionBuilder("test-election-withdraw")
         .withProtocol(protocol())
         .build()
         .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-withdraw")
+    AsyncLeaderElection<String> election2 = atomix().<String>leaderElectionBuilder("test-election-withdraw")
         .withProtocol(protocol())
         .build()
         .async();
@@ -109,26 +99,26 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
       Assert.assertEquals(node2, result.newLeadership().candidates().get(0));
     }).get(30, TimeUnit.SECONDS);
 
-    Leadership<MemberId> leadership1 = election1.getLeadership().get(30, TimeUnit.SECONDS);
+    Leadership<String> leadership1 = election1.getLeadership().get(30, TimeUnit.SECONDS);
     assertEquals(node2, leadership1.leader().id());
     assertEquals(1, leadership1.candidates().size());
 
-    Leadership<MemberId> leadership2 = election2.getLeadership().get(30, TimeUnit.SECONDS);
+    Leadership<String> leadership2 = election2.getLeadership().get(30, TimeUnit.SECONDS);
     assertEquals(node2, leadership2.leader().id());
     assertEquals(1, leadership2.candidates().size());
   }
 
   @Test
   public void testAnoint() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint")
+    AsyncLeaderElection<String> election1 = atomix().<String>leaderElectionBuilder("test-election-anoint")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint")
+    AsyncLeaderElection<String> election2 = atomix().<String>leaderElectionBuilder("test-election-anoint")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElection<MemberId> election3 = atomix().<MemberId>leaderElectionBuilder("test-election-anoint")
+    AsyncLeaderElection<String> election3 = atomix().<String>leaderElectionBuilder("test-election-anoint")
         .withProtocol(protocol())
         .build()
         .async();
@@ -175,15 +165,15 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
 
   @Test
   public void testPromote() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-promote")
+    AsyncLeaderElection<String> election1 = atomix().<String>leaderElectionBuilder("test-election-promote")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-promote")
+    AsyncLeaderElection<String> election2 = atomix().<String>leaderElectionBuilder("test-election-promote")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElection<MemberId> election3 = atomix().<MemberId>leaderElectionBuilder("test-election-promote")
+    AsyncLeaderElection<String> election3 = atomix().<String>leaderElectionBuilder("test-election-promote")
         .withProtocol(protocol())
         .build()
         .async();
@@ -234,12 +224,12 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
 
   @Test
   public void testLeaderSessionClose() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-leader-session-close")
+    AsyncLeaderElection<String> election1 = atomix().<String>leaderElectionBuilder("test-election-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-leader-session-close")
+    AsyncLeaderElection<String> election2 = atomix().<String>leaderElectionBuilder("test-election-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
@@ -256,12 +246,12 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
 
   @Test
   public void testNonLeaderSessionClose() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-non-leader-session-close")
+    AsyncLeaderElection<String> election1 = atomix().<String>leaderElectionBuilder("test-election-non-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
     election1.run(node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-non-leader-session-close")
+    AsyncLeaderElection<String> election2 = atomix().<String>leaderElectionBuilder("test-election-non-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
@@ -278,11 +268,11 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
 
   @Test
   public void testQueries() throws Throwable {
-    AsyncLeaderElection<MemberId> election1 = atomix().<MemberId>leaderElectionBuilder("test-election-query")
+    AsyncLeaderElection<String> election1 = atomix().<String>leaderElectionBuilder("test-election-query")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElection<MemberId> election2 = atomix().<MemberId>leaderElectionBuilder("test-election-query")
+    AsyncLeaderElection<String> election2 = atomix().<String>leaderElectionBuilder("test-election-query")
         .withProtocol(protocol())
         .build()
         .async();
@@ -301,12 +291,12 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
     }).get(30, TimeUnit.SECONDS);
   }
 
-  private static class LeaderEventListener implements LeadershipEventListener<MemberId> {
-    Queue<LeadershipEvent<MemberId>> eventQueue = new LinkedList<>();
-    CompletableFuture<LeadershipEvent<MemberId>> pendingFuture;
+  private static class LeaderEventListener implements LeadershipEventListener<String> {
+    Queue<LeadershipEvent<String>> eventQueue = new LinkedList<>();
+    CompletableFuture<LeadershipEvent<String>> pendingFuture;
 
     @Override
-    public void event(LeadershipEvent<MemberId> event) {
+    public void event(LeadershipEvent<String> event) {
       synchronized (this) {
         if (pendingFuture != null) {
           pendingFuture.complete(event);
@@ -325,7 +315,7 @@ public abstract class LeaderElectionTest extends AbstractPrimitiveTest<ProxyProt
       eventQueue.clear();
     }
 
-    public CompletableFuture<LeadershipEvent<MemberId>> nextEvent() {
+    public CompletableFuture<LeadershipEvent<String>> nextEvent() {
       synchronized (this) {
         if (eventQueue.isEmpty()) {
           if (pendingFuture == null) {

--- a/core/src/test/java/io/atomix/core/election/LeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/LeaderElectorTest.java
@@ -15,12 +15,8 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.cluster.MemberId;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.primitive.protocol.ProxyProtocol;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -38,19 +34,13 @@ import static org.junit.Assert.assertTrue;
  * Leader elector test.
  */
 public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProtocol> {
-  protected static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
-      .register(Namespaces.BASIC)
-      .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-      .register(MemberId.class)
-      .build());
-
-  MemberId node1 = MemberId.from("4");
-  MemberId node2 = MemberId.from("5");
-  MemberId node3 = MemberId.from("6");
+  String node1 = "4";
+  String node2 = "5";
+  String node3 = "6";
 
   @Test
   public void testRun() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-run")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-run")
         .withProtocol(protocol())
         .build()
         .async();
@@ -68,7 +58,7 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
       assertEquals(node1, result.candidates().get(0));
     }).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-run")
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-run")
         .withProtocol(protocol())
         .build()
         .async();
@@ -83,12 +73,12 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
 
   @Test
   public void testWithdraw() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-withdraw")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-withdraw")
         .withProtocol(protocol())
         .build()
         .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-withdraw")
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-withdraw")
         .withProtocol(protocol())
         .build()
         .async();
@@ -133,15 +123,15 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
 
   @Test
   public void testAnoint() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-anoint")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint")
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-anoint")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-anoint")
+    AsyncLeaderElector<String> elector3 = atomix().<String>leaderElectorBuilder("test-elector-anoint")
         .withProtocol(protocol())
         .build()
         .async();
@@ -188,15 +178,15 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
 
   @Test
   public void testPromote() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-promote")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote")
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-promote")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-promote")
+    AsyncLeaderElector<String> elector3 = atomix().<String>leaderElectorBuilder("test-elector-promote")
         .withProtocol(protocol())
         .build()
         .async();
@@ -247,12 +237,12 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
 
   @Test
   public void testLeaderSessionClose() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-session-close")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-session-close")
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
@@ -269,12 +259,12 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
 
   @Test
   public void testNonLeaderSessionClose() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-non-leader-session-close")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-non-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
     elector1.run("foo", node1).get(30, TimeUnit.SECONDS);
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-non-leader-session-close")
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-non-leader-session-close")
         .withProtocol(protocol())
         .build()
         .async();
@@ -292,7 +282,7 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
   @Test
   @Ignore // Leader balancing is currently not deterministic in this test
   public void testLeaderBalance() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-leader-balance")
         .withProtocol(protocol())
         .build()
         .async();
@@ -300,12 +290,12 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
     elector1.run("bar", node1).get(30, TimeUnit.SECONDS);
     elector1.run("baz", node1).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance").build().async();
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-leader-balance").build().async();
     elector2.run("foo", node2).get(30, TimeUnit.SECONDS);
     elector2.run("bar", node2).get(30, TimeUnit.SECONDS);
     elector2.run("baz", node2).get(30, TimeUnit.SECONDS);
 
-    AsyncLeaderElector<MemberId> elector3 = atomix().<MemberId>leaderElectorBuilder("test-elector-leader-balance")
+    AsyncLeaderElector<String> elector3 = atomix().<String>leaderElectorBuilder("test-elector-leader-balance")
         .withProtocol(protocol())
         .build()
         .async();
@@ -342,11 +332,11 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
 
   @Test
   public void testQueries() throws Throwable {
-    AsyncLeaderElector<MemberId> elector1 = atomix().<MemberId>leaderElectorBuilder("test-elector-query")
+    AsyncLeaderElector<String> elector1 = atomix().<String>leaderElectorBuilder("test-elector-query")
         .withProtocol(protocol())
         .build()
         .async();
-    AsyncLeaderElector<MemberId> elector2 = atomix().<MemberId>leaderElectorBuilder("test-elector-query")
+    AsyncLeaderElector<String> elector2 = atomix().<String>leaderElectorBuilder("test-elector-query")
         .withProtocol(protocol())
         .build()
         .async();
@@ -393,12 +383,12 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
     }).get(30, TimeUnit.SECONDS);
   }
 
-  private static class LeaderEventListener implements LeadershipEventListener<MemberId> {
-    Queue<LeadershipEvent<MemberId>> eventQueue = new LinkedList<>();
-    CompletableFuture<LeadershipEvent<MemberId>> pendingFuture;
+  private static class LeaderEventListener implements LeadershipEventListener<String> {
+    Queue<LeadershipEvent<String>> eventQueue = new LinkedList<>();
+    CompletableFuture<LeadershipEvent<String>> pendingFuture;
 
     @Override
-    public void event(LeadershipEvent<MemberId> change) {
+    public void event(LeadershipEvent<String> change) {
       synchronized (this) {
         if (pendingFuture != null) {
           pendingFuture.complete(change);
@@ -417,7 +407,7 @@ public abstract class LeaderElectorTest extends AbstractPrimitiveTest<ProxyProto
       eventQueue.clear();
     }
 
-    public CompletableFuture<LeadershipEvent<MemberId>> nextEvent() {
+    public CompletableFuture<LeadershipEvent<String>> nextEvent() {
       synchronized (this) {
         if (eventQueue.isEmpty()) {
           if (pendingFuture == null) {

--- a/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectionTest.java
@@ -25,7 +25,6 @@ public class PrimaryBackupLeaderElectionTest extends LeaderElectionTest {
   @Override
   protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
-        .withSerializer(SERIALIZER)
         .withBackups(2)
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/PrimaryBackupLeaderElectorTest.java
@@ -25,7 +25,6 @@ public class PrimaryBackupLeaderElectorTest extends LeaderElectorTest {
   @Override
   protected ProxyProtocol protocol() {
     return MultiPrimaryProtocol.builder()
-        .withSerializer(SERIALIZER)
         .withBackups(2)
         .withMaxRetries(5)
         .build();

--- a/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
@@ -25,7 +25,6 @@ public class RaftLeaderElectionTest extends LeaderElectionTest {
   @Override
   protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
-        .withSerializer(SERIALIZER)
         .withMaxRetries(5)
         .build();
   }

--- a/core/src/test/java/io/atomix/core/election/RaftLeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/RaftLeaderElectorTest.java
@@ -25,7 +25,6 @@ public class RaftLeaderElectorTest extends LeaderElectorTest {
   @Override
   protected ProxyProtocol protocol() {
     return MultiRaftProtocol.builder()
-        .withSerializer(SERIALIZER)
         .withMaxRetries(5)
         .build();
   }

--- a/core/src/test/java/io/atomix/core/list/DistributedListTest.java
+++ b/core/src/test/java/io/atomix/core/list/DistributedListTest.java
@@ -19,6 +19,8 @@ import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.primitive.protocol.ProxyProtocol;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -114,6 +116,38 @@ public abstract class DistributedListTest extends AbstractPrimitiveTest<ProxyPro
     list.clear();
     assertTrue(list.isEmpty());
     assertEquals(0, list.size());
+  }
+
+  /**
+   * Tests a map with complex types.
+   */
+  @Test
+  public void testComplexTypes() throws Throwable {
+    DistributedList<Pair<String, Integer>> list = atomix()
+        .<Pair<String, Integer>>listBuilder("testComplexTypes")
+        .withProtocol(protocol())
+        .build();
+
+    list.add(Pair.of("foo", 1));
+    assertEquals("foo", list.iterator().next().getLeft());
+    assertEquals(Integer.valueOf(1), list.iterator().next().getRight());
+  }
+
+  /**
+   * Tests a map with complex types.
+   */
+  @Test
+  public void testRequiredComplexTypes() throws Throwable {
+    DistributedList<Pair<String, Integer>> list = atomix()
+        .<Pair<String, Integer>>listBuilder("testRequiredComplexTypes")
+        .withRegistrationRequired()
+        .withElementType(ImmutablePair.class)
+        .withProtocol(protocol())
+        .build();
+
+    list.add(Pair.of("foo", 1));
+    assertEquals("foo", list.iterator().next().getLeft());
+    assertEquals(Integer.valueOf(1), list.iterator().next().getRight());
   }
 
   private static class TestQueueEventListener implements CollectionEventListener<String> {

--- a/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
@@ -19,6 +19,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.atomix.core.AbstractPrimitiveTest;
 import io.atomix.primitive.protocol.ProxyProtocol;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -267,6 +269,47 @@ public abstract class DistributedMapTest extends AbstractPrimitiveTest<ProxyProt
       map.put(String.valueOf(100 * i), String.valueOf(100 * i));
     }
     assertEquals(String.valueOf(100), map.get(String.valueOf(100)));
+  }
+
+  /**
+   * Tests a map with complex types.
+   */
+  @Test
+  public void testComplexTypes() throws Throwable {
+    DistributedMap<Key, Pair<String, Integer>> map = atomix()
+        .<Key, Pair<String, Integer>>mapBuilder("testComplexTypes")
+        .withProtocol(protocol())
+        .build();
+
+    map.put(new Key("foo"), Pair.of("foo", 1));
+    assertEquals("foo", map.get(new Key("foo")).getLeft());
+    assertEquals(Integer.valueOf(1), map.get(new Key("foo")).getRight());
+  }
+
+  /**
+   * Tests a map with complex types.
+   */
+  @Test
+  public void testRequiredComplexTypes() throws Throwable {
+    DistributedMap<Key, Pair<String, Integer>> map = atomix()
+        .<Key, Pair<String, Integer>>mapBuilder("testComplexTypes")
+        .withProtocol(protocol())
+        .withRegistrationRequired()
+        .withKeyType(Key.class)
+        .withValueType(ImmutablePair.class)
+        .build();
+
+    map.put(new Key("foo"), Pair.of("foo", 1));
+    assertEquals("foo", map.get(new Key("foo")).getLeft());
+    assertEquals(Integer.valueOf(1), map.get(new Key("foo")).getRight());
+  }
+
+  private static class Key {
+    String value;
+
+    Key(String value) {
+      this.value = value;
+    }
   }
 
   private static class TestMapEventListener implements MapEventListener<String, String> {

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
@@ -26,6 +26,10 @@ import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.Builder;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.config.ConfigurationException;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Namespaces;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +47,8 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
   protected final PrimitiveType type;
   protected final String name;
   protected final C config;
-  protected PrimitiveProtocol protocol;
+  private PrimitiveProtocol protocol;
+  private Serializer serializer;
   protected final PrimitiveManagementService managementService;
 
   public PrimitiveBuilder(PrimitiveType type, String name, C config, PrimitiveManagementService managementService) {
@@ -62,6 +67,18 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
   @SuppressWarnings("unchecked")
   protected B withProtocol(PrimitiveProtocol protocol) {
     this.protocol = protocol;
+    return (B) this;
+  }
+
+  /**
+   * Sets the primitive serializer.
+   *
+   * @param serializer the primitive serializer
+   * @return the primitive builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withSerializer(Serializer serializer) {
+    this.serializer = checkNotNull(serializer);
     return (B) this;
   }
 
@@ -112,6 +129,33 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
       }
     }
     return protocol;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  protected Serializer serializer() {
+    Serializer serializer = this.serializer;
+    if (serializer == null) {
+      synchronized (this) {
+        serializer = this.serializer;
+        if (serializer == null) {
+          NamespaceConfig config = this.config.getNamespaceConfig();
+          if (config == null) {
+            serializer = Serializer.using(Namespaces.BASIC);
+          } else {
+            serializer = Serializer.using(Namespace.builder()
+                .register(Namespaces.BASIC)
+                .register(new Namespace(config))
+                .build());
+          }
+          this.serializer = serializer;
+        }
+      }
+    }
+    return serializer;
   }
 
   protected <S> CompletableFuture<ProxyClient<S>> newProxy(Class<S> serviceType, ServiceConfig config) {

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveBuilder.java
@@ -47,8 +47,8 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
   protected final PrimitiveType type;
   protected final String name;
   protected final C config;
-  private PrimitiveProtocol protocol;
-  private Serializer serializer;
+  protected PrimitiveProtocol protocol;
+  protected Serializer serializer;
   protected final PrimitiveManagementService managementService;
 
   public PrimitiveBuilder(PrimitiveType type, String name, C config, PrimitiveManagementService managementService) {
@@ -148,6 +148,7 @@ public abstract class PrimitiveBuilder<B extends PrimitiveBuilder<B, C, P>, C ex
           } else {
             serializer = Serializer.using(Namespace.builder()
                 .register(Namespaces.BASIC)
+                .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
                 .register(new Namespace(config))
                 .build());
           }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocol.java
@@ -16,7 +16,6 @@
 package io.atomix.primitive.protocol;
 
 import io.atomix.utils.ConfiguredType;
-import io.atomix.utils.serializer.Serializer;
 
 /**
  * Primitive protocol.
@@ -48,12 +47,5 @@ public interface PrimitiveProtocol {
    * @return the protocol type
    */
   Type type();
-
-  /**
-   * Returns the protocol serializer.
-   *
-   * @return the protocol serializer
-   */
-  Serializer serializer();
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolBuilder.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolBuilder.java
@@ -16,7 +16,6 @@
 package io.atomix.primitive.protocol;
 
 import io.atomix.utils.Builder;
-import io.atomix.utils.serializer.Serializer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -28,17 +27,5 @@ public abstract class PrimitiveProtocolBuilder<B extends PrimitiveProtocolBuilde
 
   protected PrimitiveProtocolBuilder(C config) {
     this.config = checkNotNull(config);
-  }
-
-  /**
-   * Sets the protocol serializer.
-   *
-   * @param serializer the protocol serializer
-   * @return the protocol builder
-   */
-  @SuppressWarnings("unchecked")
-  public B withSerializer(Serializer serializer) {
-    config.setSerializer(serializer);
-    return (B) this;
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolConfig.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/PrimitiveProtocolConfig.java
@@ -16,75 +16,9 @@
 package io.atomix.primitive.protocol;
 
 import io.atomix.utils.config.TypedConfig;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.NamespaceConfig;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 
 /**
  * Primitive protocol configuration.
  */
 public abstract class PrimitiveProtocolConfig<C extends PrimitiveProtocolConfig<C>> implements TypedConfig<PrimitiveProtocol.Type> {
-  private volatile Serializer serializer;
-  private NamespaceConfig namespaceConfig;
-
-  /**
-   * Sets the protocol serializer.
-   *
-   * @param serializer the protocol serializer
-   * @return the protocol configuration
-   */
-  @SuppressWarnings("unchecked")
-  public C setSerializer(Serializer serializer) {
-    this.serializer = serializer;
-    return (C) this;
-  }
-
-  /**
-   * Returns the protocol serializer.
-   *
-   * @return the protocol serializer
-   */
-  public Serializer getSerializer() {
-    Serializer serializer = this.serializer;
-    if (serializer == null) {
-      synchronized (this) {
-        serializer = this.serializer;
-        if (serializer == null) {
-          NamespaceConfig config = getNamespaceConfig();
-          if (config == null) {
-            serializer = Serializer.using(Namespaces.BASIC);
-          } else {
-            serializer = Serializer.using(Namespace.builder()
-                .register(Namespaces.BASIC)
-                .register(new Namespace(config))
-                .build());
-          }
-          this.serializer = serializer;
-        }
-      }
-    }
-    return serializer;
-  }
-
-  /**
-   * Returns the namespace configuration.
-   *
-   * @return the namespace configuration
-   */
-  public NamespaceConfig getNamespaceConfig() {
-    return namespaceConfig;
-  }
-
-  /**
-   * Sets the namespace configuration.
-   *
-   * @param namespaceConfig the namespace configuration
-   * @return the protocol serializer
-   */
-  @SuppressWarnings("unchecked")
-  public C setNamespaceConfig(NamespaceConfig namespaceConfig) {
-    this.namespaceConfig = namespaceConfig;
-    return (C) this;
-  }
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/MapProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/MapProtocol.java
@@ -17,6 +17,7 @@ package io.atomix.primitive.protocol.map;
 
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Map protocol.
@@ -27,9 +28,10 @@ public interface MapProtocol extends GossipProtocol {
    * Returns a new map delegate.
    *
    * @param name the map name
+   * @param serializer the map entry serializer
    * @param managementService the primitive management service
    * @return a new map delegate
    */
-  <K, V> MapDelegate<K, V> newMapDelegate(String name, PrimitiveManagementService managementService);
+  <K, V> MapDelegate<K, V> newMapDelegate(String name, Serializer serializer, PrimitiveManagementService managementService);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/NavigableMapProtocol.java
@@ -16,6 +16,7 @@
 package io.atomix.primitive.protocol.map;
 
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Navigable map protocol.
@@ -26,9 +27,10 @@ public interface NavigableMapProtocol extends SortedMapProtocol {
    * Returns a new navigable map delegate.
    *
    * @param name the map name
+   * @param serializer the map entry serializer
    * @param managementService the primitive management service
    * @return a new map delegate
    */
-  <K, V> NavigableMapDelegate<K, V> newNavigableMapDelegate(String name, PrimitiveManagementService managementService);
+  <K, V> NavigableMapDelegate<K, V> newNavigableMapDelegate(String name, Serializer serializer, PrimitiveManagementService managementService);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/map/SortedMapProtocol.java
@@ -16,6 +16,7 @@
 package io.atomix.primitive.protocol.map;
 
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Sorted map protocol.
@@ -26,9 +27,10 @@ public interface SortedMapProtocol extends MapProtocol {
    * Returns a new sorted map delegate.
    *
    * @param name the map name
+   * @param serializer the map entry serializer
    * @param managementService the primitive management service
    * @return a new map delegate
    */
-  <K, V> NavigableMapDelegate<K, V> newSortedMapDelegate(String name, PrimitiveManagementService managementService);
+  <K, V> NavigableMapDelegate<K, V> newSortedMapDelegate(String name, Serializer serializer, PrimitiveManagementService managementService);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/NavigableSetProtocol.java
@@ -16,6 +16,7 @@
 package io.atomix.primitive.protocol.set;
 
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Navigable set protocol.
@@ -26,10 +27,11 @@ public interface NavigableSetProtocol extends SortedSetProtocol {
    * Returns a new set delegate.
    *
    * @param name the set name
+   * @param serializer the set element serializer
    * @param managementService the primitive management service
    * @param <E> the set element type
    * @return a new set delegate
    */
-  <E> NavigableSetDelegate<E> newNavigableSetDelegate(String name, PrimitiveManagementService managementService);
+  <E> NavigableSetDelegate<E> newNavigableSetDelegate(String name, Serializer serializer, PrimitiveManagementService managementService);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SetProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SetProtocol.java
@@ -17,6 +17,7 @@ package io.atomix.primitive.protocol.set;
 
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Set protocol.
@@ -27,10 +28,11 @@ public interface SetProtocol extends GossipProtocol {
    * Returns a new set delegate.
    *
    * @param name the set name
+   * @param serializer the set element serializer
    * @param managementService the primitive management service
    * @param <E> the set element type
    * @return a new set delegate
    */
-  <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService);
+  <E> SetDelegate<E> newSetDelegate(String name, Serializer serializer, PrimitiveManagementService managementService);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/set/SortedSetProtocol.java
@@ -16,6 +16,7 @@
 package io.atomix.primitive.protocol.set;
 
 import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Sorted set protocol.
@@ -26,10 +27,11 @@ public interface SortedSetProtocol extends SetProtocol {
    * Returns a new set delegate.
    *
    * @param name the set name
+   * @param serializer the set element serializer
    * @param managementService the primitive management service
    * @param <E> the set element type
    * @return a new set delegate
    */
-  <E> SortedSetDelegate<E> newSortedSetDelegate(String name, PrimitiveManagementService managementService);
+  <E> SortedSetDelegate<E> newSortedSetDelegate(String name, Serializer serializer, PrimitiveManagementService managementService);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/protocol/value/ValueProtocol.java
+++ b/primitive/src/main/java/io/atomix/primitive/protocol/value/ValueProtocol.java
@@ -17,6 +17,7 @@ package io.atomix.primitive.protocol.value;
 
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.GossipProtocol;
+import io.atomix.utils.serializer.Serializer;
 
 /**
  * Value protocol.
@@ -27,9 +28,10 @@ public interface ValueProtocol extends GossipProtocol {
    * Returns a new value delegate.
    *
    * @param name the value name
+   * @param serializer the value serializer
    * @param managementService the primitive management service
    * @return a new value delegate
    */
-  ValueDelegate newValueDelegate(String name, PrimitiveManagementService managementService);
+  ValueDelegate newValueDelegate(String name, Serializer serializer, PrimitiveManagementService managementService);
 
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/AntiEntropyProtocol.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/AntiEntropyProtocol.java
@@ -84,17 +84,12 @@ public class AntiEntropyProtocol implements GossipProtocol, MapProtocol, SetProt
   }
 
   @Override
-  public Serializer serializer() {
-    return config.getSerializer();
+  public <K, V> MapDelegate<K, V> newMapDelegate(String name, Serializer serializer, PrimitiveManagementService managementService) {
+    return new AntiEntropyMapDelegate<>(name, serializer, config, managementService);
   }
 
   @Override
-  public <K, V> MapDelegate<K, V> newMapDelegate(String name, PrimitiveManagementService managementService) {
-    return new AntiEntropyMapDelegate<>(name, config, managementService);
-  }
-
-  @Override
-  public <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService) {
-    return new AntiEntropySetDelegate<>(name, config, managementService);
+  public <E> SetDelegate<E> newSetDelegate(String name, Serializer serializer, PrimitiveManagementService managementService) {
+    return new AntiEntropySetDelegate<>(name, serializer, config, managementService);
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/CrdtProtocol.java
@@ -90,32 +90,27 @@ public class CrdtProtocol implements GossipProtocol, CounterProtocol, NavigableS
   }
 
   @Override
-  public Serializer serializer() {
-    return config.getSerializer();
-  }
-
-  @Override
   public CounterDelegate newCounterDelegate(String name, PrimitiveManagementService managementService) {
     return new CrdtCounterDelegate(name, config, managementService);
   }
 
   @Override
-  public <E> SetDelegate<E> newSetDelegate(String name, PrimitiveManagementService managementService) {
-    return new CrdtSetDelegate<>(name, config, managementService);
+  public <E> SetDelegate<E> newSetDelegate(String name, Serializer serializer, PrimitiveManagementService managementService) {
+    return new CrdtSetDelegate<>(name, serializer, config, managementService);
   }
 
   @Override
-  public <E> SortedSetDelegate<E> newSortedSetDelegate(String name, PrimitiveManagementService managementService) {
-    return new CrdtNavigableSetDelegate<>(name, config, managementService);
+  public <E> SortedSetDelegate<E> newSortedSetDelegate(String name, Serializer serializer, PrimitiveManagementService managementService) {
+    return new CrdtNavigableSetDelegate<>(name, serializer, config, managementService);
   }
 
   @Override
-  public <E> NavigableSetDelegate<E> newNavigableSetDelegate(String name, PrimitiveManagementService managementService) {
-    return new CrdtNavigableSetDelegate<>(name, config, managementService);
+  public <E> NavigableSetDelegate<E> newNavigableSetDelegate(String name, Serializer serializer, PrimitiveManagementService managementService) {
+    return new CrdtNavigableSetDelegate<>(name, serializer, config, managementService);
   }
 
   @Override
-  public ValueDelegate newValueDelegate(String name, PrimitiveManagementService managementService) {
-    return new CrdtValueDelegate(name, config, managementService);
+  public ValueDelegate newValueDelegate(String name, Serializer serializer, PrimitiveManagementService managementService) {
+    return new CrdtValueDelegate(name, serializer, config, managementService);
   }
 }

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/map/AntiEntropyMapDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/map/AntiEntropyMapDelegate.java
@@ -119,10 +119,10 @@ public class AntiEntropyMapDelegate<K, V> implements MapDelegate<K, V> {
   private volatile boolean closed = false;
   private SlidingWindowCounter counter = new SlidingWindowCounter(WINDOW_SIZE);
 
-  public AntiEntropyMapDelegate(String name, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
+  public AntiEntropyMapDelegate(String name, Serializer serializer, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
     this.localMemberId = managementService.getMembershipService().getLocalMember().id();
     this.mapName = name;
-    this.entrySerializer = config.getSerializer();
+    this.entrySerializer = serializer;
     this.serializer = Serializer.using(Namespace.builder()
         .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
         .register(Namespaces.BASIC)

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/AntiEntropySetDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/AntiEntropySetDelegate.java
@@ -25,6 +25,7 @@ import io.atomix.primitive.protocol.set.SetDelegateEventListener;
 import io.atomix.protocols.gossip.AntiEntropyProtocolConfig;
 import io.atomix.protocols.gossip.TimestampProvider;
 import io.atomix.protocols.gossip.map.AntiEntropyMapDelegate;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -37,10 +38,10 @@ public class AntiEntropySetDelegate<E> implements SetDelegate<E> {
   private final MapDelegate<E, Boolean> map;
   private final Map<SetDelegateEventListener<E>, MapDelegateEventListener<E, Boolean>> listenerMap = Maps.newConcurrentMap();
 
-  public AntiEntropySetDelegate(String name, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
+  public AntiEntropySetDelegate(String name, Serializer serializer, AntiEntropyProtocolConfig config, PrimitiveManagementService managementService) {
     TimestampProvider<E> timestampProvider = config.getTimestampProvider();
     TimestampProvider<Map.Entry<E, Boolean>> newTimestampProvider = e -> timestampProvider.get(e.getKey());
-    this.map = new AntiEntropyMapDelegate<>(name, config.setTimestampProvider(newTimestampProvider), managementService);
+    this.map = new AntiEntropyMapDelegate<>(name, serializer, config.setTimestampProvider(newTimestampProvider), managementService);
   }
 
   @Override

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSetDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtNavigableSetDelegate.java
@@ -18,6 +18,7 @@ package io.atomix.protocols.gossip.set;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.set.NavigableSetDelegate;
 import io.atomix.protocols.gossip.CrdtProtocolConfig;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.Comparator;
 import java.util.Iterator;
@@ -30,8 +31,8 @@ import java.util.stream.Collectors;
  * CRDT tree set.
  */
 public class CrdtNavigableSetDelegate<E> extends CrdtSetDelegate<E> implements NavigableSetDelegate<E> {
-  public CrdtNavigableSetDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
-    super(name, config, managementService);
+  public CrdtNavigableSetDelegate(String name, Serializer serializer, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
+    super(name, serializer, config, managementService);
   }
 
   @Override

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtSetDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/set/CrdtSetDelegate.java
@@ -57,10 +57,10 @@ public class CrdtSetDelegate<E> implements SetDelegate<E> {
   protected final Map<String, SetElement> elements = Maps.newConcurrentMap();
   private final Set<SetDelegateEventListener<E>> eventListeners = Sets.newCopyOnWriteArraySet();
 
-  public CrdtSetDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
+  public CrdtSetDelegate(String name, Serializer serializer, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
     this.clusterCommunicator = managementService.getCommunicationService();
     this.executorService = managementService.getExecutorService();
-    this.elementSerializer = config.getSerializer();
+    this.elementSerializer = serializer;
     this.timestampProvider = config.getTimestampProvider();
     this.subject = String.format("atomix-crdt-set-%s", name);
     clusterCommunicator.subscribe(subject, SERIALIZER::decode, this::updateElements, executorService);

--- a/protocols/gossip/src/main/java/io/atomix/protocols/gossip/value/CrdtValueDelegate.java
+++ b/protocols/gossip/src/main/java/io/atomix/protocols/gossip/value/CrdtValueDelegate.java
@@ -56,10 +56,10 @@ public class CrdtValueDelegate<V> implements ValueDelegate<V> {
   private final AtomicReference<Value> currentValue = new AtomicReference<>();
   private final Set<ValueDelegateEventListener<V>> eventListeners = Sets.newCopyOnWriteArraySet();
 
-  public CrdtValueDelegate(String name, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
+  public CrdtValueDelegate(String name, Serializer serializer, CrdtProtocolConfig config, PrimitiveManagementService managementService) {
     this.clusterEventService = managementService.getEventService();
     this.executorService = managementService.getExecutorService();
-    this.valueSerializer = config.getSerializer();
+    this.valueSerializer = serializer;
     this.timestampProvider = config.getTimestampProvider();
     this.subject = String.format("atomix-crdt-value-%s", name);
     subscribeFuture = clusterEventService.subscribe(subject, SERIALIZER::decode, this::updateValue, executorService);

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -24,7 +24,6 @@ import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionClient;
 import io.atomix.protocols.backup.partition.PrimaryBackupPartition;
-import io.atomix.utils.serializer.Serializer;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -101,11 +100,6 @@ public class MultiPrimaryProtocol implements ProxyProtocol {
   @Override
   public String group() {
     return config.getGroup();
-  }
-
-  @Override
-  public Serializer serializer() {
-    return config.getSerializer();
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/MultiRaftProtocol.java
@@ -24,7 +24,6 @@ import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionClient;
 import io.atomix.protocols.raft.partition.RaftPartition;
-import io.atomix.utils.serializer.Serializer;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -101,11 +100,6 @@ public class MultiRaftProtocol implements ProxyProtocol {
   @Override
   public String group() {
     return config.getGroup();
-  }
-
-  @Override
-  public Serializer serializer() {
-    return config.getSerializer();
   }
 
   @Override

--- a/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
@@ -34,12 +34,16 @@ import org.slf4j.Logger;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -179,6 +183,43 @@ public final class Namespace implements KryoFactory, KryoPool {
     public Builder register(Serializer<?> serializer, final Class<?>... classes) {
       types.add(Pair.of(classes, checkNotNull(serializer)));
       return this;
+    }
+
+    /**
+     * Registers all given types and their subtypes.
+     *
+     * @param classes the types to register
+     * @return this
+     */
+    public Builder registerSubTypes(final Class<?>... classes) {
+      for (Class<?> type : classes) {
+        register(type);
+        registerSubTypes(type);
+      }
+      return this;
+    }
+
+    /**
+     * Registers all subtypes of the given type.
+     *
+     * @param type the type for which to register subtypes
+     */
+    private void registerSubTypes(Class<?> type) {
+      getFields(type).forEach((fieldName, fieldType) -> register(fieldType));
+    }
+
+    private SortedMap<String, Class<?>> getFields(Class<?> type) {
+      if (type == Object.class) {
+        return new TreeMap<>();
+      }
+
+      SortedMap<String, Class<?>> fields = getFields(type.getSuperclass());
+      for (Field field : type.getDeclaredFields()) {
+        if (!Modifier.isTransient(field.getModifiers()) && field.getType() != Object.class) {
+          fields.put(field.getName(), field.getType());
+        }
+      }
+      return fields;
     }
 
     private Builder register(RegistrationBlock block) {


### PR DESCRIPTION
This PR adds `with*Type` methods to collection and map builders to facilitate registration of serializable types.