### PR TITLE
Add tests and bug fixes for multimap events

### DIFF
--- a/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
@@ -190,6 +190,7 @@ public class AtomicMultimapProxy
   @Override
   public CompletableFuture<Void> addListener(AtomicMultimapEventListener<String, byte[]> listener, Executor executor) {
     if (mapEventListeners.isEmpty()) {
+      mapEventListeners.put(listener, executor);
       return getProxyClient().acceptAll(service -> service.listen());
     } else {
       mapEventListeners.put(listener, executor);


### PR DESCRIPTION
This PR adds tests and fixes several bugs in multimap events.
* Multimap event listeners are not correctly added to client
* The `put` command outputs a `REMOVE` event
* The `replaceValues` command outputs events in incorrect order
* The `replaceValues` command outputs too many events