### PR TITLE
Ensure event listeners are called after cache update

### DIFF
--- a/core/src/main/java/io/atomix/core/collection/AsyncDistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/AsyncDistributedCollection.java
@@ -15,12 +15,14 @@
  */
 package io.atomix.core.collection;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import io.atomix.core.iterator.AsyncIterable;
 import io.atomix.primitive.AsyncPrimitive;
 
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Asynchronous distributed collection.
@@ -112,7 +114,19 @@ public interface AsyncDistributedCollection<E> extends AsyncPrimitive, AsyncIter
    * @param listener listener to notify about collection update events
    * @return CompletableFuture that is completed when the operation completes
    */
-  CompletableFuture<Void> addListener(CollectionEventListener<E> listener);
+  default CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
+    return addListener(listener, MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Registers the specified listener to be notified whenever
+   * the collection is updated.
+   *
+   * @param listener listener to notify about collection update events
+   * @param executor executor on which to call event listener
+   * @return CompletableFuture that is completed when the operation completes
+   */
+  CompletableFuture<Void> addListener(CollectionEventListener<E> listener, Executor executor);
 
   /**
    * Unregisters the specified listener.

--- a/core/src/main/java/io/atomix/core/collection/impl/AsyncDistributedJavaCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/AsyncDistributedJavaCollection.java
@@ -27,6 +27,7 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Asynchronous distributed Java-backed collection.
@@ -109,7 +110,7 @@ public class AsyncDistributedJavaCollection<E> implements AsyncDistributedCollec
   }
 
   @Override
-  public CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
+  public CompletableFuture<Void> addListener(CollectionEventListener<E> listener, Executor executor) {
     return CompletableFuture.completedFuture(null);
   }
 

--- a/core/src/main/java/io/atomix/core/collection/impl/DelegatingAsyncDistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/DelegatingAsyncDistributedCollection.java
@@ -24,6 +24,7 @@ import io.atomix.primitive.impl.DelegatingAsyncPrimitive;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Delegating distributed collection.
@@ -82,8 +83,8 @@ public class DelegatingAsyncDistributedCollection<E> extends DelegatingAsyncPrim
   }
 
   @Override
-  public CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
-    return delegateCollection.addListener(listener);
+  public CompletableFuture<Void> addListener(CollectionEventListener<E> listener, Executor executor) {
+    return delegateCollection.addListener(listener, executor);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/collection/impl/TranscodingAsyncDistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/TranscodingAsyncDistributedCollection.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -112,11 +113,11 @@ public class TranscodingAsyncDistributedCollection<E1, E2> extends DelegatingAsy
   }
 
   @Override
-  public CompletableFuture<Void> addListener(CollectionEventListener<E1> listener) {
+  public CompletableFuture<Void> addListener(CollectionEventListener<E1> listener, Executor executor) {
     synchronized (listeners) {
       InternalCollectionEventListener collectionListener =
           listeners.computeIfAbsent(listener, k -> new InternalCollectionEventListener(listener));
-      return backingCollection.addListener(collectionListener);
+      return backingCollection.addListener(collectionListener, executor);
     }
   }
 

--- a/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapProxy.java
@@ -341,7 +341,7 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Entry<K, Versioned<byte[]>>> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Entry<K, Versioned<byte[]>>> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -354,8 +354,10 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return AbstractAtomicMapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return AbstractAtomicMapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -488,7 +490,7 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<K> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<K> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -501,8 +503,10 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return AbstractAtomicMapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return AbstractAtomicMapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -692,7 +696,7 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Versioned<byte[]>> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Versioned<byte[]>> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -705,8 +709,10 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return AbstractAtomicMapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return AbstractAtomicMapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
@@ -464,7 +464,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<K> listener) {
+    public CompletableFuture<Void> addListener(CollectionEventListener<K> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -477,8 +477,10 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
             break;
         }
       };
-      listenerMap.put(listener, mapListener);
-      return AtomicNavigableMapProxy.this.addListener(mapListener);
+      if (listenerMap.putIfAbsent(listener, mapListener) == null) {
+        return AtomicNavigableMapProxy.this.addListener(mapListener);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -869,7 +871,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<K, Versioned<byte[]>>> listener) {
+    public CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<K, Versioned<byte[]>>> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> boundedListener = event -> {
         if (isInBounds(event.key())) {
           switch (event.type()) {
@@ -885,7 +887,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
         }
       };
       if (listenerMap.putIfAbsent(listener, boundedListener) == null) {
-        return AtomicNavigableMapProxy.this.addListener(boundedListener);
+        return AtomicNavigableMapProxy.this.addListener(boundedListener, executor);
       }
       return CompletableFuture.completedFuture(null);
     }
@@ -993,7 +995,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<Versioned<byte[]>> listener) {
+    public CompletableFuture<Void> addListener(CollectionEventListener<Versioned<byte[]>> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> boundedListener = event -> {
         if (isInBounds(event.key())) {
           switch (event.type()) {
@@ -1009,7 +1011,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
         }
       };
       if (listenerMap.putIfAbsent(listener, boundedListener) == null) {
-        return AtomicNavigableMapProxy.this.addListener(boundedListener);
+        return AtomicNavigableMapProxy.this.addListener(boundedListener, executor);
       }
       return CompletableFuture.completedFuture(null);
     }

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedMap.java
@@ -269,10 +269,10 @@ public class DelegatingAsyncDistributedMap<K, V> extends DelegatingAsyncPrimitiv
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<V> listener) {
+    public CompletableFuture<Void> addListener(CollectionEventListener<V> listener, Executor executor) {
       CollectionEventListener<Versioned<V>> atomicListener = new VersionedCollectionEventListener(listener);
       if (listenerMap.putIfAbsent(listener, atomicListener) == null) {
-        return values.addListener(atomicListener);
+        return values.addListener(atomicListener, executor);
       }
       return CompletableFuture.completedFuture(null);
     }
@@ -389,10 +389,10 @@ public class DelegatingAsyncDistributedMap<K, V> extends DelegatingAsyncPrimitiv
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<K, V>> listener) {
+    public CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<K, V>> listener, Executor executor) {
       CollectionEventListener<Map.Entry<K, Versioned<V>>> atomicListener = new VersionedCollectionEventListener(listener);
       if (listenerMap.putIfAbsent(listener, atomicListener) == null) {
-        return entries.addListener(atomicListener);
+        return entries.addListener(atomicListener, executor);
       }
       return CompletableFuture.completedFuture(null);
     }

--- a/core/src/main/java/io/atomix/core/map/impl/PartitionedAtomicMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/PartitionedAtomicMapProxy.java
@@ -379,7 +379,7 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<K, Versioned<byte[]>>> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<K, Versioned<byte[]>>> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -392,8 +392,10 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return PartitionedAtomicMapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return PartitionedAtomicMapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -525,7 +527,7 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<K> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<K> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -538,8 +540,10 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return PartitionedAtomicMapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return PartitionedAtomicMapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -733,7 +737,7 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Versioned<byte[]>> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Versioned<byte[]>> listener, Executor executor) {
       AtomicMapEventListener<K, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -746,8 +750,10 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return PartitionedAtomicMapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return PartitionedAtomicMapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
@@ -20,12 +20,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
 import io.atomix.core.collection.AsyncDistributedCollection;
-import io.atomix.core.iterator.AsyncIterator;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.core.collection.DistributedCollection;
 import io.atomix.core.collection.DistributedCollectionType;
 import io.atomix.core.collection.impl.BlockingDistributedCollection;
+import io.atomix.core.iterator.AsyncIterator;
 import io.atomix.core.iterator.impl.PartitionedProxyIterator;
 import io.atomix.core.map.AsyncDistributedMap;
 import io.atomix.core.map.DistributedMap;
@@ -463,7 +463,7 @@ public class AtomicMultimapProxy
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<String> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<String> listener, Executor executor) {
       AtomicMultimapEventListener<String, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -476,8 +476,10 @@ public class AtomicMultimapProxy
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return AtomicMultimapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return AtomicMultimapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -634,7 +636,7 @@ public class AtomicMultimapProxy
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<String> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<String> listener, Executor executor) {
       AtomicMultimapEventListener<String, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -647,8 +649,10 @@ public class AtomicMultimapProxy
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return AtomicMultimapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return AtomicMultimapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -786,7 +790,7 @@ public class AtomicMultimapProxy
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<byte[]> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<byte[]> listener, Executor executor) {
       AtomicMultimapEventListener<String, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -799,8 +803,10 @@ public class AtomicMultimapProxy
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return AtomicMultimapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return AtomicMultimapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -903,7 +909,7 @@ public class AtomicMultimapProxy
     }
 
     @Override
-    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<String, byte[]>> listener) {
+    public synchronized CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<String, byte[]>> listener, Executor executor) {
       AtomicMultimapEventListener<String, byte[]> mapListener = event -> {
         switch (event.type()) {
           case INSERT:
@@ -916,8 +922,10 @@ public class AtomicMultimapProxy
             break;
         }
       };
-      eventListeners.put(listener, mapListener);
-      return AtomicMultimapProxy.this.addListener(mapListener);
+      if (eventListeners.putIfAbsent(listener, mapListener) == null) {
+        return AtomicMultimapProxy.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/multiset/impl/DistributedMultisetProxy.java
+++ b/core/src/main/java/io/atomix/core/multiset/impl/DistributedMultisetProxy.java
@@ -16,9 +16,9 @@
 package io.atomix.core.multiset.impl;
 
 import com.google.common.collect.Multiset;
-import io.atomix.core.iterator.AsyncIterator;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.core.collection.impl.PartitionedDistributedCollectionProxy;
+import io.atomix.core.iterator.AsyncIterator;
 import io.atomix.core.iterator.impl.PartitionedProxyIterator;
 import io.atomix.core.multiset.AsyncDistributedMultiset;
 import io.atomix.core.multiset.DistributedMultiset;
@@ -37,6 +37,7 @@ import io.atomix.primitive.proxy.ProxyClient;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Distributed multiset proxy.
@@ -158,7 +159,7 @@ public class DistributedMultisetProxy
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<String> listener) {
+    public CompletableFuture<Void> addListener(CollectionEventListener<String> listener, Executor executor) {
       throw new UnsupportedOperationException();
     }
 
@@ -274,7 +275,7 @@ public class DistributedMultisetProxy
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<Multiset.Entry<String>> listener) {
+    public CompletableFuture<Void> addListener(CollectionEventListener<Multiset.Entry<String>> listener, Executor executor) {
       throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/io/atomix/core/set/impl/DescendingAsyncDistributedNavigableSet.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DescendingAsyncDistributedNavigableSet.java
@@ -29,6 +29,7 @@ import io.atomix.primitive.protocol.PrimitiveProtocol;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Descending navigable set.
@@ -186,8 +187,8 @@ public class DescendingAsyncDistributedNavigableSet<E extends Comparable<E>>
   }
 
   @Override
-  public CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
-    return delegate().addListener(listener);
+  public CompletableFuture<Void> addListener(CollectionEventListener<E> listener, Executor executor) {
+    return delegate().addListener(listener, executor);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/impl/DistributedNavigableSetProxy.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DistributedNavigableSetProxy.java
@@ -34,6 +34,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -378,8 +379,8 @@ public class DistributedNavigableSetProxy<E extends Comparable<E>>
     }
 
     @Override
-    public CompletableFuture<Void> addListener(CollectionEventListener<E> listener) {
-      return DistributedNavigableSetProxy.this.addListener(listener);
+    public CompletableFuture<Void> addListener(CollectionEventListener<E> listener, Executor executor) {
+      return DistributedNavigableSetProxy.this.addListener(listener, executor);
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/tree/AsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/AsyncAtomicDocumentTree.java
@@ -16,6 +16,7 @@
 
 package io.atomix.core.tree;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import io.atomix.primitive.AsyncPrimitive;
 import io.atomix.primitive.DistributedPrimitive;
 import io.atomix.utils.time.Versioned;
@@ -23,6 +24,7 @@ import io.atomix.utils.time.Versioned;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * A hierarchical <a href="https://en.wikipedia.org/wiki/Document_Object_Model">document tree</a> data structure.
@@ -131,7 +133,20 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * @param listener listener to be notified
    * @return a future that is completed when the operation completes
    */
-  CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V> listener);
+  default CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V> listener) {
+    return addListener(path, listener, MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Registers a listener to be notified when the subtree rooted at the specified path
+   * is modified.
+   *
+   * @param path     path to the node
+   * @param listener listener to be notified
+   * @param executor the executor with which to notify the event listener
+   * @return a future that is completed when the operation completes
+   */
+  CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V> listener, Executor executor);
 
   /**
    * Unregisters a previously added listener.
@@ -148,7 +163,18 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * @return a future that is completed when the operation completes
    */
   default CompletableFuture<Void> addListener(DocumentTreeEventListener<V> listener) {
-    return addListener(root(), listener);
+    return addListener(root(), listener, MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Registers a listener to be notified when the tree is modified.
+   *
+   * @param listener listener to be notified
+   * @param executor the executor with which to notify the event listener
+   * @return a future that is completed when the operation completes
+   */
+  default CompletableFuture<Void> addListener(DocumentTreeEventListener<V> listener, Executor executor) {
+    return addListener(root(), listener, executor);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
@@ -17,10 +17,9 @@
 package io.atomix.core.tree.impl;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.MoreExecutors;
 import io.atomix.core.tree.AsyncAtomicDocumentTree;
-import io.atomix.core.tree.DocumentPath;
 import io.atomix.core.tree.AtomicDocumentTree;
+import io.atomix.core.tree.DocumentPath;
 import io.atomix.core.tree.DocumentTreeEvent;
 import io.atomix.core.tree.DocumentTreeEventListener;
 import io.atomix.core.tree.IllegalDocumentModificationException;
@@ -156,10 +155,10 @@ public class AtomicDocumentTreeProxy
   }
 
   @Override
-  public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<byte[]> listener) {
+  public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<byte[]> listener, Executor executor) {
     checkNotNull(path);
     checkNotNull(listener);
-    InternalListener internalListener = new InternalListener(path, listener, MoreExecutors.directExecutor());
+    InternalListener internalListener = new InternalListener(path, listener, executor);
     // TODO: Support API that takes an executor
     if (!eventListeners.containsKey(listener)) {
       return getProxyClient().acceptBy(name(), service -> service.listen(path))

--- a/core/src/main/java/io/atomix/core/tree/impl/CachingAsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/CachingAsyncAtomicDocumentTree.java
@@ -18,16 +18,21 @@ package io.atomix.core.tree.impl;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.atomix.core.tree.AsyncAtomicDocumentTree;
-import io.atomix.core.tree.DocumentPath;
 import io.atomix.core.tree.AtomicDocumentTree;
+import io.atomix.core.tree.DocumentPath;
+import io.atomix.core.tree.DocumentTreeEvent;
 import io.atomix.core.tree.DocumentTreeEventListener;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.utils.time.Versioned;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 import static io.atomix.primitive.PrimitiveState.CLOSED;
@@ -44,6 +49,7 @@ public class CachingAsyncAtomicDocumentTree<V> extends DelegatingAsyncAtomicDocu
   private final LoadingCache<DocumentPath, CompletableFuture<Versioned<V>>> cache;
   private final DocumentTreeEventListener<V> cacheUpdater;
   private final Consumer<PrimitiveState> stateListener;
+  private final Map<DocumentTreeEventListener<V>, InternalListener<V>> eventListeners = new ConcurrentHashMap<>();
 
   /**
    * Default constructor.
@@ -71,6 +77,7 @@ public class CachingAsyncAtomicDocumentTree<V> extends DelegatingAsyncAtomicDocu
       } else {
         cache.put(event.path(), CompletableFuture.completedFuture(event.newValue().get()));
       }
+      eventListeners.values().forEach(listener -> listener.event(event));
     };
     stateListener = status -> {
       log.debug("{} status changed to {}", this.name(), status);
@@ -80,7 +87,7 @@ public class CachingAsyncAtomicDocumentTree<V> extends DelegatingAsyncAtomicDocu
         cache.invalidateAll();
       }
     };
-    super.addListener(cacheUpdater);
+    super.addListener(cacheUpdater, MoreExecutors.directExecutor());
     super.addStateChangeListener(stateListener);
   }
 
@@ -134,7 +141,32 @@ public class CachingAsyncAtomicDocumentTree<V> extends DelegatingAsyncAtomicDocu
   }
 
   @Override
+  public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V> listener, Executor executor) {
+    eventListeners.put(listener, new InternalListener<>(path, listener, executor));
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
   public AtomicDocumentTree<V> sync(Duration operationTimeout) {
     return new BlockingAtomicDocumentTree<>(this, operationTimeout.toMillis());
+  }
+
+  private static class InternalListener<V> implements DocumentTreeEventListener<V> {
+    private final DocumentPath path;
+    private final DocumentTreeEventListener<V> listener;
+    private final Executor executor;
+
+    public InternalListener(DocumentPath path, DocumentTreeEventListener<V> listener, Executor executor) {
+      this.path = path;
+      this.listener = listener;
+      this.executor = executor;
+    }
+
+    @Override
+    public void event(DocumentTreeEvent<V> event) {
+      if (event.path().isDescendentOf(path)) {
+        executor.execute(() -> listener.event(event));
+      }
+    }
   }
 }

--- a/core/src/main/java/io/atomix/core/tree/impl/DelegatingAsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DelegatingAsyncAtomicDocumentTree.java
@@ -26,6 +26,7 @@ import io.atomix.utils.time.Versioned;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Document tree that delegates to an underlying instance.
@@ -84,8 +85,8 @@ public class DelegatingAsyncAtomicDocumentTree<V> extends DelegatingAsyncPrimiti
   }
 
   @Override
-  public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V> listener) {
-    return delegateTree.addListener(path, listener);
+  public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V> listener, Executor executor) {
+    return delegateTree.addListener(path, listener, executor);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/TranscodingAsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/TranscodingAsyncAtomicDocumentTree.java
@@ -27,6 +27,7 @@ import io.atomix.utils.time.Versioned;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -95,11 +96,11 @@ public class TranscodingAsyncAtomicDocumentTree<V1, V2> extends DelegatingAsyncP
   }
 
   @Override
-  public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V1> listener) {
+  public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<V1> listener, Executor executor) {
     synchronized (listeners) {
       InternalDocumentTreeListener internalListener =
           listeners.computeIfAbsent(listener, k -> new InternalDocumentTreeListener(listener));
-      return backingTree.addListener(path, internalListener);
+      return backingTree.addListener(path, internalListener, executor);
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in cached primitives wherein event listeners can be called before the cache has been updated. It intercepts added listeners at the cache layer and calls them only after events update the cache. This is a bug that was discovered in ONOS.