### PR TITLE
Implement Raft log entry size limit

### DIFF
--- a/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
+++ b/core/src/main/java/io/atomix/core/profile/ConsensusProfile.java
@@ -18,6 +18,7 @@ package io.atomix.core.profile;
 import com.google.common.collect.Sets;
 import io.atomix.core.AtomixConfig;
 import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
+import io.atomix.protocols.raft.partition.RaftStorageConfig;
 
 import java.util.Collection;
 
@@ -84,12 +85,14 @@ public class ConsensusProfile implements Profile {
         .setPartitionSize(this.config.getMembers().size())
         .setPartitions(1)
         .setMembers(this.config.getMembers())
-        .setDataDirectory(String.format("%s/%s", this.config.getDataPath(), this.config.getManagementGroup())));
+        .setStorageConfig(new RaftStorageConfig()
+            .setDirectory(String.format("%s/%s", this.config.getDataPath(), this.config.getManagementGroup()))));
     config.addPartitionGroup(new RaftPartitionGroupConfig()
         .setName(this.config.getDataGroup())
         .setPartitionSize(this.config.getPartitionSize())
         .setPartitions(this.config.getPartitions())
         .setMembers(this.config.getMembers())
-        .setDataDirectory(String.format("%s/%s", this.config.getDataPath(), this.config.getDataGroup())));
+        .setStorageConfig(new RaftStorageConfig()
+            .setDirectory(String.format("%s/%s", this.config.getDataPath(), this.config.getDataGroup()))));
   }
 }

--- a/core/src/main/java/io/atomix/core/utils/config/PolymorphicConfigMapper.java
+++ b/core/src/main/java/io/atomix/core/utils/config/PolymorphicConfigMapper.java
@@ -25,6 +25,7 @@ import io.atomix.utils.config.TypedConfig;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -90,7 +91,7 @@ public class PolymorphicConfigMapper extends ConfigMapper {
     Properties properties = System.getProperties();
     Set<String> cleanNames = propertyNames
         .stream()
-        .filter(propertyName -> !isPolymorphicType(clazz) || !polymorphicTypes.stream().anyMatch(type -> type.getTypePath().equals(propertyName)))
+        .filter(propertyName -> !isPolymorphicType(clazz) || !polymorphicTypes.stream().anyMatch(type -> Objects.equals(type.getTypePath(), propertyName)))
         .map(propertyName -> toPath(path, propertyName))
         .filter(propertyName -> !properties.containsKey(propertyName))
         .filter(propertyName -> properties.entrySet().stream().noneMatch(entry -> entry.getKey().toString().startsWith(propertyName + ".")))

--- a/core/src/test/java/io/atomix/core/AtomixConfigTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixConfigTest.java
@@ -93,7 +93,7 @@ public class AtomixConfigTest {
     RaftPartitionGroupConfig managementGroup = (RaftPartitionGroupConfig) config.getManagementGroup();
     assertEquals(RaftPartitionGroup.TYPE, managementGroup.getType());
     assertEquals(1, managementGroup.getPartitions());
-    assertEquals(new MemorySize(1024 * 1024 * 16), managementGroup.getSegmentSize());
+    assertEquals(new MemorySize(1024 * 1024 * 16), managementGroup.getStorageConfig().getSegmentSize());
 
     RaftPartitionGroupConfig groupOne = (RaftPartitionGroupConfig) config.getPartitionGroups().get("one");
     assertEquals(RaftPartitionGroup.TYPE, groupOne.getType());

--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -32,7 +32,7 @@ cluster {
 management-group {
   type: raft
   partitions: 1
-  segmentSize: 16M
+  storage.segmentSize: 16M
 }
 
 partition-groups.one {

--- a/dist/src/main/resources/examples/consensus.conf
+++ b/dist/src/main/resources/examples/consensus.conf
@@ -20,13 +20,13 @@ cluster {
 management-group {
   type: raft
   partitions: 1
-  storage-level: disk
+  storage.level: disk
   members: [atomix-1, atomix-2, atomix-3]
 }
 
 partition-groups.consensus {
   type: raft
   partitions: 7
-  storage-level: mapped
+  storage.level: mapped
   members: [atomix-1, atomix-2, atomix-3]
 }

--- a/dist/src/main/resources/examples/onos.conf
+++ b/dist/src/main/resources/examples/onos.conf
@@ -20,13 +20,13 @@ cluster {
 management-group {
   type: raft
   partitions: 1
-  storage-level: disk
+  storage.level: disk
   members: [atomix-1, atomix-2, atomix-3]
 }
 
 partition-groups.raft {
   type: raft
   partitions: 7
-  storage-level: disk
+  storage.level: disk
   members: [atomix-1, atomix-2, atomix-3]
 }

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPartitionGroupMembershipService.java
@@ -30,7 +30,6 @@ import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.primitive.partition.ManagedPartitionGroupMembershipService;
 import io.atomix.primitive.partition.MemberGroupStrategy;
-import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 import io.atomix.primitive.partition.PartitionGroupMembership;
 import io.atomix.primitive.partition.PartitionGroupMembershipEvent;
@@ -50,8 +49,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -105,22 +102,16 @@ public class DefaultPartitionGroupMembershipService
           ImmutableSet.of(membershipService.getLocalMember().id()), false));
     });
 
-    Namespace.Builder namespaceBuilder = Namespace.builder()
+    serializer = Serializer.using(Namespace.builder()
         .register(Namespaces.BASIC)
         .register(MemberId.class)
         .register(PartitionGroupMembership.class)
         .register(PartitionGroupInfo.class)
         .register(PartitionGroupConfig.class)
-        .register(MemberGroupStrategy.class);
-
-    List<PartitionGroup.Type> groupTypes = Lists.newArrayList(groupTypeRegistry.getGroupTypes());
-    groupTypes.sort(Comparator.comparing(PartitionGroup.Type::name));
-    for (PartitionGroup.Type groupType : groupTypes) {
-      namespaceBuilder.register(groupType.getClass());
-      namespaceBuilder.register(groupType.newConfig().getClass());
-    }
-
-    serializer = Serializer.using(namespaceBuilder.build());
+        .register(MemberGroupStrategy.class)
+        .setRegistrationRequired(false)
+        .setClassLoader(getClass().getClassLoader())
+        .build());
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftCompactionConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftCompactionConfig.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.partition;
+
+/**
+ * Raft compaction configuration.
+ */
+public class RaftCompactionConfig {
+  private static final boolean DEFAULT_DYNAMIC_COMPACTION = true;
+  private static final double DEFAULT_FREE_DISK_BUFFER = .2;
+  private static final double DEFAULT_FREE_MEMORY_BUFFER = .2;
+
+  private boolean dynamic = DEFAULT_DYNAMIC_COMPACTION;
+  private double freeDiskBuffer = DEFAULT_FREE_DISK_BUFFER;
+  private double freeMemoryBuffer = DEFAULT_FREE_MEMORY_BUFFER;
+
+  /**
+   * Returns whether dynamic compaction is enabled.
+   *
+   * @return whether dynamic compaction is enabled
+   */
+  public boolean isDynamic() {
+    return dynamic;
+  }
+
+  /**
+   * Sets whether dynamic compaction is enabled.
+   *
+   * @param dynamic whether dynamic compaction is enabled
+   * @return the compaction configuration
+   */
+  public RaftCompactionConfig setDynamic(boolean dynamic) {
+    this.dynamic = dynamic;
+    return this;
+  }
+
+  /**
+   * Returns the free disk buffer.
+   *
+   * @return the free disk buffer
+   */
+  public double getFreeDiskBuffer() {
+    return freeDiskBuffer;
+  }
+
+  /**
+   * Sets the free disk buffer.
+   *
+   * @param freeDiskBuffer the free disk buffer
+   * @return the compaction configuration
+   */
+  public RaftCompactionConfig setFreeDiskBuffer(double freeDiskBuffer) {
+    this.freeDiskBuffer = freeDiskBuffer;
+    return this;
+  }
+
+  /**
+   * Returns the free memory buffer.
+   *
+   * @return the free memory buffer
+   */
+  public double getFreeMemoryBuffer() {
+    return freeMemoryBuffer;
+  }
+
+  /**
+   * Sets the free memory buffer.
+   *
+   * @param freeMemoryBuffer the free memory buffer
+   * @return the compaction configuration
+   */
+  public RaftCompactionConfig setFreeMemoryBuffer(double freeMemoryBuffer) {
+    this.freeMemoryBuffer = freeMemoryBuffer;
+    return this;
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
@@ -93,14 +93,12 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
   private static final Logger LOGGER = LoggerFactory.getLogger(RaftPartitionGroup.class);
 
   private static Collection<RaftPartition> buildPartitions(RaftPartitionGroupConfig config) {
-    File partitionsDir = new File(config.getDataDirectory(), "partitions");
+    File partitionsDir = new File(config.getStorageConfig().getDirectory(config.getName()), "partitions");
     List<RaftPartition> partitions = new ArrayList<>(config.getPartitions());
     for (int i = 0; i < config.getPartitions(); i++) {
       partitions.add(new RaftPartition(
           PartitionId.from(config.getName(), i + 1),
-          StorageLevel.valueOf(config.getStorageLevel().toUpperCase()),
-          config.getSegmentSize().bytes(),
-          config.isFlushOnCommit(),
+          config,
           new File(partitionsDir, String.valueOf(i + 1))));
     }
     return partitions;
@@ -316,7 +314,7 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      * @return the Raft partition group builder
      */
     public Builder withStorageLevel(StorageLevel storageLevel) {
-      config.setStorageLevel(storageLevel.name());
+      config.getStorageConfig().setLevel(storageLevel);
       return this;
     }
 
@@ -327,28 +325,50 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
      * @return the replica builder
      */
     public Builder withDataDirectory(File dataDir) {
-      config.setDataDirectory(new File("user.dir").toURI().relativize(dataDir.toURI()).getPath());
+      config.getStorageConfig().setDirectory(new File("user.dir").toURI().relativize(dataDir.toURI()).getPath());
       return this;
     }
 
     /**
      * Sets the segment size.
+     *
      * @param segmentSize the segment size
      * @return the Raft partition group builder
      */
     public Builder withSegmentSize(MemorySize segmentSize) {
-      config.setSegmentSize(segmentSize);
+      config.getStorageConfig().setSegmentSize(segmentSize);
       return this;
     }
 
     /**
      * Sets the segment size.
+     *
      * @param segmentSizeBytes the segment size in bytes
      * @return the Raft partition group builder
      */
     public Builder withSegmentSize(long segmentSizeBytes) {
-      config.setSegmentSize(new MemorySize(segmentSizeBytes));
+      return withSegmentSize(new MemorySize(segmentSizeBytes));
+    }
+
+    /**
+     * Sets the maximum Raft log entry size.
+     *
+     * @param maxEntrySize the maximum Raft log entry size
+     * @return the Raft partition group builder
+     */
+    public Builder withMaxEntrySize(MemorySize maxEntrySize) {
+      config.getStorageConfig().setMaxEntrySize(maxEntrySize);
       return this;
+    }
+
+    /**
+     * Sets the maximum Raft log entry size.
+     *
+     * @param maxEntrySize the maximum Raft log entry size
+     * @return the Raft partition group builder
+     */
+    public Builder withMaxEntrySize(int maxEntrySize) {
+      return withMaxEntrySize(new MemorySize(maxEntrySize));
     }
 
     @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
@@ -32,10 +32,8 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
 
   private Set<String> members = new HashSet<>();
   private int partitionSize;
-  private String storageLevel = StorageLevel.DISK.name();
-  private long segmentSize = 1024 * 1024 * 32;
-  private boolean flushOnCommit = true;
-  private String dataDirectory;
+  private RaftStorageConfig storageConfig = new RaftStorageConfig();
+  private RaftCompactionConfig compactionConfig = new RaftCompactionConfig();
 
   @Override
   public PartitionGroup.Type getType() {
@@ -88,83 +86,42 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   }
 
   /**
-   * Returns the partition storage level.
+   * Returns the storage configuration.
    *
-   * @return the partition storage level
+   * @return the storage configuration
    */
-  public String getStorageLevel() {
-    return storageLevel;
+  public RaftStorageConfig getStorageConfig() {
+    return storageConfig;
   }
 
   /**
-   * Sets the partition storage level.
+   * Sets the storage configuration.
    *
-   * @param storageLevel the partition storage level
+   * @param storageConfig the storage configuration
    * @return the Raft partition group configuration
    */
-  public RaftPartitionGroupConfig setStorageLevel(String storageLevel) {
-    StorageLevel.valueOf(storageLevel.toUpperCase());
-    this.storageLevel = storageLevel;
+  public RaftPartitionGroupConfig setStorageConfig(RaftStorageConfig storageConfig) {
+    this.storageConfig = storageConfig;
     return this;
   }
 
   /**
-   * Returns the Raft log segment size.
+   * Returns the compaction configuration.
    *
-   * @return the Raft log segment size
+   * @return the compaction configuration
    */
-  public MemorySize getSegmentSize() {
-    return MemorySize.from(segmentSize);
+  public RaftCompactionConfig getCompactionConfig() {
+    return compactionConfig;
   }
 
   /**
-   * Sets the Raft log segment size.
+   * Sets the compaction configuration.
    *
-   * @param segmentSize the Raft log segment size
-   * @return the partition group configuration
-   */
-  public RaftPartitionGroupConfig setSegmentSize(MemorySize segmentSize) {
-    this.segmentSize = segmentSize.bytes();
-    return this;
-  }
-
-  /**
-   * Returns whether to flush logs to disk on commit.
-   *
-   * @return whether to flush logs to disk on commit
-   */
-  public boolean isFlushOnCommit() {
-    return flushOnCommit;
-  }
-
-  /**
-   * Sets whether to flush logs to disk on commit.
-   *
-   * @param flushOnCommit whether to flush logs to disk on commit
+   * @param compactionConfig the compaction configuration
    * @return the Raft partition group configuration
    */
-  public RaftPartitionGroupConfig setFlushOnCommit(boolean flushOnCommit) {
-    this.flushOnCommit = flushOnCommit;
-    return this;
-  }
-
-  /**
-   * Returns the partition data directory.
-   *
-   * @return the partition data directory
-   */
-  public String getDataDirectory() {
-    return dataDirectory != null ? dataDirectory : System.getProperty("atomix.data", DATA_PREFIX) + "/" + getName();
-  }
-
-  /**
-   * Sets the partition data directory.
-   *
-   * @param dataDirectory the partition data directory
-   * @return the Raft partition group configuration
-   */
-  public RaftPartitionGroupConfig setDataDirectory(String dataDirectory) {
-    this.dataDirectory = dataDirectory;
+  public RaftPartitionGroupConfig setCompactionConfig(RaftCompactionConfig compactionConfig) {
+    this.compactionConfig = compactionConfig;
     return this;
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftStorageConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftStorageConfig.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.partition;
+
+import io.atomix.storage.StorageLevel;
+import io.atomix.utils.memory.MemorySize;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Raft storage configuration.
+ */
+public class RaftStorageConfig {
+  private static final String DATA_PREFIX = ".data";
+  private static final StorageLevel DEFAULT_STORAGE_LEVEL = StorageLevel.DISK;
+  private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
+  private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
+  private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
+
+  private String directory;
+  private StorageLevel level = DEFAULT_STORAGE_LEVEL;
+  private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
+  private long segmentSize = DEFAULT_MAX_SEGMENT_SIZE;
+  private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
+
+  /**
+   * Returns the partition storage level.
+   *
+   * @return the partition storage level
+   */
+  public StorageLevel getLevel() {
+    return level;
+  }
+
+  /**
+   * Sets the partition storage level.
+   *
+   * @param storageLevel the partition storage level
+   * @return the Raft partition group configuration
+   */
+  public RaftStorageConfig setLevel(StorageLevel storageLevel) {
+    this.level = checkNotNull(storageLevel);
+    return this;
+  }
+
+  /**
+   * Returns the Raft log segment size.
+   *
+   * @return the Raft log segment size
+   */
+  public MemorySize getSegmentSize() {
+    return MemorySize.from(segmentSize);
+  }
+
+  /**
+   * Sets the Raft log segment size.
+   *
+   * @param segmentSize the Raft log segment size
+   * @return the partition group configuration
+   */
+  public RaftStorageConfig setSegmentSize(MemorySize segmentSize) {
+    this.segmentSize = segmentSize.bytes();
+    return this;
+  }
+
+  /**
+   * Returns the maximum entry size.
+   *
+   * @return the maximum entry size
+   */
+  public MemorySize getMaxEntrySize() {
+    return MemorySize.from(maxEntrySize);
+  }
+
+  /**
+   * Sets the maximum entry size.
+   *
+   * @param maxEntrySize the maximum entry size
+   * @return the Raft storage configuration
+   */
+  public RaftStorageConfig setMaxEntrySize(MemorySize maxEntrySize) {
+    this.maxEntrySize = (int) maxEntrySize.bytes();
+    return this;
+  }
+
+  /**
+   * Returns whether to flush logs to disk on commit.
+   *
+   * @return whether to flush logs to disk on commit
+   */
+  public boolean isFlushOnCommit() {
+    return flushOnCommit;
+  }
+
+  /**
+   * Sets whether to flush logs to disk on commit.
+   *
+   * @param flushOnCommit whether to flush logs to disk on commit
+   * @return the Raft partition group configuration
+   */
+  public RaftStorageConfig setFlushOnCommit(boolean flushOnCommit) {
+    this.flushOnCommit = flushOnCommit;
+    return this;
+  }
+
+  /**
+   * Returns the partition data directory.
+   *
+   * @param groupName the partition group name
+   * @return the partition data directory
+   */
+  public String getDirectory(String groupName) {
+    return directory != null ? directory : System.getProperty("atomix.data", DATA_PREFIX) + "/" + groupName;
+  }
+
+  /**
+   * Sets the partition data directory.
+   *
+   * @param directory the partition data directory
+   * @return the Raft partition group configuration
+   */
+  public RaftStorageConfig setDirectory(String directory) {
+    this.directory = directory;
+    return this;
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -290,6 +290,9 @@ public class PassiveRole extends InactiveRole {
     try {
       Indexed<RaftLogEntry> indexed = writer.append(entry);
       log.trace("Appended {}", indexed);
+    } catch (StorageException.TooLarge e) {
+      log.warn("Entry size exceeds maximum allowed bytes. Ensure Raft storage configuration is consistent on all nodes!");
+      return false;
     } catch (StorageException.OutOfDiskSpace e) {
       log.trace("Append failed: {}", e);
       raft.getServiceManager().compact();

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -70,6 +70,7 @@ public class RaftStorage {
   private final File directory;
   private final Serializer serializer;
   private final int maxSegmentSize;
+  private final int maxEntrySize;
   private final int maxEntriesPerSegment;
   private final boolean dynamicCompaction;
   private final double freeDiskBuffer;
@@ -84,6 +85,7 @@ public class RaftStorage {
       File directory,
       Serializer serializer,
       int maxSegmentSize,
+      int maxEntrySize,
       int maxEntriesPerSegment,
       boolean dynamicCompaction,
       double freeDiskBuffer,
@@ -95,6 +97,7 @@ public class RaftStorage {
     this.directory = directory;
     this.serializer = serializer;
     this.maxSegmentSize = maxSegmentSize;
+    this.maxEntrySize = maxEntrySize;
     this.maxEntriesPerSegment = maxEntriesPerSegment;
     this.dynamicCompaction = dynamicCompaction;
     this.freeDiskBuffer = freeDiskBuffer;
@@ -324,6 +327,7 @@ public class RaftStorage {
         .withStorageLevel(storageLevel)
         .withSerializer(serializer)
         .withMaxSegmentSize(maxSegmentSize)
+        .withMaxEntrySize(maxEntrySize)
         .withMaxEntriesPerSegment(maxEntriesPerSegment)
         .withFlushOnCommit(flushOnCommit)
         .build();
@@ -382,6 +386,7 @@ public class RaftStorage {
     private static final String DEFAULT_PREFIX = "atomix";
     private static final String DEFAULT_DIRECTORY = System.getProperty("atomix.data", System.getProperty("user.dir"));
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
+    private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024; // 1MB
     private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
     private static final boolean DEFAULT_DYNAMIC_COMPACTION = true;
     private static final double DEFAULT_FREE_DISK_BUFFER = .2;
@@ -394,6 +399,7 @@ public class RaftStorage {
     private File directory = new File(DEFAULT_DIRECTORY);
     private Serializer serializer;
     private int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
+    private int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     private int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
     private boolean dynamicCompaction = DEFAULT_DYNAMIC_COMPACTION;
     private double freeDiskBuffer = DEFAULT_FREE_DISK_BUFFER;
@@ -486,6 +492,19 @@ public class RaftStorage {
     public Builder withMaxSegmentSize(int maxSegmentSize) {
       checkArgument(maxSegmentSize > JournalSegmentDescriptor.BYTES, "maxSegmentSize must be greater than " + JournalSegmentDescriptor.BYTES);
       this.maxSegmentSize = maxSegmentSize;
+      return this;
+    }
+
+    /**
+     * Sets the maximum entry size in bytes, returning the builder for method chaining.
+     *
+     * @param maxEntrySize the maximum entry size in bytes
+     * @return the storage builder
+     * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
+     */
+    public Builder withMaxEntrySize(int maxEntrySize) {
+      checkArgument(maxEntrySize > 0, "maxEntrySize must be positive");
+      this.maxEntrySize = maxEntrySize;
       return this;
     }
 
@@ -636,6 +655,7 @@ public class RaftStorage {
           directory,
           serializer,
           maxSegmentSize,
+          maxEntrySize,
           maxEntriesPerSegment,
           dynamicCompaction,
           freeDiskBuffer,

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -222,6 +222,18 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
     }
 
     /**
+     * Sets the maximum entry size in bytes, returning the builder for method chaining.
+     *
+     * @param maxEntrySize the maximum entry size in bytes
+     * @return the storage builder
+     * @throws IllegalArgumentException if the {@code maxEntrySize} is not positive
+     */
+    public Builder withMaxEntrySize(int maxEntrySize) {
+      journalBuilder.withMaxEntrySize(maxEntrySize);
+      return this;
+    }
+
+    /**
      * Sets the maximum number of allows entries per segment, returning the builder for method chaining.
      * <p>
      * The maximum entry count dictates when logs should roll over to new segments. As entries are written to

--- a/storage/src/main/java/io/atomix/storage/StorageException.java
+++ b/storage/src/main/java/io/atomix/storage/StorageException.java
@@ -38,6 +38,15 @@ public class StorageException extends RuntimeException {
   }
 
   /**
+   * Exception thrown when an entry being stored is too large.
+   */
+  public static class TooLarge extends StorageException {
+    public TooLarge(String message) {
+      super(message);
+    }
+  }
+
+  /**
    * Exception thrown when storage runs out of disk space.
    */
   public static class OutOfDiskSpace extends StorageException {

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
@@ -34,6 +34,7 @@ import java.util.zip.Checksum;
  */
 public class JournalSegmentReader<E> implements JournalReader<E> {
   private final Buffer buffer;
+  private final int maxEntrySize;
   private final JournalSegmentCache cache;
   private final JournalIndex index;
   private final Serializer serializer;
@@ -42,8 +43,14 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
   private Indexed<E> currentEntry;
   private Indexed<E> nextEntry;
 
-  public JournalSegmentReader(JournalSegmentDescriptor descriptor, JournalSegmentCache cache, JournalIndex index, Serializer serializer) {
+  public JournalSegmentReader(
+      JournalSegmentDescriptor descriptor,
+      int maxEntrySize,
+      JournalSegmentCache cache,
+      JournalIndex index,
+      Serializer serializer) {
     this.buffer = descriptor.buffer().slice().duplicate();
+    this.maxEntrySize = maxEntrySize;
     this.cache = cache;
     this.index = index;
     this.serializer = serializer;
@@ -139,7 +146,7 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
       final int length = buffer.readInt();
 
       // If the buffer length is zero then return.
-      if (length <= 0) {
+      if (length <= 0 || length > maxEntrySize) {
         buffer.reset();
         nextEntry = null;
         return;


### PR DESCRIPTION
#780 

Imposes a maximum Raft log entry size. This is used to avoid allocating too much memory when computing checksums for Raft log entries. This PR also refactors the Raft partition group configuration to create `storage` and `compaction` sub-configurations.