### PR TITLE
Serializer configuration improvements

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/discovery/MulticastDiscoveryProvider.java
+++ b/cluster/src/main/java/io/atomix/cluster/discovery/MulticastDiscoveryProvider.java
@@ -25,8 +25,6 @@ import io.atomix.cluster.impl.AddressSerializer;
 import io.atomix.cluster.impl.PhiAccrualFailureDetector;
 import io.atomix.utils.event.AbstractListenerManager;
 import io.atomix.utils.net.Address;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespaces;
 import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,13 +87,11 @@ public class MulticastDiscoveryProvider
   }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MulticastDiscoveryProvider.class);
-  private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
-      .register(Namespaces.BASIC)
-      .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-      .register(Node.class)
-      .register(NodeId.class)
-      .register(new AddressSerializer(), Address.class)
-      .build());
+  private static final Serializer SERIALIZER = Serializer.builder()
+      .addType(Node.class)
+      .addType(NodeId.class)
+      .addSerializer(new AddressSerializer(), Address.class)
+      .build();
 
   private static final String DISCOVERY_SUBJECT = "atomix-discovery";
 

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -28,6 +28,7 @@ import io.atomix.core.election.LeaderElector;
 import io.atomix.core.idgenerator.AtomicIdGenerator;
 import io.atomix.core.impl.CorePrimitiveCache;
 import io.atomix.core.impl.CorePrimitivesService;
+import io.atomix.core.impl.CoreSerializationService;
 import io.atomix.core.list.DistributedList;
 import io.atomix.core.lock.AtomicLock;
 import io.atomix.core.lock.DistributedLock;
@@ -74,6 +75,7 @@ import io.atomix.primitive.partition.impl.DefaultPartitionGroupTypeRegistry;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.PrimitiveProtocolConfig;
+import io.atomix.primitive.serialization.SerializationService;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -314,6 +316,7 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
   private final ScheduledExecutorService executorService;
   private final AtomixRegistry registry;
   private final ConfigService config;
+  private final SerializationService serializationService;
   private final ManagedPartitionService partitions;
   private final CorePrimitivesService primitives;
   private final boolean enableShutdownHook;
@@ -345,12 +348,14 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
         Threads.namedThreads("atomix-primitive-%d", LOGGER));
     this.registry = registry;
     this.config = new DefaultConfigService(config.getPrimitives().values());
+    this.serializationService = new CoreSerializationService(config.isTypeRegistrationRequired(), config.isCompatibleSerialization());
     this.partitions = buildPartitionService(config, getMembershipService(), getCommunicationService(), registry);
     this.primitives = new CorePrimitivesService(
         getExecutorService(),
         getMembershipService(),
         getCommunicationService(),
         getEventService(),
+        getSerializationService(),
         getPartitionService(),
         new CorePrimitiveCache(),
         registry,
@@ -387,6 +392,15 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
    */
   public ConfigService getConfigService() {
     return config;
+  }
+
+  /**
+   * Returns the primitive serialization service.
+   *
+   * @return the primitive serialization service
+   */
+  public SerializationService getSerializationService() {
+    return serializationService;
   }
 
   /**

--- a/core/src/main/java/io/atomix/core/AtomixBuilder.java
+++ b/core/src/main/java/io/atomix/core/AtomixBuilder.java
@@ -251,6 +251,46 @@ public class AtomixBuilder extends AtomixClusterBuilder {
     return this;
   }
 
+  /**
+   * Requires explicit serializable type registration for user types.
+   *
+   * @return the Atomix builder
+   */
+  public AtomixBuilder withTypeRegistrationRequired() {
+    return withTypeRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether serializable type registration is required for user types.
+   *
+   * @param required whether serializable type registration is required for user types
+   * @return the Atomix builder
+   */
+  public AtomixBuilder withTypeRegistrationRequired(boolean required) {
+    config.setTypeRegistrationRequired(required);
+    return this;
+  }
+
+  /**
+   * Enables compatible serialization for user types.
+   *
+   * @return the Atomix builder
+   */
+  public AtomixBuilder withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled for user types.
+   *
+   * @param enabled whether compatible serialization is enabled for user types
+   * @return the Atomix builder
+   */
+  public AtomixBuilder withCompatibleSerialization(boolean enabled) {
+    config.setCompatibleSerialization(enabled);
+    return this;
+  }
+
   @Override
   public AtomixBuilder withClusterId(String clusterId) {
     super.withClusterId(clusterId);

--- a/core/src/main/java/io/atomix/core/AtomixConfig.java
+++ b/core/src/main/java/io/atomix/core/AtomixConfig.java
@@ -40,6 +40,8 @@ public class AtomixConfig implements Config {
   private Map<String, PartitionGroupConfig<?>> partitionGroups = new HashMap<>();
   private Map<String, PrimitiveConfig> primitives = new HashMap<>();
   private List<ProfileConfig> profiles = new ArrayList<>();
+  private boolean typeRegistrationRequired = false;
+  private boolean compatibleSerialization = false;
 
   /**
    * Returns the cluster configuration.
@@ -206,6 +208,46 @@ public class AtomixConfig implements Config {
    */
   public AtomixConfig addProfile(ProfileConfig profile) {
     profiles.add(checkNotNull(profile, "profile cannot be null"));
+    return this;
+  }
+
+  /**
+   * Returns whether serializable type registration is required for user types.
+   *
+   * @return whether serializable type registration is required for user types
+   */
+  public boolean isTypeRegistrationRequired() {
+    return typeRegistrationRequired;
+  }
+
+  /**
+   * Sets whether serializable type registration is required for user types.
+   *
+   * @param typeRegistrationRequired whether serializable type registration is required for user types
+   * @return the Atomix configuration
+   */
+  public AtomixConfig setTypeRegistrationRequired(boolean typeRegistrationRequired) {
+    this.typeRegistrationRequired = typeRegistrationRequired;
+    return this;
+  }
+
+  /**
+   * Returns whether compatible serialization is enabled for user types.
+   *
+   * @return whether compatible serialization is enabled for user types
+   */
+  public boolean isCompatibleSerialization() {
+    return compatibleSerialization;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled for user types.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled for user types
+   * @return the Atomix configuration
+   */
+  public AtomixConfig setCompatibleSerialization(boolean compatibleSerialization) {
+    this.compatibleSerialization = compatibleSerialization;
     return this;
   }
 }

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveManagementService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveManagementService.java
@@ -25,6 +25,7 @@ import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.PartitionGroupTypeRegistry;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.protocol.PrimitiveProtocolTypeRegistry;
+import io.atomix.primitive.serialization.SerializationService;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -36,6 +37,7 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
   private final ClusterMembershipService membershipService;
   private final ClusterCommunicationService communicationService;
   private final ClusterEventService eventService;
+  private final SerializationService serializationService;
   private final PartitionService partitionService;
   private final PrimitiveCache primitiveCache;
   private final PrimitiveRegistry primitiveRegistry;
@@ -48,6 +50,7 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
       ClusterMembershipService membershipService,
       ClusterCommunicationService communicationService,
       ClusterEventService eventService,
+      SerializationService serializationService,
       PartitionService partitionService,
       PrimitiveCache primitiveCache,
       PrimitiveRegistry primitiveRegistry,
@@ -58,6 +61,7 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
     this.membershipService = membershipService;
     this.communicationService = communicationService;
     this.eventService = eventService;
+    this.serializationService = serializationService;
     this.partitionService = partitionService;
     this.primitiveCache = primitiveCache;
     this.primitiveRegistry = primitiveRegistry;
@@ -84,6 +88,11 @@ public class CorePrimitiveManagementService implements PrimitiveManagementServic
   @Override
   public ClusterEventService getEventService() {
     return eventService;
+  }
+
+  @Override
+  public SerializationService getSerializationService() {
+    return serializationService;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -99,6 +99,7 @@ import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.partition.impl.DefaultPartitionGroupTypeRegistry;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.impl.DefaultPrimitiveProtocolTypeRegistry;
+import io.atomix.primitive.serialization.SerializationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,6 +128,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
       ClusterMembershipService membershipService,
       ClusterCommunicationService communicationService,
       ClusterEventService eventService,
+      SerializationService serializationService,
       PartitionService partitionService,
       PrimitiveCache primitiveCache,
       AtomixRegistry registry,
@@ -138,6 +140,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
         membershipService,
         communicationService,
         eventService,
+        serializationService,
         partitionService,
         primitiveCache,
         primitiveRegistry,

--- a/core/src/main/java/io/atomix/core/impl/CoreSerializationService.java
+++ b/core/src/main/java/io/atomix/core/impl/CoreSerializationService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.impl;
+
+import io.atomix.primitive.serialization.SerializationService;
+import io.atomix.utils.serializer.SerializerBuilder;
+
+/**
+ * Core serialization service.
+ */
+public class CoreSerializationService implements SerializationService {
+  private final boolean registrationRequired;
+  private final boolean compatibleSerialization;
+
+  public CoreSerializationService(boolean registrationRequired, boolean compatibleSerialization) {
+    this.registrationRequired = registrationRequired;
+    this.compatibleSerialization = compatibleSerialization;
+  }
+
+  @Override
+  public SerializerBuilder newBuilder() {
+    return new SerializerBuilder()
+        .withRegistrationRequired(registrationRequired)
+        .withCompatibleSerialization(compatibleSerialization);
+  }
+
+  @Override
+  public SerializerBuilder newBuilder(String name) {
+    return new SerializerBuilder(name)
+        .withRegistrationRequired(registrationRequired)
+        .withCompatibleSerialization(compatibleSerialization);
+  }
+}

--- a/core/src/main/java/io/atomix/core/map/AtomicCounterMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicCounterMapBuilder.java
@@ -15,11 +15,16 @@
  */
 package io.atomix.core.map;
 
+import com.google.common.collect.Lists;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Serializer;
+import io.atomix.utils.serializer.SerializerBuilder;
 
 /**
  * Builder for AtomicCounterMap.
@@ -35,5 +40,119 @@ public abstract class AtomicCounterMapBuilder<K>
   @Override
   public AtomicCounterMapBuilder<K> withProtocol(ProxyProtocol protocol) {
     return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  /**
+   * Sets the key type.
+   *
+   * @param keyType the key type
+   * @return the map builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapBuilder<K> withKeyType(Class<?> keyType) {
+    config.setKeyType(keyType);
+    return this;
+  }
+
+  /**
+   * Sets extra serializable types on the map.
+   *
+   * @param extraTypes the types to set
+   * @return the map builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapBuilder<K> withExtraTypes(Class<?>... extraTypes) {
+    config.setExtraTypes(Lists.newArrayList(extraTypes));
+    return this;
+  }
+
+  /**
+   * Adds an extra serializable type to the map.
+   *
+   * @param extraType the type to add
+   * @return the map builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapBuilder<K> addExtraType(Class<?> extraType) {
+    config.addExtraType(extraType);
+    return this;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapBuilder<K> withRegistrationRequired() {
+    return withRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapBuilder<K> withRegistrationRequired(boolean registrationRequired) {
+    config.setRegistrationRequired(registrationRequired);
+    return this;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapBuilder<K> withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapBuilder<K> withCompatibleSerialization(boolean compatibleSerialization) {
+    config.setCompatibleSerialization(compatibleSerialization);
+    return this;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  protected Serializer serializer() {
+    if (serializer == null) {
+      NamespaceConfig namespaceConfig = this.config.getNamespaceConfig();
+      if (namespaceConfig == null) {
+        namespaceConfig = new NamespaceConfig();
+      }
+
+      SerializerBuilder serializerBuilder = managementService.getSerializationService().newBuilder(name);
+      serializerBuilder.withNamespace(new Namespace(namespaceConfig));
+
+      if (config.isRegistrationRequired()) {
+        serializerBuilder.withRegistrationRequired();
+      }
+      if (config.isCompatibleSerialization()) {
+        serializerBuilder.withCompatibleSerialization();
+      }
+
+      if (config.getKeyType() != null) {
+        serializerBuilder.addType(config.getKeyType());
+      }
+      if (!config.getExtraTypes().isEmpty()) {
+        serializerBuilder.withTypes(config.getExtraTypes().toArray(new Class<?>[config.getExtraTypes().size()]));
+      }
+
+      serializer = serializerBuilder.build();
+    }
+    return serializer;
   }
 }

--- a/core/src/main/java/io/atomix/core/map/AtomicCounterMapConfig.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicCounterMapConfig.java
@@ -15,15 +15,119 @@
  */
 package io.atomix.core.map;
 
-import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.config.PrimitiveConfig;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Atomic counter map configuration.
  */
 public class AtomicCounterMapConfig extends PrimitiveConfig<AtomicCounterMapConfig> {
+  private Class<?> keyType;
+  private List<Class<?>> extraTypes = new ArrayList<>();
+  private boolean registrationRequired = false;
+  private boolean compatibleSerialization = false;
+
   @Override
   public PrimitiveType getType() {
     return AtomicCounterMapType.instance();
+  }
+
+  /**
+   * Returns the key type.
+   *
+   * @return the map key type
+   */
+  public Class<?> getKeyType() {
+    return keyType;
+  }
+
+  /**
+   * Sets the map key type.
+   *
+   * @param keyType the map key type
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapConfig setKeyType(Class<?> keyType) {
+    this.keyType = keyType;
+    return this;
+  }
+
+  /**
+   * Returns the extra serializable types.
+   *
+   * @return the extra serializable types
+   */
+  public List<Class<?>> getExtraTypes() {
+    return extraTypes;
+  }
+
+  /**
+   * Sets the extra serializable types.
+   *
+   * @param extraTypes the extra serializable types
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapConfig setExtraTypes(List<Class<?>> extraTypes) {
+    this.extraTypes = extraTypes;
+    return this;
+  }
+
+  /**
+   * Adds an extra serializable type.
+   *
+   * @param extraType the extra type to add
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapConfig addExtraType(Class<?> extraType) {
+    extraTypes.add(extraType);
+    return this;
+  }
+
+  /**
+   * Returns whether registration is required for serializable types.
+   *
+   * @return whether registration is required for serializable types
+   */
+  public boolean isRegistrationRequired() {
+    return registrationRequired;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapConfig setRegistrationRequired(boolean registrationRequired) {
+    this.registrationRequired = registrationRequired;
+    return this;
+  }
+
+  /**
+   * Returns whether compatible serialization is enabled.
+   *
+   * @return whether compatible serialization is enabled
+   */
+  public boolean isCompatibleSerialization() {
+    return compatibleSerialization;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicCounterMapConfig setCompatibleSerialization(boolean compatibleSerialization) {
+    this.compatibleSerialization = compatibleSerialization;
+    return this;
   }
 }

--- a/core/src/main/java/io/atomix/core/multimap/AtomicMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/AtomicMultimapBuilder.java
@@ -16,7 +16,6 @@
 
 package io.atomix.core.multimap;
 
-import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -26,7 +25,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
  * A builder class for {@code AsyncConsistentMultimap}.
  */
 public abstract class AtomicMultimapBuilder<K, V>
-    extends CachedPrimitiveBuilder<AtomicMultimapBuilder<K, V>, AtomicMultimapConfig, AtomicMultimap<K, V>>
+    extends MultimapBuilder<AtomicMultimapBuilder<K, V>, AtomicMultimapConfig, AtomicMultimap<K, V>, K, V>
     implements ProxyCompatibleBuilder<AtomicMultimapBuilder<K, V>> {
 
   protected AtomicMultimapBuilder(String name, AtomicMultimapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/multimap/AtomicMultimapConfig.java
+++ b/core/src/main/java/io/atomix/core/multimap/AtomicMultimapConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.multimap;
 
-import io.atomix.core.cache.CachedPrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Consistent multimap configuration.
  */
-public class AtomicMultimapConfig extends CachedPrimitiveConfig<AtomicMultimapConfig> {
+public class AtomicMultimapConfig extends MultimapConfig<AtomicMultimapConfig> {
   @Override
   public PrimitiveType getType() {
     return AtomicMultimapType.instance();

--- a/core/src/main/java/io/atomix/core/multimap/DistributedMultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/DistributedMultimapBuilder.java
@@ -16,7 +16,6 @@
 
 package io.atomix.core.multimap;
 
-import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -26,7 +25,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
  * A builder class for {@code AsyncConsistentMultimap}.
  */
 public abstract class DistributedMultimapBuilder<K, V>
-    extends CachedPrimitiveBuilder<DistributedMultimapBuilder<K, V>, DistributedMultimapConfig, DistributedMultimap<K, V>>
+    extends MultimapBuilder<DistributedMultimapBuilder<K, V>, DistributedMultimapConfig, DistributedMultimap<K, V>, K, V>
     implements ProxyCompatibleBuilder<DistributedMultimapBuilder<K, V>> {
 
   protected DistributedMultimapBuilder(String name, DistributedMultimapConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/multimap/DistributedMultimapConfig.java
+++ b/core/src/main/java/io/atomix/core/multimap/DistributedMultimapConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.multimap;
 
-import io.atomix.core.cache.CachedPrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Consistent multimap configuration.
  */
-public class DistributedMultimapConfig extends CachedPrimitiveConfig<DistributedMultimapConfig> {
+public class DistributedMultimapConfig extends MultimapConfig<DistributedMultimapConfig> {
   @Override
   public PrimitiveType getType() {
     return DistributedMultimapType.instance();

--- a/core/src/main/java/io/atomix/core/multimap/MultimapBuilder.java
+++ b/core/src/main/java/io/atomix/core/multimap/MultimapBuilder.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.multimap;
+
+import com.google.common.collect.Lists;
+import io.atomix.core.cache.CachedPrimitiveBuilder;
+import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.SyncPrimitive;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Serializer;
+import io.atomix.utils.serializer.SerializerBuilder;
+
+/**
+ * Base multimap builder.
+ */
+public abstract class MultimapBuilder<B extends MultimapBuilder<B, C, P, K, V>, C extends MultimapConfig<C>, P extends SyncPrimitive, K, V>
+    extends CachedPrimitiveBuilder<B, C, P> {
+  protected MultimapBuilder(PrimitiveType type, String name, C config, PrimitiveManagementService managementService) {
+    super(type, name, config, managementService);
+  }
+
+  /**
+   * Sets the key type.
+   *
+   * @param keyType the key type
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withKeyType(Class<?> keyType) {
+    config.setKeyType(keyType);
+    return (B) this;
+  }
+
+  /**
+   * Sets the value type.
+   *
+   * @param valueType the value type
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withValueType(Class<?> valueType) {
+    config.setValueType(valueType);
+    return (B) this;
+  }
+
+  /**
+   * Sets extra serializable types on the map.
+   *
+   * @param extraTypes the types to set
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withExtraTypes(Class<?>... extraTypes) {
+    config.setExtraTypes(Lists.newArrayList(extraTypes));
+    return (B) this;
+  }
+
+  /**
+   * Adds an extra serializable type to the map.
+   *
+   * @param extraType the type to add
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B addExtraType(Class<?> extraType) {
+    config.addExtraType(extraType);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired() {
+    return withRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired(boolean registrationRequired) {
+    config.setRegistrationRequired(registrationRequired);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the multimap builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization(boolean compatibleSerialization) {
+    config.setCompatibleSerialization(compatibleSerialization);
+    return (B) this;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  protected Serializer serializer() {
+    if (serializer == null) {
+      NamespaceConfig namespaceConfig = this.config.getNamespaceConfig();
+      if (namespaceConfig == null) {
+        namespaceConfig = new NamespaceConfig();
+      }
+
+      SerializerBuilder serializerBuilder = managementService.getSerializationService().newBuilder(name);
+      serializerBuilder.withNamespace(new Namespace(namespaceConfig));
+
+      if (config.isRegistrationRequired()) {
+        serializerBuilder.withRegistrationRequired();
+      }
+      if (config.isCompatibleSerialization()) {
+        serializerBuilder.withCompatibleSerialization();
+      }
+
+      if (config.getKeyType() != null) {
+        serializerBuilder.addType(config.getKeyType());
+      }
+      if (config.getValueType() != null) {
+        serializerBuilder.addType(config.getValueType());
+      }
+      if (!config.getExtraTypes().isEmpty()) {
+        serializerBuilder.withTypes(config.getExtraTypes().toArray(new Class<?>[config.getExtraTypes().size()]));
+      }
+
+      serializer = serializerBuilder.build();
+    }
+    return serializer;
+  }
+}

--- a/core/src/main/java/io/atomix/core/multimap/MultimapConfig.java
+++ b/core/src/main/java/io/atomix/core/multimap/MultimapConfig.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.multimap;
+
+import io.atomix.core.cache.CachedPrimitiveConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Multimap configuration.
+ */
+public abstract class MultimapConfig<C extends MultimapConfig<C>> extends CachedPrimitiveConfig<C> {
+  private Class<?> keyType;
+  private Class<?> valueType;
+  private List<Class<?>> extraTypes = new ArrayList<>();
+  private boolean registrationRequired = false;
+  private boolean compatibleSerialization = false;
+
+  /**
+   * Returns the key type.
+   *
+   * @return the multimap key type
+   */
+  public Class<?> getKeyType() {
+    return keyType;
+  }
+
+  /**
+   * Sets the map key type.
+   *
+   * @param keyType the map key type
+   * @return the multimap configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setKeyType(Class<?> keyType) {
+    this.keyType = keyType;
+    return (C) this;
+  }
+
+  /**
+   * Returns the value type.
+   *
+   * @return the multimap value type
+   */
+  public Class<?> getValueType() {
+    return valueType;
+  }
+
+  /**
+   * Sets the map value type.
+   *
+   * @param valueType the map value type
+   * @return the multimap configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setValueType(Class<?> valueType) {
+    this.valueType = valueType;
+    return (C) this;
+  }
+
+  /**
+   * Returns the extra serializable types.
+   *
+   * @return the extra serializable types
+   */
+  public List<Class<?>> getExtraTypes() {
+    return extraTypes;
+  }
+
+  /**
+   * Sets the extra serializable types.
+   *
+   * @param extraTypes the extra serializable types
+   * @return the map configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setExtraTypes(List<Class<?>> extraTypes) {
+    this.extraTypes = extraTypes;
+    return (C) this;
+  }
+
+  /**
+   * Adds an extra serializable type.
+   *
+   * @param extraType the extra type to add
+   * @return the multimap configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C addExtraType(Class<?> extraType) {
+    extraTypes.add(extraType);
+    return (C) this;
+  }
+
+  /**
+   * Returns whether registration is required for serializable types.
+   *
+   * @return whether registration is required for serializable types
+   */
+  public boolean isRegistrationRequired() {
+    return registrationRequired;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the multimap configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setRegistrationRequired(boolean registrationRequired) {
+    this.registrationRequired = registrationRequired;
+    return (C) this;
+  }
+
+  /**
+   * Returns whether compatible serialization is enabled.
+   *
+   * @return whether compatible serialization is enabled
+   */
+  public boolean isCompatibleSerialization() {
+    return compatibleSerialization;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the multimap configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setCompatibleSerialization(boolean compatibleSerialization) {
+    this.compatibleSerialization = compatibleSerialization;
+    return (C) this;
+  }
+}

--- a/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeBuilder.java
+++ b/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeBuilder.java
@@ -16,11 +16,16 @@
 
 package io.atomix.core.tree;
 
+import com.google.common.collect.Lists;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
 import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Serializer;
+import io.atomix.utils.serializer.SerializerBuilder;
 
 /**
  * Builder for {@link AtomicDocumentTree}.
@@ -36,5 +41,119 @@ public abstract class AtomicDocumentTreeBuilder<V>
   @Override
   public AtomicDocumentTreeBuilder<V> withProtocol(ProxyProtocol protocol) {
     return withProtocol((PrimitiveProtocol) protocol);
+  }
+
+  /**
+   * Sets the node type.
+   *
+   * @param nodeType the node type
+   * @return the document tree builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeBuilder<V> withNodeType(Class<?> nodeType) {
+    config.setNodeType(nodeType);
+    return this;
+  }
+
+  /**
+   * Sets extra serializable types on the map.
+   *
+   * @param extraTypes the types to set
+   * @return the document tree builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeBuilder<V> withExtraTypes(Class<?>... extraTypes) {
+    config.setExtraTypes(Lists.newArrayList(extraTypes));
+    return this;
+  }
+
+  /**
+   * Adds an extra serializable type to the map.
+   *
+   * @param extraType the type to add
+   * @return the document tree builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeBuilder<V> addExtraType(Class<?> extraType) {
+    config.addExtraType(extraType);
+    return this;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @return the document tree builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeBuilder<V> withRegistrationRequired() {
+    return withRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the document tree builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeBuilder<V> withRegistrationRequired(boolean registrationRequired) {
+    config.setRegistrationRequired(registrationRequired);
+    return this;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @return the document tree builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeBuilder<V> withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the document tree builder
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeBuilder<V> withCompatibleSerialization(boolean compatibleSerialization) {
+    config.setCompatibleSerialization(compatibleSerialization);
+    return this;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  protected Serializer serializer() {
+    if (serializer == null) {
+      NamespaceConfig namespaceConfig = this.config.getNamespaceConfig();
+      if (namespaceConfig == null) {
+        namespaceConfig = new NamespaceConfig();
+      }
+
+      SerializerBuilder serializerBuilder = managementService.getSerializationService().newBuilder(name);
+      serializerBuilder.withNamespace(new Namespace(namespaceConfig));
+
+      if (config.isRegistrationRequired()) {
+        serializerBuilder.withRegistrationRequired();
+      }
+      if (config.isCompatibleSerialization()) {
+        serializerBuilder.withCompatibleSerialization();
+      }
+
+      if (config.getNodeType() != null) {
+        serializerBuilder.addType(config.getNodeType());
+      }
+      if (!config.getExtraTypes().isEmpty()) {
+        serializerBuilder.withTypes(config.getExtraTypes().toArray(new Class<?>[config.getExtraTypes().size()]));
+      }
+
+      serializer = serializerBuilder.build();
+    }
+    return serializer;
   }
 }

--- a/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeConfig.java
+++ b/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeConfig.java
@@ -15,15 +15,20 @@
  */
 package io.atomix.core.tree;
 
-import io.atomix.primitive.Ordering;
-import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.config.PrimitiveConfig;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Document tree configuration.
  */
 public class AtomicDocumentTreeConfig extends PrimitiveConfig<AtomicDocumentTreeConfig> {
-  private Ordering ordering;
+  private Class<?> nodeType;
+  private List<Class<?>> extraTypes = new ArrayList<>();
+  private boolean registrationRequired = false;
+  private boolean compatibleSerialization = false;
 
   @Override
   public PrimitiveType getType() {
@@ -31,25 +36,98 @@ public class AtomicDocumentTreeConfig extends PrimitiveConfig<AtomicDocumentTree
   }
 
   /**
-   * Sets the ordering of the tree nodes.
-   * <p>
-   * When {@link AsyncAtomicDocumentTree#getChildren(DocumentPath)} is called, children will be returned according to
-   * the specified sort order.
+   * Returns the node type.
    *
-   * @param ordering ordering of the tree nodes
-   * @return this builder
+   * @return the node type
    */
-  public AtomicDocumentTreeConfig setOrdering(Ordering ordering) {
-    this.ordering = ordering;
+  public Class<?> getNodeType() {
+    return nodeType;
+  }
+
+  /**
+   * Sets the node type.
+   *
+   * @param nodeType the document tree node type
+   * @return the document tree configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeConfig setNodeType(Class<?> nodeType) {
+    this.nodeType = nodeType;
     return this;
   }
 
   /**
-   * Returns the document tree ordering.
+   * Returns the extra serializable types.
    *
-   * @return the document tree ordering
+   * @return the extra serializable types
    */
-  public Ordering getOrdering() {
-    return ordering;
+  public List<Class<?>> getExtraTypes() {
+    return extraTypes;
+  }
+
+  /**
+   * Sets the extra serializable types.
+   *
+   * @param extraTypes the extra serializable types
+   * @return the document tree configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeConfig setExtraTypes(List<Class<?>> extraTypes) {
+    this.extraTypes = extraTypes;
+    return this;
+  }
+
+  /**
+   * Adds an extra serializable type.
+   *
+   * @param extraType the extra type to add
+   * @return the document tree configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeConfig addExtraType(Class<?> extraType) {
+    extraTypes.add(extraType);
+    return this;
+  }
+
+  /**
+   * Returns whether registration is required for serializable types.
+   *
+   * @return whether registration is required for serializable types
+   */
+  public boolean isRegistrationRequired() {
+    return registrationRequired;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the document tree configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeConfig setRegistrationRequired(boolean registrationRequired) {
+    this.registrationRequired = registrationRequired;
+    return this;
+  }
+
+  /**
+   * Returns whether compatible serialization is enabled.
+   *
+   * @return whether compatible serialization is enabled
+   */
+  public boolean isCompatibleSerialization() {
+    return compatibleSerialization;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the document tree configuration
+   */
+  @SuppressWarnings("unchecked")
+  public AtomicDocumentTreeConfig setCompatibleSerialization(boolean compatibleSerialization) {
+    this.compatibleSerialization = compatibleSerialization;
+    return this;
   }
 }

--- a/core/src/main/java/io/atomix/core/value/AtomicValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/AtomicValueBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.value;
 
-import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -27,7 +26,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
  * @param <V> atomic value type
  */
 public abstract class AtomicValueBuilder<V>
-    extends PrimitiveBuilder<AtomicValueBuilder<V>, AtomicValueConfig, AtomicValue<V>>
+    extends ValueBuilder<AtomicValueBuilder<V>, AtomicValueConfig, AtomicValue<V>, V>
     implements ProxyCompatibleBuilder<AtomicValueBuilder<V>> {
 
   protected AtomicValueBuilder(String name, AtomicValueConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/value/AtomicValueConfig.java
+++ b/core/src/main/java/io/atomix/core/value/AtomicValueConfig.java
@@ -15,13 +15,12 @@
  */
 package io.atomix.core.value;
 
-import io.atomix.primitive.config.PrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Atomic value configuration.
  */
-public class AtomicValueConfig extends PrimitiveConfig<AtomicValueConfig> {
+public class AtomicValueConfig extends ValueConfig<AtomicValueConfig> {
   @Override
   public PrimitiveType getType() {
     return AtomicValueType.instance();

--- a/core/src/main/java/io/atomix/core/value/DistributedValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/DistributedValueBuilder.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.core.value;
 
-import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -29,7 +28,7 @@ import io.atomix.primitive.protocol.value.ValueProtocol;
  * @param <V> atomic value type
  */
 public abstract class DistributedValueBuilder<V>
-    extends PrimitiveBuilder<DistributedValueBuilder<V>, DistributedValueConfig, DistributedValue<V>>
+    extends ValueBuilder<DistributedValueBuilder<V>, DistributedValueConfig, DistributedValue<V>, V>
     implements ProxyCompatibleBuilder<DistributedValueBuilder<V>>, ValueCompatibleBuilder<DistributedValueBuilder<V>> {
 
   protected DistributedValueBuilder(String name, DistributedValueConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/value/DistributedValueConfig.java
+++ b/core/src/main/java/io/atomix/core/value/DistributedValueConfig.java
@@ -16,12 +16,11 @@
 package io.atomix.core.value;
 
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.config.PrimitiveConfig;
 
 /**
  * Distributed value configuration.
  */
-public class DistributedValueConfig extends PrimitiveConfig<DistributedValueConfig> {
+public class DistributedValueConfig extends ValueConfig<DistributedValueConfig> {
   @Override
   public PrimitiveType getType() {
     return DistributedValueType.instance();

--- a/core/src/main/java/io/atomix/core/value/ValueBuilder.java
+++ b/core/src/main/java/io/atomix/core/value/ValueBuilder.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.value;
+
+import com.google.common.collect.Lists;
+import io.atomix.primitive.PrimitiveBuilder;
+import io.atomix.primitive.PrimitiveManagementService;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.SyncPrimitive;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.NamespaceConfig;
+import io.atomix.utils.serializer.Serializer;
+import io.atomix.utils.serializer.SerializerBuilder;
+
+/**
+ * Builder for constructing new value primitive instances.
+ *
+ * @param <V> value type
+ */
+public abstract class ValueBuilder<B extends ValueBuilder<B, C, P, V>, C extends ValueConfig<C>, P extends SyncPrimitive, V>
+    extends PrimitiveBuilder<B, C, P> {
+
+  protected ValueBuilder(PrimitiveType primitiveType, String name, C config, PrimitiveManagementService managementService) {
+    super(primitiveType, name, config, managementService);
+  }
+
+  /**
+   * Sets the value type.
+   *
+   * @param valueType the value type
+   * @return the value builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withValueType(Class<?> valueType) {
+    config.setValueType(valueType);
+    return (B) this;
+  }
+
+  /**
+   * Sets extra serializable types on the map.
+   *
+   * @param extraTypes the types to set
+   * @return the value builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withExtraTypes(Class<?>... extraTypes) {
+    config.setExtraTypes(Lists.newArrayList(extraTypes));
+    return (B) this;
+  }
+
+  /**
+   * Adds an extra serializable type to the map.
+   *
+   * @param extraType the type to add
+   * @return the value builder
+   */
+  @SuppressWarnings("unchecked")
+  public B addExtraType(Class<?> extraType) {
+    config.addExtraType(extraType);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @return the value builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired() {
+    return withRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the value builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withRegistrationRequired(boolean registrationRequired) {
+    config.setRegistrationRequired(registrationRequired);
+    return (B) this;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @return the value builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the value builder
+   */
+  @SuppressWarnings("unchecked")
+  public B withCompatibleSerialization(boolean compatibleSerialization) {
+    config.setCompatibleSerialization(compatibleSerialization);
+    return (B) this;
+  }
+
+  /**
+   * Returns the protocol serializer.
+   *
+   * @return the protocol serializer
+   */
+  protected Serializer serializer() {
+    if (serializer == null) {
+      NamespaceConfig namespaceConfig = this.config.getNamespaceConfig();
+      if (namespaceConfig == null) {
+        namespaceConfig = new NamespaceConfig();
+      }
+
+      SerializerBuilder serializerBuilder = managementService.getSerializationService().newBuilder(name);
+      serializerBuilder.withNamespace(new Namespace(namespaceConfig));
+
+      if (config.isRegistrationRequired()) {
+        serializerBuilder.withRegistrationRequired();
+      }
+      if (config.isCompatibleSerialization()) {
+        serializerBuilder.withCompatibleSerialization();
+      }
+
+      if (config.getValueType() != null) {
+        serializerBuilder.addType(config.getValueType());
+      }
+      if (!config.getExtraTypes().isEmpty()) {
+        serializerBuilder.withTypes(config.getExtraTypes().toArray(new Class<?>[config.getExtraTypes().size()]));
+      }
+
+      serializer = serializerBuilder.build();
+    }
+    return serializer;
+  }
+}

--- a/core/src/main/java/io/atomix/core/value/ValueConfig.java
+++ b/core/src/main/java/io/atomix/core/value/ValueConfig.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.value;
+
+import io.atomix.primitive.config.PrimitiveConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Value primitive configuration.
+ */
+public abstract class ValueConfig<C extends ValueConfig<C>> extends PrimitiveConfig<C> {
+  private Class<?> valueType;
+  private List<Class<?>> extraTypes = new ArrayList<>();
+  private boolean registrationRequired = false;
+  private boolean compatibleSerialization = false;
+
+  /**
+   * Returns the value type.
+   *
+   * @return the value type
+   */
+  public Class<?> getValueType() {
+    return valueType;
+  }
+
+  /**
+   * Sets the value type.
+   *
+   * @param valueType the map value type
+   * @return the value configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setValueType(Class<?> valueType) {
+    this.valueType = valueType;
+    return (C) this;
+  }
+
+  /**
+   * Returns the extra serializable types.
+   *
+   * @return the extra serializable types
+   */
+  public List<Class<?>> getExtraTypes() {
+    return extraTypes;
+  }
+
+  /**
+   * Sets the extra serializable types.
+   *
+   * @param extraTypes the extra serializable types
+   * @return the value configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setExtraTypes(List<Class<?>> extraTypes) {
+    this.extraTypes = extraTypes;
+    return (C) this;
+  }
+
+  /**
+   * Adds an extra serializable type.
+   *
+   * @param extraType the extra type to add
+   * @return the value configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C addExtraType(Class<?> extraType) {
+    extraTypes.add(extraType);
+    return (C) this;
+  }
+
+  /**
+   * Returns whether registration is required for serializable types.
+   *
+   * @return whether registration is required for serializable types
+   */
+  public boolean isRegistrationRequired() {
+    return registrationRequired;
+  }
+
+  /**
+   * Sets whether registration is required for serializable types.
+   *
+   * @param registrationRequired whether registration is required for serializable types
+   * @return the value configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setRegistrationRequired(boolean registrationRequired) {
+    this.registrationRequired = registrationRequired;
+    return (C) this;
+  }
+
+  /**
+   * Returns whether compatible serialization is enabled.
+   *
+   * @return whether compatible serialization is enabled
+   */
+  public boolean isCompatibleSerialization() {
+    return compatibleSerialization;
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled
+   * @return the value configuration
+   */
+  @SuppressWarnings("unchecked")
+  public C setCompatibleSerialization(boolean compatibleSerialization) {
+    this.compatibleSerialization = compatibleSerialization;
+    return (C) this;
+  }
+}

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveManagementService.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveManagementService.java
@@ -21,6 +21,7 @@ import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.primitive.partition.PartitionGroupTypeRegistry;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.protocol.PrimitiveProtocolTypeRegistry;
+import io.atomix.primitive.serialization.SerializationService;
 
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -56,6 +57,13 @@ public interface PrimitiveManagementService {
    * @return the cluster event service
    */
   ClusterEventService getEventService();
+
+  /**
+   * Returns the primitive serialization service.
+   *
+   * @return the primitive serialization service
+   */
+  SerializationService getSerializationService();
 
   /**
    * Returns the partition service.

--- a/primitive/src/main/java/io/atomix/primitive/serialization/SerializationService.java
+++ b/primitive/src/main/java/io/atomix/primitive/serialization/SerializationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-present Open Networking Foundation
+ * Copyright 2018-present Open Networking Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.utils.serializer.serializers;
+package io.atomix.primitive.serialization;
 
-import io.atomix.utils.serializer.Serializer;
+import io.atomix.utils.serializer.SerializerBuilder;
 
 /**
- * Default serializers.
+ * Primitive serialization service.
  */
-public class DefaultSerializers {
+public interface SerializationService {
 
   /**
-   * Basic serializer.
+   * Returns a new serializer builder.
+   *
+   * @return a new serializer builder
    */
-  public static Serializer BASIC = Serializer.builder().build();
+  SerializerBuilder newBuilder();
 
-  private DefaultSerializers() {
-  }
+  /**
+   * Returns a new serializer builder.
+   *
+   * @param name the serializer builder name
+   * @return the serializer builder
+   */
+  SerializerBuilder newBuilder(String name);
+
 }

--- a/storage/src/test/java/io/atomix/storage/journal/JournalTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/JournalTest.java
@@ -15,9 +15,8 @@
  */
 package io.atomix.storage.journal;
 
-import io.atomix.utils.serializer.Serializer;
-import io.atomix.utils.serializer.Namespace;
 import io.atomix.storage.StorageLevel;
+import io.atomix.utils.serializer.Serializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,10 +40,10 @@ import static org.junit.Assert.assertTrue;
  */
 public class JournalTest {
   private static final Path PATH = Paths.get("target/test-logs/");
-  private static final Serializer serializer = Serializer.using(Namespace.builder()
-      .register(TestEntry.class)
-      .register(byte[].class)
-      .build());
+  private static final Serializer serializer = Serializer.builder()
+      .addType(TestEntry.class)
+      .addType(byte[].class)
+      .build();
 
   private SegmentedJournal<TestEntry> createJournal(StorageLevel storageLevel) {
     return SegmentedJournal.<TestEntry>builder()

--- a/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
@@ -34,16 +34,12 @@ import org.slf4j.Logger;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -183,43 +179,6 @@ public final class Namespace implements KryoFactory, KryoPool {
     public Builder register(Serializer<?> serializer, final Class<?>... classes) {
       types.add(Pair.of(classes, checkNotNull(serializer)));
       return this;
-    }
-
-    /**
-     * Registers all given types and their subtypes.
-     *
-     * @param classes the types to register
-     * @return this
-     */
-    public Builder registerSubTypes(final Class<?>... classes) {
-      for (Class<?> type : classes) {
-        register(type);
-        registerSubTypes(type);
-      }
-      return this;
-    }
-
-    /**
-     * Registers all subtypes of the given type.
-     *
-     * @param type the type for which to register subtypes
-     */
-    private void registerSubTypes(Class<?> type) {
-      getFields(type).forEach((fieldName, fieldType) -> register(fieldType));
-    }
-
-    private SortedMap<String, Class<?>> getFields(Class<?> type) {
-      if (type == Object.class) {
-        return new TreeMap<>();
-      }
-
-      SortedMap<String, Class<?>> fields = getFields(type.getSuperclass());
-      for (Field field : type.getDeclaredFields()) {
-        if (!Modifier.isTransient(field.getModifiers()) && field.getType() != Object.class) {
-          fields.put(field.getName(), field.getType());
-        }
-      }
-      return fields;
     }
 
     private Builder register(RegistrationBlock block) {

--- a/utils/src/main/java/io/atomix/utils/serializer/Serializer.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Serializer.java
@@ -22,6 +22,25 @@ package io.atomix.utils.serializer;
 public interface Serializer {
 
   /**
+   * Creates a new serializer builder.
+   *
+   * @return a new serializer builder
+   */
+  static SerializerBuilder builder() {
+    return new SerializerBuilder();
+  }
+
+  /**
+   * Creates a new serializer builder.
+   *
+   * @param name the serializer name
+   * @return a new serializer builder
+   */
+  static SerializerBuilder builder(String name) {
+    return new SerializerBuilder(name);
+  }
+
+  /**
    * Serialize the specified object.
    *
    * @param object object to serialize.

--- a/utils/src/main/java/io/atomix/utils/serializer/SerializerBuilder.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/SerializerBuilder.java
@@ -121,6 +121,6 @@ public class SerializerBuilder implements Builder<Serializer> {
 
   @Override
   public Serializer build() {
-    return Serializer.using(namespaceBuilder.build(name));
+    return Serializer.using(name != null ? namespaceBuilder.build(name) : namespaceBuilder.build());
   }
 }

--- a/utils/src/main/java/io/atomix/utils/serializer/SerializerBuilder.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/SerializerBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer;
+
+import io.atomix.utils.Builder;
+
+/**
+ * Serializer builder.
+ */
+public class SerializerBuilder implements Builder<Serializer> {
+  private final String name;
+  private final Namespace.Builder namespaceBuilder = Namespace.builder()
+      .register(Namespaces.BASIC)
+      .nextId(Namespaces.BEGIN_USER_CUSTOM_ID);
+
+  public SerializerBuilder() {
+    this(null);
+  }
+
+  public SerializerBuilder(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Requires explicit serializable type registration for serializable types.
+   *
+   * @return the serializer builder
+   */
+  public SerializerBuilder withRegistrationRequired() {
+    return withRegistrationRequired(true);
+  }
+
+  /**
+   * Sets whether serializable type registration is required for serializable types.
+   *
+   * @param registrationRequired whether serializable type registration is required for serializable types
+   * @return the serializer builder
+   */
+  public SerializerBuilder withRegistrationRequired(boolean registrationRequired) {
+    namespaceBuilder.setRegistrationRequired(registrationRequired);
+    return this;
+  }
+
+  /**
+   * Enables compatible serialization for serializable types.
+   *
+   * @return the serializer builder
+   */
+  public SerializerBuilder withCompatibleSerialization() {
+    return withCompatibleSerialization(true);
+  }
+
+  /**
+   * Sets whether compatible serialization is enabled for serializable types.
+   *
+   * @param compatibleSerialization whether compatible serialization is enabled for user types
+   * @return the serializer builder
+   */
+  public SerializerBuilder withCompatibleSerialization(boolean compatibleSerialization) {
+    namespaceBuilder.setCompatible(compatibleSerialization);
+    return this;
+  }
+
+  /**
+   * Adds a namespace to the serializer.
+   *
+   * @param namespace the namespace to add
+   * @return the serializer builder
+   */
+  public SerializerBuilder withNamespace(Namespace namespace) {
+    namespaceBuilder.register(namespace);
+    return this;
+  }
+
+  /**
+   * Sets the serializable types.
+   *
+   * @param types the types to register
+   * @return the serializer builder
+   */
+  public SerializerBuilder withTypes(Class<?>... types) {
+    namespaceBuilder.register(types);
+    return this;
+  }
+
+  /**
+   * Adds a serializable type to the builder.
+   *
+   * @param type the type to add
+   * @return the serializer builder
+   */
+  public SerializerBuilder addType(Class<?> type) {
+    namespaceBuilder.register(type);
+    return this;
+  }
+
+  /**
+   * Adds a serializer to the builder.
+   *
+   * @param serializer the serializer to add
+   * @param types the serializable types
+   * @return the serializer builder
+   */
+  public SerializerBuilder addSerializer(com.esotericsoftware.kryo.Serializer serializer, Class<?>... types) {
+    namespaceBuilder.register(serializer, types);
+    return this;
+  }
+
+  @Override
+  public Serializer build() {
+    return Serializer.using(namespaceBuilder.build(name));
+  }
+}


### PR DESCRIPTION
This PR makes various improvements to the implementation of serialization in Atomix. The primary improvement is to allow serialization for user types to be configured globally. This is done by adding a `SerializationService` which provides `SerializerBuilders` that are configured with the global configuration. It also cleans up some primitive builders to ensure serializable types can be properly registered.