### PR TITLE
Deprecate maximum entries per segment

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -169,7 +169,9 @@ public class RaftStorage {
    * that are allowed to be stored in any segment in a {@link RaftLog}.
    *
    * @return The maximum number of entries per segment.
+   * @deprecated since 3.0.2
    */
+  @Deprecated
   public int maxLogEntriesPerSegment() {
     return maxEntriesPerSegment;
   }
@@ -521,7 +523,9 @@ public class RaftStorage {
      * @return The storage builder.
      * @throws IllegalArgumentException If the {@code maxEntriesPerSegment} not greater than the default max entries per
      *                                  segment
+     * @deprecated since 3.0.2
      */
+    @Deprecated
     public Builder withMaxEntriesPerSegment(int maxEntriesPerSegment) {
       checkArgument(maxEntriesPerSegment > 0, "max entries per segment must be positive");
       checkArgument(maxEntriesPerSegment <= DEFAULT_MAX_ENTRIES_PER_SEGMENT,

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -246,7 +246,9 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
      * @return The storage builder.
      * @throws IllegalArgumentException If the {@code maxEntriesPerSegment} not greater than the default max entries per
      *                                  segment
+     * @deprecated since 3.0.2
      */
+    @Deprecated
     public Builder withMaxEntriesPerSegment(int maxEntriesPerSegment) {
       journalBuilder.withMaxEntriesPerSegment(maxEntriesPerSegment);
       return this;

--- a/storage/src/main/java/io/atomix/storage/journal/JournalSegmentDescriptor.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalSegmentDescriptor.java
@@ -300,7 +300,9 @@ public final class JournalSegmentDescriptor implements AutoCloseable {
      *
      * @param maxEntries The maximum number of entries in the segment.
      * @return The segment descriptor builder.
+     * @deprecated since 3.0.2
      */
+    @Deprecated
     public Builder withMaxEntries(int maxEntries) {
       buffer.writeInt(MAX_ENTRIES_POSITION, maxEntries);
       return this;

--- a/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -160,7 +160,9 @@ public class SegmentedJournal<E> implements Journal<E> {
    * in a journal.
    *
    * @return The maximum number of entries per segment.
+   * @deprecated since 3.0.2
    */
+  @Deprecated
   public int maxEntriesPerSegment() {
     return maxEntriesPerSegment;
   }
@@ -761,7 +763,9 @@ public class SegmentedJournal<E> implements Journal<E> {
      * @return The storage builder.
      * @throws IllegalArgumentException If the {@code maxEntriesPerSegment} not greater than the default max entries
      *     per segment
+     * @deprecated since 3.0.2
      */
+    @Deprecated
     public Builder<E> withMaxEntriesPerSegment(int maxEntriesPerSegment) {
       checkArgument(maxEntriesPerSegment > 0, "max entries per segment must be positive");
       checkArgument(maxEntriesPerSegment <= DEFAULT_MAX_ENTRIES_PER_SEGMENT,


### PR DESCRIPTION
The maximum number of entries per segment is limited in its usefulness as a Raft log configuration. It makes the size of a segment dependent on the size of the entries in the segment. This PR deprecates the maximum entries per segment configuration to be removed in 3.2.0