### PR TITLE
Support deleting primitive services managed via the Raft consensus protocol

### DIFF
--- a/core/src/main/java/io/atomix/core/barrier/impl/BlockingDistributedCyclicBarrier.java
+++ b/core/src/main/java/io/atomix/core/barrier/impl/BlockingDistributedCyclicBarrier.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.barrier.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.barrier.AsyncDistributedCyclicBarrier;
 import io.atomix.core.barrier.DistributedCyclicBarrier;
 import io.atomix.primitive.PrimitiveException;
@@ -84,7 +85,12 @@ public class BlockingDistributedCyclicBarrier extends Synchronous<AsyncDistribut
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/collection/impl/AsyncDistributedJavaCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/AsyncDistributedJavaCollection.java
@@ -130,6 +130,12 @@ public class AsyncDistributedJavaCollection<E> implements AsyncDistributedCollec
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    collection.clear();
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
   public DistributedCollection<E> sync(Duration operationTimeout) {
     return new BlockingDistributedCollection<>(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/collection/impl/BlockingDistributedCollection.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/BlockingDistributedCollection.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.collection.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.collection.AsyncDistributedCollection;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.core.collection.DistributedCollection;
@@ -31,8 +32,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Implementation of {@link DistributedCollection} that merely delegates to a {@link AsyncDistributedCollection}
- * and waits for the operation to complete.
+ * Implementation of {@link DistributedCollection} that merely delegates to a {@link AsyncDistributedCollection} and
+ * waits for the operation to complete.
  *
  * @param <E> collection element type
  */
@@ -144,12 +145,13 @@ public class BlockingDistributedCollection<E> extends Synchronous<AsyncDistribut
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      if (e.getCause() instanceof PrimitiveException) {
-        throw (PrimitiveException) e.getCause();
-      } else if (e.getCause() instanceof NoSuchElementException) {
-        throw (NoSuchElementException) e.getCause();
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else if (cause instanceof NoSuchElementException) {
+        throw (NoSuchElementException) cause;
       } else {
-        throw new PrimitiveException(e.getCause());
+        throw new PrimitiveException(cause);
       }
     }
   }

--- a/core/src/main/java/io/atomix/core/counter/impl/BlockingAtomicCounter.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/BlockingAtomicCounter.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.counter.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.counter.AsyncAtomicCounter;
 import io.atomix.core.counter.AtomicCounter;
 import io.atomix.primitive.PrimitiveException;
@@ -98,7 +99,12 @@ public class BlockingAtomicCounter extends Synchronous<AsyncAtomicCounter> imple
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/counter/impl/GossipDistributedCounter.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/GossipDistributedCounter.java
@@ -100,4 +100,9 @@ public class GossipDistributedCounter implements AsyncDistributedCounter {
     counter.close();
     return CompletableFuture.completedFuture(null);
   }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    return CompletableFuture.completedFuture(null);
+  }
 }

--- a/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElection.java
+++ b/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElection.java
@@ -15,9 +15,10 @@
  */
 package io.atomix.core.election.impl;
 
-import io.atomix.core.election.Leadership;
+import com.google.common.base.Throwables;
 import io.atomix.core.election.AsyncLeaderElection;
 import io.atomix.core.election.LeaderElection;
+import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEventListener;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveState;
@@ -107,7 +108,12 @@ public class BlockingLeaderElection<T> extends Synchronous<AsyncLeaderElection<T
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.election.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.election.AsyncLeaderElector;
 import io.atomix.core.election.Leadership;
 import io.atomix.core.election.LeadershipEventListener;
@@ -124,7 +125,12 @@ public class BlockingLeaderElector<T> extends Synchronous<AsyncLeaderElector<T>>
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
+++ b/core/src/main/java/io/atomix/core/impl/CorePrimitiveRegistry.java
@@ -77,6 +77,11 @@ public class CorePrimitiveRegistry implements ManagedPrimitiveRegistry {
   }
 
   @Override
+  public CompletableFuture<Void> deletePrimitive(String name) {
+    return primitives.remove(name).thenApply(v -> null);
+  }
+
+  @Override
   public Collection<PrimitiveInfo> getPrimitives() {
     return primitives.sync().entrySet().stream()
         .map(entry -> new PrimitiveInfo(entry.getKey(), primitiveTypeRegistry.getPrimitiveType(entry.getValue().value())))

--- a/core/src/main/java/io/atomix/core/lock/impl/BlockingAtomicLock.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/BlockingAtomicLock.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.lock.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.lock.AsyncAtomicLock;
 import io.atomix.core.lock.AtomicLock;
 import io.atomix.primitive.PrimitiveException;
@@ -86,7 +87,12 @@ public class BlockingAtomicLock extends Synchronous<AsyncAtomicLock> implements 
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/lock/impl/BlockingDistributedLock.java
+++ b/core/src/main/java/io/atomix/core/lock/impl/BlockingDistributedLock.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.lock.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.lock.AsyncDistributedLock;
 import io.atomix.core.lock.DistributedLock;
 import io.atomix.primitive.PrimitiveException;
@@ -90,7 +91,12 @@ public class BlockingDistributedLock extends Synchronous<AsyncDistributedLock> i
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapProxy.java
@@ -449,7 +449,12 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return AbstractAtomicMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AbstractAtomicMapProxy.this.delete();
     }
 
     @Override
@@ -585,7 +590,12 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return AbstractAtomicMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AbstractAtomicMapProxy.this.delete();
     }
 
     @Override
@@ -692,7 +702,12 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return AbstractAtomicMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AbstractAtomicMapProxy.this.delete();
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/map/impl/AsyncDistributedJavaMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AsyncDistributedJavaMap.java
@@ -180,6 +180,12 @@ public class AsyncDistributedJavaMap<K, V> implements AsyncDistributedMap<K, V> 
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    map.clear();
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
   public DistributedMap<K, V> sync(Duration operationTimeout) {
     return new BlockingDistributedMap<>(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
@@ -257,6 +257,11 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
     public CompletableFuture<Void> close() {
       return AtomicNavigableMapProxy.this.close();
     }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicNavigableMapProxy.this.delete();
+    }
   }
 
   private class KeySet extends SubSet implements AsyncDistributedNavigableSet<K> {
@@ -510,6 +515,11 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
     @Override
     public CompletableFuture<Void> close() {
       return AtomicNavigableMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicNavigableMapProxy.this.delete();
     }
 
     @Override
@@ -929,6 +939,11 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
     @Override
     public CompletableFuture<Void> close() {
       return AtomicNavigableMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicNavigableMapProxy.this.delete();
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/map/impl/BlockingAtomicCounterMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/BlockingAtomicCounterMap.java
@@ -131,8 +131,12 @@ public class BlockingAtomicCounterMap<K> extends Synchronous<AsyncAtomicCounterM
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause());
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/map/impl/BlockingAtomicMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/BlockingAtomicMap.java
@@ -222,8 +222,12 @@ public class BlockingAtomicMap<K, V> extends Synchronous<AsyncAtomicMap<K, V>> i
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause());
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/map/impl/BlockingDistributedMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/BlockingDistributedMap.java
@@ -194,8 +194,12 @@ public class BlockingDistributedMap<K, V> extends Synchronous<AsyncDistributedMa
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause());
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DelegatingAsyncDistributedMap.java
@@ -297,6 +297,11 @@ public class DelegatingAsyncDistributedMap<K, V> extends DelegatingAsyncPrimitiv
     }
 
     @Override
+    public CompletableFuture<Void> delete() {
+      return values.delete();
+    }
+
+    @Override
     public DistributedCollection<V> sync(Duration operationTimeout) {
       return new BlockingDistributedCollection<>(this, operationTimeout.toMillis());
     }
@@ -429,6 +434,11 @@ public class DelegatingAsyncDistributedMap<K, V> extends DelegatingAsyncPrimitiv
     @Override
     public CompletableFuture<Void> close() {
       return entries.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return entries.delete();
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/map/impl/PartitionedAtomicMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/PartitionedAtomicMapProxy.java
@@ -19,12 +19,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.atomix.core.collection.AsyncDistributedCollection;
-import io.atomix.core.iterator.AsyncIterator;
 import io.atomix.core.collection.CollectionEvent;
 import io.atomix.core.collection.CollectionEventListener;
 import io.atomix.core.collection.DistributedCollection;
 import io.atomix.core.collection.DistributedCollectionType;
 import io.atomix.core.collection.impl.BlockingDistributedCollection;
+import io.atomix.core.iterator.AsyncIterator;
 import io.atomix.core.iterator.impl.PartitionedProxyIterator;
 import io.atomix.core.map.AsyncAtomicMap;
 import io.atomix.core.map.AtomicMapEvent;
@@ -486,7 +486,12 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return PartitionedAtomicMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return PartitionedAtomicMapProxy.this.delete();
     }
 
     @Override
@@ -627,7 +632,12 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return PartitionedAtomicMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return PartitionedAtomicMapProxy.this.delete();
     }
 
     @Override
@@ -733,7 +743,12 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return PartitionedAtomicMapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return PartitionedAtomicMapProxy.this.delete();
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
@@ -373,7 +373,12 @@ public class AtomicMultimapProxy
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return AtomicMultimapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicMultimapProxy.this.delete();
     }
   }
 
@@ -495,7 +500,12 @@ public class AtomicMultimapProxy
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return AtomicMultimapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicMultimapProxy.this.delete();
     }
 
     @Override
@@ -668,7 +678,12 @@ public class AtomicMultimapProxy
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return AtomicMultimapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicMultimapProxy.this.delete();
     }
 
     @Override
@@ -822,7 +837,12 @@ public class AtomicMultimapProxy
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return AtomicMultimapProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicMultimapProxy.this.delete();
     }
 
     @Override
@@ -936,6 +956,11 @@ public class AtomicMultimapProxy
       }
 
       @Override
+      public CompletableFuture<Void> delete() {
+        return AtomicMultimapProxy.this.delete();
+      }
+
+      @Override
       public DistributedSet<byte[]> sync(Duration operationTimeout) {
         return new BlockingDistributedSet<>(this, operationTimeout.toMillis());
       }
@@ -1044,6 +1069,11 @@ public class AtomicMultimapProxy
       @Override
       public CompletableFuture<Void> close() {
         return AtomicMultimapProxy.this.close();
+      }
+
+      @Override
+      public CompletableFuture<Void> delete() {
+        return AtomicMultimapProxy.this.delete();
       }
 
       @Override
@@ -1164,6 +1194,11 @@ public class AtomicMultimapProxy
     @Override
     public CompletableFuture<Void> close() {
       return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return AtomicMultimapProxy.this.delete();
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/BlockingAtomicMultimap.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/BlockingAtomicMultimap.java
@@ -174,8 +174,12 @@ public class BlockingAtomicMultimap<K, V>
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause());
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/multimap/impl/BlockingDistributedMultimap.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/BlockingDistributedMultimap.java
@@ -43,8 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Implementation of {@link DistributedMultimap} providing synchronous access to
- * {@link AsyncDistributedMultimap}.
+ * Implementation of {@link DistributedMultimap} providing synchronous access to {@link AsyncDistributedMultimap}.
  */
 public class BlockingDistributedMultimap<K, V>
     extends Synchronous<AsyncDistributedMultimap<K, V>>
@@ -175,8 +174,12 @@ public class BlockingDistributedMultimap<K, V>
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause());
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/multiset/impl/DistributedMultisetProxy.java
+++ b/core/src/main/java/io/atomix/core/multiset/impl/DistributedMultisetProxy.java
@@ -199,7 +199,12 @@ public class DistributedMultisetProxy
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return DistributedMultisetProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return DistributedMultisetProxy.this.delete();
     }
 
     @Override
@@ -315,7 +320,12 @@ public class DistributedMultisetProxy
 
     @Override
     public CompletableFuture<Void> close() {
-      return CompletableFuture.completedFuture(null);
+      return DistributedMultisetProxy.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return DistributedMultisetProxy.this.delete();
     }
 
     @Override

--- a/core/src/main/java/io/atomix/core/semaphore/impl/BlockingAtomicSemaphore.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/BlockingAtomicSemaphore.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.semaphore.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.semaphore.AsyncAtomicSemaphore;
 import io.atomix.core.semaphore.AtomicSemaphore;
 import io.atomix.core.semaphore.QueueStatus;
@@ -140,7 +141,12 @@ public class BlockingAtomicSemaphore extends Synchronous<AsyncAtomicSemaphore> i
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
       needRelease.set(acquirePermits > 0);
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/semaphore/impl/BlockingDistributedSemaphore.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/BlockingDistributedSemaphore.java
@@ -139,6 +139,11 @@ public class BlockingDistributedSemaphore extends DistributedSemaphore {
     complete(asyncSemaphore.close());
   }
 
+  @Override
+  public void delete() {
+    complete(asyncSemaphore.delete());
+  }
+
   private <T> T complete(CompletableFuture<T> future) {
     return complete(future, 0);
   }
@@ -168,7 +173,12 @@ public class BlockingDistributedSemaphore extends DistributedSemaphore {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
       needRelease.set(acquirePermits > 0);
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 

--- a/core/src/main/java/io/atomix/core/semaphore/impl/BlockingDistributedSemaphore.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/BlockingDistributedSemaphore.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.semaphore.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.semaphore.AsyncDistributedSemaphore;
 import io.atomix.core.semaphore.DistributedSemaphore;
 import io.atomix.primitive.PrimitiveException;
@@ -195,7 +196,12 @@ public class BlockingDistributedSemaphore extends DistributedSemaphore {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
       needRelease.set(acquirePermits > 0);
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/set/impl/DistributedNavigableSetProxy.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DistributedNavigableSetProxy.java
@@ -429,6 +429,11 @@ public class DistributedNavigableSetProxy<E extends Comparable<E>>
     }
 
     @Override
+    public CompletableFuture<Void> delete() {
+      return DistributedNavigableSetProxy.this.delete();
+    }
+
+    @Override
     public DistributedNavigableSet<E> sync(Duration operationTimeout) {
       return new BlockingDistributedNavigableSet<>(this, operationTimeout.toMillis());
     }

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
@@ -189,6 +189,11 @@ public class DefaultTransaction implements AsyncTransaction {
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    return abort();
+  }
+
+  @Override
   public Transaction sync(Duration operationTimeout) {
     return new BlockingTransaction(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/transaction/impl/TransactionalMapParticipant.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/TransactionalMapParticipant.java
@@ -72,6 +72,11 @@ public abstract class TransactionalMapParticipant<K, V> implements AsyncTransact
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    return consistentMap.delete();
+  }
+
+  @Override
   public TransactionalMap<K, V> sync(Duration operationTimeout) {
     return new BlockingTransactionalMap<>(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/transaction/impl/TransactionalSetParticipant.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/TransactionalSetParticipant.java
@@ -72,6 +72,11 @@ public abstract class TransactionalSetParticipant<E> implements AsyncTransaction
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    return set.delete();
+  }
+
+  @Override
   public TransactionalSet<E> sync(Duration operationTimeout) {
     return new BlockingTransactionalSet<>(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
@@ -16,7 +16,6 @@
 
 package io.atomix.core.tree.impl;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import io.atomix.core.tree.AsyncAtomicDocumentTree;
 import io.atomix.core.tree.AtomicDocumentTree;
@@ -202,11 +201,6 @@ public class AtomicDocumentTreeProxy
             getProxyClient().acceptBy(name(), service -> service.listen(root()));
           }
         })).thenApply(v -> this);
-  }
-
-  @Override
-  public CompletableFuture<Void> delete() {
-    return getProxyClient().acceptBy(name(), service -> service.clear());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
@@ -120,8 +120,12 @@ public class BlockingAtomicDocumentTree<V> extends Synchronous<AsyncAtomicDocume
     } catch (TimeoutException e) {
       throw new DocumentException.Timeout(name());
     } catch (ExecutionException e) {
-      Throwables.propagateIfPossible(e.getCause());
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/value/impl/BlockingAtomicValue.java
+++ b/core/src/main/java/io/atomix/core/value/impl/BlockingAtomicValue.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.value.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.value.AsyncAtomicValue;
 import io.atomix.core.value.AtomicValue;
 import io.atomix.core.value.AtomicValueEventListener;
@@ -86,7 +87,12 @@ public class BlockingAtomicValue<V> extends Synchronous<AsyncAtomicValue<V>> imp
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/value/impl/GossipDistributedValue.java
+++ b/core/src/main/java/io/atomix/core/value/impl/GossipDistributedValue.java
@@ -118,6 +118,17 @@ public class GossipDistributedValue<V> implements AsyncDistributedValue<V> {
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    try {
+      value.set(null);
+      value.close();
+      return CompletableFuture.completedFuture(null);
+    } catch (Exception e) {
+      return Futures.exceptionalFuture(e);
+    }
+  }
+
+  @Override
   public DistributedValue<V> sync(Duration operationTimeout) {
     return new BlockingDistributedValue<>(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/workqueue/impl/BlockingWorkQueue.java
+++ b/core/src/main/java/io/atomix/core/workqueue/impl/BlockingWorkQueue.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.core.workqueue.impl;
 
+import com.google.common.base.Throwables;
 import io.atomix.core.workqueue.AsyncWorkQueue;
 import io.atomix.core.workqueue.Task;
 import io.atomix.core.workqueue.WorkQueue;
@@ -88,7 +89,12 @@ public class BlockingWorkQueue<E> extends Synchronous<AsyncWorkQueue<E>> impleme
     } catch (TimeoutException e) {
       throw new PrimitiveException.Timeout();
     } catch (ExecutionException e) {
-      throw new PrimitiveException(e.getCause());
+      Throwable cause = Throwables.getRootCause(e);
+      if (cause instanceof PrimitiveException) {
+        throw (PrimitiveException) cause;
+      } else {
+        throw new PrimitiveException(cause);
+      }
     }
   }
 }

--- a/core/src/main/java/io/atomix/core/workqueue/impl/WorkQueueProxy.java
+++ b/core/src/main/java/io/atomix/core/workqueue/impl/WorkQueueProxy.java
@@ -71,7 +71,7 @@ public class WorkQueueProxy
   public CompletableFuture<Void> delete() {
     executor.shutdown();
     timer.cancel();
-    return getProxyClient().acceptBy(name(), service -> service.clear());
+    return super.delete();
   }
 
   @Override

--- a/core/src/test/java/io/atomix/core/barrier/RaftDistributedCyclicBarrierTest.java
+++ b/core/src/test/java/io/atomix/core/barrier/RaftDistributedCyclicBarrierTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -48,9 +49,10 @@ public class RaftDistributedCyclicBarrierTest extends DistributedCyclicBarrierTe
     barrier = atomix().cyclicBarrierBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(barrier.type()).isEmpty());
+
+    int count = client.getPrimitives(barrier.type()).size();
     barrier.delete();
-    assertTrue(client.getPrimitives(barrier.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(barrier.type()).size());
 
     try {
       barrier.getParties();
@@ -61,6 +63,6 @@ public class RaftDistributedCyclicBarrierTest extends DistributedCyclicBarrierTe
     barrier = atomix().cyclicBarrierBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(barrier.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(barrier.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/barrier/RaftDistributedCyclicBarrierTest.java
+++ b/core/src/test/java/io/atomix/core/barrier/RaftDistributedCyclicBarrierTest.java
@@ -15,10 +15,17 @@
  */
 package io.atomix.core.barrier;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
 
 import java.time.Duration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft distributed cyclic barrier test.
@@ -31,5 +38,29 @@ public class RaftDistributedCyclicBarrierTest extends DistributedCyclicBarrierTe
         .withMaxTimeout(Duration.ofSeconds(1))
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    DistributedCyclicBarrier barrier;
+    barrier = atomix().cyclicBarrierBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(barrier.type()).isEmpty());
+    barrier.delete();
+    assertTrue(client.getPrimitives(barrier.type()).isEmpty());
+
+    try {
+      barrier.getParties();
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    barrier = atomix().cyclicBarrierBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(barrier.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/counter/RaftAtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/RaftAtomicCounterTest.java
@@ -15,8 +15,18 @@
  */
 package io.atomix.core.counter;
 
+import io.atomix.core.Atomix;
+import io.atomix.core.value.AtomicValue;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft atomic counter test.
@@ -27,5 +37,35 @@ public class RaftAtomicCounterTest extends AtomicCounterTest {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    AtomicCounter counter;
+    counter = atomix().atomicCounterBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(counter.type()).isEmpty());
+
+    counter.set(1);
+    assertEquals(1, counter.get());
+    counter.delete();
+    assertTrue(client.getPrimitives(counter.type()).isEmpty());
+
+    try {
+      counter.get();
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    counter = atomix().atomicCounterBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(counter.type()).isEmpty());
+    assertEquals(0, counter.get());
+    counter.set(1);
+    assertEquals(1, counter.get());
   }
 }

--- a/core/src/test/java/io/atomix/core/counter/RaftAtomicCounterTest.java
+++ b/core/src/test/java/io/atomix/core/counter/RaftAtomicCounterTest.java
@@ -47,12 +47,13 @@ public class RaftAtomicCounterTest extends AtomicCounterTest {
     counter = atomix().atomicCounterBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(counter.type()).isEmpty());
 
     counter.set(1);
     assertEquals(1, counter.get());
+
+    int count = client.getPrimitives(counter.type()).size();
     counter.delete();
-    assertTrue(client.getPrimitives(counter.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(counter.type()).size());
 
     try {
       counter.get();
@@ -67,5 +68,6 @@ public class RaftAtomicCounterTest extends AtomicCounterTest {
     assertEquals(0, counter.get());
     counter.set(1);
     assertEquals(1, counter.get());
+    assertEquals(count, client.getPrimitives(counter.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftLeaderElectionTest extends LeaderElectionTest {
     election = atomix().<String>leaderElectionBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(election.type()).isEmpty());
+
+    int count = client.getPrimitives(election.type()).size();
     election.delete();
-    assertTrue(client.getPrimitives(election.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(election.type()).size());
 
     try {
       election.getLeadership();
@@ -57,6 +57,6 @@ public class RaftLeaderElectionTest extends LeaderElectionTest {
     election = atomix().<String>leaderElectionBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(election.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(election.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
+++ b/core/src/test/java/io/atomix/core/election/RaftLeaderElectionTest.java
@@ -15,8 +15,15 @@
  */
 package io.atomix.core.election;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft leader election test.
@@ -27,5 +34,29 @@ public class RaftLeaderElectionTest extends LeaderElectionTest {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    LeaderElection<String> election;
+    election = atomix().<String>leaderElectionBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(election.type()).isEmpty());
+    election.delete();
+    assertTrue(client.getPrimitives(election.type()).isEmpty());
+
+    try {
+      election.getLeadership();
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    election = atomix().<String>leaderElectionBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(election.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/election/RaftLeaderElectorTest.java
+++ b/core/src/test/java/io/atomix/core/election/RaftLeaderElectorTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftLeaderElectorTest extends LeaderElectorTest {
     elector = atomix().<String>leaderElectorBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(elector.type()).isEmpty());
+
+    int count = client.getPrimitives(elector.type()).size();
     elector.delete();
-    assertTrue(client.getPrimitives(elector.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(elector.type()).size());
 
     try {
       elector.getLeadership("foo");
@@ -57,6 +57,6 @@ public class RaftLeaderElectorTest extends LeaderElectorTest {
     elector = atomix().<String>leaderElectorBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(elector.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(elector.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/list/RaftDistributedListTest.java
+++ b/core/src/test/java/io/atomix/core/list/RaftDistributedListTest.java
@@ -22,8 +22,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -46,9 +45,10 @@ public class RaftDistributedListTest extends DistributedListTest {
     list = atomix().<String>listBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(list.type()).isEmpty());
+
+    int count = client.getPrimitives(list.type()).size();
     list.delete();
-    assertTrue(client.getPrimitives(list.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(list.type()).size());
 
     try {
       list.get(0);
@@ -59,6 +59,6 @@ public class RaftDistributedListTest extends DistributedListTest {
     list = atomix().<String>listBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(list.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(list.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/lock/RaftAtomicLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/RaftAtomicLockTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftAtomicLockTest extends AtomicLockTest {
     lock = atomix().atomicLockBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(lock.type()).isEmpty());
+
+    int count = client.getPrimitives(lock.type()).size();
     lock.delete();
-    assertTrue(client.getPrimitives(lock.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(lock.type()).size());
 
     try {
       lock.isLocked();
@@ -57,6 +57,6 @@ public class RaftAtomicLockTest extends AtomicLockTest {
     lock = atomix().atomicLockBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(lock.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(lock.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/lock/RaftDistributedLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/RaftDistributedLockTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftDistributedLockTest extends DistributedLockTest {
     lock = atomix().lockBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(lock.type()).isEmpty());
+
+    int count = client.getPrimitives(lock.type()).size();
     lock.delete();
-    assertTrue(client.getPrimitives(lock.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(lock.type()).size());
 
     try {
       lock.isLocked();
@@ -57,6 +57,6 @@ public class RaftDistributedLockTest extends DistributedLockTest {
     lock = atomix().lockBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(lock.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(lock.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/lock/RaftDistributedLockTest.java
+++ b/core/src/test/java/io/atomix/core/lock/RaftDistributedLockTest.java
@@ -15,8 +15,15 @@
  */
 package io.atomix.core.lock;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft distributed lock test.
@@ -27,5 +34,29 @@ public class RaftDistributedLockTest extends DistributedLockTest {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    DistributedLock lock;
+    lock = atomix().lockBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(lock.type()).isEmpty());
+    lock.delete();
+    assertTrue(client.getPrimitives(lock.type()).isEmpty());
+
+    try {
+      lock.isLocked();
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    lock = atomix().lockBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(lock.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicCounterMapTest.java
@@ -15,8 +15,15 @@
  */
 package io.atomix.core.map;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft atomic counter map test.
@@ -27,5 +34,29 @@ public class RaftAtomicCounterMapTest extends AtomicCounterMapTest {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    AtomicCounterMap<String> counterMap;
+    counterMap = atomix().<String>atomicCounterMapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(counterMap.type()).isEmpty());
+    counterMap.delete();
+    assertTrue(client.getPrimitives(counterMap.type()).isEmpty());
+
+    try {
+      counterMap.get("foo");
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    counterMap = atomix().<String>atomicCounterMapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(counterMap.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicCounterMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicCounterMapTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftAtomicCounterMapTest extends AtomicCounterMapTest {
     counterMap = atomix().<String>atomicCounterMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(counterMap.type()).isEmpty());
+
+    int count = client.getPrimitives(counterMap.type()).size();
     counterMap.delete();
-    assertTrue(client.getPrimitives(counterMap.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(counterMap.type()).size());
 
     try {
       counterMap.get("foo");
@@ -57,6 +57,6 @@ public class RaftAtomicCounterMapTest extends AtomicCounterMapTest {
     counterMap = atomix().<String>atomicCounterMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(counterMap.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(counterMap.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicMapTest.java
@@ -25,8 +25,6 @@ import org.junit.Test;
 import java.time.Duration;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -50,9 +48,10 @@ public class RaftAtomicMapTest extends AtomicMapTest {
     map = atomix().<String, String>atomicMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertEquals(2, client.getPrimitives(map.type()).size());
+
+    int count = client.getPrimitives(map.type()).size();
     map.delete();
-    assertEquals(1, client.getPrimitives(map.type()).size());
+    assertEquals(count - 1, client.getPrimitives(map.type()).size());
 
     try {
       map.get("foo");
@@ -63,6 +62,6 @@ public class RaftAtomicMapTest extends AtomicMapTest {
     map = atomix().<String, String>atomicMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertEquals(2, client.getPrimitives(map.type()).size());
+    assertEquals(count, client.getPrimitives(map.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicNavigableMapTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftAtomicNavigableMapTest extends AtomicNavigableMapTest {
     map = atomix().<String, String>atomicNavigableMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(map.type()).isEmpty());
+
+    int count = client.getPrimitives(map.type()).size();
     map.delete();
-    assertTrue(client.getPrimitives(map.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(map.type()).size());
 
     try {
       map.get("foo");
@@ -57,6 +57,6 @@ public class RaftAtomicNavigableMapTest extends AtomicNavigableMapTest {
     map = atomix().<String, String>atomicNavigableMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(map.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(map.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftAtomicNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftAtomicNavigableMapTest.java
@@ -15,8 +15,15 @@
  */
 package io.atomix.core.map;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft consistent tree map test.
@@ -27,5 +34,29 @@ public class RaftAtomicNavigableMapTest extends AtomicNavigableMapTest {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    AtomicNavigableMap<String, String> map;
+    map = atomix().<String, String>atomicNavigableMapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(map.type()).isEmpty());
+    map.delete();
+    assertTrue(client.getPrimitives(map.type()).isEmpty());
+
+    try {
+      map.get("foo");
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    map = atomix().<String, String>atomicNavigableMapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(map.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftDistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftDistributedMapTest.java
@@ -24,8 +24,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -49,9 +48,10 @@ public class RaftDistributedMapTest extends DistributedMapTest {
     map = atomix().<String, String>mapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(map.type()).isEmpty());
+
+    int count = client.getPrimitives(map.type()).size();
     map.delete();
-    assertTrue(client.getPrimitives(map.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(map.type()).size());
 
     try {
       map.get("foo");
@@ -62,6 +62,6 @@ public class RaftDistributedMapTest extends DistributedMapTest {
     map = atomix().<String, String>mapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(map.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(map.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftDistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftDistributedMapTest.java
@@ -15,11 +15,18 @@
  */
 package io.atomix.core.map;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
+import org.junit.Test;
 
 import java.time.Duration;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft distributed map test.
@@ -32,5 +39,29 @@ public class RaftDistributedMapTest extends DistributedMapTest {
         .withMaxRetries(5)
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    DistributedMap<String, String> map;
+    map = atomix().<String, String>mapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(map.type()).isEmpty());
+    map.delete();
+    assertTrue(client.getPrimitives(map.type()).isEmpty());
+
+    try {
+      map.get("foo");
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    map = atomix().<String, String>mapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(map.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftDistributedNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftDistributedNavigableMapTest.java
@@ -15,8 +15,15 @@
  */
 package io.atomix.core.map;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft distributed tree map test.
@@ -27,5 +34,29 @@ public class RaftDistributedNavigableMapTest extends DistributedNavigableMapTest
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    DistributedNavigableMap<String, String> map;
+    map = atomix().<String, String>navigableMapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(map.type()).isEmpty());
+    map.delete();
+    assertTrue(client.getPrimitives(map.type()).isEmpty());
+
+    try {
+      map.get("foo");
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    map = atomix().<String, String>navigableMapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(map.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/map/RaftDistributedNavigableMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/RaftDistributedNavigableMapTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftDistributedNavigableMapTest extends DistributedNavigableMapTest
     map = atomix().<String, String>navigableMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(map.type()).isEmpty());
+
+    int count = client.getPrimitives(map.type()).size();
     map.delete();
-    assertTrue(client.getPrimitives(map.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(map.type()).size());
 
     try {
       map.get("foo");
@@ -57,6 +57,6 @@ public class RaftDistributedNavigableMapTest extends DistributedNavigableMapTest
     map = atomix().<String, String>navigableMapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(map.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(map.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/multimap/RaftAtomicMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/RaftAtomicMultimapTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftAtomicMultimapTest extends AtomicMultimapTest {
     multimap = atomix().<String, String>atomicMultimapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(multimap.type()).isEmpty());
+
+    int count = client.getPrimitives(multimap.type()).size();
     multimap.delete();
-    assertTrue(client.getPrimitives(multimap.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(multimap.type()).size());
 
     try {
       multimap.get("foo");
@@ -57,6 +57,6 @@ public class RaftAtomicMultimapTest extends AtomicMultimapTest {
     multimap = atomix().<String, String>atomicMultimapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(multimap.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(multimap.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/multimap/RaftAtomicMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/RaftAtomicMultimapTest.java
@@ -15,8 +15,15 @@
  */
 package io.atomix.core.multimap;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft multimap test.
@@ -27,5 +34,29 @@ public class RaftAtomicMultimapTest extends AtomicMultimapTest {
     return MultiRaftProtocol.builder()
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    AtomicMultimap<String, String> multimap;
+    multimap = atomix().<String, String>atomicMultimapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(multimap.type()).isEmpty());
+    multimap.delete();
+    assertTrue(client.getPrimitives(multimap.type()).isEmpty());
+
+    try {
+      multimap.get("foo");
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    multimap = atomix().<String, String>atomicMultimapBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(multimap.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/multimap/RaftDistributedMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/RaftDistributedMultimapTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftDistributedMultimapTest extends DistributedMultimapTest {
     multimap = atomix().<String, String>multimapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(multimap.type()).isEmpty());
+
+    int count = client.getPrimitives(multimap.type()).size();
     multimap.delete();
-    assertTrue(client.getPrimitives(multimap.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(multimap.type()).size());
 
     try {
       multimap.get("foo");
@@ -57,6 +57,6 @@ public class RaftDistributedMultimapTest extends DistributedMultimapTest {
     multimap = atomix().<String, String>multimapBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(multimap.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(multimap.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/multiset/RaftDistributedMultisetTest.java
+++ b/core/src/test/java/io/atomix/core/multiset/RaftDistributedMultisetTest.java
@@ -22,8 +22,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -46,9 +45,10 @@ public class RaftDistributedMultisetTest extends DistributedMultisetTest {
     multiset = atomix().<String>multisetBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(multiset.type()).isEmpty());
+
+    int count = client.getPrimitives(multiset.type()).size();
     multiset.delete();
-    assertTrue(client.getPrimitives(multiset.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(multiset.type()).size());
 
     try {
       multiset.contains("foo");
@@ -59,6 +59,6 @@ public class RaftDistributedMultisetTest extends DistributedMultisetTest {
     multiset = atomix().<String>multisetBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(multiset.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(multiset.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/queue/RaftDistributedQueueTest.java
+++ b/core/src/test/java/io/atomix/core/queue/RaftDistributedQueueTest.java
@@ -22,8 +22,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -46,9 +45,10 @@ public class RaftDistributedQueueTest extends DistributedQueueTest {
     queue = atomix().<String>queueBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(queue.type()).isEmpty());
+
+    int count = client.getPrimitives(queue.type()).size();
     queue.delete();
-    assertTrue(client.getPrimitives(queue.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(queue.type()).size());
 
     try {
       queue.poll();
@@ -59,6 +59,6 @@ public class RaftDistributedQueueTest extends DistributedQueueTest {
     queue = atomix().<String>queueBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(queue.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(queue.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/semaphore/RaftAtomicSemaphoreTest.java
+++ b/core/src/test/java/io/atomix/core/semaphore/RaftAtomicSemaphoreTest.java
@@ -90,9 +90,10 @@ public class RaftAtomicSemaphoreTest extends AtomicSemaphoreTest {
     semaphore = atomix().atomicSemaphoreBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(semaphore.type()).isEmpty());
+
+    int count = client.getPrimitives(semaphore.type()).size();
     semaphore.delete();
-    assertTrue(client.getPrimitives(semaphore.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(semaphore.type()).size());
 
     try {
       semaphore.availablePermits();
@@ -103,6 +104,6 @@ public class RaftAtomicSemaphoreTest extends AtomicSemaphoreTest {
     semaphore = atomix().atomicSemaphoreBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(semaphore.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(semaphore.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/semaphore/RaftDistributedSemaphoreTest.java
+++ b/core/src/test/java/io/atomix/core/semaphore/RaftDistributedSemaphoreTest.java
@@ -22,8 +22,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class RaftDistributedSemaphoreTest extends DistributedSemaphoreTest {
@@ -43,9 +42,10 @@ public class RaftDistributedSemaphoreTest extends DistributedSemaphoreTest {
     semaphore = atomix().semaphoreBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(semaphore.type()).isEmpty());
+
+    int count = client.getPrimitives(semaphore.type()).size();
     semaphore.delete();
-    assertTrue(client.getPrimitives(semaphore.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(semaphore.type()).size());
 
     try {
       semaphore.availablePermits();
@@ -56,6 +56,6 @@ public class RaftDistributedSemaphoreTest extends DistributedSemaphoreTest {
     semaphore = atomix().semaphoreBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(semaphore.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(semaphore.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/set/RaftDistributedNavigableSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/RaftDistributedNavigableSetTest.java
@@ -22,8 +22,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -46,9 +45,10 @@ public class RaftDistributedNavigableSetTest extends DistributedNavigableSetTest
     set = atomix().<String>navigableSetBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(set.type()).isEmpty());
+
+    int count = client.getPrimitives(set.type()).size();
     set.delete();
-    assertTrue(client.getPrimitives(set.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(set.type()).size());
 
     try {
       set.contains("foo");
@@ -59,6 +59,6 @@ public class RaftDistributedNavigableSetTest extends DistributedNavigableSetTest
     set = atomix().<String>navigableSetBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(set.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(set.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/set/RaftDistributedNavigableSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/RaftDistributedNavigableSetTest.java
@@ -15,9 +15,16 @@
  */
 package io.atomix.core.set;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft distributed tree set test.
@@ -29,5 +36,29 @@ public class RaftDistributedNavigableSetTest extends DistributedNavigableSetTest
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    DistributedNavigableSet<String> set;
+    set = atomix().<String>navigableSetBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(set.type()).isEmpty());
+    set.delete();
+    assertTrue(client.getPrimitives(set.type()).isEmpty());
+
+    try {
+      set.contains("foo");
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    set = atomix().<String>navigableSetBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(set.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/set/RaftDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/RaftDistributedSetTest.java
@@ -15,9 +15,16 @@
  */
 package io.atomix.core.set;
 
+import io.atomix.core.Atomix;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Raft distributed set test.
@@ -29,5 +36,29 @@ public class RaftDistributedSetTest extends DistributedSetTest {
         .withReadConsistency(ReadConsistency.LINEARIZABLE)
         .withMaxRetries(5)
         .build();
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    Atomix client = atomix();
+
+    DistributedSet<String> set;
+    set = atomix().<String>setBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(set.type()).isEmpty());
+    set.delete();
+    assertTrue(client.getPrimitives(set.type()).isEmpty());
+
+    try {
+      set.contains("foo");
+      fail();
+    } catch (PrimitiveException.ClosedSession e) {
+    }
+
+    set = atomix().<String>setBuilder("test-delete")
+        .withProtocol(protocol())
+        .build();
+    assertFalse(client.getPrimitives(set.type()).isEmpty());
   }
 }

--- a/core/src/test/java/io/atomix/core/set/RaftDistributedSetTest.java
+++ b/core/src/test/java/io/atomix/core/set/RaftDistributedSetTest.java
@@ -22,8 +22,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.protocols.raft.ReadConsistency;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -46,9 +45,10 @@ public class RaftDistributedSetTest extends DistributedSetTest {
     set = atomix().<String>setBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(set.type()).isEmpty());
+
+    int count = client.getPrimitives(set.type()).size();
     set.delete();
-    assertTrue(client.getPrimitives(set.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(set.type()).size());
 
     try {
       set.contains("foo");
@@ -59,6 +59,6 @@ public class RaftDistributedSetTest extends DistributedSetTest {
     set = atomix().<String>setBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(set.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(set.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/tree/AtomicDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/AtomicDocumentTreeTest.java
@@ -335,20 +335,6 @@ public abstract class AtomicDocumentTreeTest extends AbstractPrimitiveTest<Proxy
   }
 
   /**
-   * Tests destroy.
-   */
-  @Test
-  public void testClear() throws Exception {
-    AtomicDocumentTree<String> tree = newTree(UUID.randomUUID().toString());
-    tree.create(path("/a"), "a");
-    tree.create(path("/a/b"), "ab");
-    tree.create(path("/a/c"), "ac");
-
-    tree.delete();
-    assertEquals(0, tree.getChildren(path("/")).size());
-  }
-
-  /**
    * Tests listeners.
    */
   @Test(timeout = 45000)

--- a/core/src/test/java/io/atomix/core/tree/RaftAtomicDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/RaftAtomicDocumentTreeTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftAtomicDocumentTreeTest extends AtomicDocumentTreeTest {
     tree = atomix().<String>atomicDocumentTreeBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(tree.type()).isEmpty());
+
+    int count = client.getPrimitives(tree.type()).size();
     tree.delete();
-    assertTrue(client.getPrimitives(tree.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(tree.type()).size());
 
     try {
       tree.get("/foo");
@@ -57,6 +57,6 @@ public class RaftAtomicDocumentTreeTest extends AtomicDocumentTreeTest {
     tree = atomix().<String>atomicDocumentTreeBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(tree.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(tree.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/value/RaftAtomicValueTest.java
+++ b/core/src/test/java/io/atomix/core/value/RaftAtomicValueTest.java
@@ -22,9 +22,7 @@ import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -46,12 +44,13 @@ public class RaftAtomicValueTest extends AtomicValueTest {
     value = atomix().<String>atomicValueBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(value.type()).isEmpty());
 
     value.set("Hello world!");
     assertEquals("Hello world!", value.get());
+
+    int count = client.getPrimitives(value.type()).size();
     value.delete();
-    assertTrue(client.getPrimitives(value.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(value.type()).size());
 
     try {
       value.get();
@@ -62,7 +61,7 @@ public class RaftAtomicValueTest extends AtomicValueTest {
     value = atomix().<String>atomicValueBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(value.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(value.type()).size());
     assertNull(value.get());
     value.set("Hello world again!");
     assertEquals("Hello world again!", value.get());

--- a/core/src/test/java/io/atomix/core/workqueue/RaftWorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/workqueue/RaftWorkQueueTest.java
@@ -21,8 +21,7 @@ import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.raft.MultiRaftProtocol;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -44,9 +43,10 @@ public class RaftWorkQueueTest extends WorkQueueTest {
     workQueue = atomix().<String>workQueueBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(workQueue.type()).isEmpty());
+
+    int count = client.getPrimitives(workQueue.type()).size();
     workQueue.delete();
-    assertTrue(client.getPrimitives(workQueue.type()).isEmpty());
+    assertEquals(count - 1, client.getPrimitives(workQueue.type()).size());
 
     try {
       workQueue.stats();
@@ -57,6 +57,6 @@ public class RaftWorkQueueTest extends WorkQueueTest {
     workQueue = atomix().<String>workQueueBuilder("test-delete")
         .withProtocol(protocol())
         .build();
-    assertFalse(client.getPrimitives(workQueue.type()).isEmpty());
+    assertEquals(count, client.getPrimitives(workQueue.type()).size());
   }
 }

--- a/core/src/test/java/io/atomix/core/workqueue/WorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/workqueue/WorkQueueTest.java
@@ -174,37 +174,6 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest<ProxyProtocol>
   }
 
   @Test
-  public void testDestroy() throws Exception {
-    String queueName = UUID.randomUUID().toString();
-    WorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)
-        .withProtocol(protocol())
-        .build();
-    String item = DEFAULT_PAYLOAD;
-    queue1.addOne(item);
-
-    WorkQueue<String> queue2 = atomix().<String>workQueueBuilder(queueName)
-        .withProtocol(protocol())
-        .build();
-    String task2 = DEFAULT_PAYLOAD;
-    queue2.addOne(task2);
-
-    WorkQueueStats stats = queue1.stats();
-    assertEquals(2, stats.totalPending());
-    assertEquals(0, stats.totalInProgress());
-    assertEquals(0, stats.totalCompleted());
-
-    queue2.delete();
-
-    queue1 = atomix().<String>workQueueBuilder(queueName)
-        .withProtocol(protocol())
-        .build();
-    stats = queue1.stats();
-    assertEquals(0, stats.totalPending());
-    assertEquals(0, stats.totalInProgress());
-    assertEquals(0, stats.totalCompleted());
-  }
-
-  @Test
   public void testCompleteAttemptWithIncorrectSession() throws Exception {
     String queueName = UUID.randomUUID().toString();
     WorkQueue<String> queue1 = atomix().<String>workQueueBuilder(queueName)

--- a/core/src/test/java/io/atomix/core/workqueue/WorkQueueTest.java
+++ b/core/src/test/java/io/atomix/core/workqueue/WorkQueueTest.java
@@ -195,6 +195,9 @@ public abstract class WorkQueueTest extends AbstractPrimitiveTest<ProxyProtocol>
 
     queue2.delete();
 
+    queue1 = atomix().<String>workQueueBuilder(queueName)
+        .withProtocol(protocol())
+        .build();
     stats = queue1.stats();
     assertEquals(0, stats.totalPending());
     assertEquals(0, stats.totalInProgress());

--- a/primitive/src/main/java/io/atomix/primitive/AbstractAsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/AbstractAsyncPrimitive.java
@@ -89,7 +89,7 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive, S> implem
 
   @Override
   public CompletableFuture<Void> delete() {
-    return client.delete();
+    return client.delete().thenCompose(v -> registry.deletePrimitive(name()));
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/AbstractAsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/AbstractAsyncPrimitive.java
@@ -88,6 +88,11 @@ public abstract class AbstractAsyncPrimitive<A extends AsyncPrimitive, S> implem
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    return client.delete();
+  }
+
+  @Override
   public String toString() {
     return toStringHelper(this)
         .add("proxy", client)

--- a/primitive/src/main/java/io/atomix/primitive/AsyncPrimitive.java
+++ b/primitive/src/main/java/io/atomix/primitive/AsyncPrimitive.java
@@ -39,9 +39,7 @@ public interface AsyncPrimitive extends DistributedPrimitive {
    *
    * @return {@code CompletableFuture} that is completed when the operation completes
    */
-  default CompletableFuture<Void> delete() {
-    return CompletableFuture.completedFuture(null);
-  }
+  CompletableFuture<Void> delete();
 
   /**
    * Returns a synchronous wrapper around the asynchronous primitive.

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveRegistry.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveRegistry.java
@@ -33,6 +33,14 @@ public interface PrimitiveRegistry {
   CompletableFuture<PrimitiveInfo> createPrimitive(String name, PrimitiveType type);
 
   /**
+   * Deletes the given distributed primitive.
+   *
+   * @param name the primitive name
+   * @return a future to be completed once the primitive info has been deleted
+   */
+  CompletableFuture<Void> deletePrimitive(String name);
+
+  /**
    * Returns a collection of open primitives.
    *
    * @return a collection of open primitives

--- a/primitive/src/main/java/io/atomix/primitive/PrimitiveState.java
+++ b/primitive/src/main/java/io/atomix/primitive/PrimitiveState.java
@@ -33,7 +33,12 @@ public enum PrimitiveState {
   SUSPENDED,
 
   /**
-   * Signifies a state wherein the primitive has been shutdown and therefore cannot perform its functions.
+   * Signifies a state wherein the primitive's session has been expired and therefore cannot perform its functions.
+   */
+  EXPIRED,
+
+  /**
+   * Signifies a state wherein the primitive session has been closed and therefore cannot perform its functions.
    */
   CLOSED
 }

--- a/primitive/src/main/java/io/atomix/primitive/proxy/ProxyClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/ProxyClient.java
@@ -249,4 +249,11 @@ public interface ProxyClient<S> {
    */
   CompletableFuture<Void> close();
 
+  /**
+   * Deletes the proxy client.
+   *
+   * @return a future to be completed once the service has been deleted
+   */
+  CompletableFuture<Void> delete();
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/proxy/ProxySession.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/ProxySession.java
@@ -113,4 +113,11 @@ public interface ProxySession<S> {
    */
   CompletableFuture<Void> close();
 
+  /**
+   * Closes the proxy session and deletes the service.
+   *
+   * @return a future to be completed once the service has been deleted
+   */
+  CompletableFuture<Void> delete();
+
 }

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxyClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxyClient.java
@@ -145,6 +145,15 @@ public class DefaultProxyClient<S> implements ProxyClient<S> {
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    return Futures.allOf(partitions.values()
+        .stream()
+        .map(ProxySession::delete)
+        .collect(Collectors.toList()))
+        .thenApply(v -> null);
+  }
+
+  @Override
   public CompletableFuture<Void> close() {
     return Futures.allOf(partitions.values()
         .stream()

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
@@ -19,12 +19,12 @@ import com.google.common.base.Defaults;
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
-import io.atomix.primitive.session.SessionClient;
 import io.atomix.primitive.event.Events;
 import io.atomix.primitive.operation.OperationId;
 import io.atomix.primitive.operation.Operations;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.proxy.ProxySession;
+import io.atomix.primitive.session.SessionClient;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
@@ -126,6 +126,11 @@ public class DefaultProxySession<S> implements ProxySession<S> {
   @Override
   public CompletableFuture<Void> close() {
     return session.close();
+  }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    return session.delete();
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
@@ -25,6 +25,7 @@ import io.atomix.primitive.operation.Operations;
 import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.proxy.ProxySession;
 import io.atomix.primitive.session.SessionClient;
+import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
@@ -48,6 +49,7 @@ public class DefaultProxySession<S> implements ProxySession<S> {
   private final Serializer serializer;
   private final ServiceProxy<S> proxy;
   private volatile CompletableFuture<ProxySession<S>> connectFuture;
+  private volatile boolean closed;
 
   @SuppressWarnings("unchecked")
   public DefaultProxySession(SessionClient session, Class<S> serviceType, Serializer serializer) {
@@ -93,11 +95,17 @@ public class DefaultProxySession<S> implements ProxySession<S> {
 
   @Override
   public CompletableFuture<Void> accept(Consumer<S> operation) {
+    if (closed) {
+      return Futures.exceptionalFuture(new PrimitiveException.ClosedSession());
+    }
     return proxy.accept(operation);
   }
 
   @Override
   public <R> CompletableFuture<R> apply(Function<S, R> operation) {
+    if (closed) {
+      return Futures.exceptionalFuture(new PrimitiveException.ClosedSession());
+    }
     return proxy.apply(operation);
   }
 
@@ -125,12 +133,12 @@ public class DefaultProxySession<S> implements ProxySession<S> {
 
   @Override
   public CompletableFuture<Void> close() {
-    return session.close();
+    return session.close().thenRun(() -> closed = true);
   }
 
   @Override
   public CompletableFuture<Void> delete() {
-    return session.delete();
+    return session.delete().thenRun(() -> closed = true);
   }
 
   /**

--- a/primitive/src/main/java/io/atomix/primitive/session/SessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/SessionClient.java
@@ -127,6 +127,13 @@ public interface SessionClient {
   CompletableFuture<Void> close();
 
   /**
+   * Closes the session and deletes the service.
+   *
+   * @return a future to be completed once the service has been deleted
+   */
+  CompletableFuture<Void> delete();
+
+  /**
    * Partition proxy builder.
    */
   abstract class Builder implements io.atomix.utils.Builder<SessionClient> {

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/BlockingAwareSessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/BlockingAwareSessionClient.java
@@ -103,4 +103,16 @@ public class BlockingAwareSessionClient extends DelegatingSessionClient {
     }
     return closeFuture;
   }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    if (closeFuture == null) {
+      synchronized (this) {
+        if (closeFuture == null) {
+          closeFuture = orderedFuture(asyncFuture(super.delete(), context));
+        }
+      }
+    }
+    return closeFuture;
+  }
 }

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/DelegatingSessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/DelegatingSessionClient.java
@@ -106,6 +106,11 @@ public class DelegatingSessionClient implements SessionClient {
   }
 
   @Override
+  public CompletableFuture<Void> delete() {
+    return session.delete();
+  }
+
+  @Override
   public String toString() {
     return toStringHelper(this)
         .add("client", session)

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/RecoveringSessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/RecoveringSessionClient.java
@@ -18,6 +18,7 @@ package io.atomix.primitive.session.impl;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.event.EventType;
@@ -26,6 +27,7 @@ import io.atomix.primitive.operation.PrimitiveOperation;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.session.SessionClient;
 import io.atomix.primitive.session.SessionId;
+import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.OrderedFuture;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
@@ -131,6 +133,10 @@ public class RecoveringSessionClient implements SessionClient {
         log.debug("State changed: {}", state);
         this.state = state;
         stateChangeListeners.forEach(l -> l.accept(state));
+        if (state == PrimitiveState.CLOSED) {
+          connectFuture = Futures.exceptionalFuture(new PrimitiveException.ClosedSession());
+          session = null;
+        }
       }
     }
   }

--- a/primitive/src/main/java/io/atomix/primitive/session/impl/RetryingSessionClient.java
+++ b/primitive/src/main/java/io/atomix/primitive/session/impl/RetryingSessionClient.java
@@ -70,7 +70,7 @@ public class RetryingSessionClient extends DelegatingSessionClient {
   @Override
   public CompletableFuture<byte[]> execute(PrimitiveOperation operation) {
     if (getState() == PrimitiveState.CLOSED) {
-      return Futures.exceptionalFuture(new PrimitiveException.Unavailable());
+      return Futures.exceptionalFuture(new PrimitiveException.ClosedSession());
     }
     CompletableFuture<byte[]> future = new CompletableFuture<>();
     execute(operation, 1, future);

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/session/PrimaryBackupSessionClient.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/session/PrimaryBackupSessionClient.java
@@ -42,6 +42,7 @@ import io.atomix.protocols.backup.protocol.PrimaryBackupClientProtocol;
 import io.atomix.protocols.backup.protocol.PrimaryBackupResponse.Status;
 import io.atomix.protocols.backup.protocol.PrimitiveDescriptor;
 import io.atomix.utils.concurrent.ComposableFuture;
+import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
@@ -325,6 +326,11 @@ public class PrimaryBackupSessionClient implements SessionClient {
       future.complete(null);
     }
     return future;
+  }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    return close().thenCompose(v -> Futures.exceptionalFuture(new UnsupportedOperationException("Delete not supported by primary-backup protocol")));
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftError.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftError.java
@@ -186,7 +186,7 @@ public class RaftError {
     UNKNOWN_SERVICE {
       @Override
       PrimitiveException createException() {
-        return createException("Unknown state machine");
+        return createException("Unknown primitive service");
       }
 
       @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -69,8 +69,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Internal server state machine.
  * <p>
- * The internal state machine handles application of commands to the user provided {@link PrimitiveService}
- * and keeps track of internal state like sessions and the various indexes relevant to log compaction.
+ * The internal state machine handles application of commands to the user provided {@link PrimitiveService} and keeps
+ * track of internal state like sessions and the various indexes relevant to log compaction.
  */
 public class RaftServiceManager implements AutoCloseable {
   private static final Duration SNAPSHOT_INTERVAL = Duration.ofSeconds(10);
@@ -270,8 +270,8 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Schedules a log compaction.
    *
-   * @param lastApplied the last applied index at the start of snapshotting. This represents the highest index before
-   *                    which segments can be safely removed from disk
+   * @param lastApplied the last applied index at the start of snapshotting. This represents the highest index
+   *     before which segments can be safely removed from disk
    */
   private void scheduleCompaction(long lastApplied) {
     // Schedule compaction after a randomized delay to discourage snapshots on multiple nodes at the same time.
@@ -303,8 +303,8 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Applies all commits up to the given index.
    * <p>
-   * Calls to this method are assumed not to expect a result. This allows some optimizations to be
-   * made internally since linearizable events don't have to be waited to complete the command.
+   * Calls to this method are assumed not to expect a result. This allows some optimizations to be made internally since
+   * linearizable events don't have to be waited to complete the command.
    *
    * @param index The index up to which to apply commits.
    */
@@ -315,9 +315,8 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Applies the entry at the given index to the state machine.
    * <p>
-   * Calls to this method are assumed to expect a result. This means linearizable session events
-   * triggered by the application of the command at the given index will be awaited before completing
-   * the returned future.
+   * Calls to this method are assumed to expect a result. This means linearizable session events triggered by the
+   * application of the command at the given index will be awaited before completing the returned future.
    *
    * @param index The index to apply.
    * @return A completable future to be completed once the commit has been applied.
@@ -392,8 +391,8 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Applies an entry to the state machine.
    * <p>
-   * Calls to this method are assumed to expect a result. This means linearizable session events
-   * triggered by the application of the given entry will be awaited before completing the returned future.
+   * Calls to this method are assumed to expect a result. This means linearizable session events triggered by the
+   * application of the given entry will be awaited before completing the returned future.
    *
    * @param entry The entry to apply.
    * @return A completable future to be completed with the result.
@@ -465,7 +464,7 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Takes a snapshot of the given service.
    *
-   * @param writer  the snapshot writer
+   * @param writer the snapshot writer
    * @param service the service to snapshot
    */
   private void snapshotService(SnapshotWriter writer, RaftServiceContext service) {
@@ -555,9 +554,9 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Applies a configuration entry to the internal state machine.
    * <p>
-   * Configuration entries are applied to internal server state when written to the log. Thus, no significant
-   * logic needs to take place in the handling of configuration entries. We simply release the previous configuration
-   * entry since it was overwritten by a more recent committed configuration entry.
+   * Configuration entries are applied to internal server state when written to the log. Thus, no significant logic
+   * needs to take place in the handling of configuration entries. We simply release the previous configuration entry
+   * since it was overwritten by a more recent committed configuration entry.
    */
   private CompletableFuture<Void> applyConfiguration(Indexed<ConfigurationEntry> entry) {
     for (RaftServiceContext service : raft.getServices()) {
@@ -569,25 +568,24 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Applies a session keep alive entry to the state machine.
    * <p>
-   * Keep alive entries are applied to the internal state machine to reset the timeout for a specific session.
-   * If the session indicated by the KeepAliveEntry is still held in memory, we mark the session as trusted,
-   * indicating that the client has committed a keep alive within the required timeout. Additionally, we check
-   * all other sessions for expiration based on the timestamp provided by this KeepAliveEntry. Note that sessions
-   * are never completely expired via this method. Leaders must explicitly commit an UnregisterEntry to expire
-   * a session.
+   * Keep alive entries are applied to the internal state machine to reset the timeout for a specific session. If the
+   * session indicated by the KeepAliveEntry is still held in memory, we mark the session as trusted, indicating that
+   * the client has committed a keep alive within the required timeout. Additionally, we check all other sessions for
+   * expiration based on the timestamp provided by this KeepAliveEntry. Note that sessions are never completely expired
+   * via this method. Leaders must explicitly commit an UnregisterEntry to expire a session.
    * <p>
-   * When a KeepAliveEntry is committed to the internal state machine, two specific fields provided in the entry
-   * are used to update server-side session state. The {@code commandSequence} indicates the highest command for
-   * which the session has received a successful response in the proper sequence. By applying the {@code commandSequence}
-   * to the server session, we clear command output held in memory up to that point. The {@code eventVersion} indicates
-   * the index up to which the client has received event messages in sequence for the session. Applying the
-   * {@code eventVersion} to the server-side session results in events up to that index being removed from memory
-   * as they were acknowledged by the client. It's essential that both of these fields be applied via entries committed
-   * to the Raft log to ensure they're applied on all servers in sequential order.
+   * When a KeepAliveEntry is committed to the internal state machine, two specific fields provided in the entry are
+   * used to update server-side session state. The {@code commandSequence} indicates the highest command for which the
+   * session has received a successful response in the proper sequence. By applying the {@code commandSequence} to the
+   * server session, we clear command output held in memory up to that point. The {@code eventVersion} indicates the
+   * index up to which the client has received event messages in sequence for the session. Applying the {@code
+   * eventVersion} to the server-side session results in events up to that index being removed from memory as they were
+   * acknowledged by the client. It's essential that both of these fields be applied via entries committed to the Raft
+   * log to ensure they're applied on all servers in sequential order.
    * <p>
    * Keep alive entries are retained in the log until the next time the client sends a keep alive entry or until the
-   * client's session is expired. This ensures for sessions that have long timeouts, keep alive entries cannot be cleaned
-   * from the log before they're replicated to some servers.
+   * client's session is expired. This ensures for sessions that have long timeouts, keep alive entries cannot be
+   * cleaned from the log before they're replicated to some servers.
    */
   private long[] applyKeepAlive(Indexed<KeepAliveEntry> entry) {
 
@@ -618,7 +616,25 @@ public class RaftServiceManager implements AutoCloseable {
       service.completeKeepAlive(entry.index(), entry.entry().timestamp());
     }
 
+    expireOrphanSessions(entry.entry().timestamp());
+
     return Longs.toArray(successfulSessionIds);
+  }
+
+  /**
+   * Expires sessions that have timed out.
+   */
+  private void expireOrphanSessions(long timestamp) {
+    // Iterate through registered sessions.
+    for (RaftSession session : raft.getSessions().getSessions()) {
+      if (session.isTimedOut(timestamp)) {
+        logger.debug("Session expired in {} milliseconds: {}", timestamp - session.getLastUpdated(), session);
+        session = raft.getSessions().removeSession(session.sessionId());
+        if (session != null) {
+          session.expire();
+        }
+      }
+    }
   }
 
   /**
@@ -702,9 +718,14 @@ public class RaftServiceManager implements AutoCloseable {
       throw new RaftException.UnknownSession("Unknown session: " + entry.entry().session());
     }
 
-    // Get the state machine executor associated with the session and unregister the session.
     RaftServiceContext service = session.getService();
     service.closeSession(entry.index(), entry.entry().timestamp(), session, entry.entry().expired());
+
+    // If this is a delete, unregister the service.
+    if (entry.entry().delete()) {
+      raft.getServices().unregisterService(service);
+      service.close();
+    }
   }
 
   /**
@@ -740,17 +761,16 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Applies a command entry to the state machine.
    * <p>
-   * Command entries result in commands being executed on the user provided {@link PrimitiveService} and a
-   * response being sent back to the client by completing the returned future. All command responses are
-   * cached in the command's {@link RaftSession} for fault tolerance. In the event that the same command
-   * is applied to the state machine more than once, the original response will be returned.
+   * Command entries result in commands being executed on the user provided {@link PrimitiveService} and a response
+   * being sent back to the client by completing the returned future. All command responses are cached in the command's
+   * {@link RaftSession} for fault tolerance. In the event that the same command is applied to the state machine more
+   * than once, the original response will be returned.
    * <p>
-   * Command entries are written with a sequence number. The sequence number is used to ensure that
-   * commands are applied to the state machine in sequential order. If a command entry has a sequence
-   * number that is less than the next sequence number for the session, that indicates that it is a
-   * duplicate of a command that was already applied. Otherwise, commands are assumed to have been
-   * received in sequential order. The reason for this assumption is because leaders always sequence
-   * commands as they're written to the log, so no sequence number will be skipped.
+   * Command entries are written with a sequence number. The sequence number is used to ensure that commands are applied
+   * to the state machine in sequential order. If a command entry has a sequence number that is less than the next
+   * sequence number for the session, that indicates that it is a duplicate of a command that was already applied.
+   * Otherwise, commands are assumed to have been received in sequential order. The reason for this assumption is
+   * because leaders always sequence commands as they're written to the log, so no sequence number will be skipped.
    */
   private OperationResult applyCommand(Indexed<CommandEntry> entry) {
     // First check to ensure that the session exists.
@@ -782,20 +802,19 @@ public class RaftServiceManager implements AutoCloseable {
   /**
    * Applies a query entry to the state machine.
    * <p>
-   * Query entries are applied to the user {@link PrimitiveService} for read-only operations.
-   * Because queries are read-only, they may only be applied on a single server in the cluster,
-   * and query entries do not go through the Raft log. Thus, it is critical that measures be taken
-   * to ensure clients see a consistent view of the cluster event when switching servers. To do so,
-   * clients provide a sequence and version number for each query. The sequence number is the order
-   * in which the query was sent by the client. Sequence numbers are shared across both commands and
-   * queries. The version number indicates the last index for which the client saw a command or query
-   * response. In the event that the lastApplied index of this state machine does not meet the provided
-   * version number, we wait for the state machine to catch up before applying the query. This ensures
-   * clients see state progress monotonically even when switching servers.
+   * Query entries are applied to the user {@link PrimitiveService} for read-only operations. Because queries are
+   * read-only, they may only be applied on a single server in the cluster, and query entries do not go through the Raft
+   * log. Thus, it is critical that measures be taken to ensure clients see a consistent view of the cluster event when
+   * switching servers. To do so, clients provide a sequence and version number for each query. The sequence number is
+   * the order in which the query was sent by the client. Sequence numbers are shared across both commands and queries.
+   * The version number indicates the last index for which the client saw a command or query response. In the event that
+   * the lastApplied index of this state machine does not meet the provided version number, we wait for the state
+   * machine to catch up before applying the query. This ensures clients see state progress monotonically even when
+   * switching servers.
    * <p>
-   * Because queries may only be applied on a single server in the cluster they cannot result in the
-   * publishing of session events. Events require commands to be written to the Raft log to ensure
-   * fault-tolerance and consistency across the cluster.
+   * Because queries may only be applied on a single server in the cluster they cannot result in the publishing of
+   * session events. Events require commands to be written to the Raft log to ensure fault-tolerance and consistency
+   * across the cluster.
    */
   private CompletableFuture<OperationResult> applyQuery(Indexed<QueryEntry> entry) {
     RaftSession session = raft.getSessions().getSession(entry.entry().session());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceRegistry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceRegistry.java
@@ -39,6 +39,15 @@ public class RaftServiceRegistry implements Iterable<RaftServiceContext> {
   }
 
   /**
+   * Unregisters the given service.
+   *
+   * @param service the service to unregister
+   */
+  public void unregisterService(RaftServiceContext service) {
+    services.remove(service.serviceName());
+  }
+
+  /**
    * Gets a registered service by name.
    *
    * @param name the service name

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/CloseSessionRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/CloseSessionRequest.java
@@ -15,6 +15,10 @@
  */
 package io.atomix.protocols.raft.protocol;
 
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
 /**
  * Close session request.
  */
@@ -29,18 +33,69 @@ public class CloseSessionRequest extends SessionRequest {
     return new Builder();
   }
 
-  public CloseSessionRequest(long session) {
+  private final boolean delete;
+
+  public CloseSessionRequest(long session, boolean delete) {
     super(session);
+    this.delete = delete;
   }
 
   /**
-   * Unregister request builder.
+   * Returns whether this request is a delete.
+   *
+   * @return indicates whether this is a delete request
+   */
+  public boolean delete() {
+    return delete;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), session);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || !getClass().isAssignableFrom(object.getClass())) {
+      return false;
+    }
+
+    CloseSessionRequest request = (CloseSessionRequest) object;
+    return request.session == session && request.delete == delete;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("session", session)
+        .add("delete", delete)
+        .toString();
+  }
+
+  /**
+   * Close session request builder.
    */
   public static class Builder extends SessionRequest.Builder<Builder, CloseSessionRequest> {
+    private boolean delete;
+
+    /**
+     * Sets whether the request is a delete.
+     *
+     * @param delete whether the request is a delete
+     * @return the request builder
+     */
+    public Builder withDelete(boolean delete) {
+      this.delete = delete;
+      return this;
+    }
+
     @Override
     public CloseSessionRequest build() {
       validate();
-      return new CloseSessionRequest(session);
+      return new CloseSessionRequest(session, delete);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -203,7 +203,7 @@ public final class LeaderRole extends ActiveRole {
   private void expireSession(RaftSession session) {
     if (expiring.add(session.sessionId())) {
       log.debug("Expiring session due to heartbeat failure: {}", session);
-      appendAndCompact(new CloseSessionEntry(raft.getTerm(), System.currentTimeMillis(), session.sessionId().id(), true))
+      appendAndCompact(new CloseSessionEntry(raft.getTerm(), System.currentTimeMillis(), session.sessionId().id(), true, false))
               .whenCompleteAsync((entry, error) -> {
                 if (error != null) {
                   expiring.remove(session.sessionId());
@@ -970,7 +970,7 @@ public final class LeaderRole extends ActiveRole {
     logRequest(request);
 
     CompletableFuture<CloseSessionResponse> future = new CompletableFuture<>();
-    appendAndCompact(new CloseSessionEntry(term, timestamp, request.session(), false))
+    appendAndCompact(new CloseSessionEntry(term, timestamp, request.session(), false, request.delete()))
         .whenCompleteAsync((entry, error) -> {
           if (error != null) {
             future.complete(logResponse(CloseSessionResponse.builder()

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
@@ -72,6 +72,7 @@ public class RaftServiceContext implements ServiceContext {
   private Session currentSession;
   private long currentTimestamp;
   private OperationType currentOperation;
+  private boolean deleted;
   private final LogicalClock logicalClock = new LogicalClock() {
     @Override
     public LogicalTimestamp getTime() {
@@ -280,9 +281,9 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Registers the given session.
    *
-   * @param index     The index of the registration.
+   * @param index The index of the registration.
    * @param timestamp The timestamp of the registration.
-   * @param session   The session to register.
+   * @param session The session to register.
    */
   public long openSession(long index, long timestamp, RaftSession session) {
     log.debug("Opening session {}", session.sessionId());
@@ -310,11 +311,11 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Keeps the given session alive.
    *
-   * @param index           The index of the keep-alive.
-   * @param timestamp       The timestamp of the keep-alive.
-   * @param session         The session to keep-alive.
+   * @param index The index of the keep-alive.
+   * @param timestamp The timestamp of the keep-alive.
+   * @param session The session to keep-alive.
    * @param commandSequence The session command sequence number.
-   * @param eventIndex      The session event index.
+   * @param eventIndex The session event index.
    */
   public boolean keepAlive(long index, long timestamp, RaftSession session, long commandSequence, long eventIndex) {
     // Update the state machine index/timestamp.
@@ -356,7 +357,7 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Completes a keep-alive.
    *
-   * @param index     the keep-alive index
+   * @param index the keep-alive index
    * @param timestamp the keep-alive timestamp
    */
   public void completeKeepAlive(long index, long timestamp) {
@@ -373,7 +374,7 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Keeps all sessions alive using the given timestamp.
    *
-   * @param index     the index of the timestamp
+   * @param index the index of the timestamp
    * @param timestamp the timestamp with which to reset session timeouts
    */
   public void keepAliveSessions(long index, long timestamp) {
@@ -390,10 +391,10 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Unregister the given session.
    *
-   * @param index     The index of the unregister.
+   * @param index The index of the unregister.
    * @param timestamp The timestamp of the unregister.
-   * @param session   The session to unregister.
-   * @param expired   Whether the session was expired by the leader.
+   * @param session The session to unregister.
+   * @param expired Whether the session was expired by the leader.
    */
   public void closeSession(long index, long timestamp, RaftSession session, boolean expired) {
     log.debug("Closing session {}", session.sessionId());
@@ -429,25 +430,31 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Executes the given command on the state machine.
    *
-   * @param index     The index of the command.
+   * @param index The index of the command.
    * @param timestamp The timestamp of the command.
-   * @param sequence  The command sequence number.
-   * @param session   The session that submitted the command.
+   * @param sequence The command sequence number.
+   * @param session The session that submitted the command.
    * @param operation The command to execute.
    * @return A future to be completed with the command result.
    */
   public OperationResult executeCommand(long index, long sequence, long timestamp, RaftSession session, PrimitiveOperation operation) {
-    // Update the session's timestamp to prevent it from being expired.
-    session.setLastUpdated(timestamp);
-
-    // Update the state machine index/timestamp.
-    tick(index, timestamp);
+    // If the service has been deleted then throw an unknown service exception.
+    if (deleted) {
+      log.warn("Service {} has been deleted by another process", serviceName);
+      throw new RaftException.UnknownService("Service " + serviceName + " has been deleted");
+    }
 
     // If the session is not open, fail the request.
     if (!session.getState().active()) {
       log.warn("Session not open: {}", session);
       throw new RaftException.UnknownSession("Unknown session: " + session.sessionId());
     }
+
+    // Update the session's timestamp to prevent it from being expired.
+    session.setLastUpdated(timestamp);
+
+    // Update the state machine index/timestamp.
+    tick(index, timestamp);
 
     // If the command's sequence number is less than the next session sequence number then that indicates that
     // we've received a command that was previously applied to the state machine. Ensure linearizability by
@@ -480,9 +487,9 @@ public class RaftServiceContext implements ServiceContext {
    * Applies the given commit to the state machine.
    */
   private OperationResult applyCommand(long index, long sequence, long timestamp, PrimitiveOperation operation, RaftSession session) {
-    Commit<byte[]> commit = new DefaultCommit<>(index, operation.id(), operation.value(), session, timestamp);
-
     long eventIndex = session.getEventIndex();
+
+    Commit<byte[]> commit = new DefaultCommit<>(index, operation.id(), operation.value(), session, timestamp);
 
     OperationResult result;
     try {
@@ -517,14 +524,19 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Executes the given query on the state machine.
    *
-   * @param index     The index of the query.
-   * @param sequence  The query sequence number.
+   * @param index The index of the query.
+   * @param sequence The query sequence number.
    * @param timestamp The timestamp of the query.
-   * @param session   The session that submitted the query.
+   * @param session The session that submitted the query.
    * @param operation The query to execute.
    * @return A future to be completed with the query result.
    */
-  public CompletableFuture<OperationResult> executeQuery(long index, long sequence, long timestamp, RaftSession session, PrimitiveOperation operation) {
+  public CompletableFuture<OperationResult> executeQuery(
+      long index,
+      long sequence,
+      long timestamp,
+      RaftSession session,
+      PrimitiveOperation operation) {
     CompletableFuture<OperationResult> future = new CompletableFuture<>();
     executeQuery(index, sequence, timestamp, session, operation, future);
     return future;
@@ -533,7 +545,20 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Executes a query on the state machine thread.
    */
-  private void executeQuery(long index, long sequence, long timestamp, RaftSession session, PrimitiveOperation operation, CompletableFuture<OperationResult> future) {
+  private void executeQuery(
+      long index,
+      long sequence,
+      long timestamp,
+      RaftSession session,
+      PrimitiveOperation operation,
+      CompletableFuture<OperationResult> future) {
+    // If the service has been deleted then throw an unknown service exception.
+    if (deleted) {
+      log.warn("Service {} has been deleted by another process", serviceName);
+      future.completeExceptionally(new RaftException.UnknownService("Service " + serviceName + " has been deleted"));
+      return;
+    }
+
     // If the session is not open, fail the request.
     if (!session.getState().active()) {
       log.warn("Inactive session: " + session.sessionId());
@@ -548,7 +573,13 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Sequences the given query.
    */
-  private void sequenceQuery(long index, long sequence, long timestamp, RaftSession session, PrimitiveOperation operation, CompletableFuture<OperationResult> future) {
+  private void sequenceQuery(
+      long index,
+      long sequence,
+      long timestamp,
+      RaftSession session,
+      PrimitiveOperation operation,
+      CompletableFuture<OperationResult> future) {
     // If the query's sequence number is greater than the session's current sequence number, queue the request for
     // handling once the state machine is caught up.
     long commandSequence = session.getCommandSequence();
@@ -563,7 +594,12 @@ public class RaftServiceContext implements ServiceContext {
   /**
    * Ensures the given query is applied after the appropriate index.
    */
-  private void indexQuery(long index, long timestamp, RaftSession session, PrimitiveOperation operation, CompletableFuture<OperationResult> future) {
+  private void indexQuery(
+      long index,
+      long timestamp,
+      RaftSession session,
+      PrimitiveOperation operation,
+      CompletableFuture<OperationResult> future) {
     // If the query index is greater than the session's last applied index, queue the request for handling once the
     // state machine is caught up.
     if (index > currentIndex) {
@@ -578,6 +614,13 @@ public class RaftServiceContext implements ServiceContext {
    * Applies a query to the state machine.
    */
   private void applyQuery(long timestamp, RaftSession session, PrimitiveOperation operation, CompletableFuture<OperationResult> future) {
+    // If the service has been deleted then throw an unknown service exception.
+    if (deleted) {
+      log.warn("Service {} has been deleted by another process", serviceName);
+      future.completeExceptionally(new RaftException.UnknownService("Service " + serviceName + " has been deleted"));
+      return;
+    }
+
     // If the session is not open, fail the request.
     if (!session.getState().active()) {
       log.warn("Inactive session: " + session.sessionId());
@@ -613,6 +656,18 @@ public class RaftServiceContext implements ServiceContext {
     for (RaftSession session : sessions.getSessions(primitiveId)) {
       session.commit(index);
     }
+  }
+
+  /**
+   * Closes the service context.
+   */
+  public void close() {
+    for (RaftSession serviceSession : sessions.getSessions(serviceId())) {
+      serviceSession.close();
+      service.close(serviceSession.sessionId());
+    }
+    service.close();
+    deleted = true;
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/DefaultRaftSessionClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/DefaultRaftSessionClient.java
@@ -239,7 +239,16 @@ public class DefaultRaftSessionClient implements RaftSessionClient {
   @Override
   public CompletableFuture<Void> close() {
     if (state != null) {
-      return sessionManager.closeSession(state.getSessionId())
+      return sessionManager.closeSession(state.getSessionId(), false)
+          .whenComplete((result, error) -> state.setState(PrimitiveState.CLOSED));
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    if (state != null) {
+      return sessionManager.closeSession(state.getSessionId(), true)
           .whenComplete((result, error) -> state.setState(PrimitiveState.CLOSED));
     }
     return CompletableFuture.completedFuture(null);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionManager.java
@@ -191,7 +191,7 @@ public class RaftSessionManager {
           sessions.put(state.getSessionId().id(), state);
 
           state.addStateChangeListener(s -> {
-            if (s == PrimitiveState.CLOSED) {
+            if (s == PrimitiveState.EXPIRED || s == PrimitiveState.CLOSED) {
               sessions.remove(state.getSessionId().id());
             }
           });
@@ -213,10 +213,11 @@ public class RaftSessionManager {
   /**
    * Closes a session.
    *
-   * @param sessionId The session identifier.
+   * @param sessionId the session identifier.
+   * @param delete whether to delete the service
    * @return A completable future to be completed once the session is closed.
    */
-  public CompletableFuture<Void> closeSession(SessionId sessionId) {
+  public CompletableFuture<Void> closeSession(SessionId sessionId, boolean delete) {
     RaftSessionState state = sessions.get(sessionId.id());
     if (state == null) {
       return Futures.exceptionalFuture(new RaftException.UnknownSession("Unknown session: " + sessionId));
@@ -225,6 +226,7 @@ public class RaftSessionManager {
     log.info("Closing session {}", sessionId);
     CloseSessionRequest request = CloseSessionRequest.builder()
         .withSession(sessionId.id())
+        .withDelete(delete)
         .build();
 
     CompletableFuture<Void> future = new CompletableFuture<>();
@@ -359,7 +361,7 @@ public class RaftSessionManager {
               if (keptAliveSessions.contains(session.getSessionId().id())) {
                 session.setState(PrimitiveState.CONNECTED);
               } else {
-                session.setState(PrimitiveState.CLOSED);
+                session.setState(PrimitiveState.EXPIRED);
               }
             }
             scheduleKeepAlive(System.currentTimeMillis(), sessionTimeout, delta);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionState.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionState.java
@@ -113,18 +113,20 @@ public final class RaftSessionState {
    */
   public void setState(PrimitiveState state) {
     if (this.state != state) {
-      this.state = state;
-      if (state == PrimitiveState.SUSPENDED) {
-        if (suspendedTime == null) {
-          suspendedTime = System.currentTimeMillis();
+      if (this.state != PrimitiveState.EXPIRED && this.state != PrimitiveState.CLOSED) {
+        this.state = state;
+        if (state == PrimitiveState.SUSPENDED) {
+          if (suspendedTime == null) {
+            suspendedTime = System.currentTimeMillis();
+          }
+        } else {
+          suspendedTime = null;
         }
-      } else {
-        suspendedTime = null;
+        changeListeners.forEach(l -> l.accept(state));
       }
-      changeListeners.forEach(l -> l.accept(state));
     } else if (this.state == PrimitiveState.SUSPENDED) {
       if (System.currentTimeMillis() - suspendedTime > timeout) {
-        setState(PrimitiveState.CLOSED);
+        setState(PrimitiveState.EXPIRED);
       }
     }
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/CloseSessionEntry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/entry/CloseSessionEntry.java
@@ -24,10 +24,12 @@ import static com.google.common.base.MoreObjects.toStringHelper;
  */
 public class CloseSessionEntry extends SessionEntry {
   private final boolean expired;
+  private final boolean delete;
 
-  public CloseSessionEntry(long term, long timestamp, long session, boolean expired) {
+  public CloseSessionEntry(long term, long timestamp, long session, boolean expired, boolean delete) {
     super(term, timestamp, session);
     this.expired = expired;
+    this.delete = delete;
   }
 
   /**
@@ -39,6 +41,15 @@ public class CloseSessionEntry extends SessionEntry {
     return expired;
   }
 
+  /**
+   * Returns whether to delete the service.
+   *
+   * @return whether to delete the service
+   */
+  public boolean delete() {
+    return delete;
+  }
+
   @Override
   public String toString() {
     return toStringHelper(this)
@@ -46,6 +57,7 @@ public class CloseSessionEntry extends SessionEntry {
         .add("timestamp", new TimestampPrinter(timestamp))
         .add("session", session)
         .add("expired", expired)
+        .add("delete", delete)
         .toString();
   }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1178,6 +1178,12 @@ public class RaftTest extends ConcurrentTestCase {
       resume();
     });
     await(5000);
+
+    RaftClient client3 = createClient();
+    TestPrimitive primitive3 = createPrimitive(client3);
+
+    primitive3.write("foo").thenCompose(v -> primitive3.read()).thenRun(this::resume);
+    await(5000);
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1332,6 +1332,7 @@ public class RaftTest extends ConcurrentTestCase {
         (key, partitions) -> partitions.get(0));
     PrimitiveRegistry registry = mock(PrimitiveRegistry.class);
     when(registry.createPrimitive(any(String.class), any(PrimitiveType.class))).thenReturn(CompletableFuture.completedFuture(new PrimitiveInfo("raft-test", TestPrimitiveType.INSTANCE)));
+    when(registry.deletePrimitive(any(String.class))).thenReturn(CompletableFuture.completedFuture(null));
     return new TestPrimitiveImpl(proxy, registry);
   }
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1172,6 +1172,12 @@ public class RaftTest extends ConcurrentTestCase {
       resume();
     });
     await(5000, 2);
+
+    primitive2.read().whenComplete((result, error) -> {
+      threadAssertTrue(error.getCause() instanceof PrimitiveException.ClosedSession);
+      resume();
+    });
+    await(5000);
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractLogTest {
     assertEquals(1, indexed.index());
 
     assertEquals(2, writer.getNextIndex());
-    writer.append(new Indexed<>(2, new CloseSessionEntry(1, System.currentTimeMillis(), 1, false), 0));
+    writer.append(new Indexed<>(2, new CloseSessionEntry(1, System.currentTimeMillis(), 1, false, false), 0));
     reader.reset(2);
     indexed = reader.next();
     assertEquals(2, indexed.index());
@@ -202,7 +202,7 @@ public abstract class AbstractLogTest {
     // Truncate the log and write a different entry.
     writer.truncate(1);
     assertEquals(2, writer.getNextIndex());
-    writer.append(new Indexed<>(2, new CloseSessionEntry(2, System.currentTimeMillis(), 1, false), 0));
+    writer.append(new Indexed<>(2, new CloseSessionEntry(2, System.currentTimeMillis(), 1, false, false), 0));
     reader.reset(2);
     indexed = reader.next();
     assertEquals(2, indexed.index());


### PR DESCRIPTION
This PR is an initial attempt to resolve #782 by implementing deletes in the Raft protocol.

The most significant challenge with implementing deletes is avoiding the recreation of primitive services following a delete. Primitive clients generally create primitive services using a create-if-not-exists write. So, the risk here is that after one session deletes the primitive service, another process recognizes its session has been closed and simply recreates the session, thus recreating the primitive service. Instead, when a primitive is deleted by one process, all other processes should see that the primitive has been deleted.

To ensure this is the case, the sessions that belonged to a primitive service are retained after the service itself has been deleted. Those sessions are retained in memory for as long as their session timeout. When an operation is attempted on those sessions, an `UnknownService` exception is returned, thus notifying the client that the service has been deleted rather than that its session was expired or closed.

To facilitate session recovery, an additional `PrimitiveState` is added to differentiate between `EXPIRED` sessions and `CLOSED` sessions, the latter being the state that occurs after a client's session is closed by a delete. This allows the `RecoveringSessionClient` to avoid recreating a session after a primitive has been deleted.