### PR TITLE
Classgraph fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <jaxrs.version>2.0</jaxrs.version>
     <jackson.version>2.9.6</jackson.version>
     <config.version>1.3.2</config.version>
-    <classgraph.version>4.0.3</classgraph.version>
+    <classgraph.version>4.0.6</classgraph.version>
     <resteasy.version>3.1.4.Final</resteasy.version>
     <rest-assured.version>3.0.7</rest-assured.version>
     <argparse4j.version>0.7.0</argparse4j.version>

--- a/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
+++ b/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
@@ -101,10 +101,11 @@ public class VertxRestService implements ManagedRestService {
         new ClassGraph().enableAnnotationInfo().whitelistPackages(whitelistPackages).addClassLoader(classLoader) :
         new ClassGraph().enableAnnotationInfo().addClassLoader(classLoader);
 
-    final ScanResult scanResult = classGraph.scan();
-    scanResult.getClassesWithAnnotation(AtomixResource.class.getName()).forEach(classInfo -> {
-      deployment.getRegistry().addPerInstanceResource(classInfo.loadClass(), "/v1");
-    });
+    try (final ScanResult scanResult = classGraph.scan()) {
+      scanResult.getClassesWithAnnotation(AtomixResource.class.getName()).forEach(classInfo -> {
+        deployment.getRegistry().addPerInstanceResource(classInfo.loadClass(), "/v1");
+      });
+    }
 
     deployment.getDispatcher().getProviderFactory().register(new JacksonProvider(createObjectMapper()));
 


### PR DESCRIPTION
Update of ClassGraph and closing the ScanResult will result in a lower memory footprint.