### PR TITLE
Ensure address can be printed as host:port tuple without resolving hostname

### DIFF
--- a/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -211,13 +211,12 @@ public final class Address {
 
   @Override
   public String toString() {
-    switch (type()) {
-      case IPV4:
-        return String.format("%s:%d", address().getHostName(), port());
-      case IPV6:
-        return String.format("[%s]:%d", address().getHostName(), port());
-      default:
-        throw new AssertionError();
+    String host = host();
+    int port = port();
+    if (host.matches("([0-9a-f]{1,4}:){7}([0-9a-f]){1,4}")) {
+      return String.format("[%s]:%d", host, port);
+    } else {
+      return String.format("%s:%d", host, port);
     }
   }
 

--- a/utils/src/test/java/io/atomix/utils/net/AddressTest.java
+++ b/utils/src/test/java/io/atomix/utils/net/AddressTest.java
@@ -31,7 +31,8 @@ public class AddressTest {
     Address address = Address.from("127.0.0.1:5000");
     assertEquals("127.0.0.1", address.host());
     assertEquals(5000, address.port());
-    assertEquals( InetAddress.getByName("127.0.0.1").getHostName() + ":5000", address.toString());
+    assertEquals("localhost", address.address().getHostName());
+    assertEquals( "127.0.0.1:5000", address.toString());
   }
 
   @Test
@@ -39,7 +40,8 @@ public class AddressTest {
     Address address = Address.from("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000");
     assertEquals("fe80:cd00:0000:0cde:1257:0000:211e:729c", address.host());
     assertEquals(5000, address.port());
-    assertEquals("[fe80:cd00:0:cde:1257:0:211e:729c]:5000", address.toString());
+    assertEquals("fe80:cd00:0:cde:1257:0:211e:729c", address.address().getHostName());
+    assertEquals("[fe80:cd00:0000:0cde:1257:0000:211e:729c]:5000", address.toString());
   }
 
   @Test


### PR DESCRIPTION
This PR fixes a bug in the `Address#toString` implementation. In environments where the hostname cannot be immediately resolved (i.e. k8s) the current implementation can throw an NPE. This change uses only the user-provided `host()` in the `toString` method.