### PR TITLE
Listen on all interfaces when running Atomix agent

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -15,8 +15,6 @@
  */
 package io.atomix.agent;
 
-import ch.qos.logback.classic.Level;
-import com.google.common.collect.Lists;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.NodeConfig;
 import io.atomix.cluster.discovery.BootstrapDiscoveryConfig;
@@ -38,82 +36,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 
 /**
  * Atomix agent runner.
  */
 public class AtomixAgent {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AtomixAgent.class);
 
-  /**
-   * Runs a standalone Atomix agent from the given command line arguments.
-   *
-   * @param args the program arguments
-   * @throws Exception if the supplied arguments are invalid
-   */
   public static void main(String[] args) throws Exception {
-    // Parse the command line arguments.
-    final Namespace namespace = parseArgs(args);
-    final Logger logger = createLogger(namespace);
-
-    final Atomix atomix = buildAtomix(namespace);
-    atomix.start().join();
-    logger.info("Atomix listening at {}", atomix.getMembershipService().getLocalMember().address());
-
-    final ManagedRestService rest = buildRestService(atomix, namespace);
-    rest.start().join();
-    logger.warn("The Atomix HTTP API is BETA and is intended for development and debugging purposes only!");
-    logger.info("HTTP server listening at {}", rest.address());
-
-    synchronized (Atomix.class) {
-      while (atomix.isRunning()) {
-        Atomix.class.wait();
-      }
-    }
-  }
-
-  /**
-   * Parses the command line arguments, returning an argparse4j namespace.
-   *
-   * @param args the arguments to parse
-   * @return the namespace
-   */
-  private static Namespace parseArgs(String[] args) {
-    ArgumentParser parser = createParser();
-    Namespace namespace = null;
-    try {
-      namespace = parser.parseArgs(args);
-    } catch (ArgumentParserException e) {
-      parser.handleError(e);
-      System.exit(1);
-    }
-    return namespace;
-  }
-
-  /**
-   * Creates an agent argument parser.
-   */
-  private static ArgumentParser createParser() {
-    // Argument type for node ID/location formatted id@host:port.
-    final ArgumentType<NodeConfig> nodeArgumentType = (ArgumentParser argumentParser, Argument argument, String value) -> new NodeConfig()
+    ArgumentType<NodeConfig> nodeArgumentType = (ArgumentParser argumentParser, Argument argument, String value) -> new NodeConfig()
         .setId(parseMemberId(value))
         .setAddress(parseAddress(value));
 
-    // Argument type for node addresses formatted host:port.
-    final ArgumentType<Address> addressArgumentType = (argumentParser, argument, value) -> Address.from(value);
+    ArgumentType<Address> addressArgumentType = (argumentParser, argument, value) -> Address.from(value);
 
-    // A list of all available logback log levels.
-    final List<String> logLevels = Arrays.asList(
-        Level.ALL.toString(),
-        Level.OFF.toString(),
-        Level.ERROR.toString(),
-        Level.WARN.toString(),
-        Level.INFO.toString(),
-        Level.DEBUG.toString(),
-        Level.TRACE.toString());
-
-    final ArgumentParser parser = ArgumentParsers.newArgumentParser("AtomixServer")
+    ArgumentParser parser = ArgumentParsers.newArgumentParser("AtomixServer")
         .defaultHelp(true)
         .description("Atomix server");
     parser.addArgument("--member", "-m")
@@ -143,67 +81,18 @@ public class AtomixAgent {
         .required(false)
         .help("The zone in which this member runs, used for zone-aware partition management.");
     parser.addArgument("--config", "-c")
-        .metavar("CONF|JSON|PROPERTIES")
+        .metavar("FILE|JSON|YAML")
         .type(File.class)
         .nargs("*")
         .required(false)
-        .setDefault(System.getProperty("atomix.config.files") != null
-            ? Lists.newArrayList(System.getProperty("atomix.config.files").split(","))
-            : Lists.newArrayList())
         .help("The Atomix configuration. Can be specified as a file path or JSON/YAML string.");
-    parser.addArgument("--ignore-resources")
-        .action(new StoreTrueArgumentAction())
-        .setDefault(false)
-        .help("Ignores classpath resources when loading configuration files. Only valid when configuration file(s) are provided.");
-    parser.addArgument("--log-config")
-        .metavar("FILE")
-        .type(String.class)
-        .nargs("?")
-        .setDefault(System.getProperty("atomix.logback"))
-        .help("The path to an optional logback configuration file outside the classpath.");
-    parser.addArgument("--log-dir")
-        .metavar("FILE")
-        .type(String.class)
-        .nargs("?")
-        .setDefault(System.getProperty("atomix.log.directory", new File(System.getProperty("user.dir"), "logs").getPath()))
-        .help("The path to the Atomix log directory. " +
-            "This option is only valid for logback configurations that employ the atomix.log.directory property.");
-    parser.addArgument("--log-level")
-        .metavar("LEVEL")
-        .type(String.class)
-        .choices(logLevels)
-        .nargs("?")
-        .setDefault(System.getProperty("atomix.log.level", Level.DEBUG.toString()))
-        .help("The globally filtered log level for all Atomix logs. " +
-            "This option is only valid for logback configurations that employ the atomix.log.level property.");
-    parser.addArgument("--file-log-level")
-        .metavar("LEVEL")
-        .type(String.class)
-        .choices(logLevels)
-        .nargs("?")
-        .setDefault(System.getProperty("atomix.log.file.level", Level.DEBUG.toString()))
-        .help("The file log level. This option is only valid for logback configurations that employ the " +
-            "atomix.log.file.level property.");
-    parser.addArgument("--console-log-level")
-        .metavar("LEVEL")
-        .type(String.class)
-        .choices(logLevels)
-        .nargs("?")
-        .setDefault(System.getProperty("atomix.log.console.level", Level.INFO.toString()))
-        .help("The console log level. This option is only valid for logback configurations that employ the " +
-            "atomix.log.console.level property.");
-    parser.addArgument("--data-dir")
-        .metavar("FILE")
-        .type(String.class)
-        .nargs("?")
-        .setDefault(System.getProperty("atomix.data", ".data"))
-        .help("The default Atomix data directory. Defaults to .data");
     parser.addArgument("--bootstrap", "-b")
         .nargs("*")
         .type(nodeArgumentType)
         .metavar("NAME@HOST:PORT")
         .required(false)
-        .help("The set of static members to join. When provided, bootstrap node discovery will be used.");
+        .help("The set of core members, if any. When bootstrapping a new cluster, if the local member is a core member " +
+            "then it should be present in the core configuration as well.");
     parser.addArgument("--multicast")
         .action(new StoreTrueArgumentAction())
         .setDefault(false)
@@ -216,42 +105,28 @@ public class AtomixAgent {
         .type(Integer.class)
         .metavar("PORT")
         .help("Sets the multicast port. Defaults to 54321");
+    parser.addArgument("--http-host", "-h")
+        .type(String.class)
+        .metavar("HOST")
+        .required(false)
+        .setDefault("0.0.0.0")
+        .help("Sets the interfae to which to bind the HTTP server. Defaults to 0.0.0.0 (all interfaces)")
     parser.addArgument("--http-port", "-p")
         .type(Integer.class)
         .metavar("PORT")
         .required(false)
         .setDefault(5678)
         .help("Sets the port on which to run the HTTP server. Defaults to 5678");
-    return parser;
-  }
 
-  /**
-   * Configures and creates a new logger for the given namespace.
-   *
-   * @param namespace the namespace from which to create the logger configuration
-   * @return a new agent logger
-   */
-  private static Logger createLogger(Namespace namespace) {
-    String logConfig = namespace.getString("log_config");
-    if (logConfig != null) {
-      System.setProperty("logback.configurationFile", logConfig);
+    Namespace namespace = null;
+    try {
+      namespace = parser.parseArgs(args);
+    } catch (ArgumentParserException e) {
+      parser.handleError(e);
+      System.exit(1);
     }
-    System.setProperty("atomix.log.directory", namespace.getString("log_dir"));
-    System.setProperty("atomix.log.level", namespace.getString("log_level"));
-    System.setProperty("atomix.log.console.level", namespace.getString("console_log_level"));
-    System.setProperty("atomix.log.file.level", namespace.getString("file_log_level"));
-    return LoggerFactory.getLogger(AtomixAgent.class);
-  }
 
-  /**
-   * Creates an Atomix configuration from the given namespace.
-   *
-   * @param namespace the namespace from which to create the configuration
-   * @return the Atomix configuration for the given namespace
-   */
-  private static AtomixConfig createConfig(Namespace namespace) {
     final List<File> configFiles = namespace.getList("config");
-    final boolean ignoreResources = namespace.getBoolean("ignore_resources");
     final String memberId = namespace.getString("member");
     final Address address = namespace.get("address");
     final String host = namespace.getString("host");
@@ -261,18 +136,26 @@ public class AtomixAgent {
     final boolean multicastEnabled = namespace.getBoolean("multicast");
     final String multicastGroup = namespace.get("multicast_group");
     final Integer multicastPort = namespace.get("multicast_port");
-
-    System.setProperty("atomix.data", namespace.getString("data_dir"));
+    final String httpHost = namespace.getString("http_host");
+    final Integer httpPort = namespace.getInt("http_port");
 
     // If a configuration was provided, merge the configuration's member information with the provided command line arguments.
     AtomixConfig config;
-    if (configFiles != null && !configFiles.isEmpty()) {
-      if (ignoreResources) {
-        System.setProperty("atomix.config.resources", "");
+    if (configFiles != null) {
+      for (File configFile : configFiles) {
+        if (!configFile.exists()) {
+          LOGGER.error("Failed to locate configuration file '{}'", configFile.getAbsolutePath());
+          System.exit(1);
+        }
       }
       config = Atomix.config(configFiles);
     } else {
-      config = Atomix.config();
+      String configFile = System.getProperty("atomix.config");
+      if (configFile != null) {
+        config = Atomix.config(configFile);
+      } else {
+        config = Atomix.config();
+      }
     }
 
     if (memberId != null) {
@@ -309,32 +192,29 @@ public class AtomixAgent {
         config.getClusterConfig().setDiscoveryConfig(new MulticastDiscoveryConfig());
       }
     }
-    return config;
-  }
 
-  /**
-   * Builds a new Atomix instance from the given namespace.
-   *
-   * @param namespace the namespace from which to build the instance
-   * @return the Atomix instance
-   */
-  private static Atomix buildAtomix(Namespace namespace) {
-    return Atomix.builder(createConfig(namespace)).withShutdownHookEnabled().build();
-  }
+    Atomix atomix = Atomix.builder(config).withShutdownHookEnabled().build();
 
-  /**
-   * Builds a REST service for the given Atomix instance from the given namespace.
-   *
-   * @param atomix the Atomix instance
-   * @param namespace the namespace from which to build the service
-   * @return the managed REST service
-   */
-  private static ManagedRestService buildRestService(Atomix atomix, Namespace namespace) {
-    final Integer httpPort = namespace.getInt("http_port");
-    return RestService.builder()
+    atomix.start().join();
+
+    LOGGER.info("Atomix listening at {}:{}",
+        atomix.getMembershipService().getLocalMember().address().host(),
+        atomix.getMembershipService().getLocalMember().address().port());
+
+    ManagedRestService rest = RestService.builder()
         .withAtomix(atomix)
-        .withAddress(Address.from(atomix.getMembershipService().getLocalMember().address().host(), httpPort))
+        .withAddress(Address.from(httpHost, httpPort))
         .build();
+
+    rest.start().join();
+
+    LOGGER.info("HTTP server listening at {}:{}", httpHost, httpPort);
+
+    synchronized (Atomix.class) {
+      while (atomix.isRunning()) {
+        Atomix.class.wait();
+      }
+    }
   }
 
   static MemberId parseMemberId(String address) {

--- a/rest/src/main/java/io/atomix/rest/RestService.java
+++ b/rest/src/main/java/io/atomix/rest/RestService.java
@@ -46,7 +46,7 @@ public interface RestService {
    * REST service builder.
    */
   abstract class Builder implements io.atomix.utils.Builder<ManagedRestService> {
-    protected Address address;
+    protected Address address = Address.from("0.0.0.0", 5678);
     protected Atomix atomix;
 
     /**

--- a/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
+++ b/rest/src/main/java/io/atomix/rest/impl/VertxRestService.java
@@ -166,14 +166,8 @@ public class VertxRestService implements ManagedRestService {
    * Vert.x REST service builder.
    */
   public static class Builder extends RestService.Builder {
-    private static final String DEFAULT_HOST = "0.0.0.0";
-    private static final int DEFAULT_PORT = 5678;
-
     @Override
     public ManagedRestService build() {
-      if (address == null) {
-        address = Address.from(DEFAULT_HOST, DEFAULT_PORT);
-      }
       return new VertxRestService(atomix, address);
     }
   }


### PR DESCRIPTION
There's currently no way to specify an interface for the HTTP server to listen on, so this PR ensures the server listens on all available interfaces.