### PR TITLE
Ensure cached document tree properly registers root listener

### DIFF
--- a/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/BlockingAtomicDocumentTree.java
@@ -123,6 +123,8 @@ public class BlockingAtomicDocumentTree<V> extends Synchronous<AsyncAtomicDocume
       Throwable cause = Throwables.getRootCause(e);
       if (cause instanceof PrimitiveException) {
         throw (PrimitiveException) cause;
+      } else if (cause instanceof IllegalArgumentException || cause instanceof IllegalStateException) {
+        throw (RuntimeException) cause;
       } else {
         throw new PrimitiveException(cause);
       }

--- a/core/src/test/java/io/atomix/core/tree/CachingAtomicDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/CachingAtomicDocumentTreeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.tree;
+
+/**
+ * Caching document tree test.
+ */
+public abstract class CachingAtomicDocumentTreeTest extends AtomicDocumentTreeTest {
+  @Override
+  protected AtomicDocumentTree<String> newTree(String name) throws Exception {
+    return atomix().<String>atomicDocumentTreeBuilder(name)
+        .withProtocol(protocol())
+        .withCacheEnabled()
+        .build();
+  }
+}

--- a/core/src/test/java/io/atomix/core/tree/RaftCachingAtomicDocumentTreeTest.java
+++ b/core/src/test/java/io/atomix/core/tree/RaftCachingAtomicDocumentTreeTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.tree;
+
+import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.protocols.raft.MultiRaftProtocol;
+
+/**
+ * Raft caching atomic document tree test.
+ */
+public class RaftCachingAtomicDocumentTreeTest extends CachingAtomicDocumentTreeTest {
+  @Override
+  protected ProxyProtocol protocol() {
+    return MultiRaftProtocol.builder()
+        .withMaxRetries(5)
+        .build();
+  }
+}


### PR DESCRIPTION
This PR fixes a bug in the cached `DocumentTree` primitive listeners. The primitive registers a root listener to ensure the cache is updated before events are received by the client. However, the root listener is not currently registered correctly. It currently just adds a listener to itself. This PR ensures the listener is registered on the underlying proxy using the `root()` path.