### PR TITLE
Use fixed window rolling policy to ensure logs roll over on size limit

### DIFF
--- a/dist/src/main/resources/conf/logback.xml
+++ b/dist/src/main/resources/conf/logback.xml
@@ -17,9 +17,10 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${atomix.log}/atomix.log</file>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>atomix.%d{yyyy-MM-dd}.log</fileNamePattern>
-            <maxHistory>10</maxHistory>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${atomix.log}/atomix.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
         </rollingPolicy>
 
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">


### PR DESCRIPTION
Update the distro's default logback configuration to ensure log files are rolled over correctly on size limits.