### PR TITLE
Document tree API improvements

### DIFF
--- a/core/src/main/java/io/atomix/core/tree/AsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/AsyncAtomicDocumentTree.java
@@ -47,6 +47,17 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * @return future for mapping from child name to child value
    * @throws NoSuchDocumentPathException if the path does not point to a valid node
    */
+  default CompletableFuture<Map<String, Versioned<V>>> getChildren(String path) {
+    return getChildren(DocumentPath.from(path));
+  }
+
+  /**
+   * Returns the children of node at specified path in the form of a mapping from child name to child value.
+   *
+   * @param path path to the node
+   * @return future for mapping from child name to child value
+   * @throws NoSuchDocumentPathException if the path does not point to a valid node
+   */
   CompletableFuture<Map<String, Versioned<V>>> getChildren(DocumentPath path);
 
   /**
@@ -56,7 +67,32 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * @return future that will be either be completed with node's {@link Versioned versioned} value
    * or {@code null} if path does not point to a valid node
    */
+  default CompletableFuture<Versioned<V>> get(String path) {
+    return get(DocumentPath.from(path));
+  }
+
+  /**
+   * Returns the value of the tree node at specified path.
+   *
+   * @param path path to the node
+   * @return future that will be either be completed with node's {@link Versioned versioned} value
+   * or {@code null} if path does not point to a valid node
+   */
   CompletableFuture<Versioned<V>> get(DocumentPath path);
+
+  /**
+   * Creates or updates a document tree node.
+   *
+   * @param path  path to the node
+   * @param value value to be associated with the node ({@code null} is a valid value)
+   * @return future that will either be completed with the previous {@link Versioned versioned}
+   * value or {@code null} if there was no node previously at that path.
+   * Future will be completed with a {@code IllegalDocumentModificationException}
+   * if the parent node (for the node to create/update) does not exist
+   */
+  default CompletableFuture<Versioned<V>> set(String path, V value) {
+    return set(DocumentPath.from(path), value);
+  }
 
   /**
    * Creates or updates a document tree node.
@@ -80,6 +116,20 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * Future will be completed exceptionally with a {@code IllegalDocumentModificationException} if the parent
    * node (for the node to create) does not exist
    */
+  default CompletableFuture<Boolean> create(String path, V value) {
+    return create(DocumentPath.from(path), value);
+  }
+
+  /**
+   * Creates a document tree node if one does not exist already.
+   *
+   * @param path  path to the node
+   * @param value the non-null value to be associated with the node
+   * @return future that is completed with {@code true} if the new node was successfully
+   * created. Future will be completed with {@code false} if a node already exists at the specified path.
+   * Future will be completed exceptionally with a {@code IllegalDocumentModificationException} if the parent
+   * node (for the node to create) does not exist
+   */
   CompletableFuture<Boolean> create(DocumentPath path, V value);
 
   /**
@@ -90,7 +140,32 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * @return future that is completed with {@code true} if the new node was successfully
    * created. Future will be completed with {@code false} if a node already exists at the specified path
    */
+  default CompletableFuture<Boolean> createRecursive(String path, V value) {
+    return createRecursive(DocumentPath.from(path), value);
+  }
+
+  /**
+   * Creates a document tree node recursively by creating all missing intermediate nodes in the path.
+   *
+   * @param path  path to the node
+   * @param value value to be associated with the node ({@code null} is a valid value)
+   * @return future that is completed with {@code true} if the new node was successfully
+   * created. Future will be completed with {@code false} if a node already exists at the specified path
+   */
   CompletableFuture<Boolean> createRecursive(DocumentPath path, V value);
+
+  /**
+   * Conditionally updates a tree node if the current version matches a specified version.
+   *
+   * @param path     path to the node
+   * @param newValue value to associate with the node ({@code null} is a valid value)
+   * @param version  current version of the node for update to occur
+   * @return future that is either completed with {@code true} if the update was made
+   * or {@code false} if update did not happen
+   */
+  default CompletableFuture<Boolean> replace(String path, V newValue, long version) {
+    return replace(DocumentPath.from(path), newValue, version);
+  }
 
   /**
    * Conditionally updates a tree node if the current version matches a specified version.
@@ -112,6 +187,19 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * @return future that is either completed with {@code true} if the update was made
    * or {@code false} if update did not happen
    */
+  default CompletableFuture<Boolean> replace(String path, V newValue, V currentValue) {
+    return replace(DocumentPath.from(path), newValue, currentValue);
+  }
+
+  /**
+   * Conditionally updates a tree node if the current node value matches a specified version.
+   *
+   * @param path         path to the node
+   * @param newValue     value to associate with the node ({@code null} is a valid value)
+   * @param currentValue current value of the node for update to occur
+   * @return future that is either completed with {@code true} if the update was made
+   * or {@code false} if update did not happen
+   */
   CompletableFuture<Boolean> replace(DocumentPath path, V newValue, V currentValue);
 
   /**
@@ -123,7 +211,20 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * node or has one or more children. Future will be completed with a
    * {@code NoSuchDocumentPathException} if the node to be removed does not exist
    */
-  CompletableFuture<Versioned<V>> removeNode(DocumentPath path);
+  default CompletableFuture<Versioned<V>> remove(String path) {
+    return remove(DocumentPath.from(path));
+  }
+
+  /**
+   * Removes the node with the specified path.
+   *
+   * @param path path to the node
+   * @return future for the previous value. Future will be completed with a
+   * {@code IllegalDocumentModificationException} if the node to be removed is either the root
+   * node or has one or more children. Future will be completed with a
+   * {@code NoSuchDocumentPathException} if the node to be removed does not exist
+   */
+  CompletableFuture<Versioned<V>> remove(DocumentPath path);
 
   /**
    * Registers a listener to be notified when the subtree rooted at the specified path

--- a/core/src/main/java/io/atomix/core/tree/AsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/AsyncAtomicDocumentTree.java
@@ -43,9 +43,10 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
   /**
    * Returns the children of node at specified path in the form of a mapping from child name to child value.
    *
-   * @param path path to the node
+   * @param path path to the node, must be prefixed with the root {@code /} path
    * @return future for mapping from child name to child value
    * @throws NoSuchDocumentPathException if the path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Map<String, Versioned<V>>> getChildren(String path) {
     return getChildren(DocumentPath.from(path));
@@ -57,15 +58,17 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * @param path path to the node
    * @return future for mapping from child name to child value
    * @throws NoSuchDocumentPathException if the path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Map<String, Versioned<V>>> getChildren(DocumentPath path);
 
   /**
    * Returns the value of the tree node at specified path.
    *
-   * @param path path to the node
-   * @return future that will be either be completed with node's {@link Versioned versioned} value
-   * or {@code null} if path does not point to a valid node
+   * @param path path to the node, must be prefixed with the root {@code /} path
+   * @return future that will be either be completed with node's {@link Versioned versioned} value or {@code null} if
+   *     path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Versioned<V>> get(String path) {
     return get(DocumentPath.from(path));
@@ -75,20 +78,21 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * Returns the value of the tree node at specified path.
    *
    * @param path path to the node
-   * @return future that will be either be completed with node's {@link Versioned versioned} value
-   * or {@code null} if path does not point to a valid node
+   * @return future that will be either be completed with node's {@link Versioned versioned} value or {@code null} if
+   *     path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Versioned<V>> get(DocumentPath path);
 
   /**
    * Creates or updates a document tree node.
    *
-   * @param path  path to the node
+   * @param path path to the node, must be prefixed with the root {@code /} path
    * @param value value to be associated with the node ({@code null} is a valid value)
-   * @return future that will either be completed with the previous {@link Versioned versioned}
-   * value or {@code null} if there was no node previously at that path.
-   * Future will be completed with a {@code IllegalDocumentModificationException}
-   * if the parent node (for the node to create/update) does not exist
+   * @return future that will either be completed with the previous {@link Versioned versioned} value or {@code null} if
+   *     there was no node previously at that path. Future will be completed with a {@code
+   *     IllegalDocumentModificationException} if the parent node (for the node to create/update) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Versioned<V>> set(String path, V value) {
     return set(DocumentPath.from(path), value);
@@ -97,24 +101,25 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
   /**
    * Creates or updates a document tree node.
    *
-   * @param path  path to the node
+   * @param path path to the node
    * @param value value to be associated with the node ({@code null} is a valid value)
-   * @return future that will either be completed with the previous {@link Versioned versioned}
-   * value or {@code null} if there was no node previously at that path.
-   * Future will be completed with a {@code IllegalDocumentModificationException}
-   * if the parent node (for the node to create/update) does not exist
+   * @return future that will either be completed with the previous {@link Versioned versioned} value or {@code null} if
+   *     there was no node previously at that path. Future will be completed with a {@code
+   *     IllegalDocumentModificationException} if the parent node (for the node to create/update) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Versioned<V>> set(DocumentPath path, V value);
 
   /**
    * Creates a document tree node if one does not exist already.
    *
-   * @param path  path to the node
+   * @param path path to the node, must be prefixed with the root {@code /} path
    * @param value the non-null value to be associated with the node
-   * @return future that is completed with {@code true} if the new node was successfully
-   * created. Future will be completed with {@code false} if a node already exists at the specified path.
-   * Future will be completed exceptionally with a {@code IllegalDocumentModificationException} if the parent
-   * node (for the node to create) does not exist
+   * @return future that is completed with {@code true} if the new node was successfully created. Future will be
+   *     completed with {@code false} if a node already exists at the specified path. Future will be completed
+   *     exceptionally with a {@code IllegalDocumentModificationException} if the parent node (for the node to create)
+   *     does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Boolean> create(String path, V value) {
     return create(DocumentPath.from(path), value);
@@ -123,22 +128,24 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
   /**
    * Creates a document tree node if one does not exist already.
    *
-   * @param path  path to the node
+   * @param path path to the node
    * @param value the non-null value to be associated with the node
-   * @return future that is completed with {@code true} if the new node was successfully
-   * created. Future will be completed with {@code false} if a node already exists at the specified path.
-   * Future will be completed exceptionally with a {@code IllegalDocumentModificationException} if the parent
-   * node (for the node to create) does not exist
+   * @return future that is completed with {@code true} if the new node was successfully created. Future will be
+   *     completed with {@code false} if a node already exists at the specified path. Future will be completed
+   *     exceptionally with a {@code IllegalDocumentModificationException} if the parent node (for the node to create)
+   *     does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Boolean> create(DocumentPath path, V value);
 
   /**
    * Creates a document tree node recursively by creating all missing intermediate nodes in the path.
    *
-   * @param path  path to the node
+   * @param path path to the node, must be prefixed with the root {@code /} path
    * @param value value to be associated with the node ({@code null} is a valid value)
-   * @return future that is completed with {@code true} if the new node was successfully
-   * created. Future will be completed with {@code false} if a node already exists at the specified path
+   * @return future that is completed with {@code true} if the new node was successfully created. Future will be
+   *     completed with {@code false} if a node already exists at the specified path
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Boolean> createRecursive(String path, V value) {
     return createRecursive(DocumentPath.from(path), value);
@@ -147,21 +154,23 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
   /**
    * Creates a document tree node recursively by creating all missing intermediate nodes in the path.
    *
-   * @param path  path to the node
+   * @param path path to the node
    * @param value value to be associated with the node ({@code null} is a valid value)
-   * @return future that is completed with {@code true} if the new node was successfully
-   * created. Future will be completed with {@code false} if a node already exists at the specified path
+   * @return future that is completed with {@code true} if the new node was successfully created. Future will be
+   *     completed with {@code false} if a node already exists at the specified path
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Boolean> createRecursive(DocumentPath path, V value);
 
   /**
    * Conditionally updates a tree node if the current version matches a specified version.
    *
-   * @param path     path to the node
+   * @param path path to the node, must be prefixed with the root {@code /} path
    * @param newValue value to associate with the node ({@code null} is a valid value)
-   * @param version  current version of the node for update to occur
-   * @return future that is either completed with {@code true} if the update was made
-   * or {@code false} if update did not happen
+   * @param version current version of the node for update to occur
+   * @return future that is either completed with {@code true} if the update was made or {@code false} if update did not
+   *     happen
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Boolean> replace(String path, V newValue, long version) {
     return replace(DocumentPath.from(path), newValue, version);
@@ -170,22 +179,24 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
   /**
    * Conditionally updates a tree node if the current version matches a specified version.
    *
-   * @param path     path to the node
+   * @param path path to the node
    * @param newValue value to associate with the node ({@code null} is a valid value)
-   * @param version  current version of the node for update to occur
-   * @return future that is either completed with {@code true} if the update was made
-   * or {@code false} if update did not happen
+   * @param version current version of the node for update to occur
+   * @return future that is either completed with {@code true} if the update was made or {@code false} if update did not
+   *     happen
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Boolean> replace(DocumentPath path, V newValue, long version);
 
   /**
    * Conditionally updates a tree node if the current node value matches a specified version.
    *
-   * @param path         path to the node
-   * @param newValue     value to associate with the node ({@code null} is a valid value)
+   * @param path path to the node, must be prefixed with the root {@code /} path
+   * @param newValue value to associate with the node ({@code null} is a valid value)
    * @param currentValue current value of the node for update to occur
-   * @return future that is either completed with {@code true} if the update was made
-   * or {@code false} if update did not happen
+   * @return future that is either completed with {@code true} if the update was made or {@code false} if update did not
+   *     happen
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Boolean> replace(String path, V newValue, V currentValue) {
     return replace(DocumentPath.from(path), newValue, currentValue);
@@ -194,22 +205,23 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
   /**
    * Conditionally updates a tree node if the current node value matches a specified version.
    *
-   * @param path         path to the node
-   * @param newValue     value to associate with the node ({@code null} is a valid value)
+   * @param path path to the node
+   * @param newValue value to associate with the node ({@code null} is a valid value)
    * @param currentValue current value of the node for update to occur
-   * @return future that is either completed with {@code true} if the update was made
-   * or {@code false} if update did not happen
+   * @return future that is either completed with {@code true} if the update was made or {@code false} if update did not
+   *     happen
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Boolean> replace(DocumentPath path, V newValue, V currentValue);
 
   /**
    * Removes the node with the specified path.
    *
-   * @param path path to the node
-   * @return future for the previous value. Future will be completed with a
-   * {@code IllegalDocumentModificationException} if the node to be removed is either the root
-   * node or has one or more children. Future will be completed with a
-   * {@code NoSuchDocumentPathException} if the node to be removed does not exist
+   * @param path path to the node, must be prefixed with the root {@code /} path
+   * @return future for the previous value. Future will be completed with a {@code IllegalDocumentModificationException}
+   *     if the node to be removed is either the root node or has one or more children. Future will be completed with a
+   *     {@code NoSuchDocumentPathException} if the node to be removed does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default CompletableFuture<Versioned<V>> remove(String path) {
     return remove(DocumentPath.from(path));
@@ -219,18 +231,17 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
    * Removes the node with the specified path.
    *
    * @param path path to the node
-   * @return future for the previous value. Future will be completed with a
-   * {@code IllegalDocumentModificationException} if the node to be removed is either the root
-   * node or has one or more children. Future will be completed with a
-   * {@code NoSuchDocumentPathException} if the node to be removed does not exist
+   * @return future for the previous value. Future will be completed with a {@code IllegalDocumentModificationException}
+   *     if the node to be removed is either the root node or has one or more children. Future will be completed with a
+   *     {@code NoSuchDocumentPathException} if the node to be removed does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   CompletableFuture<Versioned<V>> remove(DocumentPath path);
 
   /**
-   * Registers a listener to be notified when the subtree rooted at the specified path
-   * is modified.
+   * Registers a listener to be notified when the subtree rooted at the specified path is modified.
    *
-   * @param path     path to the node
+   * @param path path to the node
    * @param listener listener to be notified
    * @return a future that is completed when the operation completes
    */
@@ -239,10 +250,9 @@ public interface AsyncAtomicDocumentTree<V> extends AsyncPrimitive {
   }
 
   /**
-   * Registers a listener to be notified when the subtree rooted at the specified path
-   * is modified.
+   * Registers a listener to be notified when the subtree rooted at the specified path is modified.
    *
-   * @param path     path to the node
+   * @param path path to the node
    * @param listener listener to be notified
    * @param executor the executor with which to notify the event listener
    * @return a future that is completed when the operation completes

--- a/core/src/main/java/io/atomix/core/tree/AtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/AtomicDocumentTree.java
@@ -44,7 +44,28 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * @return mapping from a child name to its value
    * @throws NoSuchDocumentPathException if the path does not point to a valid node
    */
+  default Map<String, Versioned<V>> getChildren(String path) {
+    return getChildren(DocumentPath.from(path));
+  }
+
+  /**
+   * Returns the child values for this node.
+   *
+   * @param path path to the node
+   * @return mapping from a child name to its value
+   * @throws NoSuchDocumentPathException if the path does not point to a valid node
+   */
   Map<String, Versioned<V>> getChildren(DocumentPath path);
+
+  /**
+   * Returns a document tree node.
+   *
+   * @param path path to node
+   * @return node value or {@code null} if path does not point to a valid node
+   */
+  default Versioned<V> get(String path) {
+    return get(DocumentPath.from(path));
+  }
 
   /**
    * Returns a document tree node.
@@ -62,7 +83,31 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * @return the previous mapping or {@code null} if there was no previous mapping
    * @throws NoSuchDocumentPathException if the parent node (for the node to create/update) does not exist
    */
+  default Versioned<V> set(String path, V value) {
+    return set(DocumentPath.from(path), value);
+  }
+
+  /**
+   * Creates or updates a document tree node.
+   *
+   * @param path  path for the node to create or update
+   * @param value the non-null value to be associated with the key
+   * @return the previous mapping or {@code null} if there was no previous mapping
+   * @throws NoSuchDocumentPathException if the parent node (for the node to create/update) does not exist
+   */
   Versioned<V> set(DocumentPath path, V value);
+
+  /**
+   * Creates a document tree node if one does not exist already.
+   *
+   * @param path  path for the node to create
+   * @param value the non-null value to be associated with the key
+   * @return returns {@code true} if the mapping could be added successfully, {@code false} otherwise
+   * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   */
+  default boolean create(String path, V value) {
+    return create(DocumentPath.from(path), value);
+  }
 
   /**
    * Creates a document tree node if one does not exist already.
@@ -83,7 +128,33 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * a node already exists at that path
    * @throws IllegalDocumentModificationException if {@code path} points to root
    */
+  default boolean createRecursive(String path, V value) {
+    return createRecursive(DocumentPath.from(path), value);
+  }
+
+  /**
+   * Creates a document tree node by first creating any missing intermediate nodes in the path.
+   *
+   * @param path  path for the node to create
+   * @param value the non-null value to be associated with the key
+   * @return returns {@code true} if the mapping could be added successfully, {@code false} if
+   * a node already exists at that path
+   * @throws IllegalDocumentModificationException if {@code path} points to root
+   */
   boolean createRecursive(DocumentPath path, V value);
+
+  /**
+   * Conditionally updates a tree node if the current version matches a specified version.
+   *
+   * @param path     path for the node to create
+   * @param newValue the non-null value to be associated with the key
+   * @param version  current version of the value for update to occur
+   * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise
+   * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   */
+  default boolean replace(String path, V newValue, long version) {
+    return replace(DocumentPath.from(path), newValue, version);
+  }
 
   /**
    * Conditionally updates a tree node if the current version matches a specified version.
@@ -106,6 +177,20 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * This method returns {@code false} if the newValue and currentValue are same.
    * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
    */
+  default boolean replace(String path, V newValue, V currentValue) {
+    return replace(DocumentPath.from(path), newValue, currentValue);
+  }
+
+  /**
+   * Conditionally updates a tree node if the current value matches a specified value.
+   *
+   * @param path         path for the node to create
+   * @param newValue     the non-null value to be associated with the key
+   * @param currentValue current value for update to occur
+   * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise.
+   * This method returns {@code false} if the newValue and currentValue are same.
+   * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   */
   boolean replace(DocumentPath path, V newValue, V currentValue);
 
   /**
@@ -115,7 +200,18 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * @return the previous value of the node or {@code null} if it did not exist
    * @throws IllegalDocumentModificationException if the remove to be removed
    */
-  Versioned<V> removeNode(DocumentPath path);
+  default Versioned<V> remove(String path) {
+    return remove(DocumentPath.from(path));
+  }
+
+  /**
+   * Removes the node with the specified path.
+   *
+   * @param path path for the node to remove
+   * @return the previous value of the node or {@code null} if it did not exist
+   * @throws IllegalDocumentModificationException if the remove to be removed
+   */
+  Versioned<V> remove(DocumentPath path);
 
   /**
    * Registers a listener to be notified when the tree is modified.

--- a/core/src/main/java/io/atomix/core/tree/AtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/AtomicDocumentTree.java
@@ -40,9 +40,10 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   /**
    * Returns the child values for this node.
    *
-   * @param path path to the node
+   * @param path path to the node, must be prefixed with the root {@code /} path
    * @return mapping from a child name to its value
    * @throws NoSuchDocumentPathException if the path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default Map<String, Versioned<V>> getChildren(String path) {
     return getChildren(DocumentPath.from(path));
@@ -54,14 +55,16 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * @param path path to the node
    * @return mapping from a child name to its value
    * @throws NoSuchDocumentPathException if the path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   Map<String, Versioned<V>> getChildren(DocumentPath path);
 
   /**
    * Returns a document tree node.
    *
-   * @param path path to node
+   * @param path path to the node, must be prefixed with the root {@code /} path
    * @return node value or {@code null} if path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default Versioned<V> get(String path) {
     return get(DocumentPath.from(path));
@@ -72,16 +75,18 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    *
    * @param path path to node
    * @return node value or {@code null} if path does not point to a valid node
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   Versioned<V> get(DocumentPath path);
 
   /**
    * Creates or updates a document tree node.
    *
-   * @param path  path for the node to create or update
+   * @param path path to the node to create or update, must be prefixed with the root {@code /} path
    * @param value the non-null value to be associated with the key
    * @return the previous mapping or {@code null} if there was no previous mapping
    * @throws NoSuchDocumentPathException if the parent node (for the node to create/update) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default Versioned<V> set(String path, V value) {
     return set(DocumentPath.from(path), value);
@@ -90,20 +95,22 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   /**
    * Creates or updates a document tree node.
    *
-   * @param path  path for the node to create or update
+   * @param path path for the node to create or update
    * @param value the non-null value to be associated with the key
    * @return the previous mapping or {@code null} if there was no previous mapping
    * @throws NoSuchDocumentPathException if the parent node (for the node to create/update) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   Versioned<V> set(DocumentPath path, V value);
 
   /**
    * Creates a document tree node if one does not exist already.
    *
-   * @param path  path for the node to create
+   * @param path path to the node to create, must be prefixed with the root {@code /} path
    * @param value the non-null value to be associated with the key
    * @return returns {@code true} if the mapping could be added successfully, {@code false} otherwise
    * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default boolean create(String path, V value) {
     return create(DocumentPath.from(path), value);
@@ -112,21 +119,23 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   /**
    * Creates a document tree node if one does not exist already.
    *
-   * @param path  path for the node to create
+   * @param path path for the node to create
    * @param value the non-null value to be associated with the key
    * @return returns {@code true} if the mapping could be added successfully, {@code false} otherwise
    * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   boolean create(DocumentPath path, V value);
 
   /**
    * Creates a document tree node by first creating any missing intermediate nodes in the path.
    *
-   * @param path  path for the node to create
+   * @param path path to the node to create, must be prefixed with the root {@code /} path
    * @param value the non-null value to be associated with the key
-   * @return returns {@code true} if the mapping could be added successfully, {@code false} if
-   * a node already exists at that path
+   * @return returns {@code true} if the mapping could be added successfully, {@code false} if a node already exists at
+   *     that path
    * @throws IllegalDocumentModificationException if {@code path} points to root
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default boolean createRecursive(String path, V value) {
     return createRecursive(DocumentPath.from(path), value);
@@ -135,22 +144,24 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   /**
    * Creates a document tree node by first creating any missing intermediate nodes in the path.
    *
-   * @param path  path for the node to create
+   * @param path path for the node to create
    * @param value the non-null value to be associated with the key
-   * @return returns {@code true} if the mapping could be added successfully, {@code false} if
-   * a node already exists at that path
+   * @return returns {@code true} if the mapping could be added successfully, {@code false} if a node already exists at
+   *     that path
    * @throws IllegalDocumentModificationException if {@code path} points to root
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   boolean createRecursive(DocumentPath path, V value);
 
   /**
    * Conditionally updates a tree node if the current version matches a specified version.
    *
-   * @param path     path for the node to create
+   * @param path path to the node to replace, must be prefixed with the root {@code /} path
    * @param newValue the non-null value to be associated with the key
-   * @param version  current version of the value for update to occur
+   * @param version current version of the value for update to occur
    * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise
    * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default boolean replace(String path, V newValue, long version) {
     return replace(DocumentPath.from(path), newValue, version);
@@ -159,23 +170,25 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   /**
    * Conditionally updates a tree node if the current version matches a specified version.
    *
-   * @param path     path for the node to create
+   * @param path path for the node to replace
    * @param newValue the non-null value to be associated with the key
-   * @param version  current version of the value for update to occur
+   * @param version current version of the value for update to occur
    * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise
    * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   boolean replace(DocumentPath path, V newValue, long version);
 
   /**
    * Conditionally updates a tree node if the current value matches a specified value.
    *
-   * @param path         path for the node to create
-   * @param newValue     the non-null value to be associated with the key
+   * @param path path to the node to replace, must be prefixed with the root {@code /} path
+   * @param newValue the non-null value to be associated with the key
    * @param currentValue current value for update to occur
-   * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise.
-   * This method returns {@code false} if the newValue and currentValue are same.
+   * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise. This method
+   *     returns {@code false} if the newValue and currentValue are same.
    * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default boolean replace(String path, V newValue, V currentValue) {
     return replace(DocumentPath.from(path), newValue, currentValue);
@@ -184,21 +197,23 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   /**
    * Conditionally updates a tree node if the current value matches a specified value.
    *
-   * @param path         path for the node to create
-   * @param newValue     the non-null value to be associated with the key
+   * @param path path for the node to create
+   * @param newValue the non-null value to be associated with the key
    * @param currentValue current value for update to occur
-   * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise.
-   * This method returns {@code false} if the newValue and currentValue are same.
+   * @return returns {@code true} if the update was made and the tree was modified, {@code false} otherwise. This method
+   *     returns {@code false} if the newValue and currentValue are same.
    * @throws NoSuchDocumentPathException if the parent node (for the node to create) does not exist
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   boolean replace(DocumentPath path, V newValue, V currentValue);
 
   /**
    * Removes the node with the specified path.
    *
-   * @param path path for the node to remove
+   * @param path path to the node to remove, must be prefixed with the root {@code /} path
    * @return the previous value of the node or {@code null} if it did not exist
    * @throws IllegalDocumentModificationException if the remove to be removed
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   default Versioned<V> remove(String path) {
     return remove(DocumentPath.from(path));
@@ -210,6 +225,7 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * @param path path for the node to remove
    * @return the previous value of the node or {@code null} if it did not exist
    * @throws IllegalDocumentModificationException if the remove to be removed
+   * @throws IllegalArgumentException if the given path does not start at root {@code /}
    */
   Versioned<V> remove(DocumentPath path);
 
@@ -223,10 +239,9 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   }
 
   /**
-   * Registers a listener to be notified when a subtree rooted at the specified path
-   * is modified.
+   * Registers a listener to be notified when a subtree rooted at the specified path is modified.
    *
-   * @param path     path to root of subtree to monitor for updates
+   * @param path path to root of subtree to monitor for updates
    * @param listener listener to be notified
    */
   default void addListener(DocumentPath path, DocumentTreeEventListener<V> listener) {
@@ -244,10 +259,9 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   }
 
   /**
-   * Registers a listener to be notified when a subtree rooted at the specified path
-   * is modified.
+   * Registers a listener to be notified when a subtree rooted at the specified path is modified.
    *
-   * @param path     path to root of subtree to monitor for updates
+   * @param path path to root of subtree to monitor for updates
    * @param listener listener to be notified
    * @param executor the executor on which to notify the event listener
    */

--- a/core/src/main/java/io/atomix/core/tree/AtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/AtomicDocumentTree.java
@@ -16,10 +16,12 @@
 
 package io.atomix.core.tree;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import io.atomix.primitive.SyncPrimitive;
 import io.atomix.utils.time.Versioned;
 
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * A hierarchical <a href="https://en.wikipedia.org/wiki/Document_Object_Model">document tree</a> data structure.
@@ -116,13 +118,44 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
   Versioned<V> removeNode(DocumentPath path);
 
   /**
+   * Registers a listener to be notified when the tree is modified.
+   *
+   * @param listener listener to be notified
+   */
+  default void addListener(DocumentTreeEventListener<V> listener) {
+    addListener(null, listener, MoreExecutors.directExecutor());
+  }
+
+  /**
    * Registers a listener to be notified when a subtree rooted at the specified path
    * is modified.
    *
    * @param path     path to root of subtree to monitor for updates
    * @param listener listener to be notified
    */
-  void addListener(DocumentPath path, DocumentTreeEventListener<V> listener);
+  default void addListener(DocumentPath path, DocumentTreeEventListener<V> listener) {
+    addListener(path, listener, MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Registers a listener to be notified when the tree is modified.
+   *
+   * @param listener listener to be notified
+   * @param executor the executor on which to notify the event listener
+   */
+  default void addListener(DocumentTreeEventListener<V> listener, Executor executor) {
+    addListener(null, listener, executor);
+  }
+
+  /**
+   * Registers a listener to be notified when a subtree rooted at the specified path
+   * is modified.
+   *
+   * @param path     path to root of subtree to monitor for updates
+   * @param listener listener to be notified
+   * @param executor the executor on which to notify the event listener
+   */
+  void addListener(DocumentPath path, DocumentTreeEventListener<V> listener, Executor executor);
 
   /**
    * Unregisters a previously added listener.
@@ -130,15 +163,6 @@ public interface AtomicDocumentTree<V> extends SyncPrimitive {
    * @param listener listener to unregister
    */
   void removeListener(DocumentTreeEventListener<V> listener);
-
-  /**
-   * Registers a listener to be notified when the tree is modified.
-   *
-   * @param listener listener to be notified
-   */
-  default void addListener(DocumentTreeEventListener<V> listener) {
-    addListener(root(), listener);
-  }
 
   @Override
   AsyncAtomicDocumentTree<V> async();

--- a/core/src/main/java/io/atomix/core/tree/DocumentPath.java
+++ b/core/src/main/java/io/atomix/core/tree/DocumentPath.java
@@ -39,21 +39,26 @@ public class DocumentPath implements Comparable<DocumentPath> {
   /**
    * Default path separator.
    */
-  public static final String DEFAULT_SEPARATOR = "|";
+  public static final String DEFAULT_SEPARATOR = "/";
 
   /**
    * Default path separator regex.
    */
-  public static final String DEFAULT_SEPARATOR_RE = "\\|";
+  public static final String DEFAULT_SEPARATOR_RE = "/";
 
   // TODO: Add means to set the path separator and separator ERE.
   private static String pathSeparator = DEFAULT_SEPARATOR;
   private static String pathSeparatorRE = DEFAULT_SEPARATOR_RE;
 
   /**
+   * Root document path.
+   */
+  private static final String ROOT_PATH = "/";
+
+  /**
    * Root document tree path.
    */
-  public static final DocumentPath ROOT = DocumentPath.from("root");
+  public static final DocumentPath ROOT = DocumentPath.from(new String[]{""});
 
   private final List<String> pathElements = Lists.newArrayList();
 
@@ -102,6 +107,9 @@ public class DocumentPath implements Comparable<DocumentPath> {
    * @return {@code DocumentPath} instance
    */
   public static DocumentPath from(String path) {
+    if (path.equals(ROOT_PATH)) {
+      return ROOT;
+    }
     return new DocumentPath(Arrays.asList(path.split(pathSeparatorRE)));
   }
 
@@ -229,6 +237,10 @@ public class DocumentPath implements Comparable<DocumentPath> {
 
   @Override
   public String toString() {
+    if (pathElements.equals(ROOT.pathElements)) {
+      return ROOT_PATH;
+    }
+
     StringBuilder stringBuilder = new StringBuilder();
     Iterator<String> iter = pathElements.iterator();
     while (iter.hasNext()) {

--- a/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
@@ -151,7 +151,7 @@ public class AtomicDocumentTreeProxy
   }
 
   @Override
-  public CompletableFuture<Versioned<byte[]>> removeNode(DocumentPath path) {
+  public CompletableFuture<Versioned<byte[]>> remove(DocumentPath path) {
     if (path.equals(root())) {
       return Futures.exceptionalFuture(new IllegalDocumentModificationException());
     }

--- a/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
@@ -16,6 +16,7 @@
 
 package io.atomix.core.tree.impl;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.atomix.core.tree.AsyncAtomicDocumentTree;
 import io.atomix.core.tree.AtomicDocumentTree;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -56,19 +58,26 @@ public class AtomicDocumentTreeProxy
     return DocumentPath.ROOT;
   }
 
+  private void checkPath(DocumentPath path) {
+    checkArgument(!path.pathElements().isEmpty() && "".equals(path.pathElements().get(0)), "Path should start with root");
+  }
+
   @Override
   public CompletableFuture<Map<String, Versioned<byte[]>>> getChildren(DocumentPath path) {
+    checkPath(path);
     return getProxyClient().applyBy(name(), service -> service.getChildren(path))
         .thenApply(result -> result.status() == DocumentTreeResult.Status.OK ? result.result() : ImmutableMap.of());
   }
 
   @Override
   public CompletableFuture<Versioned<byte[]>> get(DocumentPath path) {
+    checkPath(path);;
     return getProxyClient().applyBy(name(), service -> service.get(path));
   }
 
   @Override
   public CompletableFuture<Versioned<byte[]>> set(DocumentPath path, byte[] value) {
+    checkPath(path);
     return getProxyClient().applyBy(name(), service -> service.set(path, value))
         .thenCompose(result -> {
           if (result.status() == DocumentTreeResult.Status.INVALID_PATH) {
@@ -83,6 +92,7 @@ public class AtomicDocumentTreeProxy
 
   @Override
   public CompletableFuture<Boolean> create(DocumentPath path, byte[] value) {
+    checkPath(path);
     return getProxyClient().applyBy(name(), service -> service.create(path, value))
         .thenCompose(result -> {
           if (result.status() == DocumentTreeResult.Status.INVALID_PATH) {
@@ -97,6 +107,7 @@ public class AtomicDocumentTreeProxy
 
   @Override
   public CompletableFuture<Boolean> createRecursive(DocumentPath path, byte[] value) {
+    checkPath(path);
     return getProxyClient().applyBy(name(), service -> service.createRecursive(path, value))
         .thenCompose(result -> {
           if (result.status() == DocumentTreeResult.Status.INVALID_PATH) {
@@ -111,6 +122,7 @@ public class AtomicDocumentTreeProxy
 
   @Override
   public CompletableFuture<Boolean> replace(DocumentPath path, byte[] newValue, long version) {
+    checkPath(path);
     return getProxyClient().applyBy(name(), service -> service.replace(path, newValue, version))
         .thenCompose(result -> {
           if (result.status() == DocumentTreeResult.Status.INVALID_PATH) {
@@ -125,6 +137,7 @@ public class AtomicDocumentTreeProxy
 
   @Override
   public CompletableFuture<Boolean> replace(DocumentPath path, byte[] newValue, byte[] currentValue) {
+    checkPath(path);
     return getProxyClient().applyBy(name(), service -> service.replace(path, newValue, currentValue))
         .thenCompose(result -> {
           if (result.status() == DocumentTreeResult.Status.INVALID_PATH) {
@@ -142,6 +155,8 @@ public class AtomicDocumentTreeProxy
     if (path.equals(root())) {
       return Futures.exceptionalFuture(new IllegalDocumentModificationException());
     }
+
+    checkPath(path);
     return getProxyClient().applyBy(name(), service -> service.removeNode(path))
         .thenCompose(result -> {
           if (result.status() == DocumentTreeResult.Status.INVALID_PATH) {
@@ -158,6 +173,8 @@ public class AtomicDocumentTreeProxy
   public CompletableFuture<Void> addListener(DocumentPath path, DocumentTreeEventListener<byte[]> listener, Executor executor) {
     checkNotNull(path);
     checkNotNull(listener);
+    checkPath(path);
+
     InternalListener internalListener = new InternalListener(path, listener, executor);
     // TODO: Support API that takes an executor
     if (!eventListeners.containsKey(listener)) {

--- a/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
@@ -18,9 +18,9 @@ package io.atomix.core.tree.impl;
 
 import com.google.common.base.Throwables;
 import io.atomix.core.tree.AsyncAtomicDocumentTree;
+import io.atomix.core.tree.AtomicDocumentTree;
 import io.atomix.core.tree.DocumentException;
 import io.atomix.core.tree.DocumentPath;
-import io.atomix.core.tree.AtomicDocumentTree;
 import io.atomix.core.tree.DocumentTreeEventListener;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.Synchronous;
@@ -29,6 +29,7 @@ import io.atomix.utils.time.Versioned;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -96,18 +97,13 @@ public class BlockingAtomicDocumentTree<V> extends Synchronous<AsyncAtomicDocume
   }
 
   @Override
-  public void addListener(DocumentPath path, DocumentTreeEventListener<V> listener) {
-    complete(backingTree.addListener(path, listener));
+  public void addListener(DocumentPath path, DocumentTreeEventListener<V> listener, Executor executor) {
+    complete(backingTree.addListener(path, listener, executor));
   }
 
   @Override
   public void removeListener(DocumentTreeEventListener<V> listener) {
     complete(backingTree.removeListener(listener));
-  }
-
-  @Override
-  public void addListener(DocumentTreeEventListener<V> listener) {
-    complete(backingTree.addListener(listener));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
@@ -92,8 +92,8 @@ public class BlockingAtomicDocumentTree<V> extends Synchronous<AsyncAtomicDocume
   }
 
   @Override
-  public Versioned<V> removeNode(DocumentPath path) {
-    return complete(backingTree.removeNode(path));
+  public Versioned<V> remove(DocumentPath path) {
+    return complete(backingTree.remove(path));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/CachingAsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/CachingAsyncAtomicDocumentTree.java
@@ -135,8 +135,8 @@ public class CachingAsyncAtomicDocumentTree<V> extends DelegatingAsyncAtomicDocu
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> removeNode(DocumentPath path) {
-    return super.removeNode(path)
+  public CompletableFuture<Versioned<V>> remove(DocumentPath path) {
+    return super.remove(path)
         .whenComplete((r, e) -> cache.invalidate(path));
   }
 

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTree.java
@@ -20,8 +20,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
 import io.atomix.core.tree.AsyncAtomicDocumentTree;
-import io.atomix.core.tree.DocumentPath;
 import io.atomix.core.tree.AtomicDocumentTree;
+import io.atomix.core.tree.DocumentPath;
 import io.atomix.core.tree.DocumentTreeEventListener;
 import io.atomix.core.tree.DocumentTreeNode;
 import io.atomix.core.tree.IllegalDocumentModificationException;
@@ -34,6 +34,7 @@ import io.atomix.utils.time.Versioned;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -43,18 +44,17 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class DefaultAtomicDocumentTree<V> implements AtomicDocumentTree<V> {
 
-  private static final DocumentPath ROOT_PATH = DocumentPath.from("root");
   final DefaultDocumentTreeNode<V> root;
   private final Supplier<Long> versionSupplier;
 
   public DefaultAtomicDocumentTree() {
     AtomicLong versionCounter = new AtomicLong(0);
     versionSupplier = versionCounter::incrementAndGet;
-    root = new DefaultDocumentTreeNode<V>(ROOT_PATH, null, versionSupplier.get(), Ordering.NATURAL, null);
+    root = new DefaultDocumentTreeNode<V>(DocumentPath.ROOT, null, versionSupplier.get(), Ordering.NATURAL, null);
   }
 
   public DefaultAtomicDocumentTree(Supplier<Long> versionSupplier, Ordering ordering) {
-    root = new DefaultDocumentTreeNode<V>(ROOT_PATH, null, versionSupplier.get(), ordering, null);
+    root = new DefaultDocumentTreeNode<V>(DocumentPath.ROOT, null, versionSupplier.get(), ordering, null);
     this.versionSupplier = versionSupplier;
   }
 
@@ -80,7 +80,7 @@ public class DefaultAtomicDocumentTree<V> implements AtomicDocumentTree<V> {
 
   @Override
   public DocumentPath root() {
-    return ROOT_PATH;
+    return DocumentPath.ROOT;
   }
 
   @Override
@@ -188,7 +188,7 @@ public class DefaultAtomicDocumentTree<V> implements AtomicDocumentTree<V> {
   }
 
   @Override
-  public void addListener(DocumentPath path, DocumentTreeEventListener<V> listener) {
+  public void addListener(DocumentPath path, DocumentTreeEventListener<V> listener, Executor executor) {
     // TODO Auto-generated method stub
   }
 
@@ -210,7 +210,7 @@ public class DefaultAtomicDocumentTree<V> implements AtomicDocumentTree<V> {
   private DefaultDocumentTreeNode<V> getNode(DocumentPath path) {
     Iterator<String> pathElements = path.pathElements().iterator();
     DefaultDocumentTreeNode<V> currentNode = root;
-    Preconditions.checkState("root".equals(pathElements.next()), "Path should start with root");
+    Preconditions.checkState("".equals(pathElements.next()), "Path should start with root");
     while (pathElements.hasNext() && currentNode != null) {
       currentNode = (DefaultDocumentTreeNode<V>) currentNode.child(pathElements.next());
     }
@@ -222,7 +222,7 @@ public class DefaultAtomicDocumentTree<V> implements AtomicDocumentTree<V> {
   }
 
   private void checkRootModification(DocumentPath path) {
-    if (ROOT_PATH.equals(path)) {
+    if (DocumentPath.ROOT.equals(path)) {
       throw new IllegalDocumentModificationException();
     }
   }

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTree.java
@@ -173,7 +173,7 @@ public class DefaultAtomicDocumentTree<V> implements AtomicDocumentTree<V> {
   }
 
   @Override
-  public Versioned<V> removeNode(DocumentPath path) {
+  public Versioned<V> remove(DocumentPath path) {
     checkRootModification(path);
     DefaultDocumentTreeNode<V> nodeToRemove = getNode(path);
     if (nodeToRemove == null) {

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
@@ -232,7 +232,7 @@ public class DefaultDocumentTreeService extends AbstractPrimitiveService<Documen
   @Override
   public DocumentTreeResult<Versioned<byte[]>> removeNode(DocumentPath path) {
     try {
-      Versioned<byte[]> result = docTree.removeNode(path);
+      Versioned<byte[]> result = docTree.remove(path);
       notifyListeners(new DocumentTreeEvent<>(DocumentTreeEvent.Type.DELETED, path, Optional.empty(), Optional.of(result)));
       return DocumentTreeResult.ok(result);
     } catch (IllegalDocumentModificationException e) {
@@ -254,7 +254,7 @@ public class DefaultDocumentTreeService extends AbstractPrimitiveService<Documen
       DocumentPath path = toClearQueue.remove();
       Map<String, Versioned<byte[]>> children = docTree.getChildren(path);
       if (children.size() == 0) {
-        docTree.removeNode(path);
+        docTree.remove(path);
       } else {
         children.keySet().forEach(name -> toClearQueue.add(new DocumentPath(name, path)));
         toClearQueue.add(path);

--- a/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DefaultDocumentTreeService.java
@@ -245,10 +245,10 @@ public class DefaultDocumentTreeService extends AbstractPrimitiveService<Documen
   @Override
   public void clear() {
     Queue<DocumentPath> toClearQueue = Queues.newArrayDeque();
-    Map<String, Versioned<byte[]>> topLevelChildren = docTree.getChildren(DocumentPath.from("root"));
+    Map<String, Versioned<byte[]>> topLevelChildren = docTree.getChildren(DocumentPath.ROOT);
     toClearQueue.addAll(topLevelChildren.keySet()
         .stream()
-        .map(name -> new DocumentPath(name, DocumentPath.from("root")))
+        .map(name -> new DocumentPath(name, DocumentPath.ROOT))
         .collect(Collectors.toList()));
     while (!toClearQueue.isEmpty()) {
       DocumentPath path = toClearQueue.remove();

--- a/core/src/main/java/io/atomix/core/tree/impl/DelegatingAsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DelegatingAsyncAtomicDocumentTree.java
@@ -80,8 +80,8 @@ public class DelegatingAsyncAtomicDocumentTree<V> extends DelegatingAsyncPrimiti
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> removeNode(DocumentPath path) {
-    return delegateTree.removeNode(path);
+  public CompletableFuture<Versioned<V>> remove(DocumentPath path) {
+    return delegateTree.remove(path);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeResource.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/DocumentTreeResource.java
@@ -159,7 +159,7 @@ public class DocumentTreeResource implements PrimitiveResource {
   @Path("/{path: .*}")
   @Produces(MediaType.APPLICATION_JSON)
   public void removeNode(@PathParam("path") List<PathSegment> path, @Suspended AsyncResponse response) {
-    tree.removeNode(getDocumentPath(path)).whenComplete((result, error) -> {
+    tree.remove(getDocumentPath(path)).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(new VersionedResult(result)).build());
       } else {

--- a/core/src/main/java/io/atomix/core/tree/impl/TranscodingAsyncAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/TranscodingAsyncAtomicDocumentTree.java
@@ -91,8 +91,8 @@ public class TranscodingAsyncAtomicDocumentTree<V1, V2> extends DelegatingAsyncP
   }
 
   @Override
-  public CompletableFuture<Versioned<V1>> removeNode(DocumentPath path) {
-    return backingTree.removeNode(path).thenApply(v -> v != null ? v.map(valueDecoder) : null);
+  public CompletableFuture<Versioned<V1>> remove(DocumentPath path) {
+    return backingTree.remove(path).thenApply(v -> v != null ? v.map(valueDecoder) : null);
   }
 
   @Override

--- a/core/src/test/java/io/atomix/core/tree/DocumentPathTest.java
+++ b/core/src/test/java/io/atomix/core/tree/DocumentPathTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.tree;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Document path test.
+ */
+public class DocumentPathTest {
+  @Test
+  public void testValidDocumentPath() {
+    assertEquals("/", DocumentPath.from("/").toString());
+    assertEquals(1, DocumentPath.from("/").pathElements().size());
+    assertEquals("/foo", DocumentPath.from("/foo").toString());
+    assertEquals(2, DocumentPath.from("/foo").pathElements().size());
+    assertEquals("/foo/bar", DocumentPath.from("/foo/bar").toString());
+    assertEquals(3, DocumentPath.from("/foo/bar").pathElements().size());
+    assertEquals("foo", DocumentPath.from("/foo").childPath().toString());
+    assertEquals("/", DocumentPath.from("/foo").parent().toString());
+    assertEquals("bar", DocumentPath.from("/foo/bar").childPath().toString());
+    assertEquals("/foo", DocumentPath.from("/foo/bar").parent().toString());
+    assertEquals("foo", DocumentPath.from("foo").toString());
+    assertEquals("foo/bar", DocumentPath.from("foo/bar").toString());
+    assertEquals(1, DocumentPath.from("foo").pathElements().size());
+    assertEquals(2, DocumentPath.from("foo/bar").pathElements().size());
+  }
+}

--- a/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
@@ -59,6 +59,20 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   }
 
   /**
+   * Tests exception.
+   */
+  @Test
+  public void testException() throws Throwable {
+    AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
+    try {
+      tree.create(path("a"), "a").get(30, TimeUnit.SECONDS);
+      fail();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
    * Tests create.
    */
   @Test

--- a/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
@@ -53,7 +53,7 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testQueries() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    Versioned<String> root = tree.get(path("root")).get(30, TimeUnit.SECONDS);
+    Versioned<String> root = tree.get(path("/")).get(30, TimeUnit.SECONDS);
     assertEquals(1, root.version());
     assertNull(root.value());
   }
@@ -78,20 +78,20 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testCreate() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
-    Versioned<String> a = tree.get(path("root.a")).get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
+    Versioned<String> a = tree.get(path("/a")).get(30, TimeUnit.SECONDS);
     assertEquals("a", a.value());
 
-    Versioned<String> ab = tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS);
+    Versioned<String> ab = tree.get(path("/a/b")).get(30, TimeUnit.SECONDS);
     assertEquals("ab", ab.value());
 
-    Versioned<String> ac = tree.get(path("root.a.c")).get(30, TimeUnit.SECONDS);
+    Versioned<String> ac = tree.get(path("/a/c")).get(30, TimeUnit.SECONDS);
     assertEquals("ac", ac.value());
 
-    tree.create(path("root.x"), null).get(30, TimeUnit.SECONDS);
-    Versioned<String> x = tree.get(path("root.x")).get(30, TimeUnit.SECONDS);
+    tree.create(path("/x"), null).get(30, TimeUnit.SECONDS);
+    Versioned<String> x = tree.get(path("/x")).get(30, TimeUnit.SECONDS);
     assertNull(x.value());
   }
 
@@ -101,14 +101,14 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testRecursiveCreate() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.createRecursive(path("root.a.b.c"), "abc").get(30, TimeUnit.SECONDS);
-    Versioned<String> a = tree.get(path("root.a")).get(30, TimeUnit.SECONDS);
+    tree.createRecursive(path("/a/b/c"), "abc").get(30, TimeUnit.SECONDS);
+    Versioned<String> a = tree.get(path("/a")).get(30, TimeUnit.SECONDS);
     assertEquals(null, a.value());
 
-    Versioned<String> ab = tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS);
+    Versioned<String> ab = tree.get(path("/a/b")).get(30, TimeUnit.SECONDS);
     assertEquals(null, ab.value());
 
-    Versioned<String> abc = tree.get(path("root.a.b.c")).get(30, TimeUnit.SECONDS);
+    Versioned<String> abc = tree.get(path("/a/b/c")).get(30, TimeUnit.SECONDS);
     assertEquals("abc", abc.value());
   }
 
@@ -118,24 +118,24 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testSet() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
 
-    tree.set(path("root.a.d"), "ad").get(30, TimeUnit.SECONDS);
-    Versioned<String> ad = tree.get(path("root.a.d")).get(30, TimeUnit.SECONDS);
+    tree.set(path("/a/d"), "ad").get(30, TimeUnit.SECONDS);
+    Versioned<String> ad = tree.get(path("/a/d")).get(30, TimeUnit.SECONDS);
     assertEquals("ad", ad.value());
 
-    tree.set(path("root.a"), "newA").get(30, TimeUnit.SECONDS);
-    Versioned<String> newA = tree.get(path("root.a")).get(30, TimeUnit.SECONDS);
+    tree.set(path("/a"), "newA").get(30, TimeUnit.SECONDS);
+    Versioned<String> newA = tree.get(path("/a")).get(30, TimeUnit.SECONDS);
     assertEquals("newA", newA.value());
 
-    tree.set(path("root.a.b"), "newAB").get(30, TimeUnit.SECONDS);
-    Versioned<String> newAB = tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS);
+    tree.set(path("/a/b"), "newAB").get(30, TimeUnit.SECONDS);
+    Versioned<String> newAB = tree.get(path("/a/b")).get(30, TimeUnit.SECONDS);
     assertEquals("newAB", newAB.value());
 
-    tree.set(path("root.x"), null).get(30, TimeUnit.SECONDS);
-    Versioned<String> x = tree.get(path("root.x")).get(30, TimeUnit.SECONDS);
+    tree.set(path("/x"), null).get(30, TimeUnit.SECONDS);
+    Versioned<String> x = tree.get(path("/x")).get(30, TimeUnit.SECONDS);
     assertNull(x.value());
   }
 
@@ -145,19 +145,19 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testReplaceVersion() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
 
-    Versioned<String> ab = tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS);
-    assertTrue(tree.replace(path("root.a.b"), "newAB", ab.version()).get(30, TimeUnit.SECONDS));
-    Versioned<String> newAB = tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS);
+    Versioned<String> ab = tree.get(path("/a/b")).get(30, TimeUnit.SECONDS);
+    assertTrue(tree.replace(path("/a/b"), "newAB", ab.version()).get(30, TimeUnit.SECONDS));
+    Versioned<String> newAB = tree.get(path("/a/b")).get(30, TimeUnit.SECONDS);
     assertEquals("newAB", newAB.value());
 
-    assertFalse(tree.replace(path("root.a.b"), "newestAB", ab.version()).get(30, TimeUnit.SECONDS));
-    assertEquals("newAB", tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS).value());
+    assertFalse(tree.replace(path("/a/b"), "newestAB", ab.version()).get(30, TimeUnit.SECONDS));
+    assertEquals("newAB", tree.get(path("/a/b")).get(30, TimeUnit.SECONDS).value());
 
-    assertFalse(tree.replace(path("root.a.d"), "foo", 1).get(30, TimeUnit.SECONDS));
+    assertFalse(tree.replace(path("/a/d"), "foo", 1).get(30, TimeUnit.SECONDS));
   }
 
   /**
@@ -166,19 +166,19 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testReplaceValue() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
 
-    Versioned<String> ab = tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS);
-    assertTrue(tree.replace(path("root.a.b"), "newAB", ab.value()).get(30, TimeUnit.SECONDS));
-    Versioned<String> newAB = tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS);
+    Versioned<String> ab = tree.get(path("/a/b")).get(30, TimeUnit.SECONDS);
+    assertTrue(tree.replace(path("/a/b"), "newAB", ab.value()).get(30, TimeUnit.SECONDS));
+    Versioned<String> newAB = tree.get(path("/a/b")).get(30, TimeUnit.SECONDS);
     assertEquals("newAB", newAB.value());
 
-    assertFalse(tree.replace(path("root.a.b"), "newestAB", ab.value()).get(30, TimeUnit.SECONDS));
-    assertEquals("newAB", tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS).value());
+    assertFalse(tree.replace(path("/a/b"), "newestAB", ab.value()).get(30, TimeUnit.SECONDS));
+    assertEquals("newAB", tree.get(path("/a/b")).get(30, TimeUnit.SECONDS).value());
 
-    assertFalse(tree.replace(path("root.a.d"), "bar", "foo").get(30, TimeUnit.SECONDS));
+    assertFalse(tree.replace(path("/a/d"), "bar", "foo").get(30, TimeUnit.SECONDS));
   }
 
   /**
@@ -187,26 +187,26 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testRemove() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
 
-    Versioned<String> ab = tree.removeNode(path("root.a.b")).get(30, TimeUnit.SECONDS);
+    Versioned<String> ab = tree.removeNode(path("/a/b")).get(30, TimeUnit.SECONDS);
     assertEquals("ab", ab.value());
-    assertNull(tree.get(path("root.a.b")).get(30, TimeUnit.SECONDS));
+    assertNull(tree.get(path("/a/b")).get(30, TimeUnit.SECONDS));
 
-    Versioned<String> ac = tree.removeNode(path("root.a.c")).get(30, TimeUnit.SECONDS);
+    Versioned<String> ac = tree.removeNode(path("/a/c")).get(30, TimeUnit.SECONDS);
     assertEquals("ac", ac.value());
-    assertNull(tree.get(path("root.a.c")).get(30, TimeUnit.SECONDS));
+    assertNull(tree.get(path("/a/c")).get(30, TimeUnit.SECONDS));
 
-    Versioned<String> a = tree.removeNode(path("root.a")).get(30, TimeUnit.SECONDS);
+    Versioned<String> a = tree.removeNode(path("/a")).get(30, TimeUnit.SECONDS);
     assertEquals("a", a.value());
-    assertNull(tree.get(path("root.a")).get(30, TimeUnit.SECONDS));
+    assertNull(tree.get(path("/a")).get(30, TimeUnit.SECONDS));
 
-    tree.create(path("root.x"), null).get(30, TimeUnit.SECONDS);
-    Versioned<String> x = tree.removeNode(path("root.x")).get(30, TimeUnit.SECONDS);
+    tree.create(path("/x"), null).get(30, TimeUnit.SECONDS);
+    Versioned<String> x = tree.removeNode(path("/x")).get(30, TimeUnit.SECONDS);
     assertNull(x.value());
-    assertNull(tree.get(path("root.a.x")).get(30, TimeUnit.SECONDS));
+    assertNull(tree.get(path("/a/x")).get(30, TimeUnit.SECONDS));
   }
 
   /**
@@ -215,26 +215,26 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testRemoveFailures() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
 
     try {
-      tree.removeNode(path("root")).get(30, TimeUnit.SECONDS);
+      tree.removeNode(path("/")).get(30, TimeUnit.SECONDS);
       fail();
     } catch (Exception e) {
       assertTrue(Throwables.getRootCause(e) instanceof IllegalDocumentModificationException);
     }
 
     try {
-      tree.removeNode(path("root.a")).get(30, TimeUnit.SECONDS);
+      tree.removeNode(path("/a")).get(30, TimeUnit.SECONDS);
       fail();
     } catch (Exception e) {
       assertTrue(Throwables.getRootCause(e) instanceof IllegalDocumentModificationException);
     }
 
     try {
-      tree.removeNode(path("root.d")).get(30, TimeUnit.SECONDS);
+      tree.removeNode(path("/d")).get(30, TimeUnit.SECONDS);
       fail();
     } catch (Exception e) {
       assertTrue(Throwables.getRootCause(e) instanceof NoSuchDocumentPathException);
@@ -248,7 +248,7 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   public void testCreateFailures() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
     try {
-      tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+      tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
       fail();
     } catch (Exception e) {
       assertTrue(Throwables.getRootCause(e) instanceof IllegalDocumentModificationException);
@@ -262,7 +262,7 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   public void testSetFailures() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
     try {
-      tree.set(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+      tree.set(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
       fail();
     } catch (Exception e) {
       assertTrue(Throwables.getRootCause(e) instanceof IllegalDocumentModificationException);
@@ -275,24 +275,24 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testGetChildren() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
 
-    Map<String, Versioned<String>> rootChildren = tree.getChildren(path("root")).get(30, TimeUnit.SECONDS);
+    Map<String, Versioned<String>> rootChildren = tree.getChildren(path("/")).get(30, TimeUnit.SECONDS);
     assertEquals(1, rootChildren.size());
     Versioned<String> a = rootChildren.get("a");
     assertEquals("a", a.value());
 
-    Map<String, Versioned<String>> children = tree.getChildren(path("root.a")).get(30, TimeUnit.SECONDS);
+    Map<String, Versioned<String>> children = tree.getChildren(path("/a")).get(30, TimeUnit.SECONDS);
     assertEquals(2, children.size());
     Versioned<String> ab = children.get("b");
     assertEquals("ab", ab.value());
     Versioned<String> ac = children.get("c");
     assertEquals("ac", ac.value());
 
-    assertEquals(0, tree.getChildren(path("root.a.b")).get(30, TimeUnit.SECONDS).size());
-    assertEquals(0, tree.getChildren(path("root.a.c")).get(30, TimeUnit.SECONDS).size());
+    assertEquals(0, tree.getChildren(path("/a/b")).get(30, TimeUnit.SECONDS).size());
+    assertEquals(0, tree.getChildren(path("/a/c")).get(30, TimeUnit.SECONDS).size());
   }
 
   /**
@@ -301,12 +301,12 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   @Test
   public void testClear() throws Exception {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("root.a"), "a").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.b"), "ab").get(30, TimeUnit.SECONDS);
-    tree.create(path("root.a.c"), "ac").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a"), "a").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/b"), "ab").get(30, TimeUnit.SECONDS);
+    tree.create(path("/a/c"), "ac").get(30, TimeUnit.SECONDS);
 
     tree.delete().get(30, TimeUnit.SECONDS);
-    assertEquals(0, tree.getChildren(path("root")).get(30, TimeUnit.SECONDS).size());
+    assertEquals(0, tree.getChildren(path("/")).get(30, TimeUnit.SECONDS).size());
   }
 
   /**
@@ -318,31 +318,31 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
     TestEventListener listener = new TestEventListener();
 
     // add listener; create a node in the tree and verify an CREATED event is received.
-    tree.addListener(listener).thenCompose(v -> tree.set(path("root.a"), "a")).get(30, TimeUnit.SECONDS);
+    tree.addListener(listener).thenCompose(v -> tree.set(path("/a"), "a")).get(30, TimeUnit.SECONDS);
     DocumentTreeEvent<String> event = listener.event();
     assertEquals(DocumentTreeEvent.Type.CREATED, event.type());
     assertFalse(event.oldValue().isPresent());
     assertEquals("a", event.newValue().get().value());
     // update a node in the tree and verify an UPDATED event is received.
-    tree.set(path("root.a"), "newA").get(30, TimeUnit.SECONDS);
+    tree.set(path("/a"), "newA").get(30, TimeUnit.SECONDS);
     event = listener.event();
     assertEquals(DocumentTreeEvent.Type.UPDATED, event.type());
     assertEquals("newA", event.newValue().get().value());
     assertEquals("a", event.oldValue().get().value());
     // remove a node in the tree and verify an REMOVED event is received.
-    tree.removeNode(path("root.a")).get(30, TimeUnit.SECONDS);
+    tree.removeNode(path("/a")).get(30, TimeUnit.SECONDS);
     event = listener.event();
     assertEquals(DocumentTreeEvent.Type.DELETED, event.type());
     assertFalse(event.newValue().isPresent());
     assertEquals("newA", event.oldValue().get().value());
     // recursively create a node and verify CREATED events for all intermediate nodes.
-    tree.createRecursive(path("root.x.y"), "xy").get(30, TimeUnit.SECONDS);
+    tree.createRecursive(path("/x/y"), "xy").get(30, TimeUnit.SECONDS);
     event = listener.event();
     assertEquals(DocumentTreeEvent.Type.CREATED, event.type());
-    assertEquals(path("root.x"), event.path());
+    assertEquals(path("/x"), event.path());
     event = listener.event();
     assertEquals(DocumentTreeEvent.Type.CREATED, event.type());
-    assertEquals(path("root.x.y"), event.path());
+    assertEquals(path("/x/y"), event.path());
     assertEquals("xy", event.newValue().get().value());
   }
 
@@ -357,23 +357,23 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
     TestEventListener listener1ab = new TestEventListener();
     TestEventListener listener2abc = new TestEventListener();
 
-    tree1.addListener(path("root.a"), listener1a).get(30, TimeUnit.SECONDS);
-    tree1.addListener(path("root.a.b"), listener1ab).get(30, TimeUnit.SECONDS);
-    tree2.addListener(path("root.a.b.c"), listener2abc).get(30, TimeUnit.SECONDS);
+    tree1.addListener(path("/a"), listener1a).get(30, TimeUnit.SECONDS);
+    tree1.addListener(path("/a/b"), listener1ab).get(30, TimeUnit.SECONDS);
+    tree2.addListener(path("/a/b/c"), listener2abc).get(30, TimeUnit.SECONDS);
 
-    tree1.createRecursive(path("root.a.b.c"), "abc").get(30, TimeUnit.SECONDS);
+    tree1.createRecursive(path("/a/b/c"), "abc").get(30, TimeUnit.SECONDS);
     DocumentTreeEvent<String> event = listener1a.event();
-    assertEquals(path("root.a"), event.path());
+    assertEquals(path("/a"), event.path());
     event = listener1a.event();
-    assertEquals(path("root.a.b"), event.path());
+    assertEquals(path("/a/b"), event.path());
     event = listener1a.event();
-    assertEquals(path("root.a.b.c"), event.path());
+    assertEquals(path("/a/b/c"), event.path());
     event = listener1ab.event();
-    assertEquals(path("root.a.b"), event.path());
+    assertEquals(path("/a/b"), event.path());
     event = listener1ab.event();
-    assertEquals(path("root.a.b.c"), event.path());
+    assertEquals(path("/a/b/c"), event.path());
     event = listener2abc.event();
-    assertEquals(path("root.a.b.c"), event.path());
+    assertEquals(path("/a/b/c"), event.path());
   }
 
   private static class TestEventListener implements DocumentTreeEventListener<String> {
@@ -394,6 +394,6 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   }
 
   private static DocumentPath path(String path) {
-    return DocumentPath.from(path.replace(".", DocumentPath.DEFAULT_SEPARATOR));
+    return DocumentPath.from(path);
   }
 }

--- a/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/DocumentTreeTest.java
@@ -65,10 +65,33 @@ public abstract class DocumentTreeTest extends AbstractPrimitiveTest<ProxyProtoc
   public void testException() throws Throwable {
     AsyncAtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
     try {
-      tree.create(path("a"), "a").get(30, TimeUnit.SECONDS);
+      tree.get(path("a")).get(30, TimeUnit.SECONDS);
       fail();
-    } catch (Exception e) {
-      e.printStackTrace();
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      tree.getChildren(path("a/b")).get(30, TimeUnit.SECONDS);
+      fail();
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      tree.set(path("a"), "a").get(30, TimeUnit.SECONDS);
+      fail();
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      tree.create(path("a/b"), "a").get(30, TimeUnit.SECONDS);
+      fail();
+    } catch (IllegalArgumentException e) {
+    }
+
+    try {
+      tree.createRecursive(path("a"), "a").get(30, TimeUnit.SECONDS);
+      fail();
+    } catch (IllegalArgumentException e) {
     }
   }
 

--- a/core/src/test/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/impl/DefaultAtomicDocumentTreeTest.java
@@ -171,7 +171,7 @@ public class DefaultAtomicDocumentTreeTest {
   @Test(expected = IllegalDocumentModificationException.class)
   public void testRemoveRoot() {
     AtomicDocumentTree<String> tree = new DefaultAtomicDocumentTree<>();
-    tree.removeNode(tree.root());
+    tree.remove(tree.root());
   }
 
   @Test
@@ -179,14 +179,14 @@ public class DefaultAtomicDocumentTreeTest {
     AtomicDocumentTree<String> tree = new DefaultAtomicDocumentTree<>();
     tree.create(path("root.a"), "bar");
     tree.create(path("root.a.b"), "alpha");
-    Assert.assertEquals("alpha", tree.removeNode(path("root.a.b")).value());
+    Assert.assertEquals("alpha", tree.remove(path("root.a.b")).value());
     Assert.assertEquals(0, tree.getChildren(path("root.a")).size());
   }
 
   @Test(expected = NoSuchDocumentPathException.class)
   public void testRemoveInvalidNode() {
     AtomicDocumentTree<String> tree = new DefaultAtomicDocumentTree<>();
-    tree.removeNode(path("root.a"));
+    tree.remove(path("root.a"));
   }
 
   private static DocumentPath path(String path) {

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveException.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveException.java
@@ -74,6 +74,10 @@ public class PrimitiveException extends AtomixRuntimeException {
     public ServiceException(String message) {
       super(message);
     }
+
+    public ServiceException(Throwable cause) {
+      super(cause);
+    }
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/service/AbstractPrimitiveService.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/AbstractPrimitiveService.java
@@ -139,7 +139,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
           try {
             method.invoke(this);
           } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new PrimitiveException.ServiceException(e.getMessage());
+            throw new PrimitiveException.ServiceException(e);
           }
         });
       } else {
@@ -147,7 +147,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
           try {
             method.invoke(this, (Object[]) args.value());
           } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new PrimitiveException.ServiceException(e.getMessage());
+            throw new PrimitiveException.ServiceException(e);
           }
         });
       }
@@ -157,7 +157,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
           try {
             return method.invoke(this);
           } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new PrimitiveException.ServiceException(e.getMessage());
+            throw new PrimitiveException.ServiceException(e);
           }
         });
       } else {
@@ -165,7 +165,7 @@ public abstract class AbstractPrimitiveService<C> implements PrimitiveService {
           try {
             return method.invoke(this, (Object[]) args.value());
           } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new PrimitiveException.ServiceException(e.getMessage());
+            throw new PrimitiveException.ServiceException(e);
           }
         });
       }

--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
@@ -182,7 +182,7 @@ public class DefaultServiceExecutor implements ServiceExecutor {
         return operation.apply(commit);
       } catch (Exception e) {
         log.warn("State machine operation failed: {}", e.getMessage());
-        throw new PrimitiveException.ServiceException();
+        throw new PrimitiveException.ServiceException(e);
       } finally {
         runTasks();
       }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft.roles;
 
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.protocols.raft.RaftError;
 import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.RaftServer;
@@ -452,6 +453,11 @@ public class PassiveRole extends InactiveRole {
     } else if (error instanceof RaftException) {
       future.complete(builder.withStatus(RaftResponse.Status.ERROR)
           .withError(((RaftException) error).getType(), error.getMessage())
+          .build());
+    } else if (error instanceof PrimitiveException.ServiceException) {
+      log.warn("An application error occurred: {}", error.getCause());
+      future.complete(builder.withStatus(RaftResponse.Status.ERROR)
+          .withError(RaftError.Type.APPLICATION_ERROR)
           .build());
     } else {
       log.warn("An unexpected error occurred: {}", error);


### PR DESCRIPTION
This PR modifies the `AtomicDocumentTree` primitive to use file system like paths.

```java
tree.set("/foo/bar", "baz");

tree.getChildren("/foo").forEach((key, value) -> {
  ...
});
```