### PR TITLE
Pluggable membership protocol

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -17,6 +17,8 @@ package io.atomix.cluster;
 
 import com.google.common.collect.Lists;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
+import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
+import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
 import io.atomix.utils.Builder;
 import io.atomix.utils.net.Address;
 
@@ -328,7 +330,10 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    */
   @Deprecated
   public AtomixClusterBuilder setBroadcastInterval(Duration interval) {
-    config.getMembershipConfig().setBroadcastInterval(interval);
+    GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
+    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
+      ((PhiMembershipProtocolConfig) protocolConfig).setHeartbeatInterval(interval);
+    }
     return this;
   }
 
@@ -340,8 +345,12 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * @param interval the reachability broadcast interval
    * @return the cluster builder
    */
+  @Deprecated
   public AtomixClusterBuilder withBroadcastInterval(Duration interval) {
-    config.getMembershipConfig().setBroadcastInterval(interval);
+    GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
+    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
+      ((PhiMembershipProtocolConfig) protocolConfig).setHeartbeatInterval(interval);
+    }
     return this;
   }
 
@@ -357,7 +366,10 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    */
   @Deprecated
   public AtomixClusterBuilder setReachabilityThreshold(int threshold) {
-    config.getMembershipConfig().setReachabilityThreshold(threshold);
+    GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
+    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
+      ((PhiMembershipProtocolConfig) protocolConfig).setFailureThreshold(threshold);
+    }
     return this;
   }
 
@@ -370,8 +382,12 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * @param threshold the reachability failure detection threshold
    * @return the cluster builder
    */
+  @Deprecated
   public AtomixClusterBuilder withReachabilityThreshold(int threshold) {
-    config.getMembershipConfig().setReachabilityThreshold(threshold);
+    GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
+    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
+      ((PhiMembershipProtocolConfig) protocolConfig).setFailureThreshold(threshold);
+    }
     return this;
   }
 
@@ -384,8 +400,12 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * @param timeout the reachability failure timeout
    * @return the cluster builder
    */
+  @Deprecated
   public AtomixClusterBuilder withReachabilityTimeout(Duration timeout) {
-    config.getMembershipConfig().setReachabilityTimeout(timeout);
+    GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
+    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
+      ((PhiMembershipProtocolConfig) protocolConfig).setFailureTimeout(timeout);
+    }
     return this;
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/ClusterConfig.java
@@ -16,6 +16,8 @@
 package io.atomix.cluster;
 
 import io.atomix.cluster.discovery.NodeDiscoveryConfig;
+import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
+import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
 import io.atomix.utils.config.Config;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -31,6 +33,7 @@ public class ClusterConfig implements Config {
   private MemberConfig nodeConfig = new MemberConfig();
   private NodeDiscoveryConfig discoveryConfig;
   private MulticastConfig multicastConfig = new MulticastConfig();
+  private GroupMembershipProtocolConfig protocolConfig = new PhiMembershipProtocolConfig();
   private MembershipConfig membershipConfig = new MembershipConfig();
 
   /**
@@ -134,10 +137,32 @@ public class ClusterConfig implements Config {
   }
 
   /**
+   * Returns the group membership protocol configuration.
+   *
+   * @return the group membership protocol configuration
+   */
+  public GroupMembershipProtocolConfig getProtocolConfig() {
+    return protocolConfig;
+  }
+
+  /**
+   * Sets the group membership protocol configuration.
+   *
+   * @param protocolConfig the group membership protocol configuration
+   * @return the cluster configuration
+   */
+  public ClusterConfig setProtocolConfig(GroupMembershipProtocolConfig protocolConfig) {
+    this.protocolConfig = protocolConfig;
+    return this;
+  }
+
+  /**
    * Returns the cluster membership configuration.
    *
    * @return the cluster membership configuration
+   * @deprecated since 3.1
    */
+  @Deprecated
   public MembershipConfig getMembershipConfig() {
     return membershipConfig;
   }
@@ -147,7 +172,9 @@ public class ClusterConfig implements Config {
    *
    * @param membershipConfig the cluster membership configuration
    * @return the cluster configuration
+   * @deprecated since 3.1
    */
+  @Deprecated
   public ClusterConfig setMembershipConfig(MembershipConfig membershipConfig) {
     this.membershipConfig = checkNotNull(membershipConfig);
     return this;

--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
@@ -15,9 +15,6 @@
  */
 package io.atomix.cluster.impl;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import io.atomix.cluster.BootstrapService;
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEventListener;
@@ -25,37 +22,19 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.ManagedClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
-import io.atomix.cluster.MembershipConfig;
-import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.ManagedNodeDiscoveryService;
-import io.atomix.cluster.discovery.NodeDiscoveryEvent;
-import io.atomix.cluster.discovery.NodeDiscoveryEventListener;
+import io.atomix.cluster.protocol.GroupMembershipEvent;
+import io.atomix.cluster.protocol.GroupMembershipEventListener;
+import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.utils.Version;
-import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.event.AbstractListenerManager;
-import io.atomix.utils.net.Address;
-import io.atomix.utils.serializer.Namespace;
-import io.atomix.utils.serializer.Namespaces;
-import io.atomix.utils.serializer.Serializer;
 import org.slf4j.Logger;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.atomix.utils.concurrent.Threads.namedThreads;
 import static org.slf4j.LoggerFactory.getLogger;
 
 /**
@@ -67,43 +46,25 @@ public class DefaultClusterMembershipService
 
   private static final Logger LOGGER = getLogger(DefaultClusterMembershipService.class);
 
-  private static final String HEARTBEAT_MESSAGE = "atomix-cluster-metadata";
+  private static final String HEARTBEAT_MESSAGE = "atomix-cluster-membership";
 
-  private static final Serializer SERIALIZER = Serializer.using(
-      Namespace.builder()
-          .register(Namespaces.BASIC)
-          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
-          .register(MemberId.class)
-          .register(StatefulMember.class)
-          .register(new AddressSerializer(), Address.class)
-          .build("ClusterMembershipService"));
-
-  private final MembershipConfig config;
   private final ManagedNodeDiscoveryService discoveryService;
   private final BootstrapService bootstrapService;
+  private final GroupMembershipProtocol protocol;
 
   private final AtomicBoolean started = new AtomicBoolean();
   private final StatefulMember localMember;
-  private volatile Properties localProperties = new Properties();
-  private final Map<MemberId, StatefulMember> members = Maps.newConcurrentMap();
-  private final Map<MemberId, PhiAccrualFailureDetector> failureDetectors = Maps.newConcurrentMap();
-  private final NodeDiscoveryEventListener discoveryEventListener = this::handleDiscoveryEvent;
-
-  private final ScheduledExecutorService heartbeatScheduler = Executors.newSingleThreadScheduledExecutor(
-      namedThreads("atomix-cluster-heartbeat-sender", LOGGER));
-  private final ExecutorService eventExecutor = Executors.newSingleThreadExecutor(
-      namedThreads("atomix-cluster-events", LOGGER));
-  private ScheduledFuture<?> heartbeatFuture;
+  private final GroupMembershipEventListener membershipEventListener = this::handleMembershipEvent;
 
   public DefaultClusterMembershipService(
       Member localMember,
       Version version,
       ManagedNodeDiscoveryService discoveryService,
       BootstrapService bootstrapService,
-      MembershipConfig config) {
+      GroupMembershipProtocol protocol) {
     this.discoveryService = checkNotNull(discoveryService, "discoveryService cannot be null");
     this.bootstrapService = checkNotNull(bootstrapService, "bootstrapService cannot be null");
-    this.config = checkNotNull(config);
+    this.protocol = checkNotNull(protocol, "protocol cannot be null");
     this.localMember = new StatefulMember(
         localMember.id(),
         localMember.address(),
@@ -121,188 +82,29 @@ public class DefaultClusterMembershipService
 
   @Override
   public Set<Member> getMembers() {
-    return ImmutableSet.copyOf(members.values());
+    return protocol.getMembers();
   }
 
   @Override
   public Member getMember(MemberId memberId) {
-    return members.get(memberId);
-  }
-
-  @Override
-  protected void post(ClusterMembershipEvent event) {
-    eventExecutor.execute(() -> super.post(event));
+    return protocol.getMember(memberId);
   }
 
   /**
-   * Handles a member location event.
-   *
-   * @param event the member location event
+   * Handles a group membership event.
    */
-  private void handleDiscoveryEvent(NodeDiscoveryEvent event) {
-    switch (event.type()) {
-      case JOIN:
-        handleJoinEvent(event.subject());
-        break;
-      case LEAVE:
-        handleLeaveEvent(event.subject());
-        break;
-      default:
-        throw new AssertionError();
-    }
-  }
-
-  /**
-   * Handles a node join event.
-   */
-  private void handleJoinEvent(Node node) {
-    StatefulMember member = new StatefulMember(MemberId.from(node.id().id()), node.address());
-    if (!members.containsKey(member.id())) {
-      sendHeartbeat(member);
-    }
-  }
-
-  /**
-   * Handles a node leave event.
-   */
-  private void handleLeaveEvent(Node node) {
-    members.compute(MemberId.from(node.id().id()), (id, member) -> member == null || !member.isActive() ? null : member);
-  }
-
-  /**
-   * Sends heartbeats to all peers.
-   */
-  private CompletableFuture<Void> sendHeartbeats() {
-    checkMetadata();
-    Stream<StatefulMember> clusterMembers = members.values().stream()
-        .filter(member -> !member.id().equals(localMember.id()));
-
-    Stream<StatefulMember> providerMembers = discoveryService.getNodes().stream()
-        .filter(node -> !members.containsKey(MemberId.from(node.id().id())))
-        .map(node -> new StatefulMember(MemberId.from(node.id().id()), node.address()));
-
-    return Futures.allOf(Stream.concat(clusterMembers, providerMembers)
-        .map(member -> {
-          LOGGER.trace("{} - Sending heartbeat: {}", localMember.id(), member);
-          return sendHeartbeat(member).exceptionally(v -> null);
-        }).collect(Collectors.toList()))
-        .thenApply(v -> null);
-  }
-
-  /**
-   * Checks the local member metadata for changes.
-   */
-  private void checkMetadata() {
-    if (!localMember.properties().equals(localProperties)) {
-      synchronized (this) {
-        if (!localMember.properties().equals(localProperties)) {
-          localProperties = localMember.properties();
-          localMember.incrementTimestamp();
-          post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.METADATA_CHANGED, localMember));
-        }
-      }
-    }
-  }
-
-  /**
-   * Sends a heartbeat to the given peer.
-   */
-  private CompletableFuture<Void> sendHeartbeat(StatefulMember member) {
-    return bootstrapService.getMessagingService().sendAndReceive(member.address(), HEARTBEAT_MESSAGE, SERIALIZER.encode(localMember))
-        .whenCompleteAsync((response, error) -> {
-          if (error == null) {
-            Collection<StatefulMember> remoteMembers = SERIALIZER.decode(response);
-            for (StatefulMember remoteMember : remoteMembers) {
-              if (remoteMember.id().equals(localMember.id()) || !remoteMember.isReachable()) {
-                continue;
-              }
-
-              StatefulMember localMember = members.get(remoteMember.id());
-              if (localMember == null) {
-                members.put(remoteMember.id(), remoteMember);
-                post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, remoteMember));
-              } else if (localMember.getTimestamp() < remoteMember.getTimestamp()) {
-                members.put(remoteMember.id(), remoteMember);
-                post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.METADATA_CHANGED, localMember));
-              }
-            }
-          } else {
-            LOGGER.debug("{} - Sending heartbeat to {} failed", localMember.id(), member, error);
-            if (member.isReachable()) {
-              member.setReachable(false);
-              post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.REACHABILITY_CHANGED, member));
-            }
-
-            PhiAccrualFailureDetector failureDetector = failureDetectors.computeIfAbsent(member.id(), n -> new PhiAccrualFailureDetector());
-            double phi = failureDetector.phi();
-            if (phi >= config.getReachabilityThreshold()
-                || (phi == 0.0 && System.currentTimeMillis() - failureDetector.lastUpdated() > config.getReachabilityTimeout().toMillis())) {
-              if (members.remove(member.id()) != null) {
-                failureDetectors.remove(member.id());
-                post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_REMOVED, member));
-              }
-            }
-          }
-        }, heartbeatScheduler).exceptionally(e -> null)
-        .thenApply(v -> null);
-  }
-
-  /**
-   * Handles a heartbeat message.
-   */
-  private byte[] handleHeartbeat(Address address, byte[] message) {
-    StatefulMember remoteMember = SERIALIZER.decode(message);
-    LOGGER.trace("{} - Received heartbeat: {}", localMember.id(), remoteMember);
-    failureDetectors.computeIfAbsent(remoteMember.id(), n -> new PhiAccrualFailureDetector()).report();
-    StatefulMember member = members.get(remoteMember.id());
-
-    if (member == null) {
-      remoteMember.setActive(true);
-      remoteMember.setReachable(true);
-      members.put(remoteMember.id(), remoteMember);
-      post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, remoteMember));
-    } else {
-      // If the member's metadata changed, overwrite the local member. We do this instead of a version check since
-      // a heartbeat from the source member always takes precedence over a more recent version.
-      if (!Objects.equals(member.version(), remoteMember.version())
-          || !Objects.equals(member.zone(), remoteMember.zone())
-          || !Objects.equals(member.rack(), remoteMember.rack())
-          || !Objects.equals(member.host(), remoteMember.host())
-          || !Objects.equals(member.properties(), remoteMember.properties())) {
-        members.put(remoteMember.id(), remoteMember);
-        if (member.isActive()) {
-          post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.METADATA_CHANGED, member));
-        }
-        member = remoteMember;
-      }
-
-      // If the local member is not active, set it to active and trigger a MEMBER_ADDED event.
-      if (!member.isActive()) {
-        member.setActive(true);
-        member.setReachable(true);
-        post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, member));
-      }
-      // If the member has been marked unreachable, mark it as reachable and trigger a REACHABILITY_CHANGED event.
-      else if (!member.isReachable()) {
-        member.setReachable(true);
-        post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.REACHABILITY_CHANGED, member));
-      }
-    }
-    return SERIALIZER.encode(Lists.newArrayList(members.values()));
+  private void handleMembershipEvent(GroupMembershipEvent event) {
+    post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.valueOf(event.type().name()), event.member()));
   }
 
   @Override
   public CompletableFuture<ClusterMembershipService> start() {
     if (started.compareAndSet(false, true)) {
-      discoveryService.addListener(discoveryEventListener);
-      return discoveryService.start().thenRun(() -> {
-        LOGGER.info("{} - Member activated: {}", localMember.id(), localMember);
+      protocol.addListener(membershipEventListener);
+      return discoveryService.start().thenCompose(v -> {
         localMember.setActive(true);
         localMember.setReachable(true);
-        members.put(localMember.id(), localMember);
-        post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.MEMBER_ADDED, localMember));
-        bootstrapService.getMessagingService().registerHandler(HEARTBEAT_MESSAGE, this::handleHeartbeat, heartbeatScheduler);
-        heartbeatFuture = heartbeatScheduler.scheduleAtFixedRate(this::sendHeartbeats, 0, config.getBroadcastInterval().toMillis(), TimeUnit.MILLISECONDS);
+        return protocol.join(bootstrapService, discoveryService, localMember);
       }).thenApply(v -> {
         LOGGER.info("Started");
         return this;
@@ -319,17 +121,13 @@ public class DefaultClusterMembershipService
   @Override
   public CompletableFuture<Void> stop() {
     if (started.compareAndSet(true, false)) {
-      return discoveryService.stop()
+      return protocol.leave(localMember)
+          .thenCompose(v -> discoveryService.stop())
           .thenRun(() -> {
-            discoveryService.removeListener(discoveryEventListener);
-            heartbeatFuture.cancel(true);
-            heartbeatScheduler.shutdownNow();
-            eventExecutor.shutdownNow();
-            LOGGER.info("{} - Member deactivated: {}", localMember.id(), localMember);
             localMember.setActive(false);
             localMember.setReachable(false);
-            members.clear();
             bootstrapService.getMessagingService().unregisterHandler(HEARTBEAT_MESSAGE);
+            protocol.removeListener(membershipEventListener);
             LOGGER.info("Stopped");
           });
     }

--- a/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipEvent.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import io.atomix.cluster.Member;
+import io.atomix.utils.event.AbstractEvent;
+
+/**
+ * Group membership protocol event.
+ */
+public class GroupMembershipEvent extends AbstractEvent<GroupMembershipEvent.Type, Member> {
+
+  /**
+   * Group membership protocol event type.
+   */
+  public enum Type {
+    /**
+     * Indicates that a new member has been added.
+     */
+    MEMBER_ADDED,
+
+    /**
+     * Indicates that a member's metadata has changed.
+     */
+    METADATA_CHANGED,
+
+    /**
+     * Indicates that a member's reachability has changed.
+     */
+    REACHABILITY_CHANGED,
+
+    /**
+     * Indicates that a member has been removed.
+     */
+    MEMBER_REMOVED,
+  }
+
+  public GroupMembershipEvent(Type type, Member subject) {
+    super(type, subject);
+  }
+
+  public GroupMembershipEvent(Type type, Member subject, long time) {
+    super(type, subject, time);
+  }
+
+  /**
+   * Returns the member.
+   *
+   * @return the member
+   */
+  public Member member() {
+    return subject();
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipEventListener.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipEventListener.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import io.atomix.utils.event.EventListener;
+
+/**
+ * Node discovery event listener.
+ */
+public interface GroupMembershipEventListener extends EventListener<GroupMembershipEvent> {
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipProtocol.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import io.atomix.cluster.BootstrapService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.discovery.NodeDiscoveryService;
+import io.atomix.utils.ConfiguredType;
+import io.atomix.utils.config.Configured;
+import io.atomix.utils.event.ListenerService;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Group membership protocol.
+ */
+public interface GroupMembershipProtocol
+    extends ListenerService<GroupMembershipEvent, GroupMembershipEventListener>,
+    Configured<GroupMembershipProtocolConfig> {
+
+  /**
+   * Group membership protocol type.
+   */
+  interface Type<C extends GroupMembershipProtocolConfig> extends ConfiguredType<C> {
+
+    /**
+     * Creates a new instance of the protocol.
+     *
+     * @param config the protocol configuration
+     * @return the protocol instance
+     */
+    GroupMembershipProtocol newProtocol(C config);
+  }
+
+  /**
+   * Returns the set of current cluster members.
+   *
+   * @return set of cluster members
+   */
+  Set<Member> getMembers();
+
+  /**
+   * Returns the specified member.
+   *
+   * @param memberId the member identifier
+   * @return the member or {@code null} if no node with the given identifier exists
+   */
+  Member getMember(MemberId memberId);
+
+  /**
+   * Joins the cluster.
+   *
+   * @param bootstrap the bootstrap service
+   * @param discovery the discovery service
+   * @param localMember the local member info
+   * @return a future to be completed once the join is complete
+   */
+  CompletableFuture<Void> join(BootstrapService bootstrap, NodeDiscoveryService discovery, Member localMember);
+
+  /**
+   * Leaves the cluster.
+   *
+   * @param localMember the local member info
+   * @return a future to be completed once the leave is complete
+   */
+  CompletableFuture<Void> leave(Member localMember);
+
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipProtocolBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipProtocolBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+/**
+ * Group membership protocol builder.
+ */
+public abstract class GroupMembershipProtocolBuilder implements io.atomix.utils.Builder<GroupMembershipProtocol> {
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipProtocolConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipProtocolConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import io.atomix.utils.config.TypedConfig;
+
+/**
+ * Group membership protocol configuration.
+ */
+public abstract class GroupMembershipProtocolConfig implements TypedConfig<GroupMembershipProtocol.Type> {
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocol.java
@@ -239,7 +239,7 @@ public class PhiMembershipProtocol
                 post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, remoteMember));
               } else if (localMember.getTimestamp() < remoteMember.getTimestamp()) {
                 members.put(remoteMember.id(), remoteMember);
-                post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember));
+                post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, remoteMember));
               }
             }
           } else {
@@ -287,7 +287,7 @@ public class PhiMembershipProtocol
           || !Objects.equals(member.properties(), remoteMember.properties())) {
         members.put(remoteMember.id(), remoteMember);
         if (member.isActive()) {
-          post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, member));
+          post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, remoteMember));
         }
         member = remoteMember;
       }

--- a/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocol.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.atomix.cluster.BootstrapService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.NodeDiscoveryEvent;
+import io.atomix.cluster.discovery.NodeDiscoveryEventListener;
+import io.atomix.cluster.discovery.NodeDiscoveryService;
+import io.atomix.cluster.impl.AddressSerializer;
+import io.atomix.cluster.impl.PhiAccrualFailureDetector;
+import io.atomix.utils.Version;
+import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.event.AbstractListenerManager;
+import io.atomix.utils.net.Address;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.atomix.utils.serializer.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Gossip based group membership protocol.
+ */
+public class PhiMembershipProtocol
+    extends AbstractListenerManager<GroupMembershipEvent, GroupMembershipEventListener>
+    implements GroupMembershipProtocol {
+
+  public static final Type TYPE = new Type();
+
+  /**
+   * Creates a new bootstrap provider builder.
+   *
+   * @return a new bootstrap provider builder
+   */
+  public static PhiMembershipProtocolBuilder builder() {
+    return new PhiMembershipProtocolBuilder();
+  }
+
+  /**
+   * Bootstrap member location provider type.
+   */
+  public static class Type implements GroupMembershipProtocol.Type<PhiMembershipProtocolConfig> {
+    private static final String NAME = "phi";
+
+    @Override
+    public String name() {
+      return NAME;
+    }
+
+    @Override
+    public PhiMembershipProtocolConfig newConfig() {
+      return new PhiMembershipProtocolConfig();
+    }
+
+    @Override
+    public GroupMembershipProtocol newProtocol(PhiMembershipProtocolConfig config) {
+      return new PhiMembershipProtocol(config);
+    }
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PhiMembershipProtocol.class);
+
+  private final PhiMembershipProtocolConfig config;
+
+  private static final String HEARTBEAT_MESSAGE = "atomix-cluster-membership";
+
+  private static final Serializer SERIALIZER = Serializer.using(
+      Namespace.builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(MemberId.class)
+          .register(GossipMember.class)
+          .register(new AddressSerializer(), Address.class)
+          .build("ClusterMembershipService"));
+
+  private volatile NodeDiscoveryService discoveryService;
+  private volatile BootstrapService bootstrapService;
+
+  private final AtomicBoolean started = new AtomicBoolean();
+  private volatile GossipMember localMember;
+  private volatile Properties localProperties = new Properties();
+  private final Map<MemberId, GossipMember> members = Maps.newConcurrentMap();
+  private final Map<MemberId, PhiAccrualFailureDetector> failureDetectors = Maps.newConcurrentMap();
+  private final NodeDiscoveryEventListener discoveryEventListener = this::handleDiscoveryEvent;
+
+  private final ScheduledExecutorService heartbeatScheduler = Executors.newSingleThreadScheduledExecutor(
+      namedThreads("atomix-cluster-heartbeat-sender", LOGGER));
+  private final ExecutorService eventExecutor = Executors.newSingleThreadExecutor(
+      namedThreads("atomix-cluster-events", LOGGER));
+  private ScheduledFuture<?> heartbeatFuture;
+
+  public PhiMembershipProtocol(PhiMembershipProtocolConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public GroupMembershipProtocolConfig config() {
+    return config;
+  }
+
+  @Override
+  public Set<Member> getMembers() {
+    return ImmutableSet.copyOf(members.values());
+  }
+
+  @Override
+  public Member getMember(MemberId memberId) {
+    return members.get(memberId);
+  }
+
+  @Override
+  protected void post(GroupMembershipEvent event) {
+    eventExecutor.execute(() -> super.post(event));
+  }
+
+  /**
+   * Handles a member location event.
+   *
+   * @param event the member location event
+   */
+  private void handleDiscoveryEvent(NodeDiscoveryEvent event) {
+    switch (event.type()) {
+      case JOIN:
+        handleJoinEvent(event.subject());
+        break;
+      case LEAVE:
+        handleLeaveEvent(event.subject());
+        break;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  /**
+   * Handles a node join event.
+   */
+  private void handleJoinEvent(Node node) {
+    GossipMember member = new GossipMember(MemberId.from(node.id().id()), node.address());
+    if (!members.containsKey(member.id())) {
+      sendHeartbeat(member);
+    }
+  }
+
+  /**
+   * Handles a node leave event.
+   */
+  private void handleLeaveEvent(Node node) {
+    members.compute(MemberId.from(node.id().id()), (id, member) -> member == null || !member.isActive() ? null : member);
+  }
+
+  /**
+   * Sends heartbeats to all peers.
+   */
+  private CompletableFuture<Void> sendHeartbeats() {
+    checkMetadata();
+    Stream<GossipMember> clusterMembers = members.values().stream()
+        .filter(member -> !member.id().equals(localMember.id()));
+
+    Stream<GossipMember> providerMembers = discoveryService.getNodes().stream()
+        .filter(node -> !members.containsKey(MemberId.from(node.id().id())))
+        .map(node -> new GossipMember(MemberId.from(node.id().id()), node.address()));
+
+    return Futures.allOf(Stream.concat(clusterMembers, providerMembers)
+        .map(member -> {
+          LOGGER.trace("{} - Sending heartbeat: {}", localMember.id(), member);
+          return sendHeartbeat(member).exceptionally(v -> null);
+        }).collect(Collectors.toList()))
+        .thenApply(v -> null);
+  }
+
+  /**
+   * Checks the local member metadata for changes.
+   */
+  private void checkMetadata() {
+    if (!localMember.properties().equals(localProperties)) {
+      synchronized (this) {
+        if (!localMember.properties().equals(localProperties)) {
+          localProperties = localMember.properties();
+          localMember.incrementTimestamp();
+          post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember));
+        }
+      }
+    }
+  }
+
+  /**
+   * Sends a heartbeat to the given peer.
+   */
+  private CompletableFuture<Void> sendHeartbeat(GossipMember member) {
+    return bootstrapService.getMessagingService().sendAndReceive(member.address(), HEARTBEAT_MESSAGE, SERIALIZER.encode(localMember))
+        .whenCompleteAsync((response, error) -> {
+          if (error == null) {
+            Collection<GossipMember> remoteMembers = SERIALIZER.decode(response);
+            for (GossipMember remoteMember : remoteMembers) {
+              if (remoteMember.id().equals(localMember.id()) || !remoteMember.isReachable()) {
+                continue;
+              }
+
+              GossipMember localMember = members.get(remoteMember.id());
+              if (localMember == null) {
+                members.put(remoteMember.id(), remoteMember);
+                post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, remoteMember));
+              } else if (localMember.getTimestamp() < remoteMember.getTimestamp()) {
+                members.put(remoteMember.id(), remoteMember);
+                post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember));
+              }
+            }
+          } else {
+            LOGGER.debug("{} - Sending heartbeat to {} failed", localMember.id(), member, error);
+            if (member.isReachable()) {
+              member.setReachable(false);
+              post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, member));
+            }
+
+            PhiAccrualFailureDetector failureDetector = failureDetectors.computeIfAbsent(member.id(), n -> new PhiAccrualFailureDetector());
+            double phi = failureDetector.phi();
+            if (phi >= config.getFailureThreshold()
+                || (phi == 0.0 && System.currentTimeMillis() - failureDetector.lastUpdated() > config.getFailureTimeout().toMillis())) {
+              if (members.remove(member.id()) != null) {
+                failureDetectors.remove(member.id());
+                post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, member));
+              }
+            }
+          }
+        }, heartbeatScheduler).exceptionally(e -> null)
+        .thenApply(v -> null);
+  }
+
+  /**
+   * Handles a heartbeat message.
+   */
+  private byte[] handleHeartbeat(Address address, byte[] message) {
+    GossipMember remoteMember = SERIALIZER.decode(message);
+    LOGGER.trace("{} - Received heartbeat: {}", localMember.id(), remoteMember);
+    failureDetectors.computeIfAbsent(remoteMember.id(), n -> new PhiAccrualFailureDetector()).report();
+    GossipMember member = members.get(remoteMember.id());
+
+    if (member == null) {
+      remoteMember.setActive(true);
+      remoteMember.setReachable(true);
+      members.put(remoteMember.id(), remoteMember);
+      post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, remoteMember));
+    } else {
+      // If the member's metadata changed, overwrite the local member. We do this instead of a version check since
+      // a heartbeat from the source member always takes precedence over a more recent version.
+      if (!Objects.equals(member.version(), remoteMember.version())
+          || !Objects.equals(member.zone(), remoteMember.zone())
+          || !Objects.equals(member.rack(), remoteMember.rack())
+          || !Objects.equals(member.host(), remoteMember.host())
+          || !Objects.equals(member.properties(), remoteMember.properties())) {
+        members.put(remoteMember.id(), remoteMember);
+        if (member.isActive()) {
+          post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, member));
+        }
+        member = remoteMember;
+      }
+
+      // If the local member is not active, set it to active and trigger a MEMBER_ADDED event.
+      if (!member.isActive()) {
+        member.setActive(true);
+        member.setReachable(true);
+        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, member));
+      }
+      // If the member has been marked unreachable, mark it as reachable and trigger a REACHABILITY_CHANGED event.
+      else if (!member.isReachable()) {
+        member.setReachable(true);
+        post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, member));
+      }
+    }
+    return SERIALIZER.encode(Lists.newArrayList(members.values()));
+  }
+
+  @Override
+  public CompletableFuture<Void> join(BootstrapService bootstrap, NodeDiscoveryService discovery, Member member) {
+    if (started.compareAndSet(false, true)) {
+      this.bootstrapService = bootstrap;
+      this.discoveryService = discovery;
+      this.localMember = new GossipMember(
+          member.id(),
+          member.address(),
+          member.zone(),
+          member.rack(),
+          member.host(),
+          member.properties(),
+          member.version());
+      discoveryService.addListener(discoveryEventListener);
+
+      LOGGER.info("{} - Member activated: {}", localMember.id(), localMember);
+      localMember.setActive(true);
+      localMember.setReachable(true);
+      members.put(localMember.id(), localMember);
+      post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, localMember));
+
+      bootstrapService.getMessagingService().registerHandler(HEARTBEAT_MESSAGE, this::handleHeartbeat, heartbeatScheduler);
+      heartbeatFuture = heartbeatScheduler.scheduleAtFixedRate(
+          this::sendHeartbeats, 0, config.getHeartbeatInterval().toMillis(), TimeUnit.MILLISECONDS);
+      LOGGER.info("Started");
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> leave(Member member) {
+    if (started.compareAndSet(true, false)) {
+      discoveryService.removeListener(discoveryEventListener);
+      heartbeatFuture.cancel(true);
+      heartbeatScheduler.shutdownNow();
+      eventExecutor.shutdownNow();
+      LOGGER.info("{} - Member deactivated: {}", localMember.id(), localMember);
+      localMember.setActive(false);
+      localMember.setReachable(false);
+      members.clear();
+      bootstrapService.getMessagingService().unregisterHandler(HEARTBEAT_MESSAGE);
+      LOGGER.info("Stopped");
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  /**
+   * Internal gossip based group member.
+   */
+  private static class GossipMember extends Member {
+    private final Version version;
+    private final AtomicLong timestamp = new AtomicLong();
+    private volatile boolean active;
+    private volatile boolean reachable;
+
+    public GossipMember(MemberId id, Address address) {
+      super(id, address);
+      this.version = null;
+      timestamp.set(0);
+    }
+
+    public GossipMember(
+        MemberId id,
+        Address address,
+        String zone,
+        String rack,
+        String host,
+        Properties properties,
+        Version version) {
+      super(id, address, zone, rack, host, properties);
+      this.version = version;
+      timestamp.set(1);
+    }
+
+    @Override
+    public Version version() {
+      return version;
+    }
+
+    /**
+     * Returns the member logical timestamp.
+     *
+     * @return the member logical timestamp
+     */
+    public long getTimestamp() {
+      return timestamp.get();
+    }
+
+    /**
+     * Sets the member's logical timestamp.
+     *
+     * @param timestamp the member's logical timestamp
+     */
+    void setTimestamp(long timestamp) {
+      this.timestamp.accumulateAndGet(timestamp, Math::max);
+    }
+
+    /**
+     * Increments the member's timestamp.
+     */
+    void incrementTimestamp() {
+      timestamp.incrementAndGet();
+    }
+
+    /**
+     * Sets whether this member is an active member of the cluster.
+     *
+     * @param active whether this member is an active member of the cluster
+     */
+    void setActive(boolean active) {
+      this.active = active;
+    }
+
+    /**
+     * Sets whether this member is reachable.
+     *
+     * @param reachable whether this member is reachable
+     */
+    void setReachable(boolean reachable) {
+      this.reachable = reachable;
+    }
+
+    @Override
+    public boolean isActive() {
+      return active;
+    }
+
+    @Override
+    public boolean isReachable() {
+      return reachable;
+    }
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocolBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocolBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import java.time.Duration;
+
+/**
+ * Gossip based group membership protocol builder.
+ */
+public class PhiMembershipProtocolBuilder extends GroupMembershipProtocolBuilder {
+  private final PhiMembershipProtocolConfig config = new PhiMembershipProtocolConfig();
+
+  /**
+   * Sets the failure detection heartbeat interval.
+   *
+   * @param heartbeatInterval the failure detection heartbeat interval
+   * @return the location provider builder
+   */
+  public PhiMembershipProtocolBuilder withHeartbeatInterval(Duration heartbeatInterval) {
+    config.setHeartbeatInterval(heartbeatInterval);
+    return this;
+  }
+
+  /**
+   * Sets the phi accrual failure threshold.
+   *
+   * @param failureThreshold the phi accrual failure threshold
+   * @return the location provider builder
+   */
+  public PhiMembershipProtocolBuilder withFailureThreshold(int failureThreshold) {
+    config.setFailureThreshold(failureThreshold);
+    return this;
+  }
+
+  /**
+   * Sets the failure timeout to use prior to phi failure detectors being populated.
+   *
+   * @param failureTimeout the failure timeout
+   * @return the location provider builder
+   */
+  public PhiMembershipProtocolBuilder withFailureTimeout(Duration failureTimeout) {
+    config.setFailureTimeout(failureTimeout);
+    return this;
+  }
+
+  @Override
+  public GroupMembershipProtocol build() {
+    return new PhiMembershipProtocol(config);
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocolConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocolConfig.java
@@ -15,11 +15,7 @@
  */
 package io.atomix.cluster.protocol;
 
-import io.atomix.cluster.NodeConfig;
-
 import java.time.Duration;
-import java.util.Collection;
-import java.util.Collections;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -34,7 +30,6 @@ public class PhiMembershipProtocolConfig extends GroupMembershipProtocolConfig {
   private Duration heartbeatInterval = Duration.ofMillis(DEFAULT_HEARTBEAT_INTERVAL);
   private int failureThreshold = DEFAULT_PHI_FAILURE_THRESHOLD;
   private Duration failureTimeout = Duration.ofMillis(DEFAULT_FAILURE_TIMEOUT);
-  private Collection<NodeConfig> nodes = Collections.emptySet();
 
   @Override
   public GroupMembershipProtocol.Type getType() {

--- a/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocolConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocolConfig.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import io.atomix.cluster.NodeConfig;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Gossip group membership protocol configuration.
+ */
+public class PhiMembershipProtocolConfig extends GroupMembershipProtocolConfig {
+  private static final int DEFAULT_HEARTBEAT_INTERVAL = 1000;
+  private static final int DEFAULT_FAILURE_TIMEOUT = 10000;
+  private static final int DEFAULT_PHI_FAILURE_THRESHOLD = 10;
+
+  private Duration heartbeatInterval = Duration.ofMillis(DEFAULT_HEARTBEAT_INTERVAL);
+  private int failureThreshold = DEFAULT_PHI_FAILURE_THRESHOLD;
+  private Duration failureTimeout = Duration.ofMillis(DEFAULT_FAILURE_TIMEOUT);
+  private Collection<NodeConfig> nodes = Collections.emptySet();
+
+  @Override
+  public GroupMembershipProtocol.Type getType() {
+    return PhiMembershipProtocol.TYPE;
+  }
+
+  /**
+   * Returns the heartbeat interval.
+   *
+   * @return the heartbeat interval
+   */
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  /**
+   * Sets the heartbeat interval.
+   *
+   * @param heartbeatInterval the heartbeat interval
+   * @return the group membership configuration
+   */
+  public PhiMembershipProtocolConfig setHeartbeatInterval(Duration heartbeatInterval) {
+    this.heartbeatInterval = checkNotNull(heartbeatInterval);
+    return this;
+  }
+
+  /**
+   * Returns the failure detector threshold.
+   *
+   * @return the failure detector threshold
+   */
+  public int getFailureThreshold() {
+    return failureThreshold;
+  }
+
+  /**
+   * Sets the failure detector threshold.
+   *
+   * @param failureThreshold the failure detector threshold
+   * @return the group membership configuration
+   */
+  public PhiMembershipProtocolConfig setFailureThreshold(int failureThreshold) {
+    this.failureThreshold = failureThreshold;
+    return this;
+  }
+
+  /**
+   * Returns the base failure timeout.
+   *
+   * @return the base failure timeout
+   */
+  public Duration getFailureTimeout() {
+    return failureTimeout;
+  }
+
+  /**
+   * Sets the base failure timeout.
+   *
+   * @param failureTimeout the base failure timeout
+   * @return the group membership configuration
+   */
+  public PhiMembershipProtocolConfig setFailureTimeout(Duration failureTimeout) {
+    this.failureTimeout = checkNotNull(failureTimeout);
+    return this;
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/package-info.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides interfaces and implementations for group membership protocols.
+ */
+package io.atomix.cluster.protocol;

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
@@ -21,12 +21,13 @@ import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.ManagedClusterMembershipService;
 import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
-import io.atomix.cluster.MembershipConfig;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.TestBootstrapService;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.messaging.impl.TestBroadcastServiceFactory;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
+import io.atomix.cluster.protocol.PhiMembershipProtocol;
+import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
 import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import org.junit.Test;
@@ -80,7 +81,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService1, localMember1, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService1,
-        new MembershipConfig());
+        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
 
     Member localMember2 = buildMember(2);
     BootstrapService bootstrapService2 = new TestBootstrapService(
@@ -91,7 +92,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService2, localMember2, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService2,
-        new MembershipConfig());
+        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
 
     Member localMember3 = buildMember(3);
     BootstrapService bootstrapService3 = new TestBootstrapService(
@@ -102,7 +103,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.0.1"),
         new DefaultNodeDiscoveryService(bootstrapService3, localMember3, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService3,
-        new MembershipConfig());
+        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
 
     assertNull(clusterService1.getMember(MemberId.from("1")));
     assertNull(clusterService1.getMember(MemberId.from("2")));
@@ -135,7 +136,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.1.0"),
         new DefaultNodeDiscoveryService(ephemeralBootstrapService, anonymousMember, new BootstrapDiscoveryProvider(bootstrapLocations)),
         ephemeralBootstrapService,
-        new MembershipConfig());
+        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
 
     assertFalse(ephemeralClusterService.getLocalMember().isActive());
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
@@ -16,19 +16,20 @@
 package io.atomix.cluster.messaging.impl;
 
 import com.google.common.util.concurrent.MoreExecutors;
-import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.BootstrapService;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.ManagedClusterMembershipService;
 import io.atomix.cluster.Member;
-import io.atomix.cluster.MembershipConfig;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.TestBootstrapService;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DefaultClusterMembershipService;
 import io.atomix.cluster.impl.DefaultNodeDiscoveryService;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.ManagedClusterEventService;
 import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.cluster.protocol.PhiMembershipProtocol;
+import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
 import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import io.atomix.utils.serializer.Namespaces;
@@ -83,7 +84,7 @@ public class DefaultClusterEventServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService1, localMember1, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService1,
-        new MembershipConfig());
+        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
     ClusterMembershipService clusterMembershipService1 = clusterService1.start().join();
     ManagedClusterEventService clusterEventingService1 = new DefaultClusterEventService(clusterMembershipService1, messagingService1);
     ClusterEventService eventService1 = clusterEventingService1.start().join();
@@ -98,7 +99,7 @@ public class DefaultClusterEventServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService2, localMember2, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService2,
-        new MembershipConfig());
+        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
     ClusterMembershipService clusterMembershipService2 = clusterService2.start().join();
     ManagedClusterEventService clusterEventingService2 = new DefaultClusterEventService(clusterMembershipService2, messagingService2);
     ClusterEventService eventService2 = clusterEventingService2.start().join();
@@ -113,7 +114,7 @@ public class DefaultClusterEventServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService3, localMember3, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService3,
-        new MembershipConfig());
+        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
     ClusterMembershipService clusterMembershipService3 = clusterService3.start().join();
     ManagedClusterEventService clusterEventingService3 = new DefaultClusterEventService(clusterMembershipService3, messagingService3);
     ClusterEventService eventService3 = clusterEventingService3.start().join();

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -15,20 +15,6 @@
  */
 package io.atomix.core;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import io.atomix.cluster.AtomixCluster;
@@ -36,6 +22,8 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.discovery.NodeDiscoveryConfig;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.cluster.protocol.GroupMembershipProtocol;
+import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
 import io.atomix.core.barrier.DistributedCyclicBarrier;
 import io.atomix.core.counter.AtomicCounter;
 import io.atomix.core.counter.DistributedCounter;
@@ -101,6 +89,20 @@ import io.atomix.utils.config.ConfigMapper;
 import io.atomix.utils.config.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -310,7 +312,8 @@ public class Atomix extends AtomixCluster implements PrimitivesService {
         new PolymorphicTypeMapper(null, PrimitiveConfig.class, PrimitiveType.class),
         new PolymorphicTypeMapper("type", PrimitiveProtocolConfig.class, PrimitiveProtocol.Type.class),
         new PolymorphicTypeMapper("type", ProfileConfig.class, Profile.Type.class),
-        new PolymorphicTypeMapper("type", NodeDiscoveryConfig.class, NodeDiscoveryProvider.Type.class));
+        new PolymorphicTypeMapper("type", NodeDiscoveryConfig.class, NodeDiscoveryProvider.Type.class),
+        new PolymorphicTypeMapper("type", GroupMembershipProtocolConfig.class, GroupMembershipProtocol.Type.class));
     return mapper.loadFiles(AtomixConfig.class, files, Lists.newArrayList(RESOURCES));
   }
 

--- a/core/src/main/java/io/atomix/core/registry/ClasspathScanningRegistry.java
+++ b/core/src/main/java/io/atomix/core/registry/ClasspathScanningRegistry.java
@@ -17,6 +17,7 @@ package io.atomix.core.registry;
 
 import com.google.common.collect.Sets;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
+import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.core.AtomixRegistry;
 import io.atomix.core.profile.Profile;
 import io.atomix.primitive.PrimitiveType;
@@ -228,7 +229,8 @@ public class ClasspathScanningRegistry implements AtomixRegistry {
               PrimitiveType.class,
               PrimitiveProtocol.Type.class,
               Profile.Type.class,
-              NodeDiscoveryProvider.Type.class),
+              NodeDiscoveryProvider.Type.class,
+              GroupMembershipProtocol.Type.class),
           whitelistPackages);
     }
   }

--- a/core/src/test/java/io/atomix/core/AtomixConfigTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixConfigTest.java
@@ -22,6 +22,7 @@ import io.atomix.cluster.MulticastConfig;
 import io.atomix.cluster.NetworkConfig;
 import io.atomix.cluster.discovery.MulticastDiscoveryConfig;
 import io.atomix.cluster.discovery.MulticastDiscoveryProvider;
+import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
 import io.atomix.core.map.AtomicMapConfig;
 import io.atomix.core.profile.ConsensusProfile;
 import io.atomix.core.profile.ConsensusProfileConfig;
@@ -85,6 +86,11 @@ public class AtomixConfigTest {
     assertTrue(multicast.isEnabled());
     assertEquals("230.0.1.1", multicast.getGroup().getHostAddress());
     assertEquals(56789, multicast.getPort());
+
+    PhiMembershipProtocolConfig protocol = (PhiMembershipProtocolConfig) cluster.getProtocolConfig();
+    assertEquals(Duration.ofMillis(200), protocol.getHeartbeatInterval());
+    assertEquals(12, protocol.getFailureThreshold());
+    assertEquals(Duration.ofSeconds(15), protocol.getFailureTimeout());
 
     MembershipConfig membership = cluster.getMembershipConfig();
     assertEquals(Duration.ofSeconds(1), membership.getBroadcastInterval());

--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -20,6 +20,12 @@ cluster {
     group: "230.0.1.1"
     port: 56789
   }
+  protocol {
+    type: phi
+    heartbeatInterval: 200ms
+    failureThreshold: 12
+    failureTimeout: 15s
+  }
   membership {
     broadcast-interval: 1s
     reachability-threshold: 12


### PR DESCRIPTION
This PR implements a pluggable group membership protocol as per #866

The protocol is configured via the `cluster.protocol` object, and the configuration has the same basic format as all other extensible configurations:
```
cluster.protocol {
  type: phi
  heartbeatInterval: 100ms
}
```

The default protocol is `phi`, which is the membership protocol which has been used in Atomix since 3.0.