### PR TITLE
Simplify node discovery providers

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryConfig.java
@@ -66,6 +66,7 @@ public class BootstrapDiscoveryConfig extends NodeDiscoveryConfig {
    *
    * @return the heartbeat interval
    */
+  @Deprecated
   public Duration getHeartbeatInterval() {
     return heartbeatInterval;
   }
@@ -76,6 +77,7 @@ public class BootstrapDiscoveryConfig extends NodeDiscoveryConfig {
    * @param heartbeatInterval the heartbeat interval
    * @return the group membership configuration
    */
+  @Deprecated
   public BootstrapDiscoveryConfig setHeartbeatInterval(Duration heartbeatInterval) {
     this.heartbeatInterval = checkNotNull(heartbeatInterval);
     return this;
@@ -86,6 +88,7 @@ public class BootstrapDiscoveryConfig extends NodeDiscoveryConfig {
    *
    * @return the failure detector threshold
    */
+  @Deprecated
   public int getFailureThreshold() {
     return failureThreshold;
   }
@@ -96,6 +99,7 @@ public class BootstrapDiscoveryConfig extends NodeDiscoveryConfig {
    * @param failureThreshold the failure detector threshold
    * @return the group membership configuration
    */
+  @Deprecated
   public BootstrapDiscoveryConfig setFailureThreshold(int failureThreshold) {
     this.failureThreshold = failureThreshold;
     return this;
@@ -106,6 +110,7 @@ public class BootstrapDiscoveryConfig extends NodeDiscoveryConfig {
    *
    * @return the base failure timeout
    */
+  @Deprecated
   public Duration getFailureTimeout() {
     return failureTimeout;
   }
@@ -116,6 +121,7 @@ public class BootstrapDiscoveryConfig extends NodeDiscoveryConfig {
    * @param failureTimeout the base failure timeout
    * @return the group membership configuration
    */
+  @Deprecated
   public BootstrapDiscoveryConfig setFailureTimeout(Duration failureTimeout) {
     this.failureTimeout = checkNotNull(failureTimeout);
     return this;

--- a/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
+++ b/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
@@ -16,41 +16,21 @@
 package io.atomix.cluster.discovery;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import io.atomix.cluster.BootstrapService;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.NodeConfig;
-import io.atomix.cluster.NodeId;
-import io.atomix.cluster.impl.AddressSerializer;
-import io.atomix.cluster.impl.PhiAccrualFailureDetector;
-import io.atomix.utils.concurrent.ComposableFuture;
-import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.event.AbstractListenerManager;
-import io.atomix.utils.net.Address;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.atomix.utils.concurrent.Threads.namedThreads;
 
 /**
  * Cluster membership provider that bootstraps membership from a pre-defined set of peers.
@@ -102,30 +82,9 @@ public class BootstrapDiscoveryProvider
   }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BootstrapDiscoveryProvider.class);
-  private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
-      .register(Namespaces.BASIC)
-      .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-      .register(Node.class)
-      .register(NodeId.class)
-      .register(new AddressSerializer(), Address.class)
-      .build());
 
-  private static final String HEARTBEAT_MESSAGE = "atomix-cluster-heartbeat";
-
-  private final Collection<Node> bootstrapNodes;
+  private final ImmutableSet<Node> bootstrapNodes;
   private final BootstrapDiscoveryConfig config;
-
-  private volatile BootstrapService bootstrap;
-
-  private Map<Address, Node> nodes = Maps.newConcurrentMap();
-
-  private final ScheduledExecutorService heartbeatScheduler = Executors.newSingleThreadScheduledExecutor(
-      namedThreads("atomix-bootstrap-heartbeat-sender", LOGGER));
-  private final ExecutorService heartbeatExecutor = Executors.newSingleThreadExecutor(
-      namedThreads("atomix-bootstrap-heartbeat-receiver", LOGGER));
-  private ScheduledFuture<?> heartbeatFuture;
-
-  private final Map<Address, PhiAccrualFailureDetector> failureDetectors = Maps.newConcurrentMap();
 
   public BootstrapDiscoveryProvider(Node... bootstrapNodes) {
     this(Arrays.asList(bootstrapNodes));
@@ -150,124 +109,18 @@ public class BootstrapDiscoveryProvider
 
   @Override
   public Set<Node> getNodes() {
-    return ImmutableSet.copyOf(nodes.values());
-  }
-
-  /**
-   * Sends heartbeats to all peers.
-   */
-  private CompletableFuture<Void> sendHeartbeats(Node localNode) {
-    Stream<Address> clusterLocations = this.nodes.values().stream()
-        .filter(node -> !node.address().equals(localNode.address()))
-        .map(node -> node.address());
-
-    Stream<Address> bootstrapLocations = this.bootstrapNodes.stream()
-        .filter(node -> !node.address().equals(localNode.address()) && !nodes.containsKey(node.address()))
-        .map(node -> node.address());
-
-    return Futures.allOf(Stream.concat(clusterLocations, bootstrapLocations).map(address -> {
-      LOGGER.trace("{} - Sending heartbeat: {}", localNode.address(), address);
-      return sendHeartbeat(localNode, address).exceptionally(v -> null);
-    }).collect(Collectors.toList()))
-        .thenApply(v -> null);
-  }
-
-  /**
-   * Sends a heartbeat to the given peer.
-   */
-  private CompletableFuture<Void> sendHeartbeat(Node localNode, Address address) {
-    return bootstrap.getMessagingService().sendAndReceive(address, HEARTBEAT_MESSAGE, SERIALIZER.encode(localNode)).whenCompleteAsync((response, error) -> {
-      if (error == null) {
-        Collection<Node> nodes = SERIALIZER.decode(response);
-        for (Node node : nodes) {
-          if (node.address().equals(address)) {
-            Node oldNode = this.nodes.put(node.address(), node);
-            if (oldNode != null && !oldNode.id().equals(node.id())) {
-              failureDetectors.remove(oldNode.address());
-              post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.LEAVE, oldNode));
-              post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.JOIN, node));
-            } else if (oldNode == null) {
-              post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.JOIN, node));
-            }
-          } else if (!this.nodes.containsKey(node.address()) || !this.nodes.get(node.address()).id().equals(node.id())) {
-            sendHeartbeat(localNode, node.address());
-          }
-        }
-      } else {
-        LOGGER.debug("{} - Sending heartbeat to {} failed", localNode, address, error);
-        PhiAccrualFailureDetector failureDetector = failureDetectors.computeIfAbsent(address, n -> new PhiAccrualFailureDetector());
-        double phi = failureDetector.phi();
-        if (phi >= config.getFailureThreshold()
-            || (phi == 0.0 && System.currentTimeMillis() - failureDetector.lastUpdated() > config.getFailureTimeout().toMillis())) {
-          Node node = this.nodes.remove(address);
-          if (node != null) {
-            failureDetectors.remove(node.address());
-            post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.LEAVE, node));
-          }
-        }
-      }
-    }, heartbeatExecutor).exceptionally(e -> null)
-        .thenApply(v -> null);
-  }
-
-  /**
-   * Handles a heartbeat message.
-   */
-  private byte[] handleHeartbeat(Node localNode, Node node) {
-    LOGGER.trace("{} - Received heartbeat: {}", localNode.address(), localNode.address());
-    failureDetectors.computeIfAbsent(localNode.address(), n -> new PhiAccrualFailureDetector()).report();
-    Node oldNode = nodes.put(node.address(), node);
-    if (oldNode != null && !oldNode.id().equals(node.id())) {
-      failureDetectors.remove(oldNode.address());
-      post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.LEAVE, oldNode));
-      post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.JOIN, node));
-    } else if (oldNode == null) {
-      post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.JOIN, node));
-    }
-    return SERIALIZER.encode(Lists.newArrayList(nodes.values()));
+    return bootstrapNodes;
   }
 
   @Override
   public CompletableFuture<Void> join(BootstrapService bootstrap, Node localNode) {
-    if (nodes.putIfAbsent(localNode.address(), localNode) == null) {
-      this.bootstrap = bootstrap;
-      post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.JOIN, localNode));
-
-      bootstrap.getMessagingService().registerHandler(
-          HEARTBEAT_MESSAGE,
-          (BiFunction<Address, byte[], byte[]>) (a, p) ->
-              handleHeartbeat(localNode, SERIALIZER.decode(p)), heartbeatExecutor);
-
-      ComposableFuture<Void> future = new ComposableFuture<>();
-      sendHeartbeats(localNode).whenComplete((r, e) -> {
-        future.complete(null);
-      });
-
-      heartbeatFuture = heartbeatScheduler.scheduleAtFixedRate(() -> {
-        sendHeartbeats(localNode);
-      }, 0, config.getHeartbeatInterval().toMillis(), TimeUnit.MILLISECONDS);
-
-      return future.thenRun(() -> {
-        LOGGER.info("Joined");
-      });
-    }
+    LOGGER.info("Joined");
     return CompletableFuture.completedFuture(null);
   }
 
   @Override
   public CompletableFuture<Void> leave(Node localNode) {
-    if (nodes.remove(localNode.address()) != null) {
-      post(new NodeDiscoveryEvent(NodeDiscoveryEvent.Type.LEAVE, localNode));
-
-      bootstrap.getMessagingService().unregisterHandler(HEARTBEAT_MESSAGE);
-      ScheduledFuture<?> heartbeatFuture = this.heartbeatFuture;
-      if (heartbeatFuture != null) {
-        heartbeatFuture.cancel(false);
-      }
-      heartbeatScheduler.shutdownNow();
-      heartbeatExecutor.shutdownNow();
-      LOGGER.info("Left");
-    }
+    LOGGER.info("Left");
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/cluster/src/main/java/io/atomix/cluster/discovery/MulticastDiscoveryConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/discovery/MulticastDiscoveryConfig.java
@@ -61,6 +61,7 @@ public class MulticastDiscoveryConfig extends NodeDiscoveryConfig {
    *
    * @return the failure detector threshold
    */
+  @Deprecated
   public int getFailureThreshold() {
     return failureThreshold;
   }
@@ -71,6 +72,7 @@ public class MulticastDiscoveryConfig extends NodeDiscoveryConfig {
    * @param failureThreshold the failure detector threshold
    * @return the group membership configuration
    */
+  @Deprecated
   public MulticastDiscoveryConfig setFailureThreshold(int failureThreshold) {
     this.failureThreshold = failureThreshold;
     return this;

--- a/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/StatefulMember.java
@@ -21,18 +21,21 @@ import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Default cluster node.
  */
 public class StatefulMember extends Member {
   private final Version version;
+  private final AtomicLong timestamp = new AtomicLong();
   private volatile boolean active;
   private volatile boolean reachable;
 
   public StatefulMember(MemberId id, Address address) {
     super(id, address);
     this.version = null;
+    timestamp.set(0);
   }
 
   public StatefulMember(
@@ -45,11 +48,37 @@ public class StatefulMember extends Member {
       Version version) {
     super(id, address, zone, rack, host, properties);
     this.version = version;
+    timestamp.set(1);
   }
 
   @Override
   public Version version() {
     return version;
+  }
+
+  /**
+   * Returns the member logical timestamp.
+   *
+   * @return the member logical timestamp
+   */
+  public long getTimestamp() {
+    return timestamp.get();
+  }
+
+  /**
+   * Sets the member's logical timestamp.
+   *
+   * @param timestamp the member's logical timestamp
+   */
+  void setTimestamp(long timestamp) {
+    this.timestamp.accumulateAndGet(timestamp, Math::max);
+  }
+
+  /**
+   * Increments the member's timestamp.
+   */
+  void incrementTimestamp() {
+    timestamp.incrementAndGet();
   }
 
   /**

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -68,7 +68,7 @@ public abstract class AbstractAtomixTest {
   protected static AtomixBuilder buildAtomix(int id, List<Integer> memberIds, Properties properties) {
     Collection<Node> nodes = memberIds.stream()
         .map(memberId -> Node.builder()
-            .withId(String.valueOf(id))
+            .withId(String.valueOf(memberId))
             .withAddress(Address.from("localhost", BASE_PORT + memberId))
             .build())
         .collect(Collectors.toList());

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -357,8 +357,6 @@ public class AtomixTest extends AbstractAtomixTest {
     // client1 added to data node
     ClusterMembershipEvent event1 = dataListener.event();
     assertEquals(ClusterMembershipEvent.Type.MEMBER_ADDED, event1.type());
-    event1 = dataListener.event();
-    assertEquals(ClusterMembershipEvent.Type.METADATA_CHANGED, event1.type());
 
     Member member = event1.subject();
 


### PR DESCRIPTION
This PR refactors node discovery providers to move failure detection solely under the purview of `ClusterMembershipService` per #868 