### PR TITLE
Read/write Raft logs in batches

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -70,10 +70,12 @@ public final class FollowerRole extends ActiveRole {
    * Handles a cluster event.
    */
   private void handleClusterEvent(ClusterMembershipEvent event) {
-    RaftMember leader = raft.getLeader();
-    if (leader != null && event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED && event.subject().id().equals(leader.memberId())) {
-      sendPollRequests();
-    }
+    raft.getThreadContext().execute(() -> {
+      RaftMember leader = raft.getLeader();
+      if (leader != null && event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED && event.subject().id().equals(leader.memberId())) {
+        sendPollRequests();
+      }
+    });
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -190,12 +190,14 @@ public final class LeaderRole extends ActiveRole {
    * Handles a cluster event.
    */
   private void handleClusterEvent(ClusterMembershipEvent event) {
-    if (event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED) {
-      log.debug("Node {} deactivated", event.subject().id());
-      raft.getSessions().getSessions().stream()
-          .filter(session -> session.memberId().equals(event.subject().id()))
-          .forEach(this::expireSession);
-    }
+    raft.getThreadContext().execute(() -> {
+      if (event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED) {
+        log.debug("Node {} deactivated", event.subject().id());
+        raft.getSessions().getSessions().stream()
+            .filter(session -> session.memberId().equals(event.subject().id()))
+            .forEach(this::expireSession);
+      }
+    });
   }
 
   /**

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/log/AbstractLogTest.java
@@ -94,6 +94,7 @@ public abstract class AbstractLogTest {
         .withMaxEntriesPerSegment(MAX_ENTRIES_PER_SEGMENT)
         .withMaxSegmentSize(MAX_SEGMENT_SIZE)
         .withIndexDensity(.2)
+        .withCacheSize(1)
         .build();
   }
 

--- a/storage/src/main/java/io/atomix/storage/buffer/FileBytes.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/FileBytes.java
@@ -81,6 +81,9 @@ public class FileBytes extends AbstractBytes {
     return new FileBytes(file, mode, (int) Math.min(Memory.Util.toPow2(size), Integer.MAX_VALUE));
   }
 
+  private static final int PAGE_SIZE = 1024 * 4;
+  private static final byte[] BLANK_PAGE = new byte[PAGE_SIZE];
+
   private final File file;
   private final String mode;
   private final RandomAccessFile randomAccessFile;
@@ -133,11 +136,14 @@ public class FileBytes extends AbstractBytes {
   public Bytes resize(int newSize) {
     if (newSize < size)
       throw new IllegalArgumentException("cannot decrease file bytes size; use zero() to decrease file size");
+    int oldSize = this.size;
     this.size = newSize;
     try {
       long length = randomAccessFile.length();
-      if (size > length)
+      if (newSize > length) {
         randomAccessFile.setLength(newSize);
+        zero(oldSize);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -215,6 +221,9 @@ public class FileBytes extends AbstractBytes {
     try {
       randomAccessFile.setLength(0);
       randomAccessFile.setLength(size);
+      for (int i = 0; i < size; i += PAGE_SIZE) {
+        randomAccessFile.write(BLANK_PAGE, 0, Math.min(size - i, PAGE_SIZE));
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -224,8 +233,12 @@ public class FileBytes extends AbstractBytes {
   @Override
   public Bytes zero(int offset) {
     try {
+      int length = Math.max(offset, size);
       randomAccessFile.setLength(offset);
-      randomAccessFile.setLength(Math.max(offset, size));
+      randomAccessFile.setLength(length);
+      for (int i = offset; i < length; i += PAGE_SIZE) {
+        randomAccessFile.write(BLANK_PAGE, 0, Math.min(length - i, PAGE_SIZE));
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/storage/src/main/java/io/atomix/storage/buffer/FileBytes.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/FileBytes.java
@@ -236,6 +236,7 @@ public class FileBytes extends AbstractBytes {
       int length = Math.max(offset, size);
       randomAccessFile.setLength(offset);
       randomAccessFile.setLength(length);
+      seekToOffset(offset);
       for (int i = offset; i < length; i += PAGE_SIZE) {
         randomAccessFile.write(BLANK_PAGE, 0, Math.min(length - i, PAGE_SIZE));
       }

--- a/storage/src/main/java/io/atomix/storage/buffer/MappedBytes.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/MappedBytes.java
@@ -67,13 +67,7 @@ public class MappedBytes extends ByteBufferBytes {
    * @see #allocate(File, int)
    */
   public static MappedBytes allocate(File file, FileChannel.MapMode mode, int size) {
-    try {
-      RandomAccessFile randomAccessFile = new RandomAccessFile(file, parseMode(mode));
-      MappedByteBuffer buffer = randomAccessFile.getChannel().map(mode, 0, size);
-      return new MappedBytes(file, randomAccessFile, buffer, mode);
-    } catch (IOException e) {
-      throw new AtomixIOException(e);
-    }
+    return FileBytes.allocate(file, size).map(0, size, mode);
   }
 
   private final File file;

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentCache.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentCache.java
@@ -78,6 +78,7 @@ class JournalSegmentCache {
   public void truncate(long index) {
     if (index < firstIndex) {
       firstIndex = index + 1;
+      lastIndex = 0;
       entries.clear();
     } else {
       int size = entries.size();

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentCache.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentCache.java
@@ -27,11 +27,21 @@ class JournalSegmentCache {
   private final int size;
   private final Map<Long, Indexed> entries;
   private long firstIndex;
+  private long lastIndex;
 
   JournalSegmentCache(long index, int size) {
     this.size = size;
     this.entries = new HashMap<>(size);
     this.firstIndex = index;
+  }
+
+  /**
+   * Returns the last cache index.
+   *
+   * @return the last cache index
+   */
+  public long index() {
+    return lastIndex;
   }
 
   /**
@@ -42,6 +52,7 @@ class JournalSegmentCache {
   public void put(Indexed indexed) {
     if (indexed.index() == firstIndex + entries.size()) {
       entries.put(indexed.index(), indexed);
+      lastIndex = indexed.index();
     }
     if (entries.size() > size) {
       entries.remove(firstIndex);
@@ -73,6 +84,7 @@ class JournalSegmentCache {
       for (long i = index + 1; i < firstIndex + size; i++) {
         entries.remove(i);
       }
+      lastIndex = firstIndex + entries.size() - 1;
     }
   }
 

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
@@ -15,12 +15,12 @@
  */
 package io.atomix.storage.journal;
 
-import io.atomix.utils.serializer.Serializer;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.Bytes;
 import io.atomix.storage.buffer.HeapBuffer;
 import io.atomix.storage.journal.index.JournalIndex;
 import io.atomix.storage.journal.index.Position;
+import io.atomix.utils.serializer.Serializer;
 
 import java.nio.BufferUnderflowException;
 import java.util.NoSuchElementException;
@@ -136,7 +136,7 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
     Indexed cachedEntry = cache.get(index);
     if (cachedEntry != null) {
       this.nextEntry = cachedEntry;
-      buffer.skip(cachedEntry.size() + Bytes.INTEGER + Bytes.INTEGER);
+      buffer.skip(memory.position() + cachedEntry.size() + Bytes.INTEGER + Bytes.INTEGER);
       memory.clear().limit(0);
       return;
     } else if (cache.index() < index) {
@@ -162,7 +162,7 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
 
       // If the buffer length is zero then return.
       if (length <= 0 || length > maxEntrySize) {
-        memory.clear().limit(0);
+        memory.reset().limit(memory.position());
         nextEntry = null;
         return;
       }
@@ -183,11 +183,11 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
         E entry = serializer.decode(bytes);
         nextEntry = new Indexed<>(index, entry, length);
       } else {
-        memory.clear().limit(0);
+        memory.reset().limit(memory.position());
         nextEntry = null;
       }
     } catch (BufferUnderflowException e) {
-      memory.clear().limit(0);
+      memory.reset().limit(memory.position());
       nextEntry = null;
     }
   }

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
@@ -137,6 +137,10 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
     if (cachedEntry != null) {
       this.nextEntry = cachedEntry;
       buffer.skip(cachedEntry.size() + Bytes.INTEGER + Bytes.INTEGER);
+      memory.clear().limit(0);
+      return;
+    } else if (cache.index() < index) {
+      this.nextEntry = null;
       return;
     }
 
@@ -158,7 +162,7 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
 
       // If the buffer length is zero then return.
       if (length <= 0 || length > maxEntrySize) {
-        memory.reset().limit(memory.position());
+        memory.clear().limit(0);
         nextEntry = null;
         return;
       }
@@ -179,11 +183,11 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
         E entry = serializer.decode(bytes);
         nextEntry = new Indexed<>(index, entry, length);
       } else {
-        memory.reset().limit(memory.position());
+        memory.clear().limit(0);
         nextEntry = null;
       }
     } catch (BufferUnderflowException e) {
-      memory.reset().limit(memory.position());
+      memory.clear().limit(0);
       nextEntry = null;
     }
   }

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentReader.java
@@ -139,7 +139,7 @@ public class JournalSegmentReader<E> implements JournalReader<E> {
       buffer.skip(memory.position() + cachedEntry.size() + Bytes.INTEGER + Bytes.INTEGER);
       memory.clear().limit(0);
       return;
-    } else if (cache.index() < index) {
+    } else if (cache.index() > 0 && cache.index() < index) {
       this.nextEntry = null;
       return;
     }

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
@@ -16,14 +16,13 @@
 package io.atomix.storage.journal;
 
 import io.atomix.storage.StorageException;
-import io.atomix.storage.buffer.Bytes;
-import io.atomix.utils.serializer.Serializer;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.FileBuffer;
 import io.atomix.storage.buffer.HeapBuffer;
 import io.atomix.storage.buffer.MappedBuffer;
 import io.atomix.storage.buffer.SlicedBuffer;
 import io.atomix.storage.journal.index.JournalIndex;
+import io.atomix.utils.serializer.Serializer;
 
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
@@ -119,6 +119,9 @@ public class JournalSegmentWriter<E> implements JournalWriter<E> {
         break;
       }
 
+      // Update the current position for indexing.
+      position = buffer.position() + memory.position();
+
       // Read more bytes from the segment if necessary.
       if (memory.remaining() < maxEntrySize) {
         buffer.skip(memory.position())
@@ -128,7 +131,6 @@ public class JournalSegmentWriter<E> implements JournalWriter<E> {
         memory.flip();
       }
 
-      position = buffer.position() + memory.position();
       length = memory.mark().readInt();
     }
 

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentWriter.java
@@ -212,10 +212,12 @@ public class JournalSegmentWriter<E> implements JournalWriter<E> {
     // Record the current buffer position;
     int position = buffer.position();
 
-    // Write the entry length and entry to the segment.
-    buffer.writeInt(length)
+    // Create a single byte[] in memory for the entire entry and write it as a batch to the underlying buffer.
+    buffer.write(memory.clear()
+        .writeInt(length)
         .writeUnsignedInt(checksum)
-        .write(bytes);
+        .write(bytes)
+        .flip());
 
     // Update the last entry with the correct index/term/length.
     Indexed<E> indexedEntry = new Indexed<>(index, entry, length);

--- a/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -396,7 +396,7 @@ public class SegmentedJournal<E> implements Journal<E> {
    */
   private JournalSegment<E> createDiskSegment(JournalSegmentDescriptor descriptor) {
     File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
-    Buffer buffer = FileBuffer.allocate(segmentFile, Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
+    Buffer buffer = FileBuffer.allocate(segmentFile, descriptor.maxSegmentSize(), descriptor.maxSegmentSize()).zero();
     descriptor.copyTo(buffer);
     JournalSegment<E> segment = newSegment(new JournalSegmentFile(segmentFile), descriptor);
     log.debug("Created disk segment: {}", segment);
@@ -408,7 +408,7 @@ public class SegmentedJournal<E> implements Journal<E> {
    */
   private JournalSegment<E> createMappedSegment(JournalSegmentDescriptor descriptor) {
     File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
-    Buffer buffer = MappedBuffer.allocate(segmentFile, Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
+    Buffer buffer = MappedBuffer.allocate(segmentFile, descriptor.maxSegmentSize(), descriptor.maxSegmentSize()).zero();
     descriptor.copyTo(buffer);
     JournalSegment<E> segment = newSegment(new JournalSegmentFile(segmentFile), descriptor);
     log.debug("Created memory mapped segment: {}", segment);
@@ -420,7 +420,7 @@ public class SegmentedJournal<E> implements Journal<E> {
    */
   private JournalSegment<E> createMemorySegment(JournalSegmentDescriptor descriptor) {
     File segmentFile = JournalSegmentFile.createSegmentFile(name, directory, descriptor.id());
-    Buffer buffer = HeapBuffer.allocate(Math.min(DEFAULT_BUFFER_SIZE, descriptor.maxSegmentSize()), Integer.MAX_VALUE);
+    Buffer buffer = HeapBuffer.allocate(descriptor.maxSegmentSize(), descriptor.maxSegmentSize());
     descriptor.copyTo(buffer);
     JournalSegment<E> segment = newSegment(new JournalSegmentFile(segmentFile), descriptor);
     log.debug("Created memory segment: {}", segment);


### PR DESCRIPTION
This PR includes several commits that optimize reading and writing the Raft log:
* Avoid system calls by reading and writing entries as a single array
* Pre-allocate contiguous Raft log segments
* Avoid cache misses and disk reads on Raft log tail reads
* Ensure cluster events are handled on the Raft server thread

The last point is a potential fix for the `Cannot apply index` issue in `RaftServiceManager`