### PR TITLE
Remove preamle checks in MessagingService implementation

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -1061,11 +1061,6 @@ public class NettyMessagingService implements ManagedMessagingService {
      * @param message the message to dispatch
      */
     private void dispatch(InternalReply message) {
-      if (message.preamble() != preamble) {
-        log.debug("Received {} with invalid preamble", message.type());
-        return;
-      }
-
       Callback callback = completeCallback(message.id());
       if (callback != null) {
         if (message.status() == InternalReply.Status.OK) {
@@ -1110,12 +1105,6 @@ public class NettyMessagingService implements ManagedMessagingService {
      * @param message the message to dispatch
      */
     private void dispatch(InternalRequest message) {
-      if (message.preamble() != preamble) {
-        log.debug("Received {} with invalid preamble from {}", message.type(), message.sender());
-        reply(message, InternalReply.Status.PROTOCOL_EXCEPTION, Optional.empty());
-        return;
-      }
-
       BiConsumer<InternalRequest, ServerConnection> handler = handlers.get(message.subject());
       if (handler != null) {
         log.trace("{} - Received message type {} from {}", localAddress, message.subject(), message.sender());


### PR DESCRIPTION
This PR removes the preamble check in the current `MessagingService` implementation. The preamble is removed since it has proven to make cluster configuration too opaque and confusing. Current deployed clusters require strict configuration on both clients and servers to communicate. In 3.1, a new messaging protocol will be implemented which re-introduces this feature as part of a handshake protocol. In the meantime, it needs to be disabled.