### PR TITLE
Fix broken serializers in distributed set service snapshot/restore methods

### DIFF
--- a/core/src/main/java/io/atomix/core/collection/impl/DefaultDistributedCollectionService.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/DefaultDistributedCollectionService.java
@@ -49,7 +49,7 @@ public abstract class DefaultDistributedCollectionService<T extends Collection<E
   protected static final int MAX_ITERATOR_BATCH_SIZE = 1000;
 
   private final Serializer serializer;
-  private T collection;
+  protected T collection;
   protected Map<Long, AbstractIteratorContext> iterators = Maps.newHashMap();
   private Set<SessionId> listeners = Sets.newHashSet();
 

--- a/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListService.java
+++ b/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListService.java
@@ -19,6 +19,8 @@ import io.atomix.core.collection.impl.CollectionUpdateResult;
 import io.atomix.core.collection.impl.DefaultDistributedCollectionService;
 import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.core.list.DistributedListType;
+import io.atomix.primitive.service.BackupInput;
+import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Serializer;
@@ -55,6 +57,16 @@ public class DefaultDistributedListService extends DefaultDistributedCollectionS
 
   private List<String> list() {
     return collection();
+  }
+
+  @Override
+  public void backup(BackupOutput output) {
+    output.writeObject(new ArrayList<>(list()));
+  }
+
+  @Override
+  public void restore(BackupInput input) {
+    collection = Collections.synchronizedList(input.readObject());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapService.java
@@ -100,7 +100,7 @@ public abstract class AbstractAtomicMapService<K> extends AbstractPrimitiveServi
   public void backup(BackupOutput writer) {
     writer.writeObject(listeners);
     writer.writeObject(preparedKeys);
-    writer.writeObject(entries());
+    writer.writeObject(Maps.newHashMap(entries()));
     writer.writeObject(activeTransactions);
     writer.writeLong(currentVersion);
     writer.writeObject(entryIterators);
@@ -110,7 +110,9 @@ public abstract class AbstractAtomicMapService<K> extends AbstractPrimitiveServi
   public void restore(BackupInput reader) {
     listeners = reader.readObject();
     preparedKeys = reader.readObject();
-    map = reader.readObject();
+    Map<K, MapEntryValue> map = reader.readObject();
+    this.map = createMap();
+    this.map.putAll(map);
     activeTransactions = reader.readObject();
     currentVersion = reader.readLong();
     entryIterators = reader.readObject();

--- a/core/src/main/java/io/atomix/core/queue/impl/DefaultDistributedQueueService.java
+++ b/core/src/main/java/io/atomix/core/queue/impl/DefaultDistributedQueueService.java
@@ -17,7 +17,10 @@ package io.atomix.core.queue.impl;
 
 import io.atomix.core.collection.impl.DefaultDistributedCollectionService;
 import io.atomix.core.queue.DistributedQueueType;
+import io.atomix.primitive.service.BackupInput;
+import io.atomix.primitive.service.BackupOutput;
 
+import java.util.ArrayDeque;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -32,6 +35,16 @@ public class DefaultDistributedQueueService extends DefaultDistributedCollection
 
   private Queue<String> queue() {
     return collection();
+  }
+
+  @Override
+  public void backup(BackupOutput output) {
+    output.writeObject(new ArrayDeque<>(queue()));
+  }
+
+  @Override
+  public void restore(BackupInput input) {
+    collection = new ConcurrentLinkedQueue<>(input.readObject());
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/impl/AbstractDistributedSetService.java
+++ b/core/src/main/java/io/atomix/core/set/impl/AbstractDistributedSetService.java
@@ -51,14 +51,16 @@ public abstract class AbstractDistributedSetService<S extends Collection<E>, E> 
 
   @Override
   public void backup(BackupOutput output) {
-    super.backup(output);
+    output.writeObject(Sets.newHashSet(collection));
     output.writeObject(lockedElements);
     output.writeObject(transactions);
   }
 
   @Override
   public void restore(BackupInput input) {
-    super.restore(input);
+    Set<E> elements = input.readObject();
+    collection.clear();
+    collection.addAll(elements);
     lockedElements = input.readObject();
     transactions = input.readObject();
   }

--- a/core/src/main/java/io/atomix/core/set/impl/AbstractDistributedSetService.java
+++ b/core/src/main/java/io/atomix/core/set/impl/AbstractDistributedSetService.java
@@ -38,8 +38,8 @@ import static io.atomix.core.collection.impl.CollectionUpdateResult.writeLockCon
  * Default distributed set service.
  */
 public abstract class AbstractDistributedSetService<S extends Collection<E>, E> extends DefaultDistributedCollectionService<S, E> implements DistributedSetService<E> {
-  private Set<E> lockedElements = Sets.newHashSet();
-  private Map<TransactionId, TransactionLog<SetUpdate<E>>> transactions = Maps.newHashMap();
+  protected Set<E> lockedElements = Sets.newHashSet();
+  protected Map<TransactionId, TransactionLog<SetUpdate<E>>> transactions = Maps.newHashMap();
 
   public AbstractDistributedSetService(PrimitiveType primitiveType, S collection) {
     super(primitiveType, collection);

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetService.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetService.java
@@ -15,14 +15,18 @@
  */
 package io.atomix.core.set.impl;
 
+import com.google.common.collect.Sets;
 import io.atomix.core.iterator.impl.IteratorBatch;
 import io.atomix.core.set.DistributedNavigableSetType;
+import io.atomix.primitive.service.BackupInput;
+import io.atomix.primitive.service.BackupOutput;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Serializer;
 
 import java.util.Iterator;
 import java.util.NavigableSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -48,6 +52,22 @@ public class DefaultDistributedNavigableSetService<E extends Comparable<E>> exte
   @Override
   public Serializer serializer() {
     return serializer;
+  }
+
+  @Override
+  public void backup(BackupOutput output) {
+    output.writeObject(Sets.newHashSet(collection));
+    output.writeObject(lockedElements);
+    output.writeObject(transactions);
+  }
+
+  @Override
+  public void restore(BackupInput input) {
+    Set<E> elements = input.readObject();
+    collection = new ConcurrentSkipListSet<>();
+    collection.addAll(elements);
+    lockedElements = input.readObject();
+    transactions = input.readObject();
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetService.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetService.java
@@ -55,22 +55,6 @@ public class DefaultDistributedNavigableSetService<E extends Comparable<E>> exte
   }
 
   @Override
-  public void backup(BackupOutput output) {
-    output.writeObject(Sets.newHashSet(collection));
-    output.writeObject(lockedElements);
-    output.writeObject(transactions);
-  }
-
-  @Override
-  public void restore(BackupInput input) {
-    Set<E> elements = input.readObject();
-    collection = new ConcurrentSkipListSet<>();
-    collection.addAll(elements);
-    lockedElements = input.readObject();
-    transactions = input.readObject();
-  }
-
-  @Override
   public E lower(E e) {
     return set().lower(e);
   }

--- a/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetService.java
+++ b/core/src/main/java/io/atomix/core/set/impl/DefaultDistributedSetService.java
@@ -17,6 +17,8 @@ package io.atomix.core.set.impl;
 
 import com.google.common.collect.Sets;
 import io.atomix.core.set.DistributedSetType;
+import io.atomix.primitive.service.BackupInput;
+import io.atomix.primitive.service.BackupOutput;
 
 import java.util.Set;
 
@@ -26,5 +28,19 @@ import java.util.Set;
 public class DefaultDistributedSetService<E> extends AbstractDistributedSetService<Set<E>, E> implements DistributedSetService<E> {
   public DefaultDistributedSetService() {
     super(DistributedSetType.instance(), Sets.newConcurrentHashSet());
+  }
+
+  @Override
+  public void backup(BackupOutput output) {
+    output.writeObject(Sets.newHashSet(collection));
+    output.writeObject(lockedElements);
+    output.writeObject(transactions);
+  }
+
+  @Override
+  public void restore(BackupInput input) {
+    collection = Sets.newConcurrentHashSet(input.readObject());
+    lockedElements = input.readObject();
+    transactions = input.readObject();
   }
 }

--- a/core/src/test/java/io/atomix/core/list/impl/DefaultDistributedListServiceTest.java
+++ b/core/src/test/java/io/atomix/core/list/impl/DefaultDistributedListServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.list.impl;
+
+import io.atomix.core.set.DistributedSetType;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.service.impl.DefaultBackupInput;
+import io.atomix.primitive.service.impl.DefaultBackupOutput;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.storage.buffer.Buffer;
+import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.utils.time.WallClock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Distributed list service test.
+ */
+public class DefaultDistributedListServiceTest {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSnapshot() throws Exception {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(DistributedSetType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
+
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+
+    DefaultDistributedListService service = new DefaultDistributedListService();
+    service.init(context);
+
+    service.add("foo");
+
+    Buffer buffer = HeapBuffer.allocate();
+    service.backup(new DefaultBackupOutput(buffer, service.serializer()));
+
+    service = new DefaultDistributedListService();
+    service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
+
+    assertEquals("foo", service.get(0));
+  }
+}

--- a/core/src/test/java/io/atomix/core/map/impl/DefaultAtomicNavigableMapServiceTest.java
+++ b/core/src/test/java/io/atomix/core/map/impl/DefaultAtomicNavigableMapServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import io.atomix.core.map.AtomicMapType;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.service.impl.DefaultBackupInput;
+import io.atomix.primitive.service.impl.DefaultBackupOutput;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.storage.buffer.Buffer;
+import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.Scheduler;
+import io.atomix.utils.time.Versioned;
+import io.atomix.utils.time.WallClock;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Consistent map service test.
+ */
+public class DefaultAtomicNavigableMapServiceTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSnapshot() throws Exception {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(AtomicMapType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
+
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+
+    AbstractAtomicNavigableMapService service = new TestAtomicNavigableMapService();
+    service.init(context);
+
+    service.put("foo", "Hello world!".getBytes());
+
+    Buffer buffer = HeapBuffer.allocate();
+    service.backup(new DefaultBackupOutput(buffer, service.serializer()));
+
+    service = new TestAtomicNavigableMapService();
+    service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
+
+    Versioned<byte[]> value = service.get("foo");
+    assertNotNull(value);
+    assertArrayEquals("Hello world!".getBytes(), value.value());
+  }
+
+  private static class TestAtomicNavigableMapService extends AbstractAtomicNavigableMapService {
+    TestAtomicNavigableMapService() {
+      super(AtomicMapType.instance());
+    }
+
+    @Override
+    protected Scheduler getScheduler() {
+      return new Scheduler() {
+        @Override
+        public Scheduled schedule(Duration delay, Runnable callback) {
+          return mock(Scheduled.class);
+        }
+
+        @Override
+        public Scheduled schedule(Duration initialDelay, Duration interval, Runnable callback) {
+          return mock(Scheduled.class);
+        }
+      };
+    }
+
+    @Override
+    protected WallClock getWallClock() {
+      return new WallClock();
+    }
+  }
+}

--- a/core/src/test/java/io/atomix/core/multiset/impl/DefaultDistributedMultisetServiceTest.java
+++ b/core/src/test/java/io/atomix/core/multiset/impl/DefaultDistributedMultisetServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.multiset.impl;
+
+import io.atomix.core.set.DistributedSetType;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.service.impl.DefaultBackupInput;
+import io.atomix.primitive.service.impl.DefaultBackupOutput;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.storage.buffer.Buffer;
+import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.utils.time.WallClock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Distributed multiset service test.
+ */
+public class DefaultDistributedMultisetServiceTest {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSnapshot() throws Exception {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(DistributedSetType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
+
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+
+    DefaultDistributedMultisetService service = new DefaultDistributedMultisetService();
+    service.init(context);
+
+    service.add("foo");
+
+    Buffer buffer = HeapBuffer.allocate();
+    service.backup(new DefaultBackupOutput(buffer, service.serializer()));
+
+    service = new DefaultDistributedMultisetService();
+    service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
+
+    assertTrue(service.contains("foo"));
+  }
+}

--- a/core/src/test/java/io/atomix/core/queue/impl/DefaultDistributedQueueServiceTest.java
+++ b/core/src/test/java/io/atomix/core/queue/impl/DefaultDistributedQueueServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.queue.impl;
+
+import io.atomix.core.set.DistributedSetType;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.service.impl.DefaultBackupInput;
+import io.atomix.primitive.service.impl.DefaultBackupOutput;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.storage.buffer.Buffer;
+import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.utils.time.WallClock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Distributed queue service test.
+ */
+public class DefaultDistributedQueueServiceTest {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSnapshot() throws Exception {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(DistributedSetType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
+
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+
+    DefaultDistributedQueueService service = new DefaultDistributedQueueService();
+    service.init(context);
+
+    service.add("foo");
+
+    Buffer buffer = HeapBuffer.allocate();
+    service.backup(new DefaultBackupOutput(buffer, service.serializer()));
+
+    service = new DefaultDistributedQueueService();
+    service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
+
+    assertEquals("foo", service.remove());
+  }
+}

--- a/core/src/test/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetServiceTest.java
+++ b/core/src/test/java/io/atomix/core/set/impl/DefaultDistributedNavigableSetServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.set.impl;
+
+import io.atomix.core.set.DistributedSetType;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.service.impl.DefaultBackupInput;
+import io.atomix.primitive.service.impl.DefaultBackupOutput;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.storage.buffer.Buffer;
+import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.utils.time.WallClock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Consistent map service test.
+ */
+public class DefaultDistributedNavigableSetServiceTest {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSnapshot() throws Exception {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(DistributedSetType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
+
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+
+    DefaultDistributedNavigableSetService service = new DefaultDistributedNavigableSetService();
+    service.init(context);
+
+    service.add("foo");
+
+    Buffer buffer = HeapBuffer.allocate();
+    service.backup(new DefaultBackupOutput(buffer, service.serializer()));
+
+    service = new DefaultDistributedNavigableSetService();
+    service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
+
+    assertTrue(service.contains("foo"));
+  }
+}

--- a/core/src/test/java/io/atomix/core/set/impl/DefaultDistributedSetServiceTest.java
+++ b/core/src/test/java/io/atomix/core/set/impl/DefaultDistributedSetServiceTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.set.impl;
+
+import io.atomix.core.set.DistributedSetType;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.service.impl.DefaultBackupInput;
+import io.atomix.primitive.service.impl.DefaultBackupOutput;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.storage.buffer.Buffer;
+import io.atomix.storage.buffer.HeapBuffer;
+import io.atomix.utils.time.WallClock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Consistent map service test.
+ */
+public class DefaultDistributedSetServiceTest {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testSnapshot() throws Exception {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(DistributedSetType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
+
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+
+    DefaultDistributedSetService service = new DefaultDistributedSetService();
+    service.init(context);
+
+    service.add("foo");
+
+    Buffer buffer = HeapBuffer.allocate();
+    service.backup(new DefaultBackupOutput(buffer, service.serializer()));
+
+    service = new DefaultDistributedSetService();
+    service.restore(new DefaultBackupInput(buffer.flip(), service.serializer()));
+
+    assertTrue(service.contains("foo"));
+  }
+}


### PR DESCRIPTION
This PR fixes #833. The problem is, changes to the distributed set data structures caused serialization exceptions. This PR adds tests for set snapshots and serializes state as simple `HashSet`s.

There may be other services that need tests for snapshots as well.