### PR TITLE
Set Docker image tag to 'latest' for snapshots

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -99,7 +99,7 @@
         </executions>
         <configuration>
           <repository>atomix/atomix</repository>
-          <tag>${project.version}</tag>
+          <tag>${dockerfile.version}</tag>
           <buildArgs>
             <VERSION>${project.version}</VERSION>
           </buildArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
     <maven.dockerfile.plugin.version>1.4.3</maven.dockerfile.plugin.version>
 
+    <dockerfile.version>latest</dockerfile.version>
+
     <argLine.common>-Xss256k -Xms512m -Xmx2G -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -Dio.atomix.whitelistPackages=io.atomix</argLine.common>
     <argLine.extras /> <!-- Overridden in some profiles -->
     <argLine.javadocs />
@@ -96,6 +98,56 @@
       <activation>
         <jdk>[1.9,)</jdk>
       </activation>
+    </profile>
+    <profile>
+      <id>sonatype-oss-release</id>
+      <properties>
+        <dockerfile.version>${project.version}</dockerfile.version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.1.2</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.7</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 


### PR DESCRIPTION
This PR updates the Dockerfile plugin and release profile to assign the `latest` tag to the Docker image when a snapshot is deployed and the release version during a release.