### PR TITLE
Implement Atomix agent distribution

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -143,7 +143,12 @@ public class AtomixAgent {
       }
       config = Atomix.config(configFiles);
     } else {
-      config = Atomix.config();
+      String configFile = System.getProperty("atomix.config");
+      if (configFile != null) {
+        config = Atomix.config(configFile);
+      } else {
+        config = Atomix.config();
+      }
     }
 
     if (memberId != null) {

--- a/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -172,7 +172,7 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
   private final AtomicBoolean started = new AtomicBoolean();
 
   public AtomixCluster(String configFile) {
-    this(loadConfig(new File(System.getProperty("user.dir"), configFile), Thread.currentThread().getContextClassLoader()));
+    this(loadConfig(new File(System.getProperty("atomix.root", System.getProperty("user.dir")), configFile), Thread.currentThread().getContextClassLoader()));
   }
 
   public AtomixCluster(File configFile) {

--- a/core/src/main/java/io/atomix/core/profile/ConsensusProfileConfig.java
+++ b/core/src/main/java/io/atomix/core/profile/ConsensusProfileConfig.java
@@ -25,7 +25,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Consensus profile configuration.
  */
 public class ConsensusProfileConfig extends ProfileConfig {
-  private String dataPath = ".data";
+  private String dataPath = System.getProperty("atomix.data", ".data");
   private String managementGroup = "system";
   private String dataGroup = "raft";
   private int partitionSize = 3;

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,0 +1,71 @@
+<!--
+  ~ Copyright 2017-present Open Networking Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.atomix</groupId>
+    <artifactId>atomix-parent</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>atomix-dist</artifactId>
+  <name>Atomix Distribution</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.atomix</groupId>
+      <artifactId>atomix-agent</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${jaxrs.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven.assembly.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>make-bundles</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <finalName>atomix-agent-${project.version}</finalName>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/main/assembly/assembly.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright 2018-present Open Networking Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<assembly>
+    <id>bin</id>
+    <!-- Specifies that our binary distribution is a zip/tar.gz package -->
+    <formats>
+        <format>zip</format>
+        <format>tar.gz</format>
+    </formats>
+
+    <!-- Ignore the project base directory -->
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <!-- Adds the dependencies of our application to the lib directory -->
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <outputDirectory>lib</outputDirectory>
+            <unpack>false</unpack>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>src/main/resources</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>..</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>LICENSE</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/dist/src/main/resources/bin/atomix-agent
+++ b/dist/src/main/resources/bin/atomix-agent
@@ -11,4 +11,16 @@ if [ -z "${JAVA_HOME}" ]; then
     fi
 fi
 
-java -jar ${ATOMIX_ROOT}/agent/target/atomix-agent.jar "$@"
+ATOMIX_ROOT="$(dirname "$(dirname "$0")")"
+
+java \
+  -XX:+UseConcMarkSweepGC \
+  -XX:+CMSIncrementalMode \
+  -Datomix.root="$ATOMIX_ROOT" \
+  -Datomix.data="$ATOMIX_ROOT/data" \
+  -Datomix.log="$ATOMIX_ROOT/log" \
+  -Datomix.config="$ATOMIX_ROOT/conf/atomix.conf" \
+  -Dlogback.configurationFile="$ATOMIX_ROOT/conf/logback.xml" \
+  -cp .:"$ATOMIX_ROOT/lib/*" \
+  io.atomix.agent.AtomixAgent \
+  "$@"

--- a/dist/src/main/resources/conf/README
+++ b/dist/src/main/resources/conf/README
@@ -1,0 +1,1 @@
+This folder is the default path for configurations used by the Atomix agent.

--- a/dist/src/main/resources/conf/atomix.conf
+++ b/dist/src/main/resources/conf/atomix.conf
@@ -1,0 +1,122 @@
+# The cluster configuration
+cluster {
+  cluster-id: atomix
+  node.id: atomix-1
+  node.address: "localhost:5679"
+}
+
+# The cluster's multicast configuration defines whether and how Atomix uses multicast for service discovery.
+cluster.multicast {
+  # Set to "true" to enable multicast
+  enabled: true
+  # Edit to change the multicast group.
+  group: 230.0.0.1
+  # Edit to change the multicast port.
+  port: 54321
+}
+
+# The cluster discovery configuration defines how nodes discover one another.
+
+# This is a multicast based discovery configuration. When multicast discovery is used, the node will broadcast
+# its information via the provided multicast group to discover other nodes.
+cluster.discovery {
+  type: multicast
+  broadcast-interval: 1s
+  failure-timeout: 10s
+  failure-threshold: 10
+}
+
+# This is a bootstrap based discovery configuration. When bootstrap discovery is used, the node connects to
+# each node in the provided set for service discovery.
+#cluster.discovery {
+#  type: bootstrap
+#  nodes.1 {
+#    id: atomix-1
+#    address: "10.192.19.171:5679"
+# }
+#  nodes.2 {
+#    id: atomix-2
+#    address: "10.192.19.172:5679"
+#  }
+#  nodes.3 {
+#    id: atomix-3
+#    address: "10.192.19.173:5679"
+# }
+#}
+
+# A management group using the Raft consensus protocol.
+management-group {
+  type: raft
+  partitions: 1
+  members: [atomix-1]
+}
+
+# A primary-backup based management group.
+#management-group {
+#  type: primary-backup
+#  partitions: 1
+#}
+
+# A consensus partition group.
+partition-groups.consensus {
+  type: raft
+  partitions: 7
+  members: [atomix-1]
+}
+
+# A primary-backup (data grid) partition group.
+partition-groups.data {
+  type: primary-backup
+  partitions: 32
+}
+
+# An example primitive configuration using a Raft partition group.
+primitives.foo {
+  # The primitive type
+  type: map
+  # The protocol to use to replicate the primitive
+  protocol {
+    # The protocol type can be "multi-raft" or "multi-primary"
+    type: multi-raft
+    # The "group" indicates the name of the partition group in which to replicate the primitive.
+    # The configured partition group must support the protocol indicated in "type" above.
+    group: consensus
+    # The read consistency indicates the consistency guarantee of reads on a Raft partition.
+    # "sequential" reads guarantee state will not go back in time but do not provide a real-time guarantee
+    # "linearizable-lease" reads guarantee linearizability assuming clock accuracy
+    # "linearizable" guarantees linearizable reads by verifying the Raft leader
+    read-consistency: sequential
+    # The communication strategy indicates the node(s) to which the primitive should communicate in each partition.
+    # "leader" indicates the primitive should communicate directly with the Raft leader
+    # "followers" indicates the primitive should favor Raft followers
+    # "any" indicates the primitive can communicate with any node in each partition
+    communication-strategy: any
+  }
+}
+
+# An example primitive configuration using a primary-backup partition group.
+primitives.bar {
+  # The primitive type
+  type: set
+  # The protocol to use to replicate the primitive
+  protocol {
+    # The protocol type can be "multi-raft" or "multi-primary"
+    type: multi-primary
+    # The "group" indicates the name of the partition group in which to replicate the primitive.
+    # The configured partition group must support the protocol indicated in "type" above.
+    group: data
+    # The "consistency" is a primary-backup specific setting indicating whether the primitive should communicate
+    # with the primary or backups on reads.
+    consistency: sequential
+    # The "replication" is a primary-backup specific setting indicating whether replication should be
+    # "synchronous" or "asynchronous"
+    replication: asynchronous
+    # The "backups" indicates the number of copies to replicate in addition to the primary copy.
+    # In other words, "2" backups means the primitive will be replicated on 3 nodes in each partition.
+    backups: 2
+    # "max-retries" is the maximum number of attempts to allow for any read or write.
+    max-retries: 2
+    # The "retry-delay" is the time to wait between retries.
+    retry-delay: 100ms
+  }
+}

--- a/dist/src/main/resources/conf/logback.xml
+++ b/dist/src/main/resources/conf/logback.xml
@@ -1,0 +1,56 @@
+<!--
+  ~ Copyright 2017-present Open Networking Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<configuration>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${atomix.log}/atomix.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>atomix.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>10</maxHistory>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>10MB</maxFileSize>
+        </triggeringPolicy>
+
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>TRACE</level>
+        </filter>
+
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.atomix" level="INFO" />
+    <logger name="io.netty.handler.logging.LoggingHandler" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/dist/src/main/resources/examples/README
+++ b/dist/src/main/resources/examples/README
@@ -1,0 +1,5 @@
+This folder contains example configurations for common Atomix cluster architectures.
+* `client.conf` - a client-only configuration designed to discover partition groups on a separate cluster
+* `consensus.conf` - a consensus-based cluster with a Raft management group and Multi-Raft partition group for primitives
+* `data-grid.conf` - a data-grid like cluster with a Raft managemet group and multi-primary data group for primitives
+* `onos.conf` - an example configuration for use with [ONOS](http://onosproject.org)

--- a/dist/src/main/resources/examples/client.conf
+++ b/dist/src/main/resources/examples/client.conf
@@ -1,0 +1,11 @@
+cluster {
+  name: atomix
+  multicast {
+    enabled: true
+    address: "230.0.0.1:54321"
+  }
+  discovery {
+    type: multicast
+    broadcast-interval: 1s
+  }
+}

--- a/dist/src/main/resources/examples/consensus.conf
+++ b/dist/src/main/resources/examples/consensus.conf
@@ -1,0 +1,32 @@
+cluster {
+  name: atomix
+  discovery {
+    type: bootstrap
+    nodes.1 {
+      id: atomix-1
+      address: "10.192.19.171:5679"
+    }
+    nodes.2 {
+      id: atomix-2
+      address: "10.192.19.172:5679"
+    }
+    nodes.3 {
+      id: atomix-3
+      address: "10.192.19.173:5679"
+    }
+  }
+}
+
+management-group {
+  type: raft
+  partitions: 1
+  storage-level: disk
+  members: [atomix-1, atomix-2, atomix-3]
+}
+
+partition-groups.consensus {
+  type: raft
+  partitions: 7
+  storage-level: mapped
+  members: [atomix-1, atomix-2, atomix-3]
+}

--- a/dist/src/main/resources/examples/data-grid.conf
+++ b/dist/src/main/resources/examples/data-grid.conf
@@ -1,0 +1,21 @@
+cluster {
+  name: atomix
+  multicast {
+    enabled: true
+    address: "230.0.0.1:54321"
+  }
+  discovery {
+    type: multicast
+    broadcast-interval: 1s
+  }
+}
+
+management-group {
+  type: primary-backup
+  partitions: 1
+}
+
+partition-groups.data {
+  type: primary-backup
+  partitions: 32
+}

--- a/dist/src/main/resources/examples/onos.conf
+++ b/dist/src/main/resources/examples/onos.conf
@@ -1,0 +1,32 @@
+cluster {
+  name: atomix
+  discovery {
+    type: bootstrap
+    nodes.1 {
+      id: atomix-1
+      address: "10.192.19.171:5679"
+    }
+    nodes.2 {
+      id: atomix-2
+      address: "10.192.19.172:5679"
+    }
+    nodes.3 {
+      id: atomix-3
+      address: "10.192.19.173:5679"
+    }
+  }
+}
+
+management-group {
+  type: raft
+  partitions: 1
+  storage-level: disk
+  members: [atomix-1, atomix-2, atomix-3]
+}
+
+partition-groups.raft {
+  type: raft
+  partitions: 7
+  storage-level: disk
+  members: [atomix-1, atomix-2, atomix-3]
+}

--- a/dist/src/main/resources/log/README
+++ b/dist/src/main/resources/log/README
@@ -1,0 +1,1 @@
+This folder contains Atomix system logs.

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <module>agent</module>
     <module>cluster</module>
     <module>core</module>
+    <module>dist</module>
     <module>primitive</module>
     <module>protocols</module>
     <module>rest</module>
@@ -264,12 +265,6 @@
             <id>attach-javadocs</id>
             <goals>
               <goal>jar</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>aggregate-javadocs</id>
-            <goals>
-              <goal>aggregate-jar</goal>
             </goals>
           </execution>
         </executions>

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
@@ -154,7 +154,7 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
    * @return the partition data directory
    */
   public String getDataDirectory() {
-    return dataDirectory != null ? dataDirectory : DATA_PREFIX + "/" + getName();
+    return dataDirectory != null ? dataDirectory : System.getProperty("atomix.data", DATA_PREFIX) + "/" + getName();
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -380,7 +380,7 @@ public class RaftStorage {
    */
   public static class Builder implements io.atomix.utils.Builder<RaftStorage> {
     private static final String DEFAULT_PREFIX = "atomix";
-    private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
+    private static final String DEFAULT_DIRECTORY = System.getProperty("atomix.data", System.getProperty("user.dir"));
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
     private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
     private static final boolean DEFAULT_DYNAMIC_COMPACTION = true;


### PR DESCRIPTION
Fixes #750

This PR adds a distribution for Atomix agent using the Maven assembly plugin. The assembly creates both a `zip` and `tar.gz` file with the following structure:
* `/bin` - the `atomix-agent` script which sets up the classpath, system properties, and logging and runs the Atomix agent
* `/conf` - `atomix.conf`, logback configuration, and additional example configurations
* `/data` - the default location for persistent partition logs
* `/log` - the default location for system logs