### PR TITLE
Refactor REST API to reference primitive types in URIs

### DIFF
--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -664,9 +664,9 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
   }
 
   @Override
-  public <P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(String name) {
+  public PrimitiveType getPrimitiveType(String typeName) {
     checkRunning();
-    return primitives.getPrimitiveAsync(name);
+    return primitives.getPrimitiveType(typeName);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/PrimitivesService.java
+++ b/core/src/main/java/io/atomix/core/PrimitivesService.java
@@ -103,18 +103,9 @@ import io.atomix.core.value.DistributedValueType;
 import io.atomix.core.workqueue.WorkQueue;
 import io.atomix.core.workqueue.WorkQueueBuilder;
 import io.atomix.core.workqueue.WorkQueueType;
-import io.atomix.primitive.PrimitiveBuilder;
-import io.atomix.primitive.PrimitiveInfo;
+import io.atomix.primitive.PrimitiveFactory;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.SyncPrimitive;
-import io.atomix.primitive.config.PrimitiveConfig;
-import io.atomix.utils.AtomixRuntimeException;
-
-import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Manages the creation of distributed primitive instances.
@@ -145,7 +136,7 @@ import java.util.concurrent.TimeoutException;
  *   }
  * </pre>
  */
-public interface PrimitivesService {
+public interface PrimitivesService extends PrimitiveFactory {
 
   /**
    * Creates a new named {@link DistributedMap} builder.
@@ -1507,194 +1498,5 @@ public interface PrimitivesService {
    * @return work queue builder
    */
   <E> WorkQueue<E> getWorkQueue(String name);
-
-  /**
-   * Gets or creates a primitive.
-   * <p>
-   * A new primitive will be created if no primitive instance with the given {@code name} exists on this node, otherwise
-   * the existing instance will be returned. The name is used to reference a distinct instance of the primitive within
-   * the cluster. The returned primitive will share the same state with primitives of the same name on other nodes.
-   * <p>
-   * The constructed primitive will be based on any pre-existing primitive configuration for the given {@code name}.
-   * <p>
-   * To get an asynchronous instance of the primitive, use the {@link SyncPrimitive#async()} method:
-   * <pre>
-   *   {@code
-   *   AsyncPrimitive async = atomix.getPrimitive("my-primitive").async();
-   *   }
-   * </pre>
-   *
-   * @param name the primitive name
-   * @param <P> the primitive type
-   * @return the primitive instance
-   */
-  default <P extends SyncPrimitive> P getPrimitive(String name) {
-    try {
-      return this.<P>getPrimitiveAsync(name).get(30, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new AtomixRuntimeException(e);
-    }
-  }
-
-  /**
-   * Gets or creates a distributed primitive.
-   * <p>
-   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
-   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
-   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
-   * primitives of the same name on other nodes.
-   * <p>
-   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
-   * defined in {@code atomix.conf}.
-   * <p>
-   * To get an asynchronous instance of the primitive, use the {@link SyncPrimitive#async()} method:
-   * <pre>
-   *   {@code
-   *   AsyncPrimitive async = atomix.getPrimitive("my-primitive").async();
-   *   }
-   * </pre>
-   *
-   * @param name the primitive name
-   * @param primitiveType the primitive type
-   * @param <P> the primitive type
-   * @return the primitive instance
-   */
-  default <P extends SyncPrimitive> P getPrimitive(String name, PrimitiveType<?, ?, P> primitiveType) {
-    try {
-      return getPrimitiveAsync(name, primitiveType).get(30, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new AtomixRuntimeException(e);
-    }
-  }
-
-  /**
-   * Gets or creates a distributed primitive.
-   * <p>
-   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
-   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
-   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
-   * primitives of the same name on other nodes.
-   * <p>
-   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
-   * defined in {@code atomix.conf}.
-   * <p>
-   * To get an asynchronous instance of the primitive, use the {@link SyncPrimitive#async()} method:
-   * <pre>
-   *   {@code
-   *   AsyncPrimitive async = atomix.getPrimitive("my-primitive").async();
-   *   }
-   * </pre>
-   *
-   * @param name the primitive name
-   * @param primitiveType the primitive type
-   * @param primitiveConfig the primitive configuration
-   * @param <C> the primitive configuration type
-   * @param <P> the primitive type
-   * @return the primitive instance
-   */
-  default <C extends PrimitiveConfig<C>, P extends SyncPrimitive> P getPrimitive(
-      String name,
-      PrimitiveType<?, C, P> primitiveType,
-      C primitiveConfig) {
-    try {
-      return getPrimitiveAsync(name, primitiveType, primitiveConfig).get(30, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new AtomixRuntimeException(e);
-    }
-  }
-
-  /**
-   * Gets or creates a primitive asynchronously.
-   * <p>
-   * A new primitive will be created if no primitive instance with the given {@code name} exists on this node, otherwise
-   * the existing instance will be returned. The name is used to reference a distinct instance of the primitive within
-   * the cluster. The returned primitive will share the same state with primitives of the same name on other nodes.
-   * <p>
-   * The constructed primitive will be based on any pre-existing primitive configuration for the given {@code name}.
-   *
-   * @param name the primitive name
-   * @param <P> the primitive type
-   * @return the primitive instance
-   */
-  <P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(String name);
-
-  /**
-   * Gets or creates a distributed primitive asynchronously.
-   * <p>
-   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
-   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
-   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
-   * primitives of the same name on other nodes.
-   * <p>
-   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
-   * defined in {@code atomix.conf}.
-   *
-   * @param name the primitive name
-   * @param primitiveType the primitive type
-   * @param <P> the primitive type
-   * @return the primitive instance
-   */
-  <P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(String name, PrimitiveType<?, ?, P> primitiveType);
-
-  /**
-   * Gets or creates a distributed primitive asynchronously.
-   * <p>
-   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
-   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
-   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
-   * primitives of the same name on other nodes.
-   * <p>
-   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
-   * defined in {@code atomix.conf}.
-   *
-   * @param name the primitive name
-   * @param primitiveType the primitive type
-   * @param primitiveConfig the primitive configuration
-   * @param <C> the primitive configuration type
-   * @param <P> the primitive type
-   * @return a future to be completed with the primitive instance
-   */
-  <C extends PrimitiveConfig<C>, P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(
-      String name, PrimitiveType<?, C, P> primitiveType, C primitiveConfig);
-
-  /**
-   * Creates a new named primitive builder of the given {@code primitiveType}.
-   * <p>
-   * The primitive name must be provided when constructing the builder. The name is used to reference a distinct instance of
-   * the primitive within the cluster. Multiple instances of the primitive with the same name will share the same state.
-   * However, the instance of the primitive constructed by the returned builder will be distinct and will not share
-   * local memory (e.g. cache) with any other instance on this node.
-   * <p>
-   * To get an asynchronous instance of the primitive, use the {@link SyncPrimitive#async()} method:
-   * <pre>
-   *   {@code
-   *   AsyncPrimitive async = atomix.primitiveBuilder("my-primitive", MyPrimitiveType.instance()).build().async();
-   *   }
-   * </pre>
-   *
-   * @param name the primitive name
-   * @param primitiveType the primitive type
-   * @param <B> the primitive builder type
-   * @param <P> the primitive type
-   * @return the primitive builder
-   */
-  <B extends PrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends SyncPrimitive> B primitiveBuilder(
-      String name,
-      PrimitiveType<B, C, P> primitiveType);
-
-  /**
-   * Returns a collection of open primitives.
-   *
-   * @return a collection of open primitives
-   */
-  Collection<PrimitiveInfo> getPrimitives();
-
-  /**
-   * Returns a collection of open primitives of the given type.
-   *
-   * @param primitiveType the primitive type
-   * @return a collection of open primitives of the given type
-   */
-  Collection<PrimitiveInfo> getPrimitives(PrimitiveType primitiveType);
 
 }

--- a/core/src/main/java/io/atomix/core/counter/AtomicCounterType.java
+++ b/core/src/main/java/io/atomix/core/counter/AtomicCounterType.java
@@ -15,12 +15,11 @@
  */
 package io.atomix.core.counter;
 
-import io.atomix.core.counter.impl.DefaultAtomicCounterBuilder;
 import io.atomix.core.counter.impl.AtomicCounterResource;
+import io.atomix.core.counter.impl.DefaultAtomicCounterBuilder;
 import io.atomix.core.counter.impl.DefaultAtomicCounterService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -53,8 +52,8 @@ public class AtomicCounterType implements PrimitiveType<AtomicCounterBuilder, At
   }
 
   @Override
-  public PrimitiveResource newResource(AtomicCounter primitive) {
-    return new AtomicCounterResource(primitive.async());
+  public Class<?> getResourceClass() {
+    return AtomicCounterResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/election/LeaderElectionType.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectionType.java
@@ -20,7 +20,6 @@ import io.atomix.core.election.impl.DefaultLeaderElectionService;
 import io.atomix.core.election.impl.LeaderElectionResource;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -65,9 +64,8 @@ public class LeaderElectionType<T> implements PrimitiveType<LeaderElectionBuilde
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(LeaderElection<T> primitive) {
-    return new LeaderElectionResource((AsyncLeaderElection<String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return LeaderElectionResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/idgenerator/AtomicIdGeneratorType.java
+++ b/core/src/main/java/io/atomix/core/idgenerator/AtomicIdGeneratorType.java
@@ -20,7 +20,6 @@ import io.atomix.core.idgenerator.impl.AtomicIdGeneratorResource;
 import io.atomix.core.idgenerator.impl.DelegatingAtomicIdGeneratorBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -53,8 +52,8 @@ public class AtomicIdGeneratorType implements PrimitiveType<AtomicIdGeneratorBui
   }
 
   @Override
-  public PrimitiveResource newResource(AtomicIdGenerator primitive) {
-    return new AtomicIdGeneratorResource(primitive.async());
+  public Class<?> getResourceClass() {
+    return AtomicIdGeneratorResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/lock/AtomicLockType.java
+++ b/core/src/main/java/io/atomix/core/lock/AtomicLockType.java
@@ -20,7 +20,6 @@ import io.atomix.core.lock.impl.DefaultAtomicLockBuilder;
 import io.atomix.core.lock.impl.DefaultAtomicLockService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -53,9 +52,8 @@ public class AtomicLockType implements PrimitiveType<AtomicLockBuilder, AtomicLo
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(AtomicLock primitive) {
-    return new AtomicLockResource(primitive.async());
+  public Class<?> getResourceClass() {
+    return AtomicLockResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/lock/DistributedLockType.java
+++ b/core/src/main/java/io/atomix/core/lock/DistributedLockType.java
@@ -20,7 +20,6 @@ import io.atomix.core.lock.impl.DefaultDistributedLockService;
 import io.atomix.core.lock.impl.DistributedLockResource;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -53,9 +52,8 @@ public class DistributedLockType implements PrimitiveType<DistributedLockBuilder
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(DistributedLock primitive) {
-    return new DistributedLockResource(primitive.async());
+  public Class<?> getResourceClass() {
+    return DistributedLockResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/lock/impl/DistributedLockResource.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/DistributedLockResource.java
@@ -16,6 +16,8 @@
 package io.atomix.core.lock.impl;
 
 import io.atomix.core.lock.AsyncDistributedLock;
+import io.atomix.core.lock.DistributedLockConfig;
+import io.atomix.core.lock.DistributedLockType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
@@ -32,20 +35,19 @@ import javax.ws.rs.core.Response;
 /**
  * Distributed lock resource.
  */
-public class DistributedLockResource implements PrimitiveResource {
+@Path("/lock")
+public class DistributedLockResource extends PrimitiveResource<AsyncDistributedLock, DistributedLockConfig> {
   private static final Logger LOGGER = LoggerFactory.getLogger(DistributedLockResource.class);
 
-  private final AsyncDistributedLock lock;
-
-  public DistributedLockResource(AsyncDistributedLock lock) {
-    this.lock = lock;
+  public DistributedLockResource() {
+    super(DistributedLockType.instance());
   }
 
   @POST
-  @Path("/lock")
+  @Path("/{name}/lock")
   @Produces(MediaType.APPLICATION_JSON)
-  public void lock(@Suspended AsyncResponse response) {
-    lock.lock().whenComplete((result, error) -> {
+  public void lock(@PathParam("name") String name, @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(lock -> lock.lock()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {
@@ -56,9 +58,9 @@ public class DistributedLockResource implements PrimitiveResource {
   }
 
   @DELETE
-  @Path("/lock")
-  public void unlock(@Suspended AsyncResponse response) {
-    lock.unlock().whenComplete((result, error) -> {
+  @Path("/{name}/lock")
+  public void unlock(@PathParam("name") String name, @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(lock -> lock.unlock()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {

--- a/core/src/main/java/io/atomix/core/map/AtomicMapType.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicMapType.java
@@ -28,7 +28,6 @@ import io.atomix.core.transaction.impl.PrepareResult;
 import io.atomix.core.transaction.impl.RollbackResult;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -97,9 +96,8 @@ public class AtomicMapType<K, V> implements PrimitiveType<AtomicMapBuilder<K, V>
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(AtomicMap<K, V> primitive) {
-    return new AtomicMapResource((AsyncAtomicMap<String, String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return AtomicMapResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/queue/DistributedQueueType.java
+++ b/core/src/main/java/io/atomix/core/queue/DistributedQueueType.java
@@ -23,7 +23,6 @@ import io.atomix.core.queue.impl.DefaultDistributedQueueService;
 import io.atomix.core.queue.impl.DistributedQueueResource;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -74,9 +73,8 @@ public class DistributedQueueType<E> implements PrimitiveType<DistributedQueueBu
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(DistributedQueue<E> primitive) {
-    return new DistributedQueueResource((AsyncDistributedQueue<String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return DistributedQueueResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/queue/impl/DistributedQueueResource.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/DistributedQueueResource.java
@@ -17,11 +17,14 @@ package io.atomix.core.queue.impl;
 
 import io.atomix.core.collection.impl.DistributedCollectionResource;
 import io.atomix.core.queue.AsyncDistributedQueue;
+import io.atomix.core.queue.DistributedQueueConfig;
+import io.atomix.core.queue.DistributedQueueType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
@@ -31,21 +34,21 @@ import javax.ws.rs.core.Response;
 /**
  * Distributed queue resource.
  */
-public class DistributedQueueResource extends DistributedCollectionResource {
+@Path("/queue")
+public class DistributedQueueResource extends DistributedCollectionResource<AsyncDistributedQueue<String>, DistributedQueueConfig> {
   private static final Logger LOGGER = LoggerFactory.getLogger(DistributedQueueResource.class);
 
-  private final AsyncDistributedQueue<String> queue;
-
-  public DistributedQueueResource(AsyncDistributedQueue<String> queue) {
-    super(queue);
-    this.queue = queue;
+  public DistributedQueueResource() {
+    super(DistributedQueueType.instance());
   }
 
   @POST
-  @Path("/remove")
+  @Path("/{name}/remove")
   @Produces(MediaType.APPLICATION_JSON)
-  public void remove(@Suspended AsyncResponse response) {
-    queue.remove().whenComplete((result, error) -> {
+  public void remove(
+      @PathParam("name") String name,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(queue -> queue.remove()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -56,10 +59,12 @@ public class DistributedQueueResource extends DistributedCollectionResource {
   }
 
   @POST
-  @Path("/poll")
+  @Path("/{name}/poll")
   @Produces(MediaType.APPLICATION_JSON)
-  public void poll(@Suspended AsyncResponse response) {
-    queue.poll().whenComplete((result, error) -> {
+  public void poll(
+      @PathParam("name") String name,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(queue -> queue.poll()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -70,10 +75,12 @@ public class DistributedQueueResource extends DistributedCollectionResource {
   }
 
   @POST
-  @Path("/element")
+  @Path("/{name}/element")
   @Produces(MediaType.APPLICATION_JSON)
-  public void element(@Suspended AsyncResponse response) {
-    queue.element().whenComplete((result, error) -> {
+  public void element(
+      @PathParam("name") String name,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(queue -> queue.element()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -84,10 +91,12 @@ public class DistributedQueueResource extends DistributedCollectionResource {
   }
 
   @POST
-  @Path("/peek")
+  @Path("/{name}/peek")
   @Produces(MediaType.APPLICATION_JSON)
-  public void peek(@Suspended AsyncResponse response) {
-    queue.peek().whenComplete((result, error) -> {
+  public void peek(
+      @PathParam("name") String name,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(queue -> queue.peek()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {

--- a/core/src/main/java/io/atomix/core/semaphore/AtomicSemaphoreType.java
+++ b/core/src/main/java/io/atomix/core/semaphore/AtomicSemaphoreType.java
@@ -21,7 +21,6 @@ import io.atomix.core.semaphore.impl.DefaultAtomicSemaphoreBuilder;
 import io.atomix.core.semaphore.impl.DefaultAtomicSemaphoreService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -77,8 +76,8 @@ public class AtomicSemaphoreType implements PrimitiveType<AtomicSemaphoreBuilder
   }
 
   @Override
-  public PrimitiveResource newResource(AtomicSemaphore primitive) {
-    return new AtomicSemaphoreResource(primitive.async());
+  public Class<?> getResourceClass() {
+    return AtomicSemaphoreResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/semaphore/DistributedSemaphoreType.java
+++ b/core/src/main/java/io/atomix/core/semaphore/DistributedSemaphoreType.java
@@ -21,7 +21,6 @@ import io.atomix.core.semaphore.impl.DefaultDistributedSemaphoreService;
 import io.atomix.core.semaphore.impl.DistributedSemaphoreResource;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -77,8 +76,8 @@ public class DistributedSemaphoreType implements PrimitiveType<DistributedSemaph
   }
 
   @Override
-  public PrimitiveResource newResource(DistributedSemaphore primitive) {
-    return new DistributedSemaphoreResource(primitive.async());
+  public Class<?> getResourceClass() {
+    return DistributedSemaphoreResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/semaphore/impl/AtomicSemaphoreResource.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/AtomicSemaphoreResource.java
@@ -16,6 +16,8 @@
 package io.atomix.core.semaphore.impl;
 
 import io.atomix.core.semaphore.AsyncAtomicSemaphore;
+import io.atomix.core.semaphore.AtomicSemaphoreConfig;
+import io.atomix.core.semaphore.AtomicSemaphoreType;
 import io.atomix.primitive.resource.PrimitiveResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +26,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
@@ -33,20 +36,23 @@ import javax.ws.rs.core.Response;
 /**
  * Distributed semaphore resource.
  */
-public class AtomicSemaphoreResource implements PrimitiveResource {
+@Path("/atomic-semaphore")
+public class AtomicSemaphoreResource extends PrimitiveResource<AsyncAtomicSemaphore, AtomicSemaphoreConfig> {
   private static final Logger LOGGER = LoggerFactory.getLogger(AtomicSemaphoreResource.class);
-  private final AsyncAtomicSemaphore semaphore;
 
-  public AtomicSemaphoreResource(AsyncAtomicSemaphore semaphore) {
-    this.semaphore = semaphore;
+  public AtomicSemaphoreResource() {
+    super(AtomicSemaphoreType.instance());
   }
 
   @POST
-  @Path("/acquire")
+  @Path("/{name}/acquire")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public void acquire(Integer permits, @Suspended AsyncResponse response) {
-    semaphore.acquire(permits != null ? permits : 1).whenComplete((result, error) -> {
+  public void acquire(
+      @PathParam("name") String name,
+      Integer permits,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(semaphore -> semaphore.acquire(permits != null ? permits : 1)).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result.value()).build());
       } else {
@@ -57,11 +63,14 @@ public class AtomicSemaphoreResource implements PrimitiveResource {
   }
 
   @POST
-  @Path("/release")
+  @Path("/{name}/release")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public void release(Integer permits, @Suspended AsyncResponse response) {
-    semaphore.release(permits != null ? permits : 1).whenComplete((result, error) -> {
+  public void release(
+      @PathParam("name") String name,
+      Integer permits,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(semaphore -> semaphore.release(permits != null ? permits : 1)).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok().build());
       } else {
@@ -72,11 +81,14 @@ public class AtomicSemaphoreResource implements PrimitiveResource {
   }
 
   @POST
-  @Path("/increase")
+  @Path("/{name}/increase")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public void increase(Integer permits, @Suspended AsyncResponse response) {
-    semaphore.increasePermits(permits != null ? permits : 1).whenComplete((result, error) -> {
+  public void increase(
+      @PathParam("name") String name,
+      Integer permits,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(semaphore -> semaphore.increasePermits(permits != null ? permits : 1)).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -87,11 +99,14 @@ public class AtomicSemaphoreResource implements PrimitiveResource {
   }
 
   @POST
-  @Path("/reduce")
+  @Path("/{name}/reduce")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public void reduce(Integer permits, @Suspended AsyncResponse response) {
-    semaphore.reducePermits(permits != null ? permits : 1).whenComplete((result, error) -> {
+  public void reduce(
+      @PathParam("name") String name,
+      Integer permits,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(semaphore -> semaphore.reducePermits(permits != null ? permits : 1)).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {
@@ -102,10 +117,12 @@ public class AtomicSemaphoreResource implements PrimitiveResource {
   }
 
   @GET
-  @Path("/permits")
+  @Path("/{name}/permits")
   @Produces(MediaType.APPLICATION_JSON)
-  public void availablePermits(@Suspended AsyncResponse response) {
-    semaphore.availablePermits().whenComplete((result, error) -> {
+  public void availablePermits(
+      @PathParam("name") String name,
+      @Suspended AsyncResponse response) {
+    getPrimitive(name).thenCompose(semaphore -> semaphore.availablePermits()).whenComplete((result, error) -> {
       if (error == null) {
         response.resume(Response.ok(result).build());
       } else {

--- a/core/src/main/java/io/atomix/core/set/DistributedNavigableSetType.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedNavigableSetType.java
@@ -20,7 +20,6 @@ import io.atomix.core.collection.impl.CollectionUpdateResult;
 import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.core.set.impl.DefaultDistributedNavigableSetBuilder;
 import io.atomix.core.set.impl.DefaultDistributedNavigableSetService;
-import io.atomix.core.set.impl.DistributedSetResource;
 import io.atomix.core.set.impl.SetUpdate;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
@@ -29,7 +28,6 @@ import io.atomix.core.transaction.impl.PrepareResult;
 import io.atomix.core.transaction.impl.RollbackResult;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -84,12 +82,6 @@ public class DistributedNavigableSetType<E extends Comparable<E>> implements Pri
   @Override
   public PrimitiveService newService(ServiceConfig config) {
     return new DefaultDistributedNavigableSetService<>();
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(DistributedNavigableSet<E> primitive) {
-    return new DistributedSetResource((AsyncDistributedSet<String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/DistributedSetType.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSetType.java
@@ -29,7 +29,6 @@ import io.atomix.core.transaction.impl.PrepareResult;
 import io.atomix.core.transaction.impl.RollbackResult;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -87,9 +86,8 @@ public class DistributedSetType<E> implements PrimitiveType<DistributedSetBuilde
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(DistributedSet<E> primitive) {
-    return new DistributedSetResource((AsyncDistributedSet<String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return DistributedSetResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/DistributedSortedSetType.java
+++ b/core/src/main/java/io/atomix/core/set/DistributedSortedSetType.java
@@ -20,7 +20,6 @@ import io.atomix.core.collection.impl.CollectionUpdateResult;
 import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.core.set.impl.DefaultDistributedNavigableSetService;
 import io.atomix.core.set.impl.DefaultDistributedSortedSetBuilder;
-import io.atomix.core.set.impl.DistributedSetResource;
 import io.atomix.core.set.impl.SetUpdate;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.core.transaction.TransactionLog;
@@ -29,7 +28,6 @@ import io.atomix.core.transaction.impl.PrepareResult;
 import io.atomix.core.transaction.impl.RollbackResult;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -84,12 +82,6 @@ public class DistributedSortedSetType<E extends Comparable<E>> implements Primit
   @Override
   public PrimitiveService newService(ServiceConfig config) {
     return new DefaultDistributedNavigableSetService<>();
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(DistributedSortedSet<E> primitive) {
-    return new DistributedSetResource((AsyncDistributedSet<String>) primitive.async());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/impl/DistributedSetResource.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DistributedSetResource.java
@@ -17,12 +17,18 @@ package io.atomix.core.set.impl;
 
 import io.atomix.core.collection.impl.DistributedCollectionResource;
 import io.atomix.core.set.AsyncDistributedSet;
+import io.atomix.core.set.DistributedSetConfig;
+import io.atomix.core.set.DistributedSetType;
+import io.atomix.primitive.PrimitiveType;
+
+import javax.ws.rs.Path;
 
 /**
  * Distributed set resource.
  */
-public class DistributedSetResource extends DistributedCollectionResource {
-  public DistributedSetResource(AsyncDistributedSet<String> set) {
-    super(set);
+@Path("/set")
+public class DistributedSetResource extends DistributedCollectionResource<AsyncDistributedSet<String>, DistributedSetConfig> {
+  public DistributedSetResource() {
+    super(DistributedSetType.instance());
   }
 }

--- a/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeType.java
+++ b/core/src/main/java/io/atomix/core/tree/AtomicDocumentTreeType.java
@@ -20,14 +20,13 @@ import io.atomix.core.transaction.TransactionLog;
 import io.atomix.core.transaction.impl.CommitResult;
 import io.atomix.core.transaction.impl.PrepareResult;
 import io.atomix.core.transaction.impl.RollbackResult;
-import io.atomix.core.tree.impl.DefaultDocumentTreeService;
 import io.atomix.core.tree.impl.DefaultAtomicDocumentTreeBuilder;
+import io.atomix.core.tree.impl.DefaultDocumentTreeService;
 import io.atomix.core.tree.impl.DocumentTreeResource;
 import io.atomix.core.tree.impl.DocumentTreeResult;
 import io.atomix.core.tree.impl.NodeUpdate;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.misc.Match;
@@ -91,9 +90,8 @@ public class AtomicDocumentTreeType<V> implements PrimitiveType<AtomicDocumentTr
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(AtomicDocumentTree<V> primitive) {
-    return new DocumentTreeResource((AsyncAtomicDocumentTree<String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return DocumentTreeResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/value/AtomicValueType.java
+++ b/core/src/main/java/io/atomix/core/value/AtomicValueType.java
@@ -20,7 +20,6 @@ import io.atomix.core.value.impl.DefaultAtomicValueBuilder;
 import io.atomix.core.value.impl.DefaultAtomicValueService;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -55,9 +54,8 @@ public class AtomicValueType<V> implements PrimitiveType<AtomicValueBuilder<V>, 
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(AtomicValue<V> primitive) {
-    return new AtomicValueResource((AsyncAtomicValue<String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return AtomicValueResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/value/DistributedValueType.java
+++ b/core/src/main/java/io/atomix/core/value/DistributedValueType.java
@@ -20,7 +20,6 @@ import io.atomix.core.value.impl.DefaultDistributedValueService;
 import io.atomix.core.value.impl.DistributedValueResource;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 
@@ -55,9 +54,8 @@ public class DistributedValueType<V> implements PrimitiveType<DistributedValueBu
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(DistributedValue<V> primitive) {
-    return new DistributedValueResource((AsyncDistributedValue<String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return DistributedValueResource.class;
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/workqueue/WorkQueueType.java
+++ b/core/src/main/java/io/atomix/core/workqueue/WorkQueueType.java
@@ -15,12 +15,11 @@
  */
 package io.atomix.core.workqueue;
 
-import io.atomix.core.workqueue.impl.DefaultWorkQueueService;
 import io.atomix.core.workqueue.impl.DefaultWorkQueueBuilder;
+import io.atomix.core.workqueue.impl.DefaultWorkQueueService;
 import io.atomix.core.workqueue.impl.WorkQueueResource;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.resource.PrimitiveResource;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.utils.serializer.Namespace;
@@ -67,9 +66,8 @@ public class WorkQueueType<E> implements PrimitiveType<WorkQueueBuilder<E>, Work
   }
 
   @Override
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource newResource(WorkQueue<E> primitive) {
-    return new WorkQueueResource((AsyncWorkQueue<String>) primitive.async());
+  public Class<?> getResourceClass() {
+    return WorkQueueResource.class;
   }
 
   @Override

--- a/primitive/pom.xml
+++ b/primitive/pom.xml
@@ -42,6 +42,13 @@
       <artifactId>atomix-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${jaxrs.version}</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveFactory.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveFactory.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive;
+
+import io.atomix.primitive.config.PrimitiveConfig;
+import io.atomix.utils.AtomixRuntimeException;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Manages the creation of distributed primitive instances.
+ * <p>
+ * The primitives service provides various methods for constructing core and custom distributed primitives.
+ * The service provides various methods for creating and operating on distributed primitives. Generally, the primitive
+ * methods are separated into two types. Primitive getters return multiton instances of a primitive. Primitives created
+ * via getters must be pre-configured in the Atomix instance configuration. Alternatively, primitive builders can be
+ * used to create and configure primitives in code:
+ * <pre>
+ *   {@code
+ *   AtomicMap<String, String> map = atomix.mapBuilder("my-map")
+ *     .withProtocol(MultiRaftProtocol.builder("raft")
+ *       .withReadConsistency(ReadConsistency.SEQUENTIAL)
+ *       .build())
+ *     .build();
+ *   }
+ * </pre>
+ * Custom primitives can be constructed by providing a custom {@link PrimitiveType} and using the
+ * {@link #primitiveBuilder(String, PrimitiveType)} method:
+ * <pre>
+ *   {@code
+ *   MyPrimitive myPrimitive = atomix.primitiveBuilder("my-primitive, MyPrimitiveType.instance())
+ *     .withProtocol(MultiRaftProtocol.builder("raft")
+ *       .withReadConsistency(ReadConsistency.SEQUENTIAL)
+ *       .build())
+ *     .build();
+ *   }
+ * </pre>
+ */
+public interface PrimitiveFactory {
+
+  /**
+   * Returns a primitive type by name.
+   *
+   * @param typeName the primitive type name
+   * @return the primitive type
+   */
+  PrimitiveType getPrimitiveType(String typeName);
+
+  /**
+   * Gets or creates a distributed primitive.
+   * <p>
+   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
+   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
+   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
+   * primitives of the same name on other nodes.
+   * <p>
+   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
+   * defined in {@code atomix.conf}.
+   * <p>
+   * To get an asynchronous instance of the primitive, use the {@link SyncPrimitive#async()} method:
+   * <pre>
+   *   {@code
+   *   AsyncPrimitive async = atomix.getPrimitive("my-primitive").async();
+   *   }
+   * </pre>
+   *
+   * @param name          the primitive name
+   * @param primitiveType the primitive type
+   * @param <P>           the primitive type
+   * @return the primitive instance
+   */
+  default <P extends SyncPrimitive> P getPrimitive(String name, PrimitiveType<?, ?, P> primitiveType) {
+    try {
+      return getPrimitiveAsync(name, primitiveType).get(30, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new AtomixRuntimeException(e);
+    }
+  }
+
+  /**
+   * Gets or creates a distributed primitive.
+   * <p>
+   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
+   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
+   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
+   * primitives of the same name on other nodes.
+   * <p>
+   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
+   * defined in {@code atomix.conf}.
+   * <p>
+   * To get an asynchronous instance of the primitive, use the {@link SyncPrimitive#async()} method:
+   * <pre>
+   *   {@code
+   *   AsyncPrimitive async = atomix.getPrimitive("my-primitive").async();
+   *   }
+   * </pre>
+   *
+   * @param name            the primitive name
+   * @param primitiveType   the primitive type
+   * @param primitiveConfig the primitive configuration
+   * @param <C>             the primitive configuration type
+   * @param <P>             the primitive type
+   * @return the primitive instance
+   */
+  default <C extends PrimitiveConfig<C>, P extends SyncPrimitive> P getPrimitive(
+      String name,
+      PrimitiveType<?, C, P> primitiveType,
+      C primitiveConfig) {
+    try {
+      return getPrimitiveAsync(name, primitiveType, primitiveConfig).get(30, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new AtomixRuntimeException(e);
+    }
+  }
+
+  /**
+   * Gets or creates a distributed primitive asynchronously.
+   * <p>
+   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
+   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
+   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
+   * primitives of the same name on other nodes.
+   * <p>
+   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
+   * defined in {@code atomix.conf}.
+   *
+   * @param name          the primitive name
+   * @param primitiveType the primitive type
+   * @param <P>           the primitive type
+   * @return the primitive instance
+   */
+  <P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(String name, PrimitiveType<?, ?, P> primitiveType);
+
+  /**
+   * Gets or creates a distributed primitive asynchronously.
+   * <p>
+   * A new primitive of the given {@code primitiveType} will be created if no primitive instance with the given
+   * {@code name} exists on this node, otherwise the existing instance will be returned. The name is used to reference
+   * a distinct instance of the primitive within the cluster. The returned primitive will share the same state with
+   * primitives of the same name on other nodes.
+   * <p>
+   * When the instance is initially constructed, it will be configured with any pre-existing primitive configuration
+   * defined in {@code atomix.conf}.
+   *
+   * @param name            the primitive name
+   * @param primitiveType   the primitive type
+   * @param primitiveConfig the primitive configuration
+   * @param <C>             the primitive configuration type
+   * @param <P>             the primitive type
+   * @return a future to be completed with the primitive instance
+   */
+  <C extends PrimitiveConfig<C>, P extends SyncPrimitive> CompletableFuture<P> getPrimitiveAsync(
+      String name, PrimitiveType<?, C, P> primitiveType, C primitiveConfig);
+
+  /**
+   * Creates a new named primitive builder of the given {@code primitiveType}.
+   * <p>
+   * The primitive name must be provided when constructing the builder. The name is used to reference a distinct instance of
+   * the primitive within the cluster. Multiple instances of the primitive with the same name will share the same state.
+   * However, the instance of the primitive constructed by the returned builder will be distinct and will not share
+   * local memory (e.g. cache) with any other instance on this node.
+   * <p>
+   * To get an asynchronous instance of the primitive, use the {@link SyncPrimitive#async()} method:
+   * <pre>
+   *   {@code
+   *   AsyncPrimitive async = atomix.primitiveBuilder("my-primitive", MyPrimitiveType.instance()).build().async();
+   *   }
+   * </pre>
+   *
+   * @param name          the primitive name
+   * @param primitiveType the primitive type
+   * @param <B>           the primitive builder type
+   * @param <P>           the primitive type
+   * @return the primitive builder
+   */
+  <B extends PrimitiveBuilder<B, C, P>, C extends PrimitiveConfig<C>, P extends SyncPrimitive> B primitiveBuilder(
+      String name,
+      PrimitiveType<B, C, P> primitiveType);
+
+  /**
+   * Returns a collection of open primitives.
+   *
+   * @return a collection of open primitives
+   */
+  Collection<PrimitiveInfo> getPrimitives();
+
+  /**
+   * Returns a collection of open primitives of the given type.
+   *
+   * @param primitiveType the primitive type
+   * @return a collection of open primitives of the given type
+   */
+  Collection<PrimitiveInfo> getPrimitives(PrimitiveType primitiveType);
+
+}

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveType.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveType.java
@@ -67,12 +67,11 @@ public interface PrimitiveType<B extends PrimitiveBuilder, C extends PrimitiveCo
   PrimitiveService newService(ServiceConfig config);
 
   /**
-   * Creates a new resource for the given primitive.
+   * Returns the primitive resource class.
    *
-   * @param primitive the primitive instance
-   * @return a new resource for the given primitive instance
+   * @return the primitive resource class
    */
-  default PrimitiveResource newResource(P primitive) {
-    return null;
+  default Class<?> getResourceClass() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/resource/PrimitiveResource.java
+++ b/primitive/src/main/java/io/atomix/primitive/resource/PrimitiveResource.java
@@ -15,8 +15,89 @@
  */
 package io.atomix.primitive.resource;
 
+import com.google.common.collect.Maps;
+import io.atomix.primitive.AsyncPrimitive;
+import io.atomix.primitive.PrimitiveFactory;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.SyncPrimitive;
+import io.atomix.primitive.config.PrimitiveConfig;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
 /**
  * Primitive resource.
  */
-public interface PrimitiveResource {
+public abstract class PrimitiveResource<P extends AsyncPrimitive, C extends PrimitiveConfig<C>> {
+  protected final PrimitiveType type;
+
+  @Context
+  protected PrimitiveFactory primitives;
+
+  protected PrimitiveResource(PrimitiveType type) {
+    this.type = type;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected CompletableFuture<P> getPrimitive(String name) {
+    return primitives.getPrimitiveAsync(name, type).thenApply(primitive -> ((SyncPrimitive) primitive).async());
+  }
+
+  @GET
+  @Path("/")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getPrimitives() {
+    Map<String, PrimitiveInfo> primitivesInfo = primitives.getPrimitives(type)
+        .stream()
+        .map(info -> Maps.immutableEntry(info.name(), new PrimitiveInfo(info.name(), info.type().name())))
+        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+    return Response.ok(primitivesInfo).build();
+  }
+
+  @POST
+  @Path("{name}")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @SuppressWarnings("unchecked")
+  public void create(
+      @PathParam("name") String name,
+      C config,
+      @Suspended AsyncResponse response) {
+    primitives.getPrimitiveAsync(name, type, config).whenComplete((result, error) -> {
+      if (error == null) {
+        response.resume(Response.ok().build());
+      } else {
+        response.resume(error);
+      }
+    });
+  }
+
+  static class PrimitiveInfo {
+    private String name;
+    private String type;
+
+    PrimitiveInfo(String name, String type) {
+      this.name = name;
+      this.type = type;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getType() {
+      return type;
+    }
+  }
 }

--- a/rest/src/main/java/io/atomix/rest/resources/PrimitivesResource.java
+++ b/rest/src/main/java/io/atomix/rest/resources/PrimitivesResource.java
@@ -15,18 +15,17 @@
  */
 package io.atomix.rest.resources;
 
+import com.google.common.collect.Maps;
 import io.atomix.core.PrimitivesService;
-import io.atomix.primitive.SyncPrimitive;
-import io.atomix.primitive.config.PrimitiveConfig;
-import io.atomix.primitive.resource.PrimitiveResource;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Primitives resource.
@@ -34,29 +33,31 @@ import javax.ws.rs.core.Response;
 @Path("/v1/primitives")
 public class PrimitivesResource extends AbstractRestResource {
 
-  /**
-   * Returns a primitive resource by name.
-   */
-  @Path("/{name}")
-  @SuppressWarnings("unchecked")
-  public PrimitiveResource getPrimitive(@PathParam("name") String name, @Context PrimitivesService primitives) {
-    SyncPrimitive primitive = primitives.getPrimitive(name);
-    return primitive.type().newResource(primitive);
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getPrimitives(@Context PrimitivesService primitives) {
+    Map<String, PrimitiveInfo> primitivesInfo = primitives.getPrimitives()
+        .stream()
+        .map(info -> Maps.immutableEntry(info.name(), new PrimitiveInfo(info.name(), info.type().name())))
+        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+    return Response.ok(primitivesInfo).build();
   }
 
-  /**
-   * Creates a new primitive resource.
-   */
-  @POST
-  @Path("/{name}")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @SuppressWarnings("unchecked")
-  public Response createPrimitive(@PathParam("name") String name, PrimitiveConfig<?> config, @Context PrimitivesService primitives) {
-    try {
-      primitives.getPrimitive(name, config.getType(), (PrimitiveConfig) config);
-      return Response.ok().build();
-    } catch (Exception e) {
-      return Response.status(Response.Status.NOT_ACCEPTABLE).build();
+  static class PrimitiveInfo {
+    private String name;
+    private String type;
+
+    PrimitiveInfo(String name, String type) {
+      this.name = name;
+      this.type = type;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getType() {
+      return type;
     }
   }
 }


### PR DESCRIPTION
This PR cleans up the REST API and all primitive resources.

The paths are refactored to use primitive types in URIs. Additionally, each primitive type provides a resource class rather than an instance. This allows `@Context` fields to be injected into the resource classes since they're top level resources and not sub resources, and it gives individual primitive types more control over how their APIs are implemented.

The API is now laid out like:
* `/v1/primitives` provides information about all registered primitives
* `/v1/map` operates on map primitives
* `/v1/set` operates on set primitves
* etc