### PR TITLE
Simplify the core Docker image to reduce size

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,18 +1,15 @@
 # Dockerfile
 
-FROM  java:8
-
-MAINTAINER  Jordan Halterman <jordan.halterman@gmail.com>
-
-RUN apt-get update && apt-get install -y iptables git stress
-
-RUN mkdir /atomix
+FROM anapsix/alpine-java:8_server-jre
 
 ARG VERSION
-COPY target/atomix-agent-${VERSION}.tar.gz /atomix/atomix-agent-${VERSION}.tar.gz
-RUN tar -xvf /atomix/atomix-agent-${VERSION}.tar.gz -C /atomix && rm /atomix/atomix-agent-${VERSION}.tar.gz
+RUN mkdir -p /root/atomix
+COPY target/atomix-agent-${VERSION}.tar.gz /root/atomix/atomix-agent-${VERSION}.tar.gz
+RUN tar -xvf /root/atomix/atomix-agent-${VERSION}.tar.gz -C /root/atomix && rm /root/atomix/atomix-agent-${VERSION}.tar.gz
+
+WORKDIR /root/atomix
 
 EXPOSE 5678
 EXPOSE 5679
 
-ENTRYPOINT ["/atomix/bin/atomix-agent"]
+ENTRYPOINT ["./bin/atomix-agent"]


### PR DESCRIPTION
This came from the Sona project:
https://github.com/sonaproject/atomix-docker
https://hub.docker.com/r/opensona/atomix-docker/tags/

Fixes #802 

Need to test the image with https://github.com/atomix/atomix-test before merging