### PR TITLE
Default to binding HTTP server to all interfaces when running Atomix Agent

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -216,6 +216,12 @@ public class AtomixAgent {
         .type(Integer.class)
         .metavar("PORT")
         .help("Sets the multicast port. Defaults to 54321");
+    parser.addArgument("--http-host", "-h")
+        .type(String.class)
+        .metavar("HOST")
+        .required(false)
+        .setDefault("0.0.0.0")
+        .help("Sets the host to which to bind the HTTP server. Defaults to 0.0.0.0 (all interfaces)");
     parser.addArgument("--http-port", "-p")
         .type(Integer.class)
         .metavar("PORT")
@@ -330,10 +336,11 @@ public class AtomixAgent {
    * @return the managed REST service
    */
   private static ManagedRestService buildRestService(Atomix atomix, Namespace namespace) {
+    final String httpHost = namespace.getString("http_host");
     final Integer httpPort = namespace.getInt("http_port");
     return RestService.builder()
         .withAtomix(atomix)
-        .withAddress(Address.from(atomix.getMembershipService().getLocalMember().address().host(), httpPort))
+        .withAddress(Address.from(httpHost, httpPort))
         .build();
   }
 


### PR DESCRIPTION
This PR defaults the HTTP server to bind to `0.0.0.0`. The setting can be overridden by specifying `--http-host` when configuring the Atomix agent. The bind host/port is logged at startup.