### PR TITLE
Create separate directory in distribution for user extensions

### DIFF
--- a/dist/src/main/assembly/assembly.xml
+++ b/dist/src/main/assembly/assembly.xml
@@ -29,7 +29,7 @@
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
-            <outputDirectory>lib</outputDirectory>
+            <outputDirectory>lib/system</outputDirectory>
             <unpack>false</unpack>
         </dependencySet>
     </dependencySets>

--- a/dist/src/main/resources/bin/atomix-agent
+++ b/dist/src/main/resources/bin/atomix-agent
@@ -21,6 +21,6 @@ java \
   -Datomix.log="$ATOMIX_ROOT/log" \
   -Datomix.config="$ATOMIX_ROOT/conf/atomix.conf" \
   -Dlogback.configurationFile="$ATOMIX_ROOT/conf/logback.xml" \
-  -cp .:"$ATOMIX_ROOT/lib/*" \
+  -cp .:"$ATOMIX_ROOT/lib/system/*":"$ATOMIX_ROOT/lib/ext/*" \
   io.atomix.agent.AtomixAgent \
   "$@"

--- a/dist/src/main/resources/lib/ext/README
+++ b/dist/src/main/resources/lib/ext/README
@@ -1,0 +1,2 @@
+This folder is the default location user libraries to extend the Atomix agent. Place jars here containing additional
+primitive implementations, discovery services, protocols, etc and they will be automatically added to the agent classpath.


### PR DESCRIPTION
This PR moves Atomix jars into the `/system` folder and preserves the `/lib` folder for user extensions (custom primitives, protocols, etc).