### PR TITLE
Assign floating ID to  block to avoid registration ID conflicts

### DIFF
--- a/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
@@ -279,7 +279,7 @@ public final class Namespace implements KryoFactory, KryoPool {
         throw new ConfigurationException("Failed to instantiate serializer from configuration", e);
       }
     }
-    blocks.add(new RegistrationBlock(Namespaces.BEGIN_USER_CUSTOM_ID, types));
+    blocks.add(new RegistrationBlock(FLOATING_ID, types));
     return blocks;
   }
 


### PR DESCRIPTION
Assigning `BEGIN_USER_CUSTOM_ID` to a `RegistrationBlock` constructed from a `NamespaceConfig` can create duplicate registration ID exceptions. This assigns a floating ID to the block which will simply use the next ID.