### PR TITLE
ClassGraph (formerly FastClasspathScanner) with caching

### DIFF
--- a/core/src/main/java/io/atomix/core/impl/ClasspathScanningAtomixRegistry.java
+++ b/core/src/main/java/io/atomix/core/impl/ClasspathScanningAtomixRegistry.java
@@ -18,6 +18,7 @@ package io.atomix.core.impl;
 import io.atomix.core.AtomixRegistry;
 import io.atomix.utils.NamedType;
 import io.atomix.utils.ServiceException;
+import io.atomix.utils.misc.StringUtils;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
 import org.slf4j.Logger;
@@ -47,9 +48,9 @@ public class ClasspathScanningAtomixRegistry implements AtomixRegistry {
             CACHE.computeIfAbsent(classLoader, cl -> new ConcurrentHashMap<>());
     final Map<Class<? extends NamedType>, Map<String, NamedType>> registrations =
             mappings.computeIfAbsent(new CacheKey(types), cacheKey -> {
-        final String scanSpec = System.getProperty("io.atomix.scanSpec");
-        final ClassGraph classGraph = scanSpec != null ?
-                new ClassGraph().enableClassInfo().whitelistPackages(scanSpec).addClassLoader(classLoader) :
+        final String[] whitelistPackages = StringUtils.split(System.getProperty("io.atomix.whitelistPackages"), ",");
+        final ClassGraph classGraph = whitelistPackages != null ?
+                new ClassGraph().enableClassInfo().whitelistPackages(whitelistPackages).addClassLoader(classLoader) :
                 new ClassGraph().enableClassInfo().addClassLoader(classLoader);
 
         final ScanResult scanResult = classGraph.scan();
@@ -67,7 +68,7 @@ public class ClasspathScanningAtomixRegistry implements AtomixRegistry {
                       oldInstance.getClass().getName(), instance.getClass().getName());
             }
           });
-          result.put(type, tmp);
+          result.put(type, Collections.unmodifiableMap(tmp));
         }
         return result;
       });

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <jaxrs.version>2.0</jaxrs.version>
     <jackson.version>2.9.6</jackson.version>
     <config.version>1.3.2</config.version>
-    <fast-classpath-scanner.version>2.21</fast-classpath-scanner.version>
+    <classgraph.version>4.0.2</classgraph.version>
     <resteasy.version>3.1.4.Final</resteasy.version>
     <rest-assured.version>3.0.7</rest-assured.version>
     <argparse4j.version>0.7.0</argparse4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <maven.bundle.plugin.version>2.5.3</maven.bundle.plugin.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
 
-    <argLine.common>-Xss256k -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Dio.atomix.scanSpec=io.atomix</argLine.common>
+    <argLine.common>-Xss256k -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Dio.atomix.whitelistPackages=io.atomix</argLine.common>
     <argLine.extras /> <!-- Overridden in some profiles -->
     <argLine.javadocs>-quiet</argLine.javadocs>
   </properties>
@@ -85,7 +85,7 @@
     <profile>
       <id>java9</id>
       <properties>
-        <argLine.common>-Xss256k -Xms512m -Xmx2G -Dio.atomix.scanSpec=io.atomix</argLine.common>
+        <argLine.common>-Xss256k -Xms512m -Xmx2G -Dio.atomix.whitelistPackages=io.atomix</argLine.common>
         <argLine.extras>--add-modules jdk.unsupported --add-opens=java.base/java.nio=ALL-UNNAMED</argLine.extras>
         <argLine.javadocs>-html5 -quiet</argLine.javadocs>
         <!-- coverall version 4.3.0 does not work with java 9, see https://github.com/trautonen/coveralls-maven-plugin/issues/112 -->
@@ -99,7 +99,7 @@
     <profile>
         <id>java11</id>
         <properties>
-          <!--argLine.common>-Xss256k -Xms512m -Xmx2G -XX:+UseShenandoahGC -XX:+UseStringDeduplication -XX:-OmitStackTraceInFastThrow -Dio.atomix.scanSpec=io.atomix</argLine.common-->
+          <!--argLine.common>-Xss256k -Xms512m -Xmx2G -XX:+UseShenandoahGC -XX:+UseStringDeduplication -XX:-OmitStackTraceInFastThrow -Dio.atomix.whitelistPackages=io.atomix</argLine.common-->
           <!-- jacoco version 0.8.1 does not work with java 11, see https://github.com/jacoco/jacoco/issues/663 -->
           <jacoco.skip>true</jacoco.skip>
         </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <jaxrs.version>2.0</jaxrs.version>
     <jackson.version>2.9.6</jackson.version>
     <config.version>1.3.2</config.version>
-    <classgraph.version>4.0.2</classgraph.version>
+    <classgraph.version>4.0.3</classgraph.version>
     <resteasy.version>3.1.4.Final</resteasy.version>
     <rest-assured.version>3.0.7</rest-assured.version>
     <argparse4j.version>0.7.0</argparse4j.version>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -53,9 +53,9 @@
       <version>${config.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.lukehutch</groupId>
-      <artifactId>fast-classpath-scanner</artifactId>
-      <version>${fast-classpath-scanner.version}</version>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <version>${classgraph.version}</version>
     </dependency>
   </dependencies>
 

--- a/utils/src/main/java/io/atomix/utils/misc/StringUtils.java
+++ b/utils/src/main/java/io/atomix/utils/misc/StringUtils.java
@@ -1,0 +1,33 @@
+package io.atomix.utils.misc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Collection of various helper methods to manipulate strings.
+ */
+public final class StringUtils {
+
+    private StringUtils() {
+    }
+
+    /**
+     * Splits the input string with the given regex and filters empty strings.
+     *
+     * @param input the string to split.
+     * @return the array of strings computed by splitting this string
+     */
+    public static String[] split(String input, String regex) {
+        if (input == null) {
+            return null;
+        }
+        String[] arr = input.split(regex);
+        List<String> results = new ArrayList<>(arr.length);
+        for (String a : arr) {
+            if (!a.trim().isEmpty()) {
+                results.add(a);
+            }
+        }
+        return results.toArray(new String[0]);
+    }
+}

--- a/utils/src/test/java/io/atomix/utils/misc/StringUtilsTest.java
+++ b/utils/src/test/java/io/atomix/utils/misc/StringUtilsTest.java
@@ -1,0 +1,23 @@
+package io.atomix.utils.misc;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class StringUtilsTest {
+
+    @Test
+    public void testNull() {
+        assertNull(StringUtils.split(null, ","));
+    }
+
+    @Test
+    public void testFilter() {
+        String[] result = StringUtils.split("1,  ,,", ",");
+        assertNotNull(result);
+        assertEquals(1, result.length);
+        assertEquals("1", result[0]);
+    }
+}


### PR DESCRIPTION
This PR migrates Atomix from the old fastclasspathscanner to the new classgraph library, the library name changed on a major release when support for modules was added.

The caching is to speed up tests and supersedes the previous PR https://github.com/atomix/atomix/pull/636 