### PR TITLE
Support caching LeaderElector primitive

### DIFF
--- a/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectorBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.primitive.PrimitiveBuilder;
+import io.atomix.core.cache.CachedPrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyCompatibleBuilder;
@@ -25,7 +25,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
  * Builder for constructing new {@link AsyncLeaderElector} instances.
  */
 public abstract class LeaderElectorBuilder<T>
-    extends PrimitiveBuilder<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>>
+    extends CachedPrimitiveBuilder<LeaderElectorBuilder<T>, LeaderElectorConfig, LeaderElector<T>>
     implements ProxyCompatibleBuilder<LeaderElectorBuilder<T>> {
 
   protected LeaderElectorBuilder(String name, LeaderElectorConfig config, PrimitiveManagementService managementService) {

--- a/core/src/main/java/io/atomix/core/election/LeaderElectorConfig.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElectorConfig.java
@@ -15,13 +15,13 @@
  */
 package io.atomix.core.election;
 
-import io.atomix.primitive.config.PrimitiveConfig;
+import io.atomix.core.cache.CachedPrimitiveConfig;
 import io.atomix.primitive.PrimitiveType;
 
 /**
  * Leader elector configuration.
  */
-public class LeaderElectorConfig extends PrimitiveConfig<LeaderElectorConfig> {
+public class LeaderElectorConfig extends CachedPrimitiveConfig<LeaderElectorConfig> {
   @Override
   public PrimitiveType getType() {
     return LeaderElectorType.instance();

--- a/core/src/main/java/io/atomix/core/election/impl/CachingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/CachingAsyncLeaderElector.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.election.impl;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.atomix.core.cache.CacheConfig;
+import io.atomix.core.election.AsyncLeaderElector;
+import io.atomix.core.election.Leadership;
+import io.atomix.core.election.LeadershipEventListener;
+import io.atomix.primitive.PrimitiveState;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Caching leader elector primitive.
+ */
+public class CachingAsyncLeaderElector<T> extends DelegatingAsyncLeaderElector<T> {
+  private final LoadingCache<String, CompletableFuture<Leadership<T>>> cache;
+  private final LeadershipEventListener<T> cacheUpdater;
+  private final Consumer<PrimitiveState> statusListener;
+
+  public CachingAsyncLeaderElector(AsyncLeaderElector<T> delegateLeaderElector, CacheConfig cacheConfig) {
+    super(delegateLeaderElector);
+    cache = CacheBuilder.newBuilder()
+        .maximumSize(cacheConfig.getSize())
+        .build(CacheLoader.from(super::getLeadership));
+
+    cacheUpdater = event -> {
+      Leadership<T> leadership = event.newLeadership();
+      cache.put(event.topic(), CompletableFuture.completedFuture(leadership));
+    };
+    statusListener = status -> {
+      if (status == PrimitiveState.SUSPENDED || status == PrimitiveState.CLOSED) {
+        cache.invalidateAll();
+      }
+    };
+    addListener(cacheUpdater);
+    addStateChangeListener(statusListener);
+  }
+
+  @Override
+  public CompletableFuture<Leadership<T>> getLeadership(String topic) {
+    return cache.getUnchecked(topic)
+        .whenComplete((r, e) -> {
+          if (e != null) {
+            cache.invalidate(topic);
+          }
+        });
+  }
+
+  @Override
+  public CompletableFuture<Leadership<T>> run(String topic, T identifier) {
+    return super.run(topic, identifier).whenComplete((r, e) -> cache.invalidate(topic));
+  }
+
+  @Override
+  public CompletableFuture<Void> withdraw(String topic, T identifier) {
+    return super.withdraw(topic, identifier).whenComplete((r, e) -> cache.invalidate(topic));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> anoint(String topic, T nodeId) {
+    return super.anoint(topic, nodeId).whenComplete((r, e) -> cache.invalidate(topic));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> promote(String topic, T nodeId) {
+    return super.promote(topic, nodeId).whenComplete((r, e) -> cache.invalidate(topic));
+  }
+
+  @Override
+  public CompletableFuture<Void> evict(T nodeId) {
+    return super.evict(nodeId).whenComplete((r, e) -> cache.invalidateAll());
+  }
+}

--- a/core/src/main/java/io/atomix/core/election/impl/DelegatingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DelegatingAsyncLeaderElector.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.election.impl;
+
+import io.atomix.core.election.AsyncLeaderElector;
+import io.atomix.core.election.LeaderElector;
+import io.atomix.core.election.Leadership;
+import io.atomix.core.election.LeadershipEventListener;
+import io.atomix.primitive.impl.DelegatingAsyncPrimitive;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Delegating asynchronous leader elector.
+ */
+public class DelegatingAsyncLeaderElector<T> extends DelegatingAsyncPrimitive<AsyncLeaderElector<T>> implements AsyncLeaderElector<T> {
+  public DelegatingAsyncLeaderElector(AsyncLeaderElector<T> primitive) {
+    super(primitive);
+  }
+
+  @Override
+  public CompletableFuture<Leadership<T>> run(String topic, T identifier) {
+    return delegate().run(topic, identifier);
+  }
+
+  @Override
+  public CompletableFuture<Void> withdraw(String topic, T identifier) {
+    return delegate().withdraw(topic, identifier);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> anoint(String topic, T identifier) {
+    return delegate().anoint(topic, identifier);
+  }
+
+  @Override
+  public CompletableFuture<Void> evict(T identifier) {
+    return delegate().evict(identifier);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> promote(String topic, T identifier) {
+    return delegate().promote(topic, identifier);
+  }
+
+  @Override
+  public CompletableFuture<Leadership<T>> getLeadership(String topic) {
+    return delegate().getLeadership(topic);
+  }
+
+  @Override
+  public CompletableFuture<Map<String, Leadership<T>>> getLeaderships() {
+    return delegate().getLeaderships();
+  }
+
+  @Override
+  public CompletableFuture<Void> addListener(LeadershipEventListener<T> listener) {
+    return delegate().addListener(listener);
+  }
+
+  @Override
+  public CompletableFuture<Void> removeListener(LeadershipEventListener<T> listener) {
+    return delegate().removeListener(listener);
+  }
+
+  @Override
+  public CompletableFuture<Void> addListener(String topic, LeadershipEventListener<T> listener) {
+    return delegate().addListener(topic, listener);
+  }
+
+  @Override
+  public CompletableFuture<Void> removeListener(String topic, LeadershipEventListener<T> listener) {
+    return delegate().removeListener(topic, listener);
+  }
+
+  @Override
+  public LeaderElector<T> sync(Duration operationTimeout) {
+    return new BlockingLeaderElector<>(this, operationTimeout.toMillis());
+  }
+}


### PR DESCRIPTION
Implements caching for the `LeaderElector` primitive.