### PR TITLE
Throw exception on duplicate storage directory in Raft servers

### DIFF
--- a/core/src/main/java/io/atomix/core/profile/ConsensusProfileBuilder.java
+++ b/core/src/main/java/io/atomix/core/profile/ConsensusProfileBuilder.java
@@ -15,6 +15,9 @@
  */
 package io.atomix.core.profile;
 
+import com.google.common.collect.Sets;
+
+import java.io.File;
 import java.util.Set;
 
 /**
@@ -32,8 +35,19 @@ public class ConsensusProfileBuilder extends ProfileBuilder {
    * @param dataPath the consensus data file path
    * @return the consensus profile builder
    */
-  public ConsensusProfileBuilder setDataPath(String dataPath) {
+  public ConsensusProfileBuilder withDataPath(String dataPath) {
     config.setDataPath(dataPath);
+    return this;
+  }
+
+  /**
+   * Sets the consensus data file path.
+   *
+   * @param dataPath the consensus data file path
+   * @return the consensus profile builder
+   */
+  public ConsensusProfileBuilder withDataPath(File dataPath) {
+    config.setDataPath(dataPath.getPath());
     return this;
   }
 
@@ -43,7 +57,7 @@ public class ConsensusProfileBuilder extends ProfileBuilder {
    * @param managementGroup the management partition group name
    * @return the consensus profile builder
    */
-  public ConsensusProfileBuilder setManagementGroup(String managementGroup) {
+  public ConsensusProfileBuilder withManagementGroup(String managementGroup) {
     config.setManagementGroup(managementGroup);
     return this;
   }
@@ -54,7 +68,7 @@ public class ConsensusProfileBuilder extends ProfileBuilder {
    * @param dataGroup the data partition group name
    * @return the consensus profile builder
    */
-  public ConsensusProfileBuilder setDataGroup(String dataGroup) {
+  public ConsensusProfileBuilder withDataGroup(String dataGroup) {
     config.setDataGroup(dataGroup);
     return this;
   }
@@ -65,7 +79,7 @@ public class ConsensusProfileBuilder extends ProfileBuilder {
    * @param partitionSize the data partition size
    * @return the consensus profile builder
    */
-  public ConsensusProfileBuilder setPartitionSize(int partitionSize) {
+  public ConsensusProfileBuilder withPartitionSize(int partitionSize) {
     config.setPartitionSize(partitionSize);
     return this;
   }
@@ -79,6 +93,16 @@ public class ConsensusProfileBuilder extends ProfileBuilder {
   public ConsensusProfileBuilder withNumPartitions(int numPartitions) {
     config.setPartitions(numPartitions);
     return this;
+  }
+
+  /**
+   * Sets the consensus members.
+   *
+   * @param members the consensus members
+   * @return the profile builder
+   */
+  public ConsensusProfileBuilder withMembers(String... members) {
+    return withMembers(Sets.newHashSet(members));
   }
 
   /**

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractAtomixTest {
   private static final int BASE_PORT = 5000;
+  protected static final File DATA_DIR = new File(System.getProperty("user.dir"), ".data");
 
   @BeforeClass
   public static void setupAtomix() throws Exception {
@@ -130,7 +131,7 @@ public abstract class AbstractAtomixTest {
    * Deletes data from the test data directory.
    */
   protected static void deleteData() throws Exception {
-    Path directory = new File(System.getProperty("user.dir"), ".data").toPath();
+    Path directory = DATA_DIR.toPath();
     if (Files.exists(directory)) {
       Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
         @Override

--- a/core/src/test/resources/primitives.conf
+++ b/core/src/test/resources/primitives.conf
@@ -17,19 +17,6 @@ cluster {
   }
 }
 
-management-group {
-  type: raft
-  partitions: 1
-  segmentSize: 16M
-  members: [1, 2, 3]
-}
-
-partition-groups.one {
-  type: raft
-  partitions: 3
-  members: [1, 2, 3]
-}
-
 partition-groups.two {
   type: primary-backup
   partitions: 7

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -23,7 +23,9 @@ import io.atomix.primitive.partition.Partition;
 import io.atomix.protocols.raft.RaftServer;
 import io.atomix.protocols.raft.partition.RaftPartition;
 import io.atomix.protocols.raft.storage.RaftStorage;
+import io.atomix.storage.StorageException;
 import io.atomix.utils.Managed;
+import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 
@@ -79,7 +81,11 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         return CompletableFuture.completedFuture(null);
       }
       synchronized (this) {
-        server = buildServer();
+        try {
+          server = buildServer();
+        } catch (StorageException e) {
+          return Futures.exceptionalFuture(e);
+        }
       }
       serverOpenFuture = server.bootstrap(partition.members());
     } else {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -240,12 +240,13 @@ public class RaftStorage {
     try {
       if (file.createNewFile()) {
         try (FileBuffer buffer = FileBuffer.allocate(file)) {
-          buffer.writeString(id);
+          buffer.writeString(id).flush();
         }
         return true;
       } else {
         try (FileBuffer buffer = FileBuffer.allocate(file)) {
-          return buffer.readString().equals(id);
+          String lock = buffer.readString();
+          return lock != null && lock.equals(id);
         }
       }
     } catch (IOException e) {

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/RaftStorageTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/RaftStorageTest.java
@@ -15,9 +15,18 @@
  */
 package io.atomix.protocols.raft.storage;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,6 +36,7 @@ import static org.junit.Assert.assertTrue;
  * Raft storage test.
  */
 public class RaftStorageTest {
+  private static final Path PATH = Paths.get("target/test-logs/");
 
   @Test
   public void testDefaultConfiguration() throws Exception {
@@ -46,7 +56,7 @@ public class RaftStorageTest {
   public void testCustomConfiguration() throws Exception {
     RaftStorage storage = RaftStorage.builder()
         .withPrefix("foo")
-        .withDirectory(new File(System.getProperty("user.dir"), "foo"))
+        .withDirectory(new File(PATH.toFile(), "foo"))
         .withMaxSegmentSize(1024 * 1024)
         .withMaxEntriesPerSegment(1024)
         .withDynamicCompaction(false)
@@ -55,7 +65,7 @@ public class RaftStorageTest {
         .withRetainStaleSnapshots()
         .build();
     assertEquals("foo", storage.prefix());
-    assertEquals(new File(System.getProperty("user.dir"), "foo"), storage.directory());
+    assertEquals(new File(PATH.toFile(), "foo"), storage.directory());
     assertEquals(1024 * 1024, storage.maxLogSegmentSize());
     assertEquals(1024, storage.maxLogEntriesPerSegment());
     assertFalse(storage.dynamicCompaction());
@@ -67,12 +77,56 @@ public class RaftStorageTest {
   @Test
   public void testCustomConfiguration2() throws Exception {
     RaftStorage storage = RaftStorage.builder()
-            .withDirectory(System.getProperty("user.dir") + "/baz")
-            .withDynamicCompaction()
-            .withFlushOnCommit()
-            .build();
-    assertEquals(new File(System.getProperty("user.dir"), "baz"), storage.directory());
+        .withDirectory(PATH.toString() + "/baz")
+        .withDynamicCompaction()
+        .withFlushOnCommit()
+        .build();
+    assertEquals(new File(PATH.toFile(), "baz"), storage.directory());
     assertTrue(storage.dynamicCompaction());
     assertTrue(storage.isFlushOnCommit());
+  }
+
+  @Test
+  public void testStorageLock() throws Exception {
+    RaftStorage storage1 = RaftStorage.builder()
+        .withDirectory(PATH.toFile())
+        .withPrefix("test")
+        .build();
+
+    assertTrue(storage1.lock("a"));
+
+    RaftStorage storage2 = RaftStorage.builder()
+        .withDirectory(PATH.toFile())
+        .withPrefix("test")
+        .build();
+
+    assertFalse(storage2.lock("b"));
+
+    RaftStorage storage3 = RaftStorage.builder()
+        .withDirectory(PATH.toFile())
+        .withPrefix("test")
+        .build();
+
+    assertTrue(storage3.lock("a"));
+  }
+
+  @Before
+  @After
+  public void cleanupStorage() throws IOException {
+    if (Files.exists(PATH)) {
+      Files.walkFileTree(PATH, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+          Files.delete(dir);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    }
   }
 }


### PR DESCRIPTION
This PR is an attempt to disambiguate Raft partition configurations by throwing exceptions when servers on different nodes are configured to use the same data directory. This is accomplished by storing a `.partition-n.lock` file which contains the local server ID. When a Raft server context is created, the constructor validates that its storage directory does not conflict with another node's storage directory. 