### PR TITLE
Support default primitive configurations

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -255,11 +255,12 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
     ConfigMapper mapper = new PolymorphicConfigMapper(
         classLoader,
         registry,
-        new PolymorphicTypeMapper(PartitionGroupConfig.class, PartitionGroup.Type.class),
-        new PolymorphicTypeMapper(PrimitiveConfig.class, PrimitiveType.class),
-        new PolymorphicTypeMapper(PrimitiveProtocolConfig.class, PrimitiveProtocol.Type.class),
-        new PolymorphicTypeMapper(ProfileConfig.class, Profile.Type.class),
-        new PolymorphicTypeMapper(NodeDiscoveryConfig.class, NodeDiscoveryProvider.Type.class));
+        new PolymorphicTypeMapper("type", PartitionGroupConfig.class, PartitionGroup.Type.class),
+        new PolymorphicTypeMapper("type", PrimitiveConfig.class, PrimitiveType.class),
+        new PolymorphicTypeMapper(null, PrimitiveConfig.class, PrimitiveType.class),
+        new PolymorphicTypeMapper("type", PrimitiveProtocolConfig.class, PrimitiveProtocol.Type.class),
+        new PolymorphicTypeMapper("type", ProfileConfig.class, Profile.Type.class),
+        new PolymorphicTypeMapper("type", NodeDiscoveryConfig.class, NodeDiscoveryProvider.Type.class));
     return mapper.loadFiles(AtomixConfig.class, files, RESOURCES);
   }
 
@@ -382,7 +383,7 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
         Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 8), 4),
         Threads.namedThreads("atomix-primitive-%d", LOGGER));
     this.registry = registry;
-    this.config = new DefaultConfigService(config.getPrimitives().values());
+    this.config = new DefaultConfigService(config.getPrimitiveDefaults().values(), config.getPrimitives().values());
     this.serializationService = new CoreSerializationService(config.isTypeRegistrationRequired(), config.isCompatibleSerialization());
     this.partitions = buildPartitionService(config, getMembershipService(), getCommunicationService(), registry);
     this.primitives = new CorePrimitivesService(

--- a/core/src/main/java/io/atomix/core/AtomixConfig.java
+++ b/core/src/main/java/io/atomix/core/AtomixConfig.java
@@ -38,6 +38,7 @@ public class AtomixConfig implements Config {
   private boolean enableShutdownHook;
   private PartitionGroupConfig managementGroup;
   private Map<String, PartitionGroupConfig<?>> partitionGroups = new HashMap<>();
+  private Map<String, PrimitiveConfig> primitiveDefaults = new HashMap<>();
   private Map<String, PrimitiveConfig> primitives = new HashMap<>();
   private List<ProfileConfig> profiles = new ArrayList<>();
   private boolean typeRegistrationRequired = false;
@@ -134,6 +135,38 @@ public class AtomixConfig implements Config {
   public AtomixConfig addPartitionGroup(PartitionGroupConfig partitionGroup) {
     partitionGroups.put(partitionGroup.getName(), partitionGroup);
     return this;
+  }
+
+  /**
+   * Returns the primitive default configurations.
+   *
+   * @return the primitive default configurations
+   */
+  public Map<String, PrimitiveConfig> getPrimitiveDefaults() {
+    return primitiveDefaults;
+  }
+
+  /**
+   * Sets the primitive default configurations.
+   *
+   * @param primitiveDefaults the primitive default configurations
+   * @return the Atomix configuration
+   */
+  public AtomixConfig setPrimitiveDefaults(Map<String, PrimitiveConfig> primitiveDefaults) {
+    this.primitiveDefaults = primitiveDefaults;
+    return this;
+  }
+
+  /**
+   * Returns a default primitive configuration.
+   *
+   * @param name the primitive name
+   * @param <C>  the configuration type
+   * @return the primitive configuration
+   */
+  @SuppressWarnings("unchecked")
+  public <C extends PrimitiveConfig<C>> C getPrimitiveDefault(String name) {
+    return (C) primitiveDefaults.get(name);
   }
 
   /**

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitivesService.java
@@ -100,6 +100,8 @@ import io.atomix.primitive.partition.impl.DefaultPartitionGroupTypeRegistry;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.impl.DefaultPrimitiveProtocolTypeRegistry;
 import io.atomix.primitive.serialization.SerializationService;
+import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.config.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,153 +169,153 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
 
   @Override
   public <K, V> DistributedMap<K, V> getMap(String name) {
-    return getPrimitive(name, DistributedMapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedMapType.instance());
   }
 
   @Override
   public <K extends Comparable<K>, V> DistributedSortedMap<K, V> getSortedMap(String name) {
-    return getPrimitive(name, DistributedSortedMapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedSortedMapType.instance());
   }
 
   @Override
   public <K extends Comparable<K>, V> DistributedNavigableMap<K, V> getNavigableMap(String name) {
-    return getPrimitive(name, DistributedNavigableMapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedNavigableMapType.instance());
   }
 
   @Override
   public <K, V> DistributedMultimap<K, V> getMultimap(String name) {
-    return getPrimitive(name, DistributedMultimapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedMultimapType.instance());
   }
 
   @Override
   public <K, V> AtomicMap<K, V> getAtomicMap(String name) {
-    return getPrimitive(name, AtomicMapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicMapType.instance());
   }
 
   @Override
   public <V> AtomicDocumentTree<V> getAtomicDocumentTree(String name) {
-    return getPrimitive(name, AtomicDocumentTreeType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicDocumentTreeType.instance());
   }
 
   @Override
   public <K extends Comparable<K>, V> AtomicSortedMap<K, V> getAtomicSortedMap(String name) {
-    return getPrimitive(name, AtomicSortedMapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicSortedMapType.instance());
   }
 
   @Override
   public <K extends Comparable<K>, V> AtomicNavigableMap<K, V> getAtomicNavigableMap(String name) {
-    return getPrimitive(name, AtomicNavigableMapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicNavigableMapType.instance());
   }
 
   @Override
   public <K, V> AtomicMultimap<K, V> getAtomicMultimap(String name) {
-    return getPrimitive(name, AtomicMultimapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicMultimapType.instance());
   }
 
   @Override
   public <K> AtomicCounterMap<K> getAtomicCounterMap(String name) {
-    return getPrimitive(name, AtomicCounterMapType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicCounterMapType.instance());
   }
 
   @Override
   public <E> DistributedSet<E> getSet(String name) {
-    return getPrimitive(name, DistributedSetType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedSetType.instance());
   }
 
   @Override
   public <E extends Comparable<E>> DistributedSortedSet<E> getSortedSet(String name) {
-    return getPrimitive(name, DistributedSortedSetType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedSortedSetType.instance());
   }
 
   @Override
   public <E extends Comparable<E>> DistributedNavigableSet<E> getNavigableSet(String name) {
-    return getPrimitive(name, DistributedNavigableSetType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedNavigableSetType.instance());
   }
 
   @Override
   public <E> DistributedQueue<E> getQueue(String name) {
-    return getPrimitive(name, DistributedQueueType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedQueueType.instance());
   }
 
   @Override
   public <E> DistributedList<E> getList(String name) {
-    return getPrimitive(name, DistributedListType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedListType.instance());
   }
 
   @Override
   public <E> DistributedMultiset<E> getMultiset(String name) {
-    return getPrimitive(name, DistributedMultisetType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedMultisetType.instance());
   }
 
   @Override
   public DistributedCounter getCounter(String name) {
-    return getPrimitive(name, DistributedCounterType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedCounterType.instance());
   }
 
   @Override
   public AtomicCounter getAtomicCounter(String name) {
-    return getPrimitive(name, AtomicCounterType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicCounterType.instance());
   }
 
   @Override
   public AtomicIdGenerator getAtomicIdGenerator(String name) {
-    return getPrimitive(name, AtomicIdGeneratorType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicIdGeneratorType.instance());
   }
 
   @Override
   public <V> DistributedValue<V> getValue(String name) {
-    return getPrimitive(name, DistributedValueType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedValueType.instance());
   }
 
   @Override
   public <V> AtomicValue<V> getAtomicValue(String name) {
-    return getPrimitive(name, AtomicValueType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicValueType.instance());
   }
 
   @Override
   public <T> LeaderElection<T> getLeaderElection(String name) {
-    return getPrimitive(name, LeaderElectionType.instance(), configService.getConfig(name));
+    return getPrimitive(name, LeaderElectionType.instance());
   }
 
   @Override
   public <T> LeaderElector<T> getLeaderElector(String name) {
-    return getPrimitive(name, LeaderElectorType.instance(), configService.getConfig(name));
+    return getPrimitive(name, LeaderElectorType.instance());
   }
 
   @Override
   public DistributedLock getLock(String name) {
-    return getPrimitive(name, DistributedLockType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedLockType.instance());
   }
 
   @Override
   public AtomicLock getAtomicLock(String name) {
-    return getPrimitive(name, AtomicLockType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicLockType.instance());
   }
 
   @Override
   public DistributedCyclicBarrier getCyclicBarrier(String name) {
-    return getPrimitive(name, DistributedCyclicBarrierType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedCyclicBarrierType.instance());
   }
 
   @Override
   public DistributedSemaphore getSemaphore(String name) {
-    return getPrimitive(name, DistributedSemaphoreType.instance(), configService.getConfig(name));
+    return getPrimitive(name, DistributedSemaphoreType.instance());
   }
 
   @Override
   public AtomicSemaphore getAtomicSemaphore(String name) {
-    return getPrimitive(name, AtomicSemaphoreType.instance(), configService.getConfig(name));
+    return getPrimitive(name, AtomicSemaphoreType.instance());
   }
 
   @Override
   public <E> WorkQueue<E> getWorkQueue(String name) {
-    return getPrimitive(name, WorkQueueType.instance(), configService.getConfig(name));
+    return getPrimitive(name, WorkQueueType.instance());
   }
 
   @Override
   public <B extends PrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends SyncPrimitive> B primitiveBuilder(
       String name, PrimitiveType<B, C, P> primitiveType) {
-    return primitiveType.newBuilder(name, primitiveType.newConfig(), managementService);
+    return primitiveType.newBuilder(name, configService.getConfig(name, primitiveType), managementService);
   }
 
   @Override
@@ -322,25 +324,20 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
     return cache.getPrimitive(name, () -> {
       PrimitiveInfo info = primitiveRegistry.getPrimitive(name);
       if (info == null) {
-        PrimitiveConfig<?> primitiveConfig = configService.getConfig(name);
+        PrimitiveConfig<?> primitiveConfig = configService.getConfig(name, null);
         if (primitiveConfig == null) {
-          return CompletableFuture.completedFuture(null);
+          return Futures.exceptionalFuture(new ConfigurationException("No configuration provided for " + name));
         }
         return primitiveConfig.getType().newBuilder(name, primitiveConfig, managementService).buildAsync();
       }
-
-      PrimitiveConfig primitiveConfig = configService.getConfig(name);
-      if (primitiveConfig == null) {
-        primitiveConfig = info.type().newConfig();
-      }
-      return info.type().newBuilder(name, primitiveConfig, managementService).buildAsync();
+      return info.type().newBuilder(name, (PrimitiveConfig) configService.getConfig(name, info.type()), managementService).buildAsync();
     });
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public <P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(String name, PrimitiveType<?, ?, P> primitiveType) {
-    return getPrimitiveAsync(name, (PrimitiveType) primitiveType, (PrimitiveConfig) configService.getConfig(name));
+    return getPrimitiveAsync(name, (PrimitiveType) primitiveType, null);
   }
 
   @Override
@@ -350,10 +347,7 @@ public class CorePrimitivesService implements ManagedPrimitivesService {
     return cache.getPrimitive(name, () -> {
       C config = primitiveConfig;
       if (config == null) {
-        config = configService.getConfig(name);
-        if (config == null) {
-          config = primitiveType.newConfig();
-        }
+        config = configService.getConfig(name, primitiveType);
       }
       return primitiveType.newBuilder(name, config, managementService).buildAsync();
     });

--- a/core/src/main/java/io/atomix/core/utils/config/PolymorphicTypeMapper.java
+++ b/core/src/main/java/io/atomix/core/utils/config/PolymorphicTypeMapper.java
@@ -23,10 +23,12 @@ import io.atomix.utils.config.TypedConfig;
  * Polymorphic type mapper.
  */
 public class PolymorphicTypeMapper {
+  private final String typePath;
   private final Class<? extends TypedConfig> configClass;
   private final Class<? extends ConfiguredType> typeClass;
 
-  public PolymorphicTypeMapper(Class<? extends TypedConfig> configClass, Class<? extends ConfiguredType> typeClass) {
+  public PolymorphicTypeMapper(String typePath, Class<? extends TypedConfig> configClass, Class<? extends ConfiguredType> typeClass) {
+    this.typePath = typePath;
     this.configClass = configClass;
     this.typeClass = typeClass;
   }
@@ -55,7 +57,7 @@ public class PolymorphicTypeMapper {
    * @return the type path
    */
   public String getTypePath() {
-    return "type";
+    return typePath;
   }
 
   /**

--- a/core/src/test/java/io/atomix/core/AtomixConfigTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixConfigTest.java
@@ -118,6 +118,10 @@ public class AtomixConfigTest {
     assertEquals("data", dataGridProfile.getDataGroup());
     assertEquals(32, dataGridProfile.getPartitions());
 
+    AtomicMapConfig fooDefaults = config.getPrimitiveDefault("atomic-map");
+    assertEquals("atomic-map", fooDefaults.getType().name());
+    assertEquals("two", ((MultiPrimaryProtocolConfig) fooDefaults.getProtocolConfig()).getGroup());
+
     AtomicMapConfig foo = config.getPrimitive("foo");
     assertEquals("atomic-map", foo.getType().name());
     assertTrue(foo.isNullValues());

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -553,119 +553,119 @@ public class AtomixTest extends AbstractAtomixTest {
 
     atomix.start().get(30, TimeUnit.SECONDS);
 
-    assertEquals(AtomicCounterType.instance(), atomix.getPrimitive("atomic-counter").type());
+    assertEquals(AtomicCounterType.instance(), atomix.getPrimitive("atomic-counter", AtomicCounterType.instance()).type());
     assertEquals("atomic-counter", atomix.getAtomicCounter("atomic-counter").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicCounter("atomic-counter").protocol()).group());
 
-    assertEquals(AtomicMapType.instance(), atomix.getPrimitive("atomic-map").type());
+    assertEquals(AtomicMapType.instance(), atomix.getPrimitive("atomic-map", AtomicMapType.instance()).type());
     assertEquals("atomic-map", atomix.getAtomicMap("atomic-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicMap("atomic-map").protocol()).group());
 
-    assertEquals(AtomicCounterMapType.instance(), atomix.getPrimitive("atomic-counter-map").type());
+    assertEquals(AtomicCounterMapType.instance(), atomix.getPrimitive("atomic-counter-map", AtomicCounterMapType.instance()).type());
     assertEquals("atomic-counter-map", atomix.getAtomicCounterMap("atomic-counter-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicCounterMap("atomic-counter-map").protocol()).group());
 
-    assertEquals(AtomicDocumentTreeType.instance(), atomix.getPrimitive("atomic-document-tree").type());
+    assertEquals(AtomicDocumentTreeType.instance(), atomix.getPrimitive("atomic-document-tree", AtomicDocumentTreeType.instance()).type());
     assertEquals("atomic-document-tree", atomix.getAtomicDocumentTree("atomic-document-tree").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicDocumentTree("atomic-document-tree").protocol()).group());
 
-    assertEquals(AtomicIdGeneratorType.instance(), atomix.getPrimitive("atomic-id-generator").type());
+    assertEquals(AtomicIdGeneratorType.instance(), atomix.getPrimitive("atomic-id-generator", AtomicIdGeneratorType.instance()).type());
     assertEquals("atomic-id-generator", atomix.getAtomicIdGenerator("atomic-id-generator").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicIdGenerator("atomic-id-generator").protocol()).group());
 
-    assertEquals(AtomicLockType.instance(), atomix.getPrimitive("atomic-lock").type());
+    assertEquals(AtomicLockType.instance(), atomix.getPrimitive("atomic-lock", AtomicLockType.instance()).type());
     assertEquals("atomic-lock", atomix.getAtomicLock("atomic-lock").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicLock("atomic-lock").protocol()).group());
 
-    assertEquals(AtomicMultimapType.instance(), atomix.getPrimitive("atomic-multimap").type());
+    assertEquals(AtomicMultimapType.instance(), atomix.getPrimitive("atomic-multimap", AtomicMultimapType.instance()).type());
     assertEquals("atomic-multimap", atomix.getAtomicMultimap("atomic-multimap").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicMultimap("atomic-multimap").protocol()).group());
 
-    assertEquals(AtomicNavigableMapType.instance(), atomix.getPrimitive("atomic-navigable-map").type());
+    assertEquals(AtomicNavigableMapType.instance(), atomix.getPrimitive("atomic-navigable-map", AtomicNavigableMapType.instance()).type());
     assertEquals("atomic-navigable-map", atomix.getAtomicNavigableMap("atomic-navigable-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicNavigableMap("atomic-navigable-map").protocol()).group());
 
-    assertEquals(AtomicSemaphoreType.instance(), atomix.getPrimitive("atomic-semaphore").type());
+    assertEquals(AtomicSemaphoreType.instance(), atomix.getPrimitive("atomic-semaphore", AtomicSemaphoreType.instance()).type());
     assertEquals("atomic-semaphore", atomix.getAtomicSemaphore("atomic-semaphore").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicSemaphore("atomic-semaphore").protocol()).group());
 
-    assertEquals(AtomicSortedMapType.instance(), atomix.getPrimitive("atomic-sorted-map").type());
+    assertEquals(AtomicSortedMapType.instance(), atomix.getPrimitive("atomic-sorted-map", AtomicSortedMapType.instance()).type());
     assertEquals("atomic-sorted-map", atomix.getAtomicSortedMap("atomic-sorted-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicSortedMap("atomic-sorted-map").protocol()).group());
 
-    assertEquals(AtomicValueType.instance(), atomix.getPrimitive("atomic-value").type());
+    assertEquals(AtomicValueType.instance(), atomix.getPrimitive("atomic-value", AtomicValueType.instance()).type());
     assertEquals("atomic-value", atomix.getAtomicValue("atomic-value").name());
     assertEquals("two", ((ProxyProtocol) atomix.getAtomicValue("atomic-value").protocol()).group());
 
-    assertEquals(DistributedCounterType.instance(), atomix.getPrimitive("counter").type());
+    assertEquals(DistributedCounterType.instance(), atomix.getPrimitive("counter", DistributedCounterType.instance()).type());
     assertEquals("counter", atomix.getCounter("counter").name());
     assertEquals("two", ((ProxyProtocol) atomix.getCounter("counter").protocol()).group());
 
-    assertEquals(DistributedCyclicBarrierType.instance(), atomix.getPrimitive("cyclic-barrier").type());
+    assertEquals(DistributedCyclicBarrierType.instance(), atomix.getPrimitive("cyclic-barrier", DistributedCyclicBarrierType.instance()).type());
     assertEquals("cyclic-barrier", atomix.getCyclicBarrier("cyclic-barrier").name());
     assertEquals("two", ((ProxyProtocol) atomix.getCyclicBarrier("cyclic-barrier").protocol()).group());
 
-    assertEquals(LeaderElectionType.instance(), atomix.getPrimitive("leader-election").type());
+    assertEquals(LeaderElectionType.instance(), atomix.getPrimitive("leader-election", LeaderElectionType.instance()).type());
     assertEquals("leader-election", atomix.getLeaderElection("leader-election").name());
     assertEquals("two", ((ProxyProtocol) atomix.getLeaderElection("leader-election").protocol()).group());
 
-    assertEquals(LeaderElectorType.instance(), atomix.getPrimitive("leader-elector").type());
+    assertEquals(LeaderElectorType.instance(), atomix.getPrimitive("leader-elector", LeaderElectorType.instance()).type());
     assertEquals("leader-elector", atomix.getLeaderElector("leader-elector").name());
     assertEquals("two", ((ProxyProtocol) atomix.getLeaderElector("leader-elector").protocol()).group());
 
-    assertEquals(DistributedListType.instance(), atomix.getPrimitive("list").type());
+    assertEquals(DistributedListType.instance(), atomix.getPrimitive("list", DistributedListType.instance()).type());
     assertEquals("list", atomix.getList("list").name());
     assertEquals("two", ((ProxyProtocol) atomix.getList("list").protocol()).group());
 
-    assertEquals(DistributedLockType.instance(), atomix.getPrimitive("lock").type());
+    assertEquals(DistributedLockType.instance(), atomix.getPrimitive("lock", DistributedLockType.instance()).type());
     assertEquals("lock", atomix.getLock("lock").name());
     assertEquals("two", ((ProxyProtocol) atomix.getLock("lock").protocol()).group());
 
-    assertEquals(DistributedMapType.instance(), atomix.getPrimitive("map").type());
+    assertEquals(DistributedMapType.instance(), atomix.getPrimitive("map", DistributedMapType.instance()).type());
     assertEquals("map", atomix.getMap("map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getMap("map").protocol()).group());
 
-    assertEquals(DistributedMultimapType.instance(), atomix.getPrimitive("multimap").type());
+    assertEquals(DistributedMultimapType.instance(), atomix.getPrimitive("multimap", DistributedMultimapType.instance()).type());
     assertEquals("multimap", atomix.getMultimap("multimap").name());
     assertEquals("two", ((ProxyProtocol) atomix.getMultimap("multimap").protocol()).group());
 
-    assertEquals(DistributedMultisetType.instance(), atomix.getPrimitive("multiset").type());
+    assertEquals(DistributedMultisetType.instance(), atomix.getPrimitive("multiset", DistributedMultisetType.instance()).type());
     assertEquals("multiset", atomix.getMultiset("multiset").name());
     assertEquals("two", ((ProxyProtocol) atomix.getMultiset("multiset").protocol()).group());
 
-    assertEquals(DistributedNavigableMapType.instance(), atomix.getPrimitive("navigable-map").type());
+    assertEquals(DistributedNavigableMapType.instance(), atomix.getPrimitive("navigable-map", DistributedNavigableMapType.instance()).type());
     assertEquals("navigable-map", atomix.getNavigableMap("navigable-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getNavigableMap("navigable-map").protocol()).group());
 
-    assertEquals(DistributedNavigableSetType.instance(), atomix.getPrimitive("navigable-set").type());
+    assertEquals(DistributedNavigableSetType.instance(), atomix.getPrimitive("navigable-set", DistributedNavigableSetType.instance()).type());
     assertEquals("navigable-set", atomix.getNavigableSet("navigable-set").name());
     assertEquals("two", ((ProxyProtocol) atomix.getNavigableSet("navigable-set").protocol()).group());
 
-    assertEquals(DistributedQueueType.instance(), atomix.getPrimitive("queue").type());
+    assertEquals(DistributedQueueType.instance(), atomix.getPrimitive("queue", DistributedQueueType.instance()).type());
     assertEquals("queue", atomix.getQueue("queue").name());
     assertEquals("two", ((ProxyProtocol) atomix.getQueue("queue").protocol()).group());
 
-    assertEquals(DistributedSemaphoreType.instance(), atomix.getPrimitive("semaphore").type());
+    assertEquals(DistributedSemaphoreType.instance(), atomix.getPrimitive("semaphore", DistributedSemaphoreType.instance()).type());
     assertEquals("semaphore", atomix.getSemaphore("semaphore").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSemaphore("semaphore").protocol()).group());
 
-    assertEquals(DistributedSetType.instance(), atomix.getPrimitive("set").type());
+    assertEquals(DistributedSetType.instance(), atomix.getPrimitive("set", DistributedSetType.instance()).type());
     assertEquals("set", atomix.getSet("set").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSet("set").protocol()).group());
 
-    assertEquals(DistributedSortedMapType.instance(), atomix.getPrimitive("sorted-map").type());
+    assertEquals(DistributedSortedMapType.instance(), atomix.getPrimitive("sorted-map", DistributedSortedMapType.instance()).type());
     assertEquals("sorted-map", atomix.getSortedMap("sorted-map").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSortedMap("sorted-map").protocol()).group());
 
-    assertEquals(DistributedSortedSetType.instance(), atomix.getPrimitive("sorted-set").type());
+    assertEquals(DistributedSortedSetType.instance(), atomix.getPrimitive("sorted-set", DistributedSortedSetType.instance()).type());
     assertEquals("sorted-set", atomix.getSortedSet("sorted-set").name());
     assertEquals("two", ((ProxyProtocol) atomix.getSortedSet("sorted-set").protocol()).group());
 
-    assertEquals(DistributedValueType.instance(), atomix.getPrimitive("value").type());
+    assertEquals(DistributedValueType.instance(), atomix.getPrimitive("value", DistributedValueType.instance()).type());
     assertEquals("value", atomix.getValue("value").name());
     assertEquals("two", ((ProxyProtocol) atomix.getValue("value").protocol()).group());
 
-    assertEquals(WorkQueueType.instance(), atomix.getPrimitive("work-queue").type());
+    assertEquals(WorkQueueType.instance(), atomix.getPrimitive("work-queue", WorkQueueType.instance()).type());
     assertEquals("work-queue", atomix.getWorkQueue("work-queue").name());
     assertEquals("two", ((ProxyProtocol) atomix.getWorkQueue("work-queue").protocol()).group());
   }

--- a/core/src/test/resources/primitives.conf
+++ b/core/src/test/resources/primitives.conf
@@ -30,6 +30,13 @@ primitives.atomic-counter {
   }
 }
 
+primitive-defaults.atomic-map {
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
 primitives.atomic-map {
   type: atomic-map
   key-type: io.atomix.core.types.Type1

--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -60,6 +60,13 @@ profiles.2 {
   partitions: 32
 }
 
+primitive-defaults.atomic-map {
+  protocol {
+    type: multi-primary
+    group: two
+  }
+}
+
 primitives.foo {
   type: atomic-map
   null-values: true

--- a/primitive/src/main/java/io/atomix/primitive/config/ConfigService.java
+++ b/primitive/src/main/java/io/atomix/primitive/config/ConfigService.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.primitive.config;
 
+import io.atomix.primitive.PrimitiveType;
+
 /**
  * Configuration service.
  */
@@ -24,20 +26,10 @@ public interface ConfigService {
    * Returns the registered configuration for the given primitive.
    *
    * @param primitiveName the primitive name
+   * @param primitiveType the primitive type
    * @param <C>           the configuration type
    * @return the primitive configuration
    */
-  <C extends PrimitiveConfig<C>> C getConfig(String primitiveName);
-
-  /**
-   * Adds a primitive configuration.
-   * <p>
-   * If a configuration is already registered it will not be overridden. The returned configuration represents the
-   * configuration that will be used when constructing a new primitive with the given name.
-   *
-   * @param config the configuration to add
-   * @return the registered primitive configuration
-   */
-  PrimitiveConfig addConfig(PrimitiveConfig config);
+  <C extends PrimitiveConfig<C>> C getConfig(String primitiveName, PrimitiveType primitiveType);
 
 }

--- a/primitive/src/main/java/io/atomix/primitive/config/impl/DefaultConfigService.java
+++ b/primitive/src/main/java/io/atomix/primitive/config/impl/DefaultConfigService.java
@@ -16,34 +16,39 @@
 package io.atomix.primitive.config.impl;
 
 import com.google.common.collect.Maps;
+import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.config.ConfigService;
 import io.atomix.primitive.config.PrimitiveConfig;
 
 import java.util.Collection;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Default configuration service.
  */
 public class DefaultConfigService implements ConfigService {
+  private final Map<String, PrimitiveConfig> defaultConfigs = Maps.newConcurrentMap();
   private final Map<String, PrimitiveConfig> configs = Maps.newConcurrentMap();
 
-  public DefaultConfigService(Collection<PrimitiveConfig> configs) {
+  public DefaultConfigService(Collection<PrimitiveConfig> defaultConfigs, Collection<PrimitiveConfig> configs) {
+    defaultConfigs.forEach(config -> this.defaultConfigs.put(((PrimitiveType) config.getType()).name(), config));
     configs.forEach(config -> this.configs.put(config.getName(), config));
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <C extends PrimitiveConfig<C>> C getConfig(String primitiveName) {
-    return (C) configs.get(primitiveName);
-  }
-
-  @Override
-  public PrimitiveConfig addConfig(PrimitiveConfig config) {
-    checkNotNull(config, "config cannot be null");
-    PrimitiveConfig previous = configs.putIfAbsent(config.getName(), config);
-    return previous != null ? previous : config;
+  public <C extends PrimitiveConfig<C>> C getConfig(String primitiveName, PrimitiveType primitiveType) {
+    C config = (C) configs.get(primitiveName);
+    if (config != null) {
+      return config;
+    }
+    if (primitiveType == null) {
+      return null;
+    }
+    config = (C) defaultConfigs.get(primitiveType.name());
+    if (config != null) {
+      return config;
+    }
+    return (C) primitiveType.newConfig();
   }
 }

--- a/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
+++ b/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
@@ -132,7 +132,7 @@ public class ConfigMapper {
     return map(config, null, null, clazz);
   }
 
-  protected <T> T newInstance(Config config, Class<T> clazz) {
+  protected <T> T newInstance(Config config, String key, Class<T> clazz) {
     try {
       return clazz.newInstance();
     } catch (InstantiationException | IllegalAccessException e) {
@@ -148,7 +148,7 @@ public class ConfigMapper {
    */
   @SuppressWarnings("unchecked")
   protected <T> T map(Config config, String path, String name, Class<T> clazz) {
-    T instance = newInstance(config, clazz);
+    T instance = newInstance(config, name, clazz);
 
     // Map config property names to bean properties.
     Map<String, String> propertyNames = new HashMap<>();


### PR DESCRIPTION
This PR adds support for default primitive configurations which are applied to primitives and builders when the configuration is not explicitly overridden by name.

In the configuration file this is done by the `primitive-defaults` key:

```hocon
primitive-defaults.atomic-map {
  protocol {
    type: multi-primary
    group: data
    backups: 2
  }
}
```