### PR TITLE
Avoid globally expiring sessions that have not been orphaned by a deleted primitive service

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -640,8 +640,8 @@ public class RaftServiceManager implements AutoCloseable {
   private void expireOrphanSessions(long timestamp) {
     // Iterate through registered sessions.
     for (RaftSession session : raft.getSessions().getSessions()) {
-      if (session.isTimedOut(timestamp)) {
-        logger.debug("Session expired in {} milliseconds: {}", timestamp - session.getLastUpdated(), session);
+      if (session.getService().deleted() && session.isTimedOut(timestamp)) {
+        logger.debug("Orphaned session expired in {} milliseconds: {}", timestamp - session.getLastUpdated(), session);
         session = raft.getSessions().removeSession(session.sessionId());
         if (session != null) {
           session.expire();

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
@@ -110,6 +110,15 @@ public class RaftServiceContext implements ServiceContext {
     service.init(this);
   }
 
+  /**
+   * Returns a boolean indicating whether the service has been deleted.
+   *
+   * @return indicates whether the service has been deleted
+   */
+  public boolean deleted() {
+    return deleted;
+  }
+
   @Override
   public PrimitiveId serviceId() {
     return primitiveId;
@@ -319,6 +328,12 @@ public class RaftServiceContext implements ServiceContext {
    * @param eventIndex The session event index.
    */
   public boolean keepAlive(long index, long timestamp, RaftSession session, long commandSequence, long eventIndex) {
+    // If the service has been deleted then throw an unknown service exception.
+    if (deleted) {
+      log.warn("Service {} has been deleted by another process", serviceName);
+      throw new RaftException.UnknownService("Service " + serviceName + " has been deleted");
+    }
+
     // Update the state machine index/timestamp.
     tick(index, timestamp);
 


### PR DESCRIPTION
This PR fixes a bug in the implementation of deletes for Raft primitives. The implementation of deletes expires Raft sessions outside the context of specific primitive services to ensure that sessions that are active for a deleted primitive are eventually expired if the primitive client doesn't send a keep-alive. But the current implementation does not just expire sessions for deleted primitives, it expires them for all primitives. So, if the `RaftServiceManager` expires a session for a service, the service's `expire` method is never called and the still active service will hold on to a session that's been expired. When the service then attempts to send events to an expired session that it never removed, it will get an `IllegalStateException`.

This PR exposes the `deleted` state of the service associated with each session and avoids expiring sessions for services that haven't been deleted, thus leaving it up to each individual service to expire its sessions while active.