### PR TITLE
Share thread pool for all partitions in a Raft partition group

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftClient.java
@@ -23,6 +23,7 @@ import io.atomix.protocols.raft.impl.DefaultRaftClient;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.session.CommunicationStrategy;
 import io.atomix.protocols.raft.session.RaftSessionClient;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.concurrent.ThreadModel;
 
 import java.util.Arrays;
@@ -189,6 +190,7 @@ public interface RaftClient {
     protected RaftClientProtocol protocol;
     protected ThreadModel threadModel = ThreadModel.SHARED_THREAD_POOL;
     protected int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
+    protected ThreadContextFactory threadContextFactory;
 
     protected Builder(Collection<MemberId> cluster) {
       this.cluster = checkNotNull(cluster, "cluster cannot be null");
@@ -267,6 +269,18 @@ public interface RaftClient {
     public Builder withThreadPoolSize(int threadPoolSize) {
       checkArgument(threadPoolSize > 0, "threadPoolSize must be positive");
       this.threadPoolSize = threadPoolSize;
+      return this;
+    }
+
+    /**
+     * Sets the client thread context factory.
+     *
+     * @param threadContextFactory the client thread context factory
+     * @return the client builder
+     * @throws NullPointerException if the factory is null
+     */
+    public Builder withThreadContextFactory(ThreadContextFactory threadContextFactory) {
+      this.threadContextFactory = checkNotNull(threadContextFactory, "threadContextFactory cannot be null");
       return this;
     }
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -27,6 +27,7 @@ import io.atomix.protocols.raft.protocol.RaftServerProtocol;
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.protocols.raft.storage.log.RaftLog;
 import io.atomix.storage.StorageLevel;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.concurrent.ThreadModel;
 
 import java.net.InetAddress;
@@ -564,6 +565,7 @@ public interface RaftServer {
     protected PrimitiveTypeRegistry primitiveTypes;
     protected ThreadModel threadModel = DEFAULT_THREAD_MODEL;
     protected int threadPoolSize = DEFAULT_THREAD_POOL_SIZE;
+    protected ThreadContextFactory threadContextFactory;
 
     protected Builder(MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -696,6 +698,18 @@ public interface RaftServer {
     public Builder withThreadPoolSize(int threadPoolSize) {
       checkArgument(threadPoolSize > 0, "threadPoolSize must be positive");
       this.threadPoolSize = threadPoolSize;
+      return this;
+    }
+
+    /**
+     * Sets the client thread context factory.
+     *
+     * @param threadContextFactory the client thread context factory
+     * @return the server builder
+     * @throws NullPointerException if the factory is null
+     */
+    public Builder withThreadContextFactory(ThreadContextFactory threadContextFactory) {
+      this.threadContextFactory = checkNotNull(threadContextFactory, "threadContextFactory cannot be null");
       return this;
     }
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftClient.java
@@ -53,6 +53,7 @@ public class DefaultRaftClient implements RaftClient {
   private final Collection<MemberId> cluster;
   private final RaftClientProtocol protocol;
   private final ThreadContextFactory threadContextFactory;
+  private final boolean closeThreadFactoryOnClose;
   private final ThreadContext threadContext;
   private final RaftMetadataClient metadata;
   private final MemberSelectorManager selectorManager = new MemberSelectorManager();
@@ -64,7 +65,8 @@ public class DefaultRaftClient implements RaftClient {
       MemberId memberId,
       Collection<MemberId> cluster,
       RaftClientProtocol protocol,
-      ThreadContextFactory threadContextFactory) {
+      ThreadContextFactory threadContextFactory,
+      boolean closeThreadFactoryOnClose) {
     this.clientId = checkNotNull(clientId, "clientId cannot be null");
     this.partitionId = checkNotNull(partitionId, "partitionId cannot be null");
     this.cluster = checkNotNull(cluster, "cluster cannot be null");
@@ -73,6 +75,7 @@ public class DefaultRaftClient implements RaftClient {
     this.threadContext = threadContextFactory.createContext();
     this.metadata = new DefaultRaftMetadataClient(clientId, protocol, selectorManager, threadContextFactory.createContext());
     this.sessionManager = new RaftSessionManager(clientId, memberId, protocol, selectorManager, threadContextFactory);
+    this.closeThreadFactoryOnClose = closeThreadFactoryOnClose;
   }
 
   @Override
@@ -176,7 +179,11 @@ public class DefaultRaftClient implements RaftClient {
 
   @Override
   public synchronized CompletableFuture<Void> close() {
-    return sessionManager.close().thenRunAsync(threadContextFactory::close);
+    return sessionManager.close().thenRunAsync(() -> {
+      if (closeThreadFactoryOnClose) {
+        threadContextFactory.close();
+      }
+    });
   }
 
   @Override
@@ -200,8 +207,19 @@ public class DefaultRaftClient implements RaftClient {
       Logger log = ContextualLoggerFactory.getLogger(DefaultRaftClient.class, LoggerContext.builder(RaftClient.class)
           .addValue(clientId)
           .build());
-      ThreadContextFactory threadContextFactory = threadModel.factory("raft-client-" + clientId + "-%d", threadPoolSize, log);
-      return new DefaultRaftClient(clientId, partitionId, memberId, cluster, protocol, threadContextFactory);
+
+      // If a ThreadContextFactory was not provided, create one and ensure it's closed when the client is stopped.
+      boolean closeThreadFactoryOnClose;
+      ThreadContextFactory threadContextFactory;
+      if (this.threadContextFactory == null) {
+        threadContextFactory = threadModel.factory("raft-client-" + clientId + "-%d", threadPoolSize, log);
+        closeThreadFactoryOnClose = true;
+      } else {
+        threadContextFactory = this.threadContextFactory;
+        closeThreadFactoryOnClose = false;
+      }
+
+      return new DefaultRaftClient(clientId, partitionId, memberId, cluster, protocol, threadContextFactory, closeThreadFactoryOnClose);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -23,6 +23,7 @@ import io.atomix.protocols.raft.cluster.RaftCluster;
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.utils.concurrent.AtomixFuture;
 import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import org.slf4j.Logger;
@@ -226,6 +227,10 @@ public class DefaultRaftServer implements RaftServer {
 
     @Override
     public RaftServer build() {
+      Logger log = ContextualLoggerFactory.getLogger(RaftServer.class, LoggerContext.builder(RaftServer.class)
+          .addValue(name)
+          .build());
+
       if (primitiveTypes == null) {
         primitiveTypes = new ClasspathScanningPrimitiveTypeRegistry(Thread.currentThread().getContextClassLoader());
       }
@@ -243,7 +248,26 @@ public class DefaultRaftServer implements RaftServer {
         storage = RaftStorage.builder().build();
       }
 
-      RaftContext raft = new RaftContext(name, localMemberId, membershipService, protocol, storage, primitiveTypes, threadModel, threadPoolSize);
+      // If a ThreadContextFactory was not provided, create one and ensure it's closed when the server is stopped.
+      boolean closeOnStop;
+      ThreadContextFactory threadContextFactory;
+      if (this.threadContextFactory == null) {
+        threadContextFactory = threadModel.factory("raft-server-" + name + "-%d", threadPoolSize, log);
+        closeOnStop = true;
+      } else {
+        threadContextFactory = this.threadContextFactory;
+        closeOnStop = false;
+      }
+
+      RaftContext raft = new RaftContext(
+          name,
+          localMemberId,
+          membershipService,
+          protocol,
+          storage,
+          primitiveTypes,
+          threadContextFactory,
+          closeOnStop);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
       raft.setSessionTimeout(sessionTimeout);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -106,6 +106,7 @@ public class RaftContext implements AutoCloseable {
   private final ThreadContextFactory threadContextFactory;
   private final ThreadContext loadContext;
   private final ThreadContext stateContext;
+  private final boolean closeOnStop;
   protected RaftRole role = new InactiveRole(this);
   private Duration electionTimeout = Duration.ofMillis(500);
   private Duration heartbeatInterval = Duration.ofMillis(150);
@@ -125,8 +126,8 @@ public class RaftContext implements AutoCloseable {
       RaftServerProtocol protocol,
       RaftStorage storage,
       PrimitiveTypeRegistry primitiveTypes,
-      ThreadModel threadModel,
-      int threadPoolSize) {
+      ThreadContextFactory threadContextFactory,
+      boolean closeOnStop) {
     this.name = checkNotNull(name, "name cannot be null");
     this.membershipService = checkNotNull(membershipService, "membershipService cannot be null");
     this.protocol = checkNotNull(protocol, "protocol cannot be null");
@@ -146,7 +147,8 @@ public class RaftContext implements AutoCloseable {
     this.loadContext = new SingleThreadContext(namedThreads(baseThreadName + "-load", log));
     this.stateContext = new SingleThreadContext(namedThreads(baseThreadName + "-state", log));
 
-    this.threadContextFactory = threadModel.factory(baseThreadName + "-%d", threadPoolSize, log);
+    this.threadContextFactory = checkNotNull(threadContextFactory, "threadContextFactory cannot be null");
+    this.closeOnStop = closeOnStop;
 
     this.loadMonitor = new LoadMonitor(LOAD_WINDOW_SIZE, HIGH_LOAD_THRESHOLD, loadContext);
 
@@ -882,7 +884,11 @@ public class RaftContext implements AutoCloseable {
     threadContext.close();
     loadContext.close();
     stateContext.close();
-    threadContextFactory.close();
+
+    // Only close the thread context factory if indicated.
+    if (closeOnStop) {
+      threadContextFactory.close();
+    }
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -24,6 +24,7 @@ import io.atomix.protocols.raft.partition.impl.RaftClientCommunicator;
 import io.atomix.protocols.raft.partition.impl.RaftNamespaces;
 import io.atomix.protocols.raft.partition.impl.RaftPartitionClient;
 import io.atomix.protocols.raft.partition.impl.RaftPartitionServer;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.serializer.Serializer;
 
 import java.io.File;
@@ -41,14 +42,20 @@ public class RaftPartition implements Partition {
   private final PartitionId partitionId;
   private final RaftPartitionGroupConfig config;
   private final File dataDirectory;
+  private final ThreadContextFactory threadContextFactory;
   private PartitionMetadata partition;
   private RaftPartitionClient client;
   private RaftPartitionServer server;
 
-  public RaftPartition(PartitionId partitionId, RaftPartitionGroupConfig config, File dataDirectory) {
+  public RaftPartition(
+      PartitionId partitionId,
+      RaftPartitionGroupConfig config,
+      File dataDirectory,
+      ThreadContextFactory threadContextFactory) {
     this.partitionId = partitionId;
     this.config = config;
     this.dataDirectory = dataDirectory;
+    this.threadContextFactory = threadContextFactory;
   }
 
   @Override
@@ -168,7 +175,8 @@ public class RaftPartition implements Partition {
         managementService.getMembershipService().getLocalMember().id(),
         managementService.getMembershipService(),
         managementService.getMessagingService(),
-        managementService.getPrimitiveTypes());
+        managementService.getPrimitiveTypes(),
+        threadContextFactory);
   }
 
   /**
@@ -181,7 +189,8 @@ public class RaftPartition implements Partition {
         new RaftClientCommunicator(
             name(),
             Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
-            managementService.getMessagingService()));
+            managementService.getMessagingService()),
+        threadContextFactory);
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
@@ -17,8 +17,6 @@ package io.atomix.protocols.raft.partition;
 
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionGroupConfig;
-import io.atomix.storage.StorageLevel;
-import io.atomix.utils.memory.MemorySize;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -28,7 +26,6 @@ import java.util.Set;
  */
 public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartitionGroupConfig> {
   private static final int DEFAULT_PARTITIONS = 7;
-  private static final String DATA_PREFIX = ".data";
 
   private Set<String> members = new HashSet<>();
   private int partitionSize;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionClient.java
@@ -24,6 +24,7 @@ import io.atomix.protocols.raft.partition.RaftPartition;
 import io.atomix.protocols.raft.protocol.RaftClientProtocol;
 import io.atomix.protocols.raft.session.RaftSessionClient;
 import io.atomix.utils.Managed;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import org.slf4j.Logger;
 
 import java.util.concurrent.CompletableFuture;
@@ -40,12 +41,18 @@ public class RaftPartitionClient implements PartitionClient, Managed<RaftPartiti
   private final RaftPartition partition;
   private final MemberId localMemberId;
   private final RaftClientProtocol protocol;
+  private final ThreadContextFactory threadContextFactory;
   private RaftClient client;
 
-  public RaftPartitionClient(RaftPartition partition, MemberId localMemberId, RaftClientProtocol protocol) {
+  public RaftPartitionClient(
+      RaftPartition partition,
+      MemberId localMemberId,
+      RaftClientProtocol protocol,
+      ThreadContextFactory threadContextFactory) {
     this.partition = partition;
     this.localMemberId = localMemberId;
     this.protocol = protocol;
+    this.threadContextFactory = threadContextFactory;
   }
 
   /**
@@ -101,6 +108,7 @@ public class RaftPartitionClient implements PartitionClient, Managed<RaftPartiti
         .withPartitionId(partition.id())
         .withMemberId(localMemberId)
         .withProtocol(protocol)
+        .withThreadContextFactory(threadContextFactory)
         .build();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -27,6 +27,7 @@ import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.storage.StorageException;
 import io.atomix.utils.Managed;
 import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 
@@ -58,6 +59,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   private final ClusterMembershipService membershipService;
   private final ClusterCommunicationService clusterCommunicator;
   private final PrimitiveTypeRegistry primitiveTypes;
+  private final ThreadContextFactory threadContextFactory;
   private RaftServer server;
 
   public RaftPartitionServer(
@@ -66,13 +68,15 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
       MemberId localMemberId,
       ClusterMembershipService membershipService,
       ClusterCommunicationService clusterCommunicator,
-      PrimitiveTypeRegistry primitiveTypes) {
+      PrimitiveTypeRegistry primitiveTypes,
+      ThreadContextFactory threadContextFactory) {
     this.partition = partition;
     this.config = config;
     this.localMemberId = localMemberId;
     this.membershipService = membershipService;
     this.clusterCommunicator = clusterCommunicator;
     this.primitiveTypes = primitiveTypes;
+    this.threadContextFactory = threadContextFactory;
   }
 
   @Override
@@ -163,6 +167,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
             .withFreeMemoryBuffer(config.getCompactionConfig().getFreeMemoryBuffer())
             .withSerializer(Serializer.using(RaftNamespaces.RAFT_STORAGE))
             .build())
+        .withThreadContextFactory(threadContextFactory)
         .build();
   }
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
@@ -32,6 +32,7 @@ import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.service.ServiceExecutor;
+import io.atomix.protocols.raft.RaftServer;
 import io.atomix.protocols.raft.ReadConsistency;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;
@@ -54,6 +55,7 @@ import io.atomix.utils.serializer.Serializer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -251,8 +253,8 @@ public class RaftServiceManagerTest {
         mock(RaftServerProtocol.class),
         storage,
         registry,
-        ThreadModel.SHARED_THREAD_POOL,
-        1);
+        ThreadModel.SHARED_THREAD_POOL.factory("raft-server-test-%d", 1, LoggerFactory.getLogger(RaftServer.class)),
+        true);
 
     snapshotTaken = new AtomicBoolean();
     snapshotInstalled = new AtomicBoolean();


### PR DESCRIPTION
Large Raft partition groups currently use far too many threads. The `AtomicMap` performance test creates around a thousand threads. This PR ensures Raft partition clients and servers share a thread pool for each partition group.