### PR TITLE
Add primitive getter and builder tests

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -93,6 +93,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Atomix!
@@ -342,6 +343,7 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
 
   @Override
   public TransactionBuilder transactionBuilder(String name) {
+    checkRunning();
     return primitives.transactionBuilder(name);
   }
 
@@ -349,178 +351,220 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
   public <B extends PrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends SyncPrimitive> B primitiveBuilder(
       String name,
       PrimitiveType<B, C, P> primitiveType) {
+    checkRunning();
     return primitives.primitiveBuilder(name, primitiveType);
   }
 
   @Override
   public <K, V> DistributedMap<K, V> getMap(String name) {
+    checkRunning();
     return primitives.getMap(name);
   }
 
   @Override
   public <K extends Comparable<K>, V> DistributedSortedMap<K, V> getSortedMap(String name) {
+    checkRunning();
     return primitives.getSortedMap(name);
   }
 
   @Override
   public <K extends Comparable<K>, V> DistributedNavigableMap<K, V> getNavigableMap(String name) {
+    checkRunning();
     return primitives.getNavigableMap(name);
   }
 
   @Override
   public <K, V> DistributedMultimap<K, V> getMultimap(String name) {
+    checkRunning();
     return primitives.getMultimap(name);
   }
 
   @Override
   public <K, V> AtomicMap<K, V> getAtomicMap(String name) {
+    checkRunning();
     return primitives.getAtomicMap(name);
   }
 
   @Override
   public <V> AtomicDocumentTree<V> getAtomicDocumentTree(String name) {
+    checkRunning();
     return primitives.getAtomicDocumentTree(name);
   }
 
   @Override
   public <K extends Comparable<K>, V> AtomicSortedMap<K, V> getAtomicSortedMap(String name) {
+    checkRunning();
     return primitives.getAtomicSortedMap(name);
   }
 
   @Override
   public <K extends Comparable<K>, V> AtomicNavigableMap<K, V> getAtomicNavigableMap(String name) {
+    checkRunning();
     return primitives.getAtomicNavigableMap(name);
   }
 
   @Override
   public <K, V> AtomicMultimap<K, V> getAtomicMultimap(String name) {
+    checkRunning();
     return primitives.getAtomicMultimap(name);
   }
 
   @Override
   public <K> AtomicCounterMap<K> getAtomicCounterMap(String name) {
+    checkRunning();
     return primitives.getAtomicCounterMap(name);
   }
 
   @Override
   public <E> DistributedSet<E> getSet(String name) {
+    checkRunning();
     return primitives.getSet(name);
   }
 
   @Override
   public <E extends Comparable<E>> DistributedSortedSet<E> getSortedSet(String name) {
+    checkRunning();
     return primitives.getSortedSet(name);
   }
 
   @Override
   public <E extends Comparable<E>> DistributedNavigableSet<E> getNavigableSet(String name) {
+    checkRunning();
     return primitives.getNavigableSet(name);
   }
 
   @Override
   public <E> DistributedQueue<E> getQueue(String name) {
+    checkRunning();
     return primitives.getQueue(name);
   }
 
   @Override
   public <E> DistributedList<E> getList(String name) {
+    checkRunning();
     return primitives.getList(name);
   }
 
   @Override
   public <E> DistributedMultiset<E> getMultiset(String name) {
+    checkRunning();
     return primitives.getMultiset(name);
   }
 
   @Override
   public DistributedCounter getCounter(String name) {
+    checkRunning();
     return primitives.getCounter(name);
   }
 
   @Override
   public AtomicCounter getAtomicCounter(String name) {
+    checkRunning();
     return primitives.getAtomicCounter(name);
   }
 
   @Override
   public AtomicIdGenerator getAtomicIdGenerator(String name) {
+    checkRunning();
     return primitives.getAtomicIdGenerator(name);
   }
 
   @Override
   public <V> DistributedValue<V> getValue(String name) {
+    checkRunning();
     return primitives.getValue(name);
   }
 
   @Override
   public <V> AtomicValue<V> getAtomicValue(String name) {
+    checkRunning();
     return primitives.getAtomicValue(name);
   }
 
   @Override
   public <T> LeaderElection<T> getLeaderElection(String name) {
+    checkRunning();
     return primitives.getLeaderElection(name);
   }
 
   @Override
   public <T> LeaderElector<T> getLeaderElector(String name) {
+    checkRunning();
     return primitives.getLeaderElector(name);
   }
 
   @Override
   public DistributedLock getLock(String name) {
+    checkRunning();
     return primitives.getLock(name);
   }
 
   @Override
   public AtomicLock getAtomicLock(String name) {
+    checkRunning();
     return primitives.getAtomicLock(name);
   }
 
   @Override
   public DistributedCyclicBarrier getCyclicBarrier(String name) {
+    checkRunning();
     return primitives.getCyclicBarrier(name);
   }
 
   @Override
   public DistributedSemaphore getSemaphore(String name) {
+    checkRunning();
     return primitives.getSemaphore(name);
   }
 
   @Override
   public AtomicSemaphore getAtomicSemaphore(String name) {
+    checkRunning();
     return primitives.getAtomicSemaphore(name);
   }
 
   @Override
   public <E> WorkQueue<E> getWorkQueue(String name) {
+    checkRunning();
     return primitives.getWorkQueue(name);
   }
 
   @Override
   public <P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(String name) {
+    checkRunning();
     return primitives.getPrimitiveAsync(name);
   }
 
   @Override
   public <P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(String name, PrimitiveType<?, ?, P> primitiveType) {
+    checkRunning();
     return primitives.getPrimitiveAsync(name, primitiveType);
   }
 
   @Override
   public <C extends PrimitiveConfig<C>, P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(
       String name, PrimitiveType<?, C, P> primitiveType, C primitiveConfig) {
+    checkRunning();
     return primitives.getPrimitiveAsync(name, primitiveType, primitiveConfig);
   }
 
   @Override
   public Collection<PrimitiveInfo> getPrimitives() {
+    checkRunning();
     return primitives.getPrimitives();
   }
 
   @Override
   public Collection<PrimitiveInfo> getPrimitives(PrimitiveType primitiveType) {
+    checkRunning();
     return primitives.getPrimitives(primitiveType);
+  }
+
+  /**
+   * Checks that the instance is running.
+   */
+  private void checkRunning() {
+    checkState(isRunning(), "Atomix instance is not running");
   }
 
   /**

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -326,9 +326,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
       if (primitiveConfig == null) {
         primitiveConfig = info.type().newConfig();
       }
-      return info.type().newBuilder(name, primitiveConfig, managementService)
-          .buildAsync()
-          .thenApply(primitive -> ((SyncPrimitive) primitive).async());
+      return info.type().newBuilder(name, primitiveConfig, managementService).buildAsync();
     });
   }
 
@@ -350,9 +348,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
           config = primitiveType.newConfig();
         }
       }
-      return primitiveType.newBuilder(name, config, managementService)
-          .buildAsync()
-          .thenApply(primitive -> ((SyncPrimitive) primitive).async());
+      return primitiveType.newBuilder(name, config, managementService).buildAsync();
     });
   }
 

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -319,7 +319,11 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
     return cache.getPrimitive(name, () -> {
       PrimitiveInfo info = primitiveRegistry.getPrimitive(name);
       if (info == null) {
-        return CompletableFuture.completedFuture(null);
+        PrimitiveConfig<?> primitiveConfig = configService.getConfig(name);
+        if (primitiveConfig == null) {
+          return CompletableFuture.completedFuture(null);
+        }
+        return primitiveConfig.getType().newBuilder(name, primitiveConfig, managementService).buildAsync();
       }
 
       PrimitiveConfig primitiveConfig = configService.getConfig(name);

--- a/core/src/main/java/io/atomix/core/map/AtomicSortedMapType.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicSortedMapType.java
@@ -30,7 +30,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  */
 public class AtomicSortedMapType<K extends Comparable<K>, V>
     implements PrimitiveType<AtomicSortedMapBuilder<K, V>, AtomicSortedMapConfig, AtomicSortedMap<K, V>> {
-  private static final String NAME = "atomic-sortedf-map";
+  private static final String NAME = "atomic-sorted-map";
   private static final AtomicSortedMapType INSTANCE = new AtomicSortedMapType();
 
   /**

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedNavigableMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedNavigableMap.java
@@ -19,7 +19,9 @@ import com.google.common.collect.Maps;
 import io.atomix.core.map.AsyncAtomicNavigableMap;
 import io.atomix.core.map.AsyncDistributedNavigableMap;
 import io.atomix.core.map.DistributedNavigableMap;
+import io.atomix.core.map.DistributedNavigableMapType;
 import io.atomix.core.set.AsyncDistributedNavigableSet;
+import io.atomix.primitive.PrimitiveType;
 import io.atomix.utils.time.Versioned;
 
 import java.time.Duration;
@@ -29,7 +31,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Delegating asynchronous distributed navigable map.
  */
-public class DelegatingAsyncDistributedNavigableMap<K extends Comparable<K>, V> extends DelegatingAsyncDistributedSortedMap<K, V> implements AsyncDistributedNavigableMap<K, V> {
+public class DelegatingAsyncDistributedNavigableMap<K extends Comparable<K>, V>
+    extends DelegatingAsyncDistributedSortedMap<K, V> implements AsyncDistributedNavigableMap<K, V> {
   private final AsyncAtomicNavigableMap<K, V> atomicMap;
 
   public DelegatingAsyncDistributedNavigableMap(AsyncAtomicNavigableMap<K, V> atomicMap) {
@@ -39,6 +42,11 @@ public class DelegatingAsyncDistributedNavigableMap<K extends Comparable<K>, V> 
 
   private Map.Entry<K, V> convertEntry(Map.Entry<K, Versioned<V>> entry) {
     return entry == null ? null : Maps.immutableEntry(entry.getKey(), Versioned.valueOrNull(entry.getValue()));
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return DistributedNavigableMapType.instance();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedSortedMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedSortedMap.java
@@ -18,6 +18,8 @@ package io.atomix.core.map.impl;
 import io.atomix.core.map.AsyncAtomicSortedMap;
 import io.atomix.core.map.AsyncDistributedSortedMap;
 import io.atomix.core.map.DistributedSortedMap;
+import io.atomix.core.map.DistributedSortedMapType;
+import io.atomix.primitive.PrimitiveType;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -31,6 +33,11 @@ public class DelegatingAsyncDistributedSortedMap<K extends Comparable<K>, V> ext
   public DelegatingAsyncDistributedSortedMap(AsyncAtomicSortedMap<K, V> atomicMap) {
     super(atomicMap);
     this.atomicMap = atomicMap;
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return DistributedSortedMapType.instance();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/multimap/DistributedMultimapConfig.java
+++ b/core/src/main/java/io/atomix/core/multimap/DistributedMultimapConfig.java
@@ -24,6 +24,6 @@ import io.atomix.primitive.PrimitiveType;
 public class DistributedMultimapConfig extends CachedPrimitiveConfig<DistributedMultimapConfig> {
   @Override
   public PrimitiveType getType() {
-    return AtomicMultimapType.instance();
+    return DistributedMultimapType.instance();
   }
 }

--- a/core/src/main/java/io/atomix/core/multimap/impl/DelegatingAsyncDistributedMultimap.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/DelegatingAsyncDistributedMultimap.java
@@ -24,10 +24,12 @@ import io.atomix.core.multimap.AsyncDistributedMultimap;
 import io.atomix.core.multimap.AtomicMultimapEvent;
 import io.atomix.core.multimap.AtomicMultimapEventListener;
 import io.atomix.core.multimap.DistributedMultimap;
+import io.atomix.core.multimap.DistributedMultimapType;
 import io.atomix.core.multimap.MultimapEvent;
 import io.atomix.core.multimap.MultimapEventListener;
 import io.atomix.core.multiset.AsyncDistributedMultiset;
 import io.atomix.core.set.AsyncDistributedSet;
+import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.impl.DelegatingAsyncPrimitive;
 import io.atomix.utils.time.Versioned;
 
@@ -47,6 +49,11 @@ public class DelegatingAsyncDistributedMultimap<K, V> extends DelegatingAsyncPri
   public DelegatingAsyncDistributedMultimap(AsyncAtomicMultimap<K, V> atomicMultimap) {
     super(atomicMultimap);
     this.atomicMultimap = atomicMultimap;
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return DistributedMultimapType.instance();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/semaphore/DistributedSemaphoreConfig.java
+++ b/core/src/main/java/io/atomix/core/semaphore/DistributedSemaphoreConfig.java
@@ -26,7 +26,7 @@ public class DistributedSemaphoreConfig extends PrimitiveConfig<DistributedSemap
 
   @Override
   public PrimitiveType getType() {
-    return AtomicSemaphoreType.instance();
+    return DistributedSemaphoreType.instance();
   }
 
   /**

--- a/core/src/main/java/io/atomix/core/semaphore/impl/DelegatingAsyncDistributedSemaphore.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/DelegatingAsyncDistributedSemaphore.java
@@ -18,7 +18,9 @@ package io.atomix.core.semaphore.impl;
 import io.atomix.core.semaphore.AsyncAtomicSemaphore;
 import io.atomix.core.semaphore.AsyncDistributedSemaphore;
 import io.atomix.core.semaphore.DistributedSemaphore;
+import io.atomix.core.semaphore.DistributedSemaphoreType;
 import io.atomix.core.semaphore.QueueStatus;
+import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.impl.DelegatingAsyncPrimitive;
 
 import java.time.Duration;
@@ -31,6 +33,11 @@ import java.util.concurrent.CompletableFuture;
 public class DelegatingAsyncDistributedSemaphore extends DelegatingAsyncPrimitive<AsyncAtomicSemaphore> implements AsyncDistributedSemaphore {
   public DelegatingAsyncDistributedSemaphore(AsyncAtomicSemaphore primitive) {
     super(primitive);
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return DistributedSemaphoreType.instance();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/DistributedSortedSetConfig.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSortedSetConfig.java
@@ -24,6 +24,6 @@ import io.atomix.primitive.PrimitiveType;
 public class DistributedSortedSetConfig extends DistributedCollectionConfig<DistributedSortedSetConfig> {
   @Override
   public PrimitiveType getType() {
-    return DistributedNavigableSetType.instance();
+    return DistributedSortedSetType.instance();
   }
 }

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -18,7 +18,36 @@ package io.atomix.core;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.Member;
+import io.atomix.core.barrier.DistributedCyclicBarrierType;
+import io.atomix.core.counter.AtomicCounterType;
+import io.atomix.core.counter.DistributedCounterType;
+import io.atomix.core.election.LeaderElectionType;
+import io.atomix.core.election.LeaderElectorType;
+import io.atomix.core.idgenerator.AtomicIdGeneratorType;
+import io.atomix.core.list.DistributedListType;
+import io.atomix.core.lock.AtomicLockType;
+import io.atomix.core.lock.DistributedLockType;
+import io.atomix.core.map.AtomicCounterMapType;
+import io.atomix.core.map.AtomicMapType;
+import io.atomix.core.map.AtomicNavigableMapType;
+import io.atomix.core.map.AtomicSortedMapType;
+import io.atomix.core.map.DistributedMapType;
+import io.atomix.core.map.DistributedNavigableMapType;
+import io.atomix.core.map.DistributedSortedMapType;
+import io.atomix.core.multimap.AtomicMultimapType;
+import io.atomix.core.multimap.DistributedMultimapType;
+import io.atomix.core.multiset.DistributedMultisetType;
 import io.atomix.core.profile.Profile;
+import io.atomix.core.queue.DistributedQueueType;
+import io.atomix.core.semaphore.AtomicSemaphoreType;
+import io.atomix.core.semaphore.DistributedSemaphoreType;
+import io.atomix.core.set.DistributedNavigableSetType;
+import io.atomix.core.set.DistributedSetType;
+import io.atomix.core.set.DistributedSortedSetType;
+import io.atomix.core.tree.AtomicDocumentTreeType;
+import io.atomix.core.value.AtomicValueType;
+import io.atomix.core.value.DistributedValueType;
+import io.atomix.core.workqueue.WorkQueueType;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.net.Address;
 import org.junit.After;
@@ -40,6 +69,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -296,6 +326,133 @@ public class AtomixTest extends AbstractAtomixTest {
     assertNotNull(member.properties());
     assertEquals(1, member.properties().size());
     assertEquals("a-value", member.properties().get("a-key"));
+  }
+
+  @Test
+  public void testPrimitiveGetters() throws Exception {
+    List<CompletableFuture<Atomix>> futures = new ArrayList<>();
+    futures.add(startAtomix(1, Arrays.asList(1, 2, 3), Profile.consensus("1", "2", "3")));
+    futures.add(startAtomix(2, Arrays.asList(1, 2, 3), Profile.consensus("1", "2", "3")));
+    futures.add(startAtomix(3, Arrays.asList(1, 2, 3), Profile.consensus("1", "2", "3")));
+    Futures.allOf(futures).get(30, TimeUnit.SECONDS);
+
+    Atomix atomix = startAtomix(4, Arrays.asList(1, 2, 3), Profile.client()).get(30, TimeUnit.SECONDS);
+
+    assertEquals("a", atomix.getAtomicCounter("a").name());
+    assertEquals(AtomicCounterType.instance(), atomix.getAtomicCounter("a").type());
+    assertSame(atomix.getAtomicCounter("a"), atomix.getAtomicCounter("a"));
+
+    assertEquals("b", atomix.getAtomicMap("b").name());
+    assertEquals(AtomicMapType.instance(), atomix.getAtomicMap("b").type());
+    assertSame(atomix.getAtomicMap("b"), atomix.getAtomicMap("b"));
+
+    assertEquals("c", atomix.getAtomicCounterMap("c").name());
+    assertEquals(AtomicCounterMapType.instance(), atomix.getAtomicCounterMap("c").type());
+    assertSame(atomix.getAtomicCounterMap("c"), atomix.getAtomicCounterMap("c"));
+
+    assertEquals("d", atomix.getAtomicDocumentTree("d").name());
+    assertEquals(AtomicDocumentTreeType.instance(), atomix.getAtomicDocumentTree("d").type());
+    assertSame(atomix.getAtomicDocumentTree("d"), atomix.getAtomicDocumentTree("d"));
+
+    assertEquals("e", atomix.getAtomicIdGenerator("e").name());
+    assertEquals(AtomicIdGeneratorType.instance(), atomix.getAtomicIdGenerator("e").type());
+    assertSame(atomix.getAtomicIdGenerator("e"), atomix.getAtomicIdGenerator("e"));
+
+    assertEquals("f", atomix.getAtomicLock("f").name());
+    assertEquals(AtomicLockType.instance(), atomix.getAtomicLock("f").type());
+    assertSame(atomix.getAtomicLock("f"), atomix.getAtomicLock("f"));
+
+    assertEquals("g", atomix.getAtomicMultimap("g").name());
+    assertEquals(AtomicMultimapType.instance(), atomix.getAtomicMultimap("g").type());
+    assertSame(atomix.getAtomicMultimap("g"), atomix.getAtomicMultimap("g"));
+
+    assertEquals("h", atomix.getAtomicNavigableMap("h").name());
+    assertEquals(AtomicNavigableMapType.instance(), atomix.getAtomicNavigableMap("h").type());
+    assertSame(atomix.getAtomicNavigableMap("h"), atomix.getAtomicNavigableMap("h"));
+
+    assertEquals("i", atomix.getAtomicSemaphore("i").name());
+    assertEquals(AtomicSemaphoreType.instance(), atomix.getAtomicSemaphore("i").type());
+    assertSame(atomix.getAtomicSemaphore("i"), atomix.getAtomicSemaphore("i"));
+
+    assertEquals("j", atomix.getAtomicSortedMap("j").name());
+    assertEquals(AtomicSortedMapType.instance(), atomix.getAtomicSortedMap("j").type());
+    assertSame(atomix.getAtomicSortedMap("j"), atomix.getAtomicSortedMap("j"));
+
+    assertEquals("k", atomix.getAtomicValue("k").name());
+    assertEquals(AtomicValueType.instance(), atomix.getAtomicValue("k").type());
+    assertSame(atomix.getAtomicValue("k"), atomix.getAtomicValue("k"));
+
+    assertEquals("l", atomix.getCounter("l").name());
+    assertEquals(DistributedCounterType.instance(), atomix.getCounter("l").type());
+    assertSame(atomix.getCounter("l"), atomix.getCounter("l"));
+
+    assertEquals("m", atomix.getCyclicBarrier("m").name());
+    assertEquals(DistributedCyclicBarrierType.instance(), atomix.getCyclicBarrier("m").type());
+    assertSame(atomix.getCyclicBarrier("m"), atomix.getCyclicBarrier("m"));
+
+    assertEquals("n", atomix.getLeaderElection("n").name());
+    assertEquals(LeaderElectionType.instance(), atomix.getLeaderElection("n").type());
+    assertSame(atomix.getLeaderElection("n"), atomix.getLeaderElection("n"));
+
+    assertEquals("o", atomix.getLeaderElector("o").name());
+    assertEquals(LeaderElectorType.instance(), atomix.getLeaderElector("o").type());
+    assertSame(atomix.getLeaderElector("o"), atomix.getLeaderElector("o"));
+
+    assertEquals("p", atomix.getList("p").name());
+    assertEquals(DistributedListType.instance(), atomix.getList("p").type());
+    assertSame(atomix.getList("p"), atomix.getList("p"));
+
+    assertEquals("q", atomix.getLock("q").name());
+    assertEquals(DistributedLockType.instance(), atomix.getLock("q").type());
+    assertSame(atomix.getLock("q"), atomix.getLock("q"));
+
+    assertEquals("r", atomix.getMap("r").name());
+    assertEquals(DistributedMapType.instance(), atomix.getMap("r").type());
+    assertSame(atomix.getMap("r"), atomix.getMap("r"));
+
+    assertEquals("s", atomix.getMultimap("s").name());
+    assertEquals(DistributedMultimapType.instance(), atomix.getMultimap("s").type());
+    assertSame(atomix.getMultimap("s"), atomix.getMultimap("s"));
+
+    assertEquals("t", atomix.getMultiset("t").name());
+    assertEquals(DistributedMultisetType.instance(), atomix.getMultiset("t").type());
+    assertSame(atomix.getMultiset("t"), atomix.getMultiset("t"));
+
+    assertEquals("u", atomix.getNavigableMap("u").name());
+    assertEquals(DistributedNavigableMapType.instance(), atomix.getNavigableMap("u").type());
+    assertSame(atomix.getNavigableMap("u"), atomix.getNavigableMap("u"));
+
+    assertEquals("v", atomix.getNavigableSet("v").name());
+    assertEquals(DistributedNavigableSetType.instance(), atomix.getNavigableSet("v").type());
+    assertSame(atomix.getNavigableSet("v"), atomix.getNavigableSet("v"));
+
+    assertEquals("w", atomix.getQueue("w").name());
+    assertEquals(DistributedQueueType.instance(), atomix.getQueue("w").type());
+    assertSame(atomix.getQueue("w"), atomix.getQueue("w"));
+
+    assertEquals("x", atomix.getSemaphore("x").name());
+    assertEquals(DistributedSemaphoreType.instance(), atomix.getSemaphore("x").type());
+    assertSame(atomix.getSemaphore("x"), atomix.getSemaphore("x"));
+
+    assertEquals("y", atomix.getSet("y").name());
+    assertEquals(DistributedSetType.instance(), atomix.getSet("y").type());
+    assertSame(atomix.getSet("y"), atomix.getSet("y"));
+
+    assertEquals("z", atomix.getSortedMap("z").name());
+    assertEquals(DistributedSortedMapType.instance(), atomix.getSortedMap("z").type());
+    assertSame(atomix.getSortedMap("z"), atomix.getSortedMap("z"));
+
+    assertEquals("aa", atomix.getSortedSet("aa").name());
+    assertEquals(DistributedSortedSetType.instance(), atomix.getSortedSet("aa").type());
+    assertSame(atomix.getSortedSet("aa"), atomix.getSortedSet("aa"));
+
+    assertEquals("bb", atomix.getValue("bb").name());
+    assertEquals(DistributedValueType.instance(), atomix.getValue("bb").type());
+    assertSame(atomix.getValue("bb"), atomix.getValue("bb"));
+
+    assertEquals("cc", atomix.getWorkQueue("cc").name());
+    assertEquals(WorkQueueType.instance(), atomix.getWorkQueue("cc").type());
+    assertSame(atomix.getWorkQueue("cc"), atomix.getWorkQueue("cc"));
   }
 
   private static class TestClusterMembershipEventListener implements ClusterMembershipEventListener {

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -455,6 +455,104 @@ public class AtomixTest extends AbstractAtomixTest {
     assertSame(atomix.getWorkQueue("cc"), atomix.getWorkQueue("cc"));
   }
 
+  @Test
+  public void testPrimitiveBuilders() throws Exception {
+    List<CompletableFuture<Atomix>> futures = new ArrayList<>();
+    futures.add(startAtomix(1, Arrays.asList(1, 2, 3), Profile.consensus("1", "2", "3")));
+    futures.add(startAtomix(2, Arrays.asList(1, 2, 3), Profile.consensus("1", "2", "3")));
+    futures.add(startAtomix(3, Arrays.asList(1, 2, 3), Profile.consensus("1", "2", "3")));
+    Futures.allOf(futures).get(30, TimeUnit.SECONDS);
+
+    Atomix atomix = startAtomix(4, Arrays.asList(1, 2, 3), Profile.client()).get(30, TimeUnit.SECONDS);
+
+    assertEquals("a", atomix.atomicCounterBuilder("a").build().name());
+    assertEquals(AtomicCounterType.instance(), atomix.atomicCounterBuilder("a").build().type());
+
+    assertEquals("b", atomix.atomicMapBuilder("b").build().name());
+    assertEquals(AtomicMapType.instance(), atomix.atomicMapBuilder("b").build().type());
+
+    assertEquals("c", atomix.atomicCounterMapBuilder("c").build().name());
+    assertEquals(AtomicCounterMapType.instance(), atomix.atomicCounterMapBuilder("c").build().type());
+
+    assertEquals("d", atomix.atomicDocumentTreeBuilder("d").build().name());
+    assertEquals(AtomicDocumentTreeType.instance(), atomix.atomicDocumentTreeBuilder("d").build().type());
+
+    assertEquals("e", atomix.atomicIdGeneratorBuilder("e").build().name());
+    assertEquals(AtomicIdGeneratorType.instance(), atomix.atomicIdGeneratorBuilder("e").build().type());
+
+    assertEquals("f", atomix.atomicLockBuilder("f").build().name());
+    assertEquals(AtomicLockType.instance(), atomix.atomicLockBuilder("f").build().type());
+
+    assertEquals("g", atomix.atomicMultimapBuilder("g").build().name());
+    assertEquals(AtomicMultimapType.instance(), atomix.atomicMultimapBuilder("g").build().type());
+
+    assertEquals("h", atomix.atomicNavigableMapBuilder("h").build().name());
+    assertEquals(AtomicNavigableMapType.instance(), atomix.atomicNavigableMapBuilder("h").build().type());
+
+    assertEquals("i", atomix.atomicSemaphoreBuilder("i").build().name());
+    assertEquals(AtomicSemaphoreType.instance(), atomix.atomicSemaphoreBuilder("i").build().type());
+
+    assertEquals("j", atomix.atomicSortedMapBuilder("j").build().name());
+    assertEquals(AtomicSortedMapType.instance(), atomix.atomicSortedMapBuilder("j").build().type());
+
+    assertEquals("k", atomix.atomicValueBuilder("k").build().name());
+    assertEquals(AtomicValueType.instance(), atomix.atomicValueBuilder("k").build().type());
+
+    assertEquals("l", atomix.counterBuilder("l").build().name());
+    assertEquals(DistributedCounterType.instance(), atomix.counterBuilder("l").build().type());
+
+    assertEquals("m", atomix.cyclicBarrierBuilder("m").build().name());
+    assertEquals(DistributedCyclicBarrierType.instance(), atomix.cyclicBarrierBuilder("m").build().type());
+
+    assertEquals("n", atomix.leaderElectionBuilder("n").build().name());
+    assertEquals(LeaderElectionType.instance(), atomix.leaderElectionBuilder("n").build().type());
+
+    assertEquals("o", atomix.leaderElectorBuilder("o").build().name());
+    assertEquals(LeaderElectorType.instance(), atomix.leaderElectorBuilder("o").build().type());
+
+    assertEquals("p", atomix.listBuilder("p").build().name());
+    assertEquals(DistributedListType.instance(), atomix.listBuilder("p").build().type());
+
+    assertEquals("q", atomix.lockBuilder("q").build().name());
+    assertEquals(DistributedLockType.instance(), atomix.lockBuilder("q").build().type());
+
+    assertEquals("r", atomix.mapBuilder("r").build().name());
+    assertEquals(DistributedMapType.instance(), atomix.mapBuilder("r").build().type());
+
+    assertEquals("s", atomix.multimapBuilder("s").build().name());
+    assertEquals(DistributedMultimapType.instance(), atomix.multimapBuilder("s").build().type());
+
+    assertEquals("t", atomix.multisetBuilder("t").build().name());
+    assertEquals(DistributedMultisetType.instance(), atomix.multisetBuilder("t").build().type());
+
+    assertEquals("u", atomix.navigableMapBuilder("u").build().name());
+    assertEquals(DistributedNavigableMapType.instance(), atomix.navigableMapBuilder("u").build().type());
+
+    assertEquals("v", atomix.navigableSetBuilder("v").build().name());
+    assertEquals(DistributedNavigableSetType.instance(), atomix.navigableSetBuilder("v").build().type());
+
+    assertEquals("w", atomix.queueBuilder("w").build().name());
+    assertEquals(DistributedQueueType.instance(), atomix.queueBuilder("w").build().type());
+
+    assertEquals("x", atomix.semaphoreBuilder("x").build().name());
+    assertEquals(DistributedSemaphoreType.instance(), atomix.semaphoreBuilder("x").build().type());
+
+    assertEquals("y", atomix.setBuilder("y").build().name());
+    assertEquals(DistributedSetType.instance(), atomix.setBuilder("y").build().type());
+
+    assertEquals("z", atomix.sortedMapBuilder("z").build().name());
+    assertEquals(DistributedSortedMapType.instance(), atomix.sortedMapBuilder("z").build().type());
+
+    assertEquals("aa", atomix.sortedSetBuilder("aa").build().name());
+    assertEquals(DistributedSortedSetType.instance(), atomix.sortedSetBuilder("aa").build().type());
+
+    assertEquals("bb", atomix.valueBuilder("bb").build().name());
+    assertEquals(DistributedValueType.instance(), atomix.valueBuilder("bb").build().type());
+
+    assertEquals("cc", atomix.workQueueBuilder("cc").build().name());
+    assertEquals(WorkQueueType.instance(), atomix.workQueueBuilder("cc").build().type());
+  }
+
   private static class TestClusterMembershipEventListener implements ClusterMembershipEventListener {
     private final BlockingQueue<ClusterMembershipEvent> queue = new LinkedBlockingQueue<>();
 

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -479,90 +479,119 @@ public class AtomixTest extends AbstractAtomixTest {
 
     atomix.start().get(30, TimeUnit.SECONDS);
 
+    assertEquals(AtomicCounterType.instance(), atomix.getPrimitive("atomic-counter").type());
     assertEquals("atomic-counter", atomix.getAtomicCounter("atomic-counter").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicCounter("atomic-counter").protocol()).group());
 
+    assertEquals(AtomicMapType.instance(), atomix.getPrimitive("atomic-map").type());
     assertEquals("atomic-map", atomix.getAtomicMap("atomic-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicMap("atomic-map").protocol()).group());
 
+    assertEquals(AtomicCounterMapType.instance(), atomix.getPrimitive("atomic-counter-map").type());
     assertEquals("atomic-counter-map", atomix.getAtomicCounterMap("atomic-counter-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicCounterMap("atomic-counter-map").protocol()).group());
 
+    assertEquals(AtomicDocumentTreeType.instance(), atomix.getPrimitive("atomic-document-tree").type());
     assertEquals("atomic-document-tree", atomix.getAtomicDocumentTree("atomic-document-tree").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicDocumentTree("atomic-document-tree").protocol()).group());
 
+    assertEquals(AtomicIdGeneratorType.instance(), atomix.getPrimitive("atomic-id-generator").type());
     assertEquals("atomic-id-generator", atomix.getAtomicIdGenerator("atomic-id-generator").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicIdGenerator("atomic-id-generator").protocol()).group());
 
+    assertEquals(AtomicLockType.instance(), atomix.getPrimitive("atomic-lock").type());
     assertEquals("atomic-lock", atomix.getAtomicLock("atomic-lock").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicLock("atomic-lock").protocol()).group());
 
+    assertEquals(AtomicMultimapType.instance(), atomix.getPrimitive("atomic-multimap").type());
     assertEquals("atomic-multimap", atomix.getAtomicMultimap("atomic-multimap").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicMultimap("atomic-multimap").protocol()).group());
 
+    assertEquals(AtomicNavigableMapType.instance(), atomix.getPrimitive("atomic-navigable-map").type());
     assertEquals("atomic-navigable-map", atomix.getAtomicNavigableMap("atomic-navigable-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicNavigableMap("atomic-navigable-map").protocol()).group());
 
+    assertEquals(AtomicSemaphoreType.instance(), atomix.getPrimitive("atomic-semaphore").type());
     assertEquals("atomic-semaphore", atomix.getAtomicSemaphore("atomic-semaphore").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicSemaphore("atomic-semaphore").protocol()).group());
 
+    assertEquals(AtomicSortedMapType.instance(), atomix.getPrimitive("atomic-sorted-map").type());
     assertEquals("atomic-sorted-map", atomix.getAtomicSortedMap("atomic-sorted-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicSortedMap("atomic-sorted-map").protocol()).group());
 
+    assertEquals(AtomicValueType.instance(), atomix.getPrimitive("atomic-value").type());
     assertEquals("atomic-value", atomix.getAtomicValue("atomic-value").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicValue("atomic-value").protocol()).group());
 
+    assertEquals(DistributedCounterType.instance(), atomix.getPrimitive("counter").type());
     assertEquals("counter", atomix.getCounter("counter").name());
     assertEquals("two", ((ProxyProtocol) atomix.getCounter("counter").protocol()).group());
 
+    assertEquals(DistributedCyclicBarrierType.instance(), atomix.getPrimitive("cyclic-barrier").type());
     assertEquals("cyclic-barrier", atomix.getCyclicBarrier("cyclic-barrier").name());
     assertEquals("two", ((ProxyProtocol) atomix.getCyclicBarrier("cyclic-barrier").protocol()).group());
 
+    assertEquals(LeaderElectionType.instance(), atomix.getPrimitive("leader-election").type());
     assertEquals("leader-election", atomix.getLeaderElection("leader-election").name());
     assertEquals("two", ((ProxyProtocol) atomix.getLeaderElection("leader-election").protocol()).group());
 
+    assertEquals(LeaderElectorType.instance(), atomix.getPrimitive("leader-elector").type());
     assertEquals("leader-elector", atomix.getLeaderElector("leader-elector").name());
     assertEquals("two", ((ProxyProtocol) atomix.getLeaderElector("leader-elector").protocol()).group());
 
+    assertEquals(DistributedListType.instance(), atomix.getPrimitive("list").type());
     assertEquals("list", atomix.getList("list").name());
     assertEquals("two", ((ProxyProtocol) atomix.getList("list").protocol()).group());
 
+    assertEquals(DistributedLockType.instance(), atomix.getPrimitive("lock").type());
     assertEquals("lock", atomix.getLock("lock").name());
     assertEquals("two", ((ProxyProtocol) atomix.getLock("lock").protocol()).group());
 
+    assertEquals(DistributedMapType.instance(), atomix.getPrimitive("map").type());
     assertEquals("map", atomix.getMap("map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getMap("map").protocol()).group());
 
+    assertEquals(DistributedMultimapType.instance(), atomix.getPrimitive("multimap").type());
     assertEquals("multimap", atomix.getMultimap("multimap").name());
     assertEquals("two", ((ProxyProtocol) atomix.getMultimap("multimap").protocol()).group());
 
+    assertEquals(DistributedMultisetType.instance(), atomix.getPrimitive("multiset").type());
     assertEquals("multiset", atomix.getMultiset("multiset").name());
     assertEquals("two", ((ProxyProtocol) atomix.getMultiset("multiset").protocol()).group());
 
+    assertEquals(DistributedNavigableMapType.instance(), atomix.getPrimitive("navigable-map").type());
     assertEquals("navigable-map", atomix.getNavigableMap("navigable-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getNavigableMap("navigable-map").protocol()).group());
 
+    assertEquals(DistributedNavigableSetType.instance(), atomix.getPrimitive("navigable-set").type());
     assertEquals("navigable-set", atomix.getNavigableSet("navigable-set").name());
     assertEquals("two", ((ProxyProtocol) atomix.getNavigableSet("navigable-set").protocol()).group());
 
+    assertEquals(DistributedQueueType.instance(), atomix.getPrimitive("queue").type());
     assertEquals("queue", atomix.getQueue("queue").name());
     assertEquals("two", ((ProxyProtocol) atomix.getQueue("queue").protocol()).group());
 
+    assertEquals(DistributedSemaphoreType.instance(), atomix.getPrimitive("semaphore").type());
     assertEquals("semaphore", atomix.getSemaphore("semaphore").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSemaphore("semaphore").protocol()).group());
 
+    assertEquals(DistributedSetType.instance(), atomix.getPrimitive("set").type());
     assertEquals("set", atomix.getSet("set").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSet("set").protocol()).group());
 
+    assertEquals(DistributedSortedMapType.instance(), atomix.getPrimitive("sorted-map").type());
     assertEquals("sorted-map", atomix.getSortedMap("sorted-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSortedMap("sorted-map").protocol()).group());
 
+    assertEquals(DistributedSortedSetType.instance(), atomix.getPrimitive("sorted-set").type());
     assertEquals("sorted-set", atomix.getSortedSet("sorted-set").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSortedSet("sorted-set").protocol()).group());
 
+    assertEquals(DistributedValueType.instance(), atomix.getPrimitive("value").type());
     assertEquals("value", atomix.getValue("value").name());
     assertEquals("two", ((ProxyProtocol) atomix.getValue("value").protocol()).group());
 
+    assertEquals(WorkQueueType.instance(), atomix.getPrimitive("work-queue").type());
     assertEquals("work-queue", atomix.getWorkQueue("work-queue").name());
     assertEquals("two", ((ProxyProtocol) atomix.getWorkQueue("work-queue").protocol()).group());
   }

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -48,6 +48,7 @@ import io.atomix.core.tree.AtomicDocumentTreeType;
 import io.atomix.core.value.AtomicValueType;
 import io.atomix.core.value.DistributedValueType;
 import io.atomix.core.workqueue.WorkQueueType;
+import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.net.Address;
 import org.junit.After;
@@ -66,6 +67,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -453,6 +455,116 @@ public class AtomixTest extends AbstractAtomixTest {
     assertEquals("cc", atomix.getWorkQueue("cc").name());
     assertEquals(WorkQueueType.instance(), atomix.getWorkQueue("cc").type());
     assertSame(atomix.getWorkQueue("cc"), atomix.getWorkQueue("cc"));
+  }
+
+  @Test
+  public void testPrimitiveConfigurations() throws Exception {
+    IntStream.range(1, 4).forEach(i ->
+        instances.add(Atomix.builder(getClass().getResource("/primitives.conf").getFile())
+            .withMemberId(String.valueOf(i))
+            .withAddress("localhost", 5000 + i)
+            .build()));
+    Futures.allOf(instances.stream().map(Atomix::start)).get(30, TimeUnit.SECONDS);
+
+    Atomix atomix = Atomix.builder(getClass().getResource("/primitives.conf").getFile())
+        .withAddress("localhost:5000")
+        .build();
+    instances.add(atomix);
+
+    try {
+      atomix.getAtomicCounter("foo");
+      fail();
+    } catch (IllegalStateException e) {
+    }
+
+    atomix.start().get(30, TimeUnit.SECONDS);
+
+    assertEquals("atomic-counter", atomix.getAtomicCounter("atomic-counter").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicCounter("atomic-counter").protocol()).group());
+
+    assertEquals("atomic-map", atomix.getAtomicMap("atomic-map").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicMap("atomic-map").protocol()).group());
+
+    assertEquals("atomic-counter-map", atomix.getAtomicCounterMap("atomic-counter-map").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicCounterMap("atomic-counter-map").protocol()).group());
+
+    assertEquals("atomic-document-tree", atomix.getAtomicDocumentTree("atomic-document-tree").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicDocumentTree("atomic-document-tree").protocol()).group());
+
+    assertEquals("atomic-id-generator", atomix.getAtomicIdGenerator("atomic-id-generator").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicIdGenerator("atomic-id-generator").protocol()).group());
+
+    assertEquals("atomic-lock", atomix.getAtomicLock("atomic-lock").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicLock("atomic-lock").protocol()).group());
+
+    assertEquals("atomic-multimap", atomix.getAtomicMultimap("atomic-multimap").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicMultimap("atomic-multimap").protocol()).group());
+
+    assertEquals("atomic-navigable-map", atomix.getAtomicNavigableMap("atomic-navigable-map").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicNavigableMap("atomic-navigable-map").protocol()).group());
+
+    assertEquals("atomic-semaphore", atomix.getAtomicSemaphore("atomic-semaphore").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicSemaphore("atomic-semaphore").protocol()).group());
+
+    assertEquals("atomic-sorted-map", atomix.getAtomicSortedMap("atomic-sorted-map").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicSortedMap("atomic-sorted-map").protocol()).group());
+
+    assertEquals("atomic-value", atomix.getAtomicValue("atomic-value").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getAtomicValue("atomic-value").protocol()).group());
+
+    assertEquals("counter", atomix.getCounter("counter").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getCounter("counter").protocol()).group());
+
+    assertEquals("cyclic-barrier", atomix.getCyclicBarrier("cyclic-barrier").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getCyclicBarrier("cyclic-barrier").protocol()).group());
+
+    assertEquals("leader-election", atomix.getLeaderElection("leader-election").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getLeaderElection("leader-election").protocol()).group());
+
+    assertEquals("leader-elector", atomix.getLeaderElector("leader-elector").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getLeaderElector("leader-elector").protocol()).group());
+
+    assertEquals("list", atomix.getList("list").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getList("list").protocol()).group());
+
+    assertEquals("lock", atomix.getLock("lock").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getLock("lock").protocol()).group());
+
+    assertEquals("map", atomix.getMap("map").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getMap("map").protocol()).group());
+
+    assertEquals("multimap", atomix.getMultimap("multimap").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getMultimap("multimap").protocol()).group());
+
+    assertEquals("multiset", atomix.getMultiset("multiset").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getMultiset("multiset").protocol()).group());
+
+    assertEquals("navigable-map", atomix.getNavigableMap("navigable-map").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getNavigableMap("navigable-map").protocol()).group());
+
+    assertEquals("navigable-set", atomix.getNavigableSet("navigable-set").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getNavigableSet("navigable-set").protocol()).group());
+
+    assertEquals("queue", atomix.getQueue("queue").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getQueue("queue").protocol()).group());
+
+    assertEquals("semaphore", atomix.getSemaphore("semaphore").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getSemaphore("semaphore").protocol()).group());
+
+    assertEquals("set", atomix.getSet("set").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getSet("set").protocol()).group());
+
+    assertEquals("sorted-map", atomix.getSortedMap("sorted-map").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getSortedMap("sorted-map").protocol()).group());
+
+    assertEquals("sorted-set", atomix.getSortedSet("sorted-set").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getSortedSet("sorted-set").protocol()).group());
+
+    assertEquals("value", atomix.getValue("value").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getValue("value").protocol()).group());
+
+    assertEquals("work-queue", atomix.getWorkQueue("work-queue").name());
+    assertEquals("two", ((ProxyProtocol) atomix.getWorkQueue("work-queue").protocol()).group());
   }
 
   @Test

--- a/core/src/test/resources/primitives.conf
+++ b/core/src/test/resources/primitives.conf
@@ -1,0 +1,268 @@
+cluster {
+  cluster-id: test
+  discovery {
+    type: bootstrap
+    nodes.1 {
+      id: 1
+      address: "localhost:5001"
+    }
+    nodes.2 {
+      id: 2
+      address: "localhost:5002"
+    }
+    nodes.3 {
+      id: 3
+      address: "localhost:5003"
+    }
+  }
+}
+
+management-group {
+  type: raft
+  partitions: 1
+  segmentSize: 16M
+  members: [1, 2, 3]
+}
+
+partition-groups.one {
+  type: raft
+  partitions: 3
+  members: [1, 2, 3]
+}
+
+partition-groups.two {
+  type: primary-backup
+  partitions: 7
+}
+
+primitives.atomic-counter {
+  type: atomic-counter
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-map {
+  type: atomic-map
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-counter-map {
+  type: atomic-counter-map
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-document-tree {
+  type: atomic-document-tree
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-id-generator {
+  type: atomic-id-generator
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-lock {
+  type: atomic-lock
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-multimap {
+  type: atomic-multimap
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-navigable-map {
+  type: atomic-navigable-map
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-semaphore {
+  type: atomic-semaphore
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-sorted-map {
+  type: atomic-sorted-map
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.atomic-value {
+  type: atomic-value
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.counter {
+  type: counter
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.cyclic-barrier {
+  type: cyclic-barrier
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.leader-election {
+  type: leader-election
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.leader-elector {
+  type: leader-elector
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.list {
+  type: list
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.lock {
+  type: lock
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.map {
+  type: map
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.multimap {
+  type: multimap
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.multiset {
+  type: multiset
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.navigable-map {
+  type: navigable-map
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.navigable-set {
+  type: navigable-set
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.queue {
+  type: queue
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.semaphore {
+  type: semaphore
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.set {
+  type: set
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.sorted-map {
+  type: sorted-map
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.sorted-set {
+  type: sorted-set
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.value {
+  type: value
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
+primitives.work-queue {
+  type: work-queue
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
+++ b/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
@@ -237,7 +237,7 @@ public class ConfigMapper {
       return new MemorySize(size.toBytes());
     } else if (parameterClass == Object.class) {
       return config.getAnyRef(configPropName);
-    } else if (parameterClass == List.class) {
+    } else if (parameterClass == List.class || parameterClass == Collection.class) {
       return getListValue(beanClass, parameterType, parameterClass, config, configPath, configPropName);
     } else if (parameterClass == Set.class) {
       return getSetValue(beanClass, parameterType, parameterClass, config, configPath, configPropName);


### PR DESCRIPTION
This PR adds various tests for primitive getters and builders. It tests all specific primitive getters, abstract pre-configured primitive getters, and primitive builder methods to ensure all methods return valid and correct primitive instances.