### PR TITLE
Quiet javadocs.

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -89,6 +89,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
         <configuration>
           <archive>
             <manifest>

--- a/bin/ci-push-javadoc.sh
+++ b/bin/ci-push-javadoc.sh
@@ -4,7 +4,7 @@
 PROJECT=atomix
 
 if [ "$TRAVIS_REPO_SLUG" == "atomix/$PROJECT" ] && \
-   [ "$TRAVIS_JDK_VERSION" == "openjdk10" ] && \
+   [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ] && \
    [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
    [ "$TRAVIS_BRANCH" == "master" ]; then
   echo -e "Publishing Javadoc...\n"

--- a/bin/ci-push-javadoc.sh
+++ b/bin/ci-push-javadoc.sh
@@ -9,19 +9,19 @@ if [ "$TRAVIS_REPO_SLUG" == "atomix/$PROJECT" ] && \
    [ "$TRAVIS_BRANCH" == "master" ]; then
   echo -e "Publishing Javadoc...\n"
   
-  mvn javadoc:javadoc -Djv=latest --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  mvn javadoc:aggregate -Djv=latest --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   TARGET="$(pwd)/target"
 
   cd $HOME
   git clone --quiet https://${GH_TOKEN}@github.com/atomix/atomix.github.io gh-pages > /dev/null
   
   cd gh-pages
-  git config --global user.email "travis@travis-ci.org"
-  git config --global user.name "travis-ci"
-  git rm -rf $PROJECT/api/latest
-  mkdir -p $PROJECT/api/latest
-  mv -v $TARGET/site/apidocs/* $PROJECT/api/latest
-  git add -A -f $PROJECT/api/latest
+  git config user.email "travis@travis-ci.org"
+  git config user.name "travis-ci"
+  git rm -rf docs/latest/api
+  mkdir -p docs/latest/api
+  mv -v $TARGET/site/apidocs/* docs/latest/api
+  git add -A -f docs/latest/api
   git commit -m "Travis generated Javadoc for $PROJECT build $TRAVIS_BUILD_NUMBER"
   git push -fq origin > /dev/null
 

--- a/bin/push-javadoc.sh
+++ b/bin/push-javadoc.sh
@@ -5,7 +5,7 @@
 echo "Enter the API version to generate docs for: "
 read apiVersion
 
-mvn javadoc:javadoc -Djv=$apiVersion
+mvn javadoc:aggregate -Djv=$apiVersion
 rm -rf target/docs
 git clone git@github.com:atomix/atomix.github.io.git target/docs > /dev/null
 cd target/docs

--- a/core/src/main/java/io/atomix/core/collection/impl/DistributedCollectionService.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/DistributedCollectionService.java
@@ -28,8 +28,8 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
 
   /**
    * Returns the number of elements in this collection.  If this collection
-   * contains more than <tt>Integer.MAX_VALUE</tt> elements, returns
-   * <tt>Integer.MAX_VALUE</tt>.
+   * contains more than <code>Integer.MAX_VALUE</code> elements, returns
+   * <code>Integer.MAX_VALUE</code>.
    *
    * @return the number of elements in this collection
    */
@@ -37,21 +37,21 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
   int size();
 
   /**
-   * Returns <tt>true</tt> if this collection contains no elements.
+   * Returns <code>true</code> if this collection contains no elements.
    *
-   * @return <tt>true</tt> if this collection contains no elements
+   * @return <code>true</code> if this collection contains no elements
    */
   @Query
   boolean isEmpty();
 
   /**
-   * Returns <tt>true</tt> if this collection contains the specified element.
-   * More formally, returns <tt>true</tt> if and only if this collection
-   * contains at least one element <tt>e</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+   * Returns <code>true</code> if this collection contains the specified element.
+   * More formally, returns <code>true</code> if and only if this collection
+   * contains at least one element <code>e</code> such that
+   * <code>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</code>.
    *
    * @param o element whose presence in this collection is to be tested
-   * @return <tt>true</tt> if this collection contains the specified
+   * @return <code>true</code> if this collection contains the specified
    *         element
    * @throws ClassCastException if the type of the specified element
    *         is incompatible with this collection
@@ -65,27 +65,27 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
 
   /**
    * Ensures that this collection contains the specified element (optional
-   * operation).  Returns <tt>true</tt> if this collection changed as a
-   * result of the call.  (Returns <tt>false</tt> if this collection does
+   * operation).  Returns <code>true</code> if this collection changed as a
+   * result of the call.  (Returns <code>false</code> if this collection does
    * not permit duplicates and already contains the specified element.)<p>
    *
    * Collections that support this operation may place limitations on what
    * elements may be added to this collection.  In particular, some
-   * collections will refuse to add <tt>null</tt> elements, and others will
+   * collections will refuse to add <code>null</code> elements, and others will
    * impose restrictions on the type of elements that may be added.
    * Collection classes should clearly specify in their documentation any
    * restrictions on what elements may be added.<p>
    *
    * If a collection refuses to add a particular element for any reason
    * other than that it already contains the element, it <i>must</i> throw
-   * an exception (rather than returning <tt>false</tt>).  This preserves
+   * an exception (rather than returning <code>false</code>).  This preserves
    * the invariant that a collection always contains the specified element
    * after this call returns.
    *
    * @param element element whose presence in this collection is to be ensured
-   * @return <tt>true</tt> if this collection changed as a result of the
+   * @return <code>true</code> if this collection changed as a result of the
    *         call
-   * @throws UnsupportedOperationException if the <tt>add</tt> operation
+   * @throws UnsupportedOperationException if the <code>add</code> operation
    *         is not supported by this collection
    * @throws ClassCastException if the class of the specified element
    *         prevents it from being added to this collection
@@ -102,32 +102,32 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
   /**
    * Removes a single instance of the specified element from this
    * collection, if it is present (optional operation).  More formally,
-   * removes an element <tt>e</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>, if
+   * removes an element <code>e</code> such that
+   * <code>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</code>, if
    * this collection contains one or more such elements.  Returns
-   * <tt>true</tt> if this collection contained the specified element (or
+   * <code>true</code> if this collection contained the specified element (or
    * equivalently, if this collection changed as a result of the call).
    *
    * @param o element to be removed from this collection, if present
-   * @return <tt>true</tt> if an element was removed as a result of this call
+   * @return <code>true</code> if an element was removed as a result of this call
    * @throws ClassCastException if the type of the specified element
    *         is incompatible with this collection
    *         (<a href="#optional-restrictions">optional</a>)
    * @throws NullPointerException if the specified element is null and this
    *         collection does not permit null elements
    *         (<a href="#optional-restrictions">optional</a>)
-   * @throws UnsupportedOperationException if the <tt>remove</tt> operation
+   * @throws UnsupportedOperationException if the <code>remove</code> operation
    *         is not supported by this collection
    */
   @Command("removeValue")
   CollectionUpdateResult<Boolean> remove(E o);
 
   /**
-   * Returns <tt>true</tt> if this collection contains all of the elements
+   * Returns <code>true</code> if this collection contains all of the elements
    * in the specified collection.
    *
    * @param  c collection to be checked for containment in this collection
-   * @return <tt>true</tt> if this collection contains all of the elements
+   * @return <code>true</code> if this collection contains all of the elements
    *         in the specified collection
    * @throws ClassCastException if the types of one or more elements
    *         in the specified collection are incompatible with this
@@ -152,8 +152,8 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
    * nonempty.)
    *
    * @param c collection containing elements to be added to this collection
-   * @return <tt>true</tt> if this collection changed as a result of the call
-   * @throws UnsupportedOperationException if the <tt>addAll</tt> operation
+   * @return <code>true</code> if this collection changed as a result of the call
+   * @throws UnsupportedOperationException if the <code>addAll</code> operation
    *         is not supported by this collection
    * @throws ClassCastException if the class of an element of the specified
    *         collection prevents it from being added to this collection
@@ -177,8 +177,8 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
    * specified collection.
    *
    * @param c collection containing elements to be retained in this collection
-   * @return <tt>true</tt> if this collection changed as a result of the call
-   * @throws UnsupportedOperationException if the <tt>retainAll</tt> operation
+   * @return <code>true</code> if this collection changed as a result of the call
+   * @throws UnsupportedOperationException if the <code>retainAll</code> operation
    *         is not supported by this collection
    * @throws ClassCastException if the types of one or more elements
    *         in this collection are incompatible with the specified
@@ -202,9 +202,9 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
    * collection.
    *
    * @param c collection containing elements to be removed from this collection
-   * @return <tt>true</tt> if this collection changed as a result of the
+   * @return <code>true</code> if this collection changed as a result of the
    *         call
-   * @throws UnsupportedOperationException if the <tt>removeAll</tt> method
+   * @throws UnsupportedOperationException if the <code>removeAll</code> method
    *         is not supported by this collection
    * @throws ClassCastException if the types of one or more elements
    *         in this collection are incompatible with the specified
@@ -225,7 +225,7 @@ public interface DistributedCollectionService<E> extends IterableService<E> {
    * Removes all of the elements from this collection (optional operation).
    * The collection will be empty after this method returns.
    *
-   * @throws UnsupportedOperationException if the <tt>clear</tt> operation
+   * @throws UnsupportedOperationException if the <code>clear</code> operation
    *         is not supported by this collection
    */
   @Command

--- a/core/src/main/java/io/atomix/core/list/AsyncDistributedList.java
+++ b/core/src/main/java/io/atomix/core/list/AsyncDistributedList.java
@@ -40,8 +40,8 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    * @param index index at which to insert the first element from the
    *              specified collection
    * @param c collection containing elements to be added to this list
-   * @return <tt>true</tt> if this list changed as a result of the call
-   * @throws UnsupportedOperationException if the <tt>addAll</tt> operation
+   * @return <code>true</code> if this list changed as a result of the call
+   * @throws UnsupportedOperationException if the <code>addAll</code> operation
    *         is not supported by this list
    * @throws ClassCastException if the class of an element of the specified
    *         collection prevents it from being added to this list
@@ -51,7 +51,7 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    * @throws IllegalArgumentException if some property of an element of the
    *         specified collection prevents it from being added to this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt; size()</tt>)
+   *         (<code>index &lt; 0 || index &gt; size()</code>)
    */
   CompletableFuture<Boolean> addAll(int index, Collection<? extends E> c);
 
@@ -61,7 +61,7 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    * @param index index of the element to return
    * @return the element at the specified position in this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   *         (<code>index &lt; 0 || index &gt;= size()</code>)
    */
   CompletableFuture<E> get(int index);
 
@@ -72,7 +72,7 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    * @param index index of the element to replace
    * @param element element to be stored at the specified position
    * @return the element previously at the specified position
-   * @throws UnsupportedOperationException if the <tt>set</tt> operation
+   * @throws UnsupportedOperationException if the <code>set</code> operation
    *         is not supported by this list
    * @throws ClassCastException if the class of the specified element
    *         prevents it from being added to this list
@@ -81,7 +81,7 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    * @throws IllegalArgumentException if some property of the specified
    *         element prevents it from being added to this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   *         (<code>index &lt; 0 || index &gt;= size()</code>)
    */
   CompletableFuture<E> set(int index, E element);
 
@@ -93,7 +93,7 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    *
    * @param index index at which the specified element is to be inserted
    * @param element element to be inserted
-   * @throws UnsupportedOperationException if the <tt>add</tt> operation
+   * @throws UnsupportedOperationException if the <code>add</code> operation
    *         is not supported by this list
    * @throws ClassCastException if the class of the specified element
    *         prevents it from being added to this list
@@ -102,7 +102,7 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    * @throws IllegalArgumentException if some property of the specified
    *         element prevents it from being added to this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt; size()</tt>)
+   *         (<code>index &lt; 0 || index &gt; size()</code>)
    */
   CompletableFuture<Void> add(int index, E element);
 
@@ -114,18 +114,18 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
    *
    * @param index the index of the element to be removed
    * @return the element previously at the specified position
-   * @throws UnsupportedOperationException if the <tt>remove</tt> operation
+   * @throws UnsupportedOperationException if the <code>remove</code> operation
    *         is not supported by this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   *         (<code>index &lt; 0 || index &gt;= size()</code>)
    */
   CompletableFuture<E> remove(int index);
 
   /**
    * Returns the index of the first occurrence of the specified element
    * in this list, or -1 if this list does not contain the element.
-   * More formally, returns the lowest index <tt>i</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</tt>,
+   * More formally, returns the lowest index <code>i</code> such that
+   * <code>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</code>,
    * or -1 if there is no such index.
    *
    * @param o element to search for
@@ -143,8 +143,8 @@ public interface AsyncDistributedList<E> extends AsyncDistributedCollection<E> {
   /**
    * Returns the index of the last occurrence of the specified element
    * in this list, or -1 if this list does not contain the element.
-   * More formally, returns the highest index <tt>i</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</tt>,
+   * More formally, returns the highest index <code>i</code> such that
+   * <code>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</code>,
    * or -1 if there is no such index.
    *
    * @param o element to search for

--- a/core/src/main/java/io/atomix/core/list/impl/DistributedListService.java
+++ b/core/src/main/java/io/atomix/core/list/impl/DistributedListService.java
@@ -41,8 +41,8 @@ public interface DistributedListService extends DistributedCollectionService<Str
    * @param index index at which to insert the first element from the
    *              specified collection
    * @param c collection containing elements to be added to this list
-   * @return <tt>true</tt> if this list changed as a result of the call
-   * @throws UnsupportedOperationException if the <tt>addAll</tt> operation
+   * @return <code>true</code> if this list changed as a result of the call
+   * @throws UnsupportedOperationException if the <code>addAll</code> operation
    *         is not supported by this list
    * @throws ClassCastException if the class of an element of the specified
    *         collection prevents it from being added to this list
@@ -52,7 +52,7 @@ public interface DistributedListService extends DistributedCollectionService<Str
    * @throws IllegalArgumentException if some property of an element of the
    *         specified collection prevents it from being added to this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt; size()</tt>)
+   *         (<code>index &lt; 0 || index &gt; size()</code>)
    */
   @Command("addAllIndex")
   CollectionUpdateResult<Boolean> addAll(int index, Collection<? extends String> c);
@@ -63,7 +63,7 @@ public interface DistributedListService extends DistributedCollectionService<Str
    * @param index index of the element to return
    * @return the element at the specified position in this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   *         (<code>index &lt; 0 || index &gt;= size()</code>)
    */
   @Query("getIndex")
   String get(int index);
@@ -75,7 +75,7 @@ public interface DistributedListService extends DistributedCollectionService<Str
    * @param index index of the element to replace
    * @param element element to be stored at the specified position
    * @return the element previously at the specified position
-   * @throws UnsupportedOperationException if the <tt>set</tt> operation
+   * @throws UnsupportedOperationException if the <code>set</code> operation
    *         is not supported by this list
    * @throws ClassCastException if the class of the specified element
    *         prevents it from being added to this list
@@ -84,7 +84,7 @@ public interface DistributedListService extends DistributedCollectionService<Str
    * @throws IllegalArgumentException if some property of the specified
    *         element prevents it from being added to this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   *         (<code>index &lt; 0 || index &gt;= size()</code>)
    */
   @Command("setIndex")
   CollectionUpdateResult<String> set(int index, String element);
@@ -97,7 +97,7 @@ public interface DistributedListService extends DistributedCollectionService<Str
    *
    * @param index index at which the specified element is to be inserted
    * @param element element to be inserted
-   * @throws UnsupportedOperationException if the <tt>add</tt> operation
+   * @throws UnsupportedOperationException if the <code>add</code> operation
    *         is not supported by this list
    * @throws ClassCastException if the class of the specified element
    *         prevents it from being added to this list
@@ -106,7 +106,7 @@ public interface DistributedListService extends DistributedCollectionService<Str
    * @throws IllegalArgumentException if some property of the specified
    *         element prevents it from being added to this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt; size()</tt>)
+   *         (<code>index &lt; 0 || index &gt; size()</code>)
    */
   @Command("addIndex")
   CollectionUpdateResult<Void> add(int index, String element);
@@ -119,10 +119,10 @@ public interface DistributedListService extends DistributedCollectionService<Str
    *
    * @param index the index of the element to be removed
    * @return the element previously at the specified position
-   * @throws UnsupportedOperationException if the <tt>remove</tt> operation
+   * @throws UnsupportedOperationException if the <code>remove</code> operation
    *         is not supported by this list
    * @throws IndexOutOfBoundsException if the index is out of range
-   *         (<tt>index &lt; 0 || index &gt;= size()</tt>)
+   *         (<code>index &lt; 0 || index &gt;= size()</code>)
    */
   @Command("removeIndex")
   CollectionUpdateResult<String> remove(int index);
@@ -130,8 +130,8 @@ public interface DistributedListService extends DistributedCollectionService<Str
   /**
    * Returns the index of the first occurrence of the specified element
    * in this list, or -1 if this list does not contain the element.
-   * More formally, returns the lowest index <tt>i</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</tt>,
+   * More formally, returns the lowest index <code>i</code> such that
+   * <code>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</code>,
    * or -1 if there is no such index.
    *
    * @param o element to search for
@@ -150,8 +150,8 @@ public interface DistributedListService extends DistributedCollectionService<Str
   /**
    * Returns the index of the last occurrence of the specified element
    * in this list, or -1 if this list does not contain the element.
-   * More formally, returns the highest index <tt>i</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</tt>,
+   * More formally, returns the highest index <code>i</code> such that
+   * <code>(o==null&nbsp;?&nbsp;get(i)==null&nbsp;:&nbsp;o.equals(get(i)))</code>,
    * or -1 if there is no such index.
    *
    * @param o element to search for

--- a/core/src/main/java/io/atomix/core/map/AsyncAtomicNavigableMap.java
+++ b/core/src/main/java/io/atomix/core/map/AsyncAtomicNavigableMap.java
@@ -300,7 +300,7 @@ public interface AsyncAtomicNavigableMap<K extends Comparable<K>, V> extends Asy
    * operation), the results of the iteration are undefined.
    *
    * <p>The returned map has an ordering equivalent to
-   * <tt>{@link Collections#reverseOrder(Comparator) Collections.reverseOrder}(comparator())</tt>.
+   * <code>{@link Collections#reverseOrder(Comparator) Collections.reverseOrder}(comparator())</code>.
    * The expression {@code m.descendingMap().descendingMap()} returns a
    * view of {@code m} essentially equivalent to {@code m}.
    *

--- a/core/src/main/java/io/atomix/core/map/AsyncDistributedMap.java
+++ b/core/src/main/java/io/atomix/core/map/AsyncDistributedMap.java
@@ -35,30 +35,30 @@ import java.util.function.Function;
 public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
 
   /**
-   * Returns the number of key-value mappings in this map.  If the map contains more than <tt>Integer.MAX_VALUE</tt>
+   * Returns the number of key-value mappings in this map.  If the map contains more than <code>Integer.MAX_VALUE</code>
    * elements, returns
-   * <tt>Integer.MAX_VALUE</tt>.
+   * <code>Integer.MAX_VALUE</code>.
    *
    * @return the number of key-value mappings in this map
    */
   CompletableFuture<Integer> size();
 
   /**
-   * Returns <tt>true</tt> if this map contains no key-value mappings.
+   * Returns <code>true</code> if this map contains no key-value mappings.
    *
-   * @return <tt>true</tt> if this map contains no key-value mappings
+   * @return <code>true</code> if this map contains no key-value mappings
    */
   CompletableFuture<Boolean> isEmpty();
 
   /**
-   * Returns <tt>true</tt> if this map contains a mapping for the specified key.  More formally, returns <tt>true</tt>
-   * if and only if this map contains a mapping for a key <tt>k</tt> such that
-   * <tt>(key==null ? k==null : key.equals(k))</tt>.  (There can be
+   * Returns <code>true</code> if this map contains a mapping for the specified key.  More formally, returns <code>true</code>
+   * if and only if this map contains a mapping for a key <code>k</code> such that
+   * <code>(key==null ? k==null : key.equals(k))</code>.  (There can be
    * at most one such mapping.)
    *
    * @param key key whose presence in this map is to be tested
    *
-   * @return <tt>true</tt> if this map contains a mapping for the specified
+   * @return <code>true</code> if this map contains a mapping for the specified
    *     key
    *
    * @throws ClassCastException if the key is of an inappropriate type for this map (<a
@@ -69,14 +69,14 @@ public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
   CompletableFuture<Boolean> containsKey(K key);
 
   /**
-   * Returns <tt>true</tt> if this map maps one or more keys to the specified value.  More formally, returns
-   * <tt>true</tt> if and only if this map contains at least one mapping to a value <tt>v</tt> such that
-   * <tt>(value==null ? v==null : value.equals(v))</tt>.  This operation
-   * will probably require time linear in the map size for most implementations of the <tt>Map</tt> interface.
+   * Returns <code>true</code> if this map maps one or more keys to the specified value.  More formally, returns
+   * <code>true</code> if and only if this map contains at least one mapping to a value <code>v</code> such that
+   * <code>(value==null ? v==null : value.equals(v))</code>.  This operation
+   * will probably require time linear in the map size for most implementations of the <code>Map</code> interface.
    *
    * @param value value whose presence in this map is to be tested
    *
-   * @return <tt>true</tt> if this map maps one or more keys to the
+   * @return <code>true</code> if this map maps one or more keys to the
    *     specified value
    *
    * @throws ClassCastException if the value is of an inappropriate type for this map (<a
@@ -113,19 +113,19 @@ public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
   /**
    * Associates the specified value with the specified key in this map (optional operation).  If the map previously
    * contained a mapping for the key, the old value is replaced by the specified value.  (A map
-   * <tt>m</tt> is said to contain a mapping for a key <tt>k</tt> if and only
+   * <code>m</code> is said to contain a mapping for a key <code>k</code> if and only
    * if {@link #containsKey(Object) m.containsKey(k)} would return
-   * <tt>true</tt>.)
+   * <code>true</code>.)
    *
    * @param key key with which the specified value is to be associated
    * @param value value to be associated with the specified key
    *
-   * @return the previous value associated with <tt>key</tt>, or
-   *     <tt>null</tt> if there was no mapping for <tt>key</tt>.
-   *     (A <tt>null</tt> return can also indicate that the map previously associated <tt>null</tt> with <tt>key</tt>,
-   *     if the implementation supports <tt>null</tt> values.)
+   * @return the previous value associated with <code>key</code>, or
+   *     <code>null</code> if there was no mapping for <code>key</code>.
+   *     (A <code>null</code> return can also indicate that the map previously associated <code>null</code> with <code>key</code>,
+   *     if the implementation supports <code>null</code> values.)
    *
-   * @throws UnsupportedOperationException if the <tt>put</tt> operation is not supported by this map
+   * @throws UnsupportedOperationException if the <code>put</code> operation is not supported by this map
    * @throws ClassCastException if the class of the specified key or value prevents it from being stored in this
    *     map
    * @throws NullPointerException if the specified key or value is null and this map does not permit null keys or
@@ -137,26 +137,26 @@ public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
 
   /**
    * Removes the mapping for a key from this map if it is present (optional operation).   More formally, if this map
-   * contains a mapping from key <tt>k</tt> to value <tt>v</tt> such that
+   * contains a mapping from key <code>k</code> to value <code>v</code> such that
    * <code>(key==null ?  k==null : key.equals(k))</code>, that mapping
    * is removed.  (The map can contain at most one such mapping.)
    *
    * <p>Returns the value to which this map previously associated the key,
-   * or <tt>null</tt> if the map contained no mapping for the key.
+   * or <code>null</code> if the map contained no mapping for the key.
    *
    * <p>If this map permits null values, then a return value of
-   * <tt>null</tt> does not <i>necessarily</i> indicate that the map
-   * contained no mapping for the key; it's also possible that the map explicitly mapped the key to <tt>null</tt>.
+   * <code>null</code> does not <i>necessarily</i> indicate that the map
+   * contained no mapping for the key; it's also possible that the map explicitly mapped the key to <code>null</code>.
    *
    * <p>The map will not contain a mapping for the specified key once the
    * call returns.
    *
    * @param key key whose mapping is to be removed from the map
    *
-   * @return the previous value associated with <tt>key</tt>, or
-   *     <tt>null</tt> if there was no mapping for <tt>key</tt>.
+   * @return the previous value associated with <code>key</code>, or
+   *     <code>null</code> if there was no mapping for <code>key</code>.
    *
-   * @throws UnsupportedOperationException if the <tt>remove</tt> operation is not supported by this map
+   * @throws UnsupportedOperationException if the <code>remove</code> operation is not supported by this map
    * @throws ClassCastException if the key is of an inappropriate type for this map (<a
    *     href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
    * @throws NullPointerException if the specified key is null and this map does not permit null keys (<a
@@ -167,12 +167,12 @@ public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
   /**
    * Copies all of the mappings from the specified map to this map (optional operation).  The effect of this call is
    * equivalent to that of calling {@link #put(Object, Object) put(k, v)} on this map once for each mapping from key
-   * <tt>k</tt> to value <tt>v</tt> in the specified map.  The behavior of this operation is undefined if the specified
+   * <code>k</code> to value <code>v</code> in the specified map.  The behavior of this operation is undefined if the specified
    * map is modified while the operation is in progress.
    *
    * @param m mappings to be stored in this map
    *
-   * @throws UnsupportedOperationException if the <tt>putAll</tt> operation is not supported by this map
+   * @throws UnsupportedOperationException if the <code>putAll</code> operation is not supported by this map
    * @throws ClassCastException if the class of a key or value in the specified map prevents it from being stored in
    *     this map
    * @throws NullPointerException if the specified map is null, or if this map does not permit null keys or values,
@@ -185,18 +185,18 @@ public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
   /**
    * Removes all of the mappings from this map (optional operation). The map will be empty after this call returns.
    *
-   * @throws UnsupportedOperationException if the <tt>clear</tt> operation is not supported by this map
+   * @throws UnsupportedOperationException if the <code>clear</code> operation is not supported by this map
    */
   CompletableFuture<Void> clear();
 
   /**
    * Returns a {@link Set} view of the keys contained in this map. The set is backed by the map, so changes to the map
    * are reflected in the set, and vice-versa.  If the map is modified while an iteration over the set is in progress
-   * (except through the iterator's own <tt>remove</tt> operation), the results of the iteration are undefined.  The set
+   * (except through the iterator's own <code>remove</code> operation), the results of the iteration are undefined.  The set
    * supports element removal, which removes the corresponding mapping from the map, via the
-   * <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-   * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-   * operations.  It does not support the <tt>add</tt> or <tt>addAll</tt> operations.
+   * <code>Iterator.remove</code>, <code>Set.remove</code>,
+   * <code>removeAll</code>, <code>retainAll</code>, and <code>clear</code>
+   * operations.  It does not support the <code>add</code> or <code>addAll</code> operations.
    *
    * @return a set view of the keys contained in this map
    */
@@ -205,12 +205,12 @@ public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
   /**
    * Returns a {@link Collection} view of the values contained in this map. The collection is backed by the map, so
    * changes to the map are reflected in the collection, and vice-versa.  If the map is modified while an iteration over
-   * the collection is in progress (except through the iterator's own <tt>remove</tt> operation), the results of the
+   * the collection is in progress (except through the iterator's own <code>remove</code> operation), the results of the
    * iteration are undefined.  The collection supports element removal, which removes the corresponding mapping from the
-   * map, via the <tt>Iterator.remove</tt>,
-   * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-   * <tt>retainAll</tt> and <tt>clear</tt> operations.  It does not
-   * support the <tt>add</tt> or <tt>addAll</tt> operations.
+   * map, via the <code>Iterator.remove</code>,
+   * <code>Collection.remove</code>, <code>removeAll</code>,
+   * <code>retainAll</code> and <code>clear</code> operations.  It does not
+   * support the <code>add</code> or <code>addAll</code> operations.
    *
    * @return a collection view of the values contained in this map
    */
@@ -219,13 +219,13 @@ public interface AsyncDistributedMap<K, V> extends AsyncPrimitive {
   /**
    * Returns a {@link Set} view of the mappings contained in this map. The set is backed by the map, so changes to the
    * map are reflected in the set, and vice-versa.  If the map is modified while an iteration over the set is in
-   * progress (except through the iterator's own <tt>remove</tt> operation, or through the
-   * <tt>setValue</tt> operation on a map entry returned by the
+   * progress (except through the iterator's own <code>remove</code> operation, or through the
+   * <code>setValue</code> operation on a map entry returned by the
    * iterator) the results of the iteration are undefined.  The set supports element removal, which removes the
-   * corresponding mapping from the map, via the <tt>Iterator.remove</tt>,
-   * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt> and
-   * <tt>clear</tt> operations.  It does not support the
-   * <tt>add</tt> or <tt>addAll</tt> operations.
+   * corresponding mapping from the map, via the <code>Iterator.remove</code>,
+   * <code>Set.remove</code>, <code>removeAll</code>, <code>retainAll</code> and
+   * <code>clear</code> operations.  It does not support the
+   * <code>add</code> or <code>addAll</code> operations.
    *
    * @return a set view of the mappings contained in this map
    */

--- a/core/src/main/java/io/atomix/core/map/AsyncDistributedNavigableMap.java
+++ b/core/src/main/java/io/atomix/core/map/AsyncDistributedNavigableMap.java
@@ -189,7 +189,7 @@ public interface AsyncDistributedNavigableMap<K extends Comparable<K>, V> extend
    * operation), the results of the iteration are undefined.
    *
    * <p>The returned map has an ordering equivalent to
-   * <tt>{@link Collections#reverseOrder(Comparator) Collections.reverseOrder}(comparator())</tt>.
+   * <code>{@link Collections#reverseOrder(Comparator) Collections.reverseOrder}(comparator())</code>.
    * The expression {@code m.descendingMap().descendingMap()} returns a
    * view of {@code m} essentially equivalent to {@code m}.
    *

--- a/core/src/main/java/io/atomix/core/set/AsyncDistributedNavigableSet.java
+++ b/core/src/main/java/io/atomix/core/set/AsyncDistributedNavigableSet.java
@@ -108,7 +108,7 @@ public interface AsyncDistributedNavigableSet<E extends Comparable<E>> extends A
    * the iteration are undefined.
    *
    * <p>The returned set has an ordering equivalent to
-   * <tt>{@link Collections#reverseOrder(Comparator) Collections.reverseOrder}(comparator())</tt>.
+   * <code>{@link Collections#reverseOrder(Comparator) Collections.reverseOrder}(comparator())</code>.
    * The expression {@code s.descendingSet().descendingSet()} returns a
    * view of {@code s} essentially equivalent to {@code s}.
    *

--- a/core/src/main/java/io/atomix/core/set/AsyncDistributedSortedSet.java
+++ b/core/src/main/java/io/atomix/core/set/AsyncDistributedSortedSet.java
@@ -26,87 +26,87 @@ public interface AsyncDistributedSortedSet<E extends Comparable<E>> extends Asyn
 
   /**
    * Returns a view of the portion of this set whose elements range
-   * from <tt>fromElement</tt>, inclusive, to <tt>toElement</tt>,
-   * exclusive.  (If <tt>fromElement</tt> and <tt>toElement</tt> are
+   * from <code>fromElement</code>, inclusive, to <code>toElement</code>,
+   * exclusive.  (If <code>fromElement</code> and <code>toElement</code> are
    * equal, the returned set is empty.)  The returned set is backed
    * by this set, so changes in the returned set are reflected in
    * this set, and vice-versa.  The returned set supports all
    * optional set operations that this set supports.
    *
-   * <p>The returned set will throw an <tt>IllegalArgumentException</tt>
+   * <p>The returned set will throw an <code>IllegalArgumentException</code>
    * on an attempt to insert an element outside its range.
    *
    * @param fromElement low endpoint (inclusive) of the returned set
    * @param toElement   high endpoint (exclusive) of the returned set
    * @return a view of the portion of this set whose elements range from
-   * <tt>fromElement</tt>, inclusive, to <tt>toElement</tt>, exclusive
-   * @throws ClassCastException       if <tt>fromElement</tt> and
-   *                                  <tt>toElement</tt> cannot be compared to one another using this
+   * <code>fromElement</code>, inclusive, to <code>toElement</code>, exclusive
+   * @throws ClassCastException       if <code>fromElement</code> and
+   *                                  <code>toElement</code> cannot be compared to one another using this
    *                                  set's comparator (or, if the set has no comparator, using
    *                                  natural ordering).  Implementations may, but are not required
-   *                                  to, throw this exception if <tt>fromElement</tt> or
-   *                                  <tt>toElement</tt> cannot be compared to elements currently in
+   *                                  to, throw this exception if <code>fromElement</code> or
+   *                                  <code>toElement</code> cannot be compared to elements currently in
    *                                  the set.
-   * @throws NullPointerException     if <tt>fromElement</tt> or
-   *                                  <tt>toElement</tt> is null and this set does not permit null
+   * @throws NullPointerException     if <code>fromElement</code> or
+   *                                  <code>toElement</code> is null and this set does not permit null
    *                                  elements
-   * @throws IllegalArgumentException if <tt>fromElement</tt> is
-   *                                  greater than <tt>toElement</tt>; or if this set itself
-   *                                  has a restricted range, and <tt>fromElement</tt> or
-   *                                  <tt>toElement</tt> lies outside the bounds of the range
+   * @throws IllegalArgumentException if <code>fromElement</code> is
+   *                                  greater than <code>toElement</code>; or if this set itself
+   *                                  has a restricted range, and <code>fromElement</code> or
+   *                                  <code>toElement</code> lies outside the bounds of the range
    */
   AsyncDistributedSortedSet<E> subSet(E fromElement, E toElement);
 
   /**
    * Returns a view of the portion of this set whose elements are
-   * strictly less than <tt>toElement</tt>.  The returned set is
+   * strictly less than <code>toElement</code>.  The returned set is
    * backed by this set, so changes in the returned set are
    * reflected in this set, and vice-versa.  The returned set
    * supports all optional set operations that this set supports.
    *
-   * <p>The returned set will throw an <tt>IllegalArgumentException</tt>
+   * <p>The returned set will throw an <code>IllegalArgumentException</code>
    * on an attempt to insert an element outside its range.
    *
    * @param toElement high endpoint (exclusive) of the returned set
    * @return a view of the portion of this set whose elements are strictly
-   * less than <tt>toElement</tt>
-   * @throws ClassCastException       if <tt>toElement</tt> is not compatible
+   * less than <code>toElement</code>
+   * @throws ClassCastException       if <code>toElement</code> is not compatible
    *                                  with this set's comparator (or, if the set has no comparator,
-   *                                  if <tt>toElement</tt> does not implement {@link Comparable}).
+   *                                  if <code>toElement</code> does not implement {@link Comparable}).
    *                                  Implementations may, but are not required to, throw this
-   *                                  exception if <tt>toElement</tt> cannot be compared to elements
+   *                                  exception if <code>toElement</code> cannot be compared to elements
    *                                  currently in the set.
-   * @throws NullPointerException     if <tt>toElement</tt> is null and
+   * @throws NullPointerException     if <code>toElement</code> is null and
    *                                  this set does not permit null elements
    * @throws IllegalArgumentException if this set itself has a
-   *                                  restricted range, and <tt>toElement</tt> lies outside the
+   *                                  restricted range, and <code>toElement</code> lies outside the
    *                                  bounds of the range
    */
   AsyncDistributedSortedSet<E> headSet(E toElement);
 
   /**
    * Returns a view of the portion of this set whose elements are
-   * greater than or equal to <tt>fromElement</tt>.  The returned
+   * greater than or equal to <code>fromElement</code>.  The returned
    * set is backed by this set, so changes in the returned set are
    * reflected in this set, and vice-versa.  The returned set
    * supports all optional set operations that this set supports.
    *
-   * <p>The returned set will throw an <tt>IllegalArgumentException</tt>
+   * <p>The returned set will throw an <code>IllegalArgumentException</code>
    * on an attempt to insert an element outside its range.
    *
    * @param fromElement low endpoint (inclusive) of the returned set
    * @return a view of the portion of this set whose elements are greater
-   * than or equal to <tt>fromElement</tt>
-   * @throws ClassCastException       if <tt>fromElement</tt> is not compatible
+   * than or equal to <code>fromElement</code>
+   * @throws ClassCastException       if <code>fromElement</code> is not compatible
    *                                  with this set's comparator (or, if the set has no comparator,
-   *                                  if <tt>fromElement</tt> does not implement {@link Comparable}).
+   *                                  if <code>fromElement</code> does not implement {@link Comparable}).
    *                                  Implementations may, but are not required to, throw this
-   *                                  exception if <tt>fromElement</tt> cannot be compared to elements
+   *                                  exception if <code>fromElement</code> cannot be compared to elements
    *                                  currently in the set.
-   * @throws NullPointerException     if <tt>fromElement</tt> is null
+   * @throws NullPointerException     if <code>fromElement</code> is null
    *                                  and this set does not permit null elements
    * @throws IllegalArgumentException if this set itself has a
-   *                                  restricted range, and <tt>fromElement</tt> lies outside the
+   *                                  restricted range, and <code>fromElement</code> lies outside the
    *                                  bounds of the range
    */
   AsyncDistributedSortedSet<E> tailSet(E fromElement);

--- a/core/src/main/java/io/atomix/core/transaction/AsyncTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/AsyncTransactionalSet.java
@@ -29,43 +29,43 @@ public interface AsyncTransactionalSet<E> extends AsyncPrimitive {
   /**
    * Adds the specified element to this set if it is not already present
    * (optional operation).  More formally, adds the specified element
-   * <tt>e</tt> to this set if the set contains no element <tt>e2</tt>
+   * <code>e</code> to this set if the set contains no element <code>e2</code>
    * such that
-   * <tt>(e==null&nbsp;?&nbsp;e2==null&nbsp;:&nbsp;e.equals(e2))</tt>.
+   * <code>(e==null&nbsp;?&nbsp;e2==null&nbsp;:&nbsp;e.equals(e2))</code>.
    * If this set already contains the element, the call leaves the set
-   * unchanged and returns <tt>false</tt>.  In combination with the
+   * unchanged and returns <code>false</code>.  In combination with the
    * restriction on constructors, this ensures that sets never contain
    * duplicate elements.
    *
    * @param e element to be added to this set
-   * @return <tt>true</tt> if this set did not already contain the specified
+   * @return <code>true</code> if this set did not already contain the specified
    * element
    */
   CompletableFuture<Boolean> add(E e);
 
   /**
    * Removes the specified element from this set if it is present
-   * (optional operation).  More formally, removes an element <tt>e</tt>
+   * (optional operation).  More formally, removes an element <code>e</code>
    * such that
-   * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>, if
-   * this set contains such an element.  Returns <tt>true</tt> if this set
+   * <code>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</code>, if
+   * this set contains such an element.  Returns <code>true</code> if this set
    * contained the element (or equivalently, if this set changed as a
    * result of the call).  (This set will not contain the element once the
    * call returns.)
    *
    * @param e element to be removed to this set
-   * @return <tt>true</tt> if this set contained the specified element
+   * @return <code>true</code> if this set contained the specified element
    */
   CompletableFuture<Boolean> remove(E e);
 
   /**
-   * Returns <tt>true</tt> if this set contains the specified element.
-   * More formally, returns <tt>true</tt> if and only if this set
-   * contains an element <tt>e</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+   * Returns <code>true</code> if this set contains the specified element.
+   * More formally, returns <code>true</code> if and only if this set
+   * contains an element <code>e</code> such that
+   * <code>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</code>.
    *
    * @param e element whose presence in this set is to be tested
-   * @return <tt>true</tt> if this set contains the specified element
+   * @return <code>true</code> if this set contains the specified element
    * @throws ClassCastException   if the type of the specified element
    *                              is incompatible with this set
    * @throws NullPointerException if the specified element is null and this

--- a/core/src/main/java/io/atomix/core/transaction/TransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/TransactionalSet.java
@@ -25,43 +25,43 @@ public interface TransactionalSet<E> extends SyncPrimitive {
   /**
    * Adds the specified element to this set if it is not already present
    * (optional operation).  More formally, adds the specified element
-   * <tt>e</tt> to this set if the set contains no element <tt>e2</tt>
+   * <code>e</code> to this set if the set contains no element <code>e2</code>
    * such that
-   * <tt>(e==null&nbsp;?&nbsp;e2==null&nbsp;:&nbsp;e.equals(e2))</tt>.
+   * <code>(e==null&nbsp;?&nbsp;e2==null&nbsp;:&nbsp;e.equals(e2))</code>.
    * If this set already contains the element, the call leaves the set
-   * unchanged and returns <tt>false</tt>.  In combination with the
+   * unchanged and returns <code>false</code>.  In combination with the
    * restriction on constructors, this ensures that sets never contain
    * duplicate elements.
    *
    * @param e element to be added to this set
-   * @return <tt>true</tt> if this set did not already contain the specified
+   * @return <code>true</code> if this set did not already contain the specified
    * element
    */
   boolean add(E e);
 
   /**
    * Removes the specified element from this set if it is present
-   * (optional operation).  More formally, removes an element <tt>e</tt>
+   * (optional operation).  More formally, removes an element <code>e</code>
    * such that
-   * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>, if
-   * this set contains such an element.  Returns <tt>true</tt> if this set
+   * <code>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</code>, if
+   * this set contains such an element.  Returns <code>true</code> if this set
    * contained the element (or equivalently, if this set changed as a
    * result of the call).  (This set will not contain the element once the
    * call returns.)
    *
    * @param e element to be removed to this set
-   * @return <tt>true</tt> if this set contained the specified element
+   * @return <code>true</code> if this set contained the specified element
    */
   boolean remove(E e);
 
   /**
-   * Returns <tt>true</tt> if this set contains the specified element.
-   * More formally, returns <tt>true</tt> if and only if this set
-   * contains an element <tt>e</tt> such that
-   * <tt>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</tt>.
+   * Returns <code>true</code> if this set contains the specified element.
+   * More formally, returns <code>true</code> if and only if this set
+   * contains an element <code>e</code> such that
+   * <code>(o==null&nbsp;?&nbsp;e==null&nbsp;:&nbsp;o.equals(e))</code>.
    *
    * @param e element whose presence in this set is to be tested
-   * @return <tt>true</tt> if this set contains the specified element
+   * @return <code>true</code> if this set contains the specified element
    * @throws ClassCastException   if the type of the specified element
    *                              is incompatible with this set
    * @throws NullPointerException if the specified element is null and this

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     <!-- Maven plugins -->
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+    <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
     <maven.failsafe.plugin.version>2.21.0</maven.failsafe.plugin.version>
     <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
     <maven.clean.plugin.version>2.5</maven.clean.plugin.version>
@@ -78,7 +79,7 @@
 
     <argLine.common>-Xss256k -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Dio.atomix.whitelistPackages=io.atomix</argLine.common>
     <argLine.extras /> <!-- Overridden in some profiles -->
-    <argLine.javadocs>-quiet</argLine.javadocs>
+    <argLine.javadocs />
   </properties>
 
   <profiles>
@@ -88,7 +89,7 @@
       <properties>
         <argLine.common>-Xss256k -Xms512m -Xmx2G -Dio.atomix.whitelistPackages=io.atomix</argLine.common>
         <argLine.extras>--add-modules jdk.unsupported --add-opens=java.base/java.nio=ALL-UNNAMED</argLine.extras>
-        <argLine.javadocs>-html5 -quiet</argLine.javadocs>
+        <argLine.javadocs>-html5</argLine.javadocs>
         <!-- coverall version 4.3.0 does not work with java 9, see https://github.com/trautonen/coveralls-maven-plugin/issues/112 -->
         <coveralls.skip>true</coveralls.skip>
       </properties>
@@ -270,6 +271,8 @@
           </execution>
         </executions>
         <configuration>
+          <verbose>false</verbose>
+          <quiet>true</quiet>
           <additionalparam>${argLine.javadocs}</additionalparam>
           <show>public</show>
           <doctitle>Atomix API Reference (${jv})</doctitle>


### PR DESCRIPTION
This PR really enables quiet mode for javadocs which removes the verbose logging from the Travis build, corrects lint errors, and also fixes the automated javadoc deployment and uses the old layout as html5 still requires some tweaks.