### PR TITLE
Fix test failures.

### DIFF
--- a/core/src/test/java/io/atomix/core/election/LeaderElectorConfigTest.java
+++ b/core/src/test/java/io/atomix/core/election/LeaderElectorConfigTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertFalse;
 public class LeaderElectorConfigTest {
   @Test
   public void testLoadConfig() throws Exception {
-    LeaderElectionConfig config = Atomix.config(getClass().getClassLoader().getResource("primitives.conf").getPath())
+    LeaderElectorConfig config = Atomix.config(getClass().getClassLoader().getResource("primitives.conf").getPath())
         .getPrimitive("leader-elector");
     assertEquals("leader-elector", config.getName());
     assertEquals(MultiPrimaryProtocol.TYPE, config.getProtocolConfig().getType());

--- a/core/src/test/java/io/atomix/core/idgenerator/IdGeneratorConfigTest.java
+++ b/core/src/test/java/io/atomix/core/idgenerator/IdGeneratorConfigTest.java
@@ -16,7 +16,6 @@
 package io.atomix.core.idgenerator;
 
 import io.atomix.core.Atomix;
-import io.atomix.core.election.LeaderElectionConfig;
 import io.atomix.protocols.backup.MultiPrimaryProtocol;
 import org.junit.Test;
 
@@ -29,7 +28,7 @@ import static org.junit.Assert.assertFalse;
 public class IdGeneratorConfigTest {
   @Test
   public void testLoadConfig() throws Exception {
-    LeaderElectionConfig config = Atomix.config(getClass().getClassLoader().getResource("primitives.conf").getPath())
+    AtomicIdGeneratorConfig config = Atomix.config(getClass().getClassLoader().getResource("primitives.conf").getPath())
         .getPrimitive("atomic-id-generator");
     assertEquals("atomic-id-generator", config.getName());
     assertEquals(MultiPrimaryProtocol.TYPE, config.getProtocolConfig().getType());

--- a/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
@@ -271,7 +271,7 @@ public final class Namespace implements KryoFactory, KryoPool {
     for (NamespaceTypeConfig type : config.getTypes()) {
       try {
         if (type.getId() == null) {
-          types.add(Pair.of(new Class[]{type.getType()}, type.getSerializer().newInstance()));
+          types.add(Pair.of(new Class[]{type.getType()}, type.getSerializer() != null ? type.getSerializer().newInstance() : null));
         } else {
           blocks.add(new RegistrationBlock(type.getId(), Collections.singletonList(Pair.of(new Class[]{type.getType()}, type.getSerializer().newInstance()))));
         }


### PR DESCRIPTION
io.atomix.core.AtomixTest#testPrimitiveConfigurations

```

io.atomix.utils.AtomixRuntimeException: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Failed to register [class io.atomix.core.types.Type3] as 504, class com.google.common.collect.ImmutableList$SubList was already registered.

	at io.atomix.core.PrimitivesService.getPrimitive(PrimitivesService.java:1535)
	at io.atomix.core.AtomixTest.testPrimitiveConfigurations(AtomixTest.java:486)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Failed to register [class io.atomix.core.types.Type3] as 504, class com.google.common.collect.ImmutableList$SubList was already registered.
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1915)
	at io.atomix.core.PrimitivesService.getPrimitive(PrimitivesService.java:1533)
	... 27 more
Caused by: java.lang.IllegalStateException: Failed to register [class io.atomix.core.types.Type3] as 504, class com.google.common.collect.ImmutableList$SubList was already registered.
	at io.atomix.utils.serializer.Namespace.register(Namespace.java:538)
	at io.atomix.utils.serializer.Namespace.create(Namespace.java:509)
	at io.atomix.utils.serializer.Namespace.populate(Namespace.java:320)
```