### PR TITLE
Iterator optimizations

### DIFF
--- a/core/src/main/java/io/atomix/core/iterator/impl/IterableService.java
+++ b/core/src/main/java/io/atomix/core/iterator/impl/IterableService.java
@@ -29,7 +29,7 @@ public interface IterableService<E> {
    * @return the iterator ID
    */
   @Command
-  long iterate();
+  IteratorBatch<E> iterate();
 
   /**
    * Returns the next batch of elements for the given iterator.

--- a/core/src/main/java/io/atomix/core/iterator/impl/IteratorBatch.java
+++ b/core/src/main/java/io/atomix/core/iterator/impl/IteratorBatch.java
@@ -22,13 +22,26 @@ import java.util.Iterator;
  * Iterator batch.
  */
 public final class IteratorBatch<T> implements Iterator<T> {
+  private final long id;
   private final int position;
   private final Collection<T> entries;
+  private final boolean complete;
   private transient volatile Iterator<T> iterator;
 
-  public IteratorBatch(int position, Collection<T> entries) {
+  public IteratorBatch(long id, int position, Collection<T> entries, boolean complete) {
+    this.id = id;
     this.position = position;
     this.entries = entries;
+    this.complete = complete;
+  }
+
+  /**
+   * Returns the iterator identifier.
+   *
+   * @return the iterator identifier
+   */
+  public long id() {
+    return id;
   }
 
   /**
@@ -47,6 +60,15 @@ public final class IteratorBatch<T> implements Iterator<T> {
    */
   public Collection<T> entries() {
     return entries;
+  }
+
+  /**
+   * Returns a boolean indicating whether the batch is complete.
+   *
+   * @return indicates whether this batch completes iteration
+   */
+  public boolean complete() {
+    return complete;
   }
 
   private Iterator<T> iterator() {

--- a/core/src/main/java/io/atomix/core/iterator/impl/OpenFunction.java
+++ b/core/src/main/java/io/atomix/core/iterator/impl/OpenFunction.java
@@ -19,13 +19,14 @@ package io.atomix.core.iterator.impl;
  * Iterator open function.
  */
 @FunctionalInterface
-public interface OpenFunction<S> {
+public interface OpenFunction<S, T> {
 
   /**
    * Opens the iterator using the given service proxy.
    *
    * @param service the service proxy
-   * @return
+   * @return the initial iterator batch
    */
-  long open(S service);
+  IteratorBatch<T> open(S service);
+
 }

--- a/core/src/main/java/io/atomix/core/iterator/impl/PartitionedProxyIterator.java
+++ b/core/src/main/java/io/atomix/core/iterator/impl/PartitionedProxyIterator.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class PartitionedProxyIterator<S, T> implements AsyncIterator<T> {
   private final ProxyClient<S> client;
   private final Iterator<AsyncIterator<T>> partitions;
-  private final OpenFunction<S> openFunction;
+  private final OpenFunction<S, T> openFunction;
   private final NextFunction<S, T> nextFunction;
   private final CloseFunction<S> closeFunction;
   private volatile AsyncIterator<T> iterator;
@@ -37,7 +37,7 @@ public class PartitionedProxyIterator<S, T> implements AsyncIterator<T> {
 
   public PartitionedProxyIterator(
       ProxyClient<S> client,
-      OpenFunction<S> openFunction,
+      OpenFunction<S, T> openFunction,
       NextFunction<S, T> nextFunction,
       CloseFunction<S> closeFunction) {
     this.client = client;

--- a/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicNavigableMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicNavigableMapService.java
@@ -17,6 +17,7 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.collect.Maps;
+import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.core.map.AtomicNavigableMapType;
 import io.atomix.core.transaction.TransactionId;
 import io.atomix.primitive.PrimitiveType;
@@ -253,15 +254,28 @@ public abstract class AbstractAtomicNavigableMapService<K extends Comparable<K>>
   }
 
   @Override
-  public long subMapIterate(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
-    entryIterators.put(getCurrentIndex(), new AscendingIterator(getCurrentSession().sessionId().id(), fromKey, fromInclusive, toKey, toInclusive));
-    return getCurrentIndex();
+  public IteratorBatch<K> subMapIterateKeys(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
+    return iterate(sessionId -> new AscendingIterator(sessionId, fromKey, fromInclusive, toKey, toInclusive), (k, v) -> k);
   }
 
   @Override
-  public long subMapIterateDescending(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
-    entryIterators.put(getCurrentIndex(), new DescendingIterator(getCurrentSession().sessionId().id(), fromKey, fromInclusive, toKey, toInclusive));
-    return getCurrentIndex();
+  public IteratorBatch<Map.Entry<K, Versioned<byte[]>>> subMapIterateEntries(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
+    return iterate(sessionId -> new AscendingIterator(sessionId, fromKey, fromInclusive, toKey, toInclusive), Maps::immutableEntry);
+  }
+
+  @Override
+  public IteratorBatch<Versioned<byte[]>> subMapIterateValues(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
+    return iterate(sessionId -> new AscendingIterator(sessionId, fromKey, fromInclusive, toKey, toInclusive), (k, v) -> v);
+  }
+
+  @Override
+  public IteratorBatch<K> subMapIterateDescendingKeys(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
+    return iterate(sessionId -> new DescendingIterator(sessionId, fromKey, fromInclusive, toKey, toInclusive), (k, v) -> k);
+  }
+
+  @Override
+  public IteratorBatch<Map.Entry<K, Versioned<byte[]>>> subMapIterateDescendingEntries(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive) {
+    return iterate(sessionId -> new DescendingIterator(sessionId, fromKey, fromInclusive, toKey, toInclusive), Maps::immutableEntry);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicMapService.java
@@ -295,7 +295,7 @@ public interface AtomicMapService<K> {
    * @return the key iterator ID
    */
   @Command
-  long iterateKeys();
+  IteratorBatch<K> iterateKeys();
 
   /**
    * Returns the next batch of entries for the given iterator.
@@ -321,7 +321,7 @@ public interface AtomicMapService<K> {
    * @return the values iterator ID
    */
   @Command
-  long iterateValues();
+  IteratorBatch<Versioned<byte[]>> iterateValues();
 
   /**
    * Returns the next batch of values for the given iterator.
@@ -347,7 +347,7 @@ public interface AtomicMapService<K> {
    * @return the entry iterator ID
    */
   @Command
-  long iterateEntries();
+  IteratorBatch<Map.Entry<K, Versioned<byte[]>>> iterateEntries();
 
   /**
    * Returns the next batch of entries for the given iterator.

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
@@ -306,7 +306,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
       return new ProxyIterator<>(
           getProxyClient(),
           getProxyClient().getPartitionId(name()),
-          service -> service.subMapIterate(fromKey, fromInclusive, toKey, toInclusive),
+          service -> service.subMapIterateKeys(fromKey, fromInclusive, toKey, toInclusive),
           AtomicTreeMapService::nextKeys,
           AtomicTreeMapService::closeKeys);
     }
@@ -316,7 +316,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
       return new ProxyIterator<>(
           getProxyClient(),
           getProxyClient().getPartitionId(name()),
-          service -> service.subMapIterateDescending(fromKey, fromInclusive, toKey, toInclusive),
+          service -> service.subMapIterateDescendingKeys(fromKey, fromInclusive, toKey, toInclusive),
           AtomicTreeMapService::nextKeys,
           AtomicTreeMapService::closeKeys);
     }
@@ -906,7 +906,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
       return new ProxyIterator<>(
           getProxyClient(),
           getProxyClient().getPartitionId(name()),
-          service -> service.subMapIterate(fromKey, fromInclusive, toKey, toInclusive),
+          service -> service.subMapIterateEntries(fromKey, fromInclusive, toKey, toInclusive),
           AtomicTreeMapService::nextEntries,
           AtomicTreeMapService::closeEntries);
     }
@@ -1030,7 +1030,7 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
       return new ProxyIterator<>(
           getProxyClient(),
           getProxyClient().getPartitionId(name()),
-          service -> service.subMapIterate(fromKey, fromInclusive, toKey, toInclusive),
+          service -> service.subMapIterateValues(fromKey, fromInclusive, toKey, toInclusive),
           AtomicTreeMapService::nextValues,
           AtomicTreeMapService::closeValues);
     }

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicTreeMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicTreeMapService.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.map.impl;
 
+import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.primitive.operation.Command;
 import io.atomix.primitive.operation.Query;
 import io.atomix.utils.time.Versioned;
@@ -384,7 +385,7 @@ public interface AtomicTreeMapService<K extends Comparable<K>> extends AtomicMap
    * @return the key iterator ID
    */
   @Command
-  long subMapIterate(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
+  IteratorBatch<K> subMapIterateKeys(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
 
   /**
    * Returns a key iterator.
@@ -396,7 +397,43 @@ public interface AtomicTreeMapService<K extends Comparable<K>> extends AtomicMap
    * @return the key iterator ID
    */
   @Command
-  long subMapIterateDescending(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
+  IteratorBatch<Map.Entry<K, Versioned<byte[]>>> subMapIterateEntries(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
+
+  /**
+   * Returns a key iterator.
+   *
+   * @param fromKey the from key
+   * @param fromInclusive whether the from key is inclusive
+   * @param toKey the to key
+   * @param toInclusive whether the to key is inclusive
+   * @return the key iterator ID
+   */
+  @Command
+  IteratorBatch<Versioned<byte[]>> subMapIterateValues(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
+
+  /**
+   * Returns a key iterator.
+   *
+   * @param fromKey the from key
+   * @param fromInclusive whether the from key is inclusive
+   * @param toKey the to key
+   * @param toInclusive whether the to key is inclusive
+   * @return the key iterator ID
+   */
+  @Command
+  IteratorBatch<K> subMapIterateDescendingKeys(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
+
+  /**
+   * Returns a key iterator.
+   *
+   * @param fromKey the from key
+   * @param fromInclusive whether the from key is inclusive
+   * @param toKey the to key
+   * @param toInclusive whether the to key is inclusive
+   * @return the key iterator ID
+   */
+  @Command
+  IteratorBatch<Map.Entry<K, Versioned<byte[]>>> subMapIterateDescendingEntries(K fromKey, boolean fromInclusive, K toKey, boolean toInclusive);
 
   /**
    * Clears the given view from the set.

--- a/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapService.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapService.java
@@ -222,7 +222,7 @@ public interface AtomicMultimapService {
    * @return the key iterator ID
    */
   @Command
-  long iterateKeySet();
+  IteratorBatch<String> iterateKeySet();
 
   /**
    * Returns the next batch of entries for the given iterator.
@@ -248,7 +248,7 @@ public interface AtomicMultimapService {
    * @return the key iterator ID
    */
   @Command
-  long iterateKeys();
+  IteratorBatch<String> iterateKeys();
 
   /**
    * Returns the next batch of entries for the given iterator.
@@ -274,7 +274,7 @@ public interface AtomicMultimapService {
    * @return the values iterator ID
    */
   @Command
-  long iterateValues();
+  IteratorBatch<byte[]> iterateValues();
 
   /**
    * Returns the next batch of values for the given iterator.
@@ -300,7 +300,7 @@ public interface AtomicMultimapService {
    * @return the entry iterator ID
    */
   @Command
-  long iterateEntries();
+  IteratorBatch<Map.Entry<String, byte[]>> iterateEntries();
 
   /**
    * Returns the next batch of entries for the given iterator.
@@ -326,7 +326,7 @@ public interface AtomicMultimapService {
    * @return the values entry iterator ID
    */
   @Command
-  long iterateValuesSet();
+  IteratorBatch<Multiset.Entry<byte[]>> iterateValuesSet();
 
   /**
    * Returns the next batch of values entries for the given iterator.

--- a/core/src/main/java/io/atomix/core/multiset/impl/DistributedMultisetService.java
+++ b/core/src/main/java/io/atomix/core/multiset/impl/DistributedMultisetService.java
@@ -136,7 +136,7 @@ public interface DistributedMultisetService extends DistributedCollectionService
    * @return the iterator ID
    */
   @Command
-  long iterateElements();
+  IteratorBatch<String> iterateElements();
 
   /**
    * Returns the next batch of elements for the given iterator.
@@ -162,7 +162,7 @@ public interface DistributedMultisetService extends DistributedCollectionService
    * @return the iterator ID
    */
   @Command
-  long iterateEntries();
+  IteratorBatch<Multiset.Entry<String>> iterateEntries();
 
   /**
    * Returns the next batch of elements for the given iterator.

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetService.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetService.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.set.impl;
 
+import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.core.set.DistributedNavigableSetType;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.Namespace;
@@ -140,21 +141,18 @@ public class DefaultDistributedNavigableSetService<E extends Comparable<E>> exte
   }
 
   @Override
-  public long subSetIterate(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive) {
-    iterators.put(getCurrentIndex(), new SubSetIteratorContext(getCurrentSession().sessionId().id(), fromElement, fromInclusive, toElement, toInclusive));
-    return getCurrentIndex();
+  public IteratorBatch<E> subSetIterate(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive) {
+    return iterate(sessionId -> new SubSetIteratorContext(sessionId, fromElement, fromInclusive, toElement, toInclusive));
   }
 
   @Override
-  public long subSetIterateDescending(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive) {
-    iterators.put(getCurrentIndex(), new DescendingSubSetIteratorContext(getCurrentSession().sessionId().id(), fromElement, fromInclusive, toElement, toInclusive));
-    return getCurrentIndex();
+  public IteratorBatch<E> subSetIterateDescending(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive) {
+    return iterate(sessionId -> new DescendingSubSetIteratorContext(sessionId, fromElement, fromInclusive, toElement, toInclusive));
   }
 
   @Override
-  public long iterateDescending() {
-    iterators.put(getCurrentIndex(), new DescendingIteratorContext(getCurrentSession().sessionId().id()));
-    return getCurrentIndex();
+  public IteratorBatch<E> iterateDescending() {
+    return iterate(DescendingIteratorContext::new);
   }
 
   private void subSetAccept(Consumer<NavigableSet<E>> function, E fromElement, boolean fromInclusive, E toElement, boolean toInclusive) {

--- a/core/src/main/java/io/atomix/core/set/impl/DistributedTreeSetService.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DistributedTreeSetService.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.set.impl;
 
+import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.primitive.operation.Command;
 import io.atomix.primitive.operation.Query;
 
@@ -182,7 +183,7 @@ public interface DistributedTreeSetService<E extends Comparable<E>> extends Dist
    * @return the descending iterator ID
    */
   @Command
-  long iterateDescending();
+  IteratorBatch<E> iterateDescending();
 
   /**
    * Returns a descending iterator.
@@ -194,7 +195,7 @@ public interface DistributedTreeSetService<E extends Comparable<E>> extends Dist
    * @return the descending iterator ID
    */
   @Command
-  long subSetIterate(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive);
+  IteratorBatch<E> subSetIterate(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive);
 
   /**
    * Returns a descending iterator.
@@ -206,6 +207,6 @@ public interface DistributedTreeSetService<E extends Comparable<E>> extends Dist
    * @return the descending iterator ID
    */
   @Command
-  long subSetIterateDescending(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive);
+  IteratorBatch<E> subSetIterateDescending(E fromElement, boolean fromInclusive, E toElement, boolean toInclusive);
 
 }


### PR DESCRIPTION
This PR optimizes iterators to resolve #776 

Optimization is done in two ways:
1. Partitioned iterators now request batches in parallel upon initialization. This is done by simple immediately creating a partition iterator for each partition.
2. Partition iterators require only a single write operation unless multiple batches are required. A flag in the `IteratorBatch` is used to indicate whether multiple batches are needed after the iterator context has been created. When multiple batches are needed, the first operation is a write, further batch requests are reads with a `position` context, and a final `close()` operation is required to clean up the iterator context.

These optimizations will limit iterators for small primitives to n parallel writes where n is the total number of partitions. We could perhaps optimize this even further to execute n parallel reads and only create an iterator context when the batch size is exceeded.