### PR TITLE
Disable leader balancing in LeaderElector primitive

### DIFF
--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
@@ -352,7 +352,7 @@ public class DefaultLeaderElectorService extends AbstractPrimitiveService<Leader
                 .collect(Collectors.toList());
         if (leader.sessionId() == session.sessionId().id()) {
           if (!updatedRegistrations.isEmpty()) {
-            sortRegistrations(topic, updatedRegistrations);
+            //sortRegistrations(topic, updatedRegistrations);
             return new ElectionState(updatedRegistrations,
                 updatedRegistrations.get(0),
                 termCounter.get(),
@@ -416,7 +416,7 @@ public class DefaultLeaderElectorService extends AbstractPrimitiveService<Leader
       if (!registrations.stream().anyMatch(r -> r.sessionId() == registration.sessionId())) {
         List<Registration> updatedRegistrations = new LinkedList<>(registrations);
         updatedRegistrations.add(registration);
-        sortRegistrations(topic, updatedRegistrations);
+        //sortRegistrations(topic, updatedRegistrations);
         Registration firstRegistration = updatedRegistrations.get(0);
         Registration leader = this.leader;
         long term = this.term;


### PR DESCRIPTION
This change is needed for consistency with current behavior in ONOS.