### PR TITLE
Use agent distribution in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,30 +6,13 @@ MAINTAINER  Jordan Halterman <jordan.halterman@gmail.com>
 
 RUN apt-get update && apt-get install -y iptables git stress
 
-ARG YOURKIT_VERSION=2017.02-b75
-ENV yourkit_version=$YOURKIT_VERSION
-RUN wget https://www.yourkit.com/download/YourKit-JavaProfiler-$yourkit_version.zip \
-  && unzip YourKit-JavaProfiler-$yourkit_version.zip -d /tmp \
-  && rm YourKit-JavaProfiler-$yourkit_version.zip \
-  && mkdir /atomix \
-  && mv /tmp/YourKit-JavaProfiler-$(echo $yourkit_version | sed 's/\(.*\)-.*/\1/')/bin/linux-x86-64/libyjpagent.so /atomix/libyjpagent.so
+RUN mkdir /atomix
 
-ENV log_level=INFO
-ENV console_log_level=INFO
-ENV file_log_level=INFO
-
-ENV profile false
-RUN echo '#!/bin/bash' >> run_atomix \
-  && echo 'if [ "$profile" = true ]; then \
-    java -agentpath:/atomix/libyjpagent.so -jar -Datomix.logging.file.path=/data/logs -Datomix.logging.level=$log_level -Datomix.logging.console.level=$console_log_level -Datomix.logging.file.level=$file_log_level /atomix/atomix-agent.jar "$@"; \
-    else \
-    java -jar -Datomix.logging.file.path=/data/logs -Datomix.logging.level=$log_level -Datomix.logging.console.level=$console_log_level -Datomix.logging.file.level=$file_log_level /atomix/atomix-agent.jar "$@"; \
-    fi' >> run_atomix \
-  && chmod +x run_atomix
+ARG VERSION
+COPY /dist/target/atomix-agent-${VERSION}.tar.gz /atomix/atomix-agent-${VERSION}.tar.gz
+RUN tar -xvf /atomix/atomix-agent-${VERSION}.tar.gz -C /atomix && rm /atomix/atomix-agent-${VERSION}.tar.gz
 
 EXPOSE 5678
 EXPOSE 5679
 
-ADD /agent/target/atomix-agent.jar /atomix/atomix-agent.jar
-
-ENTRYPOINT ["/bin/bash", "run_atomix"]
+ENTRYPOINT ["/atomix/bin/atomix-agent"]

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
     <maven.bundle.plugin.version>2.5.3</maven.bundle.plugin.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
+    <maven.dockerfile.plugin.version>1.4.3</maven.dockerfile.plugin.version>
 
     <argLine.common>-Xss256k -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Dio.atomix.scanSpec=io.atomix</argLine.common>
     <argLine.extras /> <!-- Overridden in some profiles -->
@@ -254,6 +255,28 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>${maven.bundle.plugin.version}</version>
         <extensions>true</extensions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+        <version>${maven.dockerfile.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+              <goal>push</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <repository>atomix/atomix</repository>
+          <tag>${project.version}</tag>
+          <buildArgs>
+            <VERSION>${project.version}</VERSION>
+          </buildArgs>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Updates the Dockerfile to use the Atomix agent distribution. The distro needs to be updated separately to support profiling.