### PR TITLE
Swim membership protocol

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -31,6 +31,7 @@ import io.atomix.cluster.messaging.ManagedClusterCommunicationService;
 import io.atomix.cluster.messaging.ManagedClusterEventService;
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.cluster.messaging.UnicastService;
 import io.atomix.cluster.messaging.impl.DefaultClusterCommunicationService;
 import io.atomix.cluster.messaging.impl.DefaultClusterEventService;
 import io.atomix.cluster.messaging.impl.NettyBroadcastService;
@@ -192,6 +193,20 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
     this.membershipService = buildClusterMembershipService(config, this, discoveryProvider, membershipProtocol, version);
     this.communicationService = buildClusterMessagingService(membershipService, messagingService);
     this.eventService = buildClusterEventService(membershipService, messagingService);
+  }
+
+  /**
+   * Returns the cluster unicast service.
+   * <p>
+   * The unicast service supports unreliable uni-directional messaging via UDP. This is a
+   * low-level cluster communication API. For higher level messaging, use the
+   * {@link #getCommunicationService() communication service} or {@link #getEventService() event service}.
+   *
+   * @return the cluster unicast service
+   */
+  @Override
+  public UnicastService getUnicastService() {
+    return null;
   }
 
   /**

--- a/cluster/src/main/java/io/atomix/cluster/BootstrapService.java
+++ b/cluster/src/main/java/io/atomix/cluster/BootstrapService.java
@@ -17,6 +17,7 @@ package io.atomix.cluster;
 
 import io.atomix.cluster.messaging.BroadcastService;
 import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.cluster.messaging.UnicastService;
 
 /**
  * Cluster bootstrap service.
@@ -31,6 +32,13 @@ public interface BootstrapService {
    * @return the cluster messaging service
    */
   MessagingService getMessagingService();
+
+  /**
+   * Returns the cluster unicast service.
+   *
+   * @return the cluster unicast service
+   */
+  UnicastService getUnicastService();
 
   /**
    * Returns the cluster broadcast service

--- a/cluster/src/main/java/io/atomix/cluster/messaging/ManagedUnicastService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/ManagedUnicastService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging;
+
+import io.atomix.utils.Managed;
+
+/**
+ * Managed unicast service.
+ */
+public interface ManagedUnicastService extends UnicastService, Managed<UnicastService> {
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/UnicastService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/UnicastService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.atomix.utils.net.Address;
+
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+
+/**
+ * Service for unreliable unicast messaging between nodes.
+ * <p>
+ * The broadcast service is an unreliable broadcast messaging service backed by multicast. This service provides no
+ * guaranteed regarding reliability or order of messages.
+ */
+public interface UnicastService {
+
+  /**
+   * Broadcasts the given message to all listeners for the given subject.
+   * <p>
+   * The message will be broadcast to all listeners for the given {@code subject}. This service makes no guarantee
+   * regarding the reliability or order of delivery of the message.
+   *
+   * @param address the address to which to unicast the message
+   * @param subject the message subject
+   * @param message the message to broadcast
+   */
+  void unicast(Address address, String subject, byte[] message);
+
+  /**
+   * Adds a broadcast listener for the given subject.
+   * <p>
+   * Messages broadcast to the given {@code subject} will be delivered to the provided listener. This service provides
+   * no guarantee regarding the order in which messages arrive.
+   *
+   * @param subject the message subject
+   * @param listener the broadcast listener to add
+   */
+  default void addListener(String subject, BiConsumer<Address, byte[]> listener) {
+    addListener(subject, listener, MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Adds a broadcast listener for the given subject.
+   * <p>
+   * Messages broadcast to the given {@code subject} will be delivered to the provided listener. This service provides
+   * no guarantee regarding the order in which messages arrive.
+   *
+   * @param subject the message subject
+   * @param listener the broadcast listener to add
+   * @param executor an executor with which to call the listener
+   */
+  void addListener(String subject, BiConsumer<Address, byte[]> listener, Executor executor);
+
+  /**
+   * Removes a broadcast listener for the given subject.
+   *
+   * @param subject the message subject
+   * @param listener the broadcast listener to remove
+   */
+  void removeListener(String subject, BiConsumer<Address, byte[]> listener);
+
+  /**
+   * Broadcast service builder.
+   */
+  interface Builder extends io.atomix.utils.Builder<UnicastService> {
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import com.google.common.collect.Maps;
+import io.atomix.cluster.impl.AddressSerializer;
+import io.atomix.cluster.messaging.ManagedUnicastService;
+import io.atomix.cluster.messaging.UnicastService;
+import io.atomix.utils.net.Address;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.atomix.utils.serializer.Serializer;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * Netty unicast service.
+ */
+public class NettyUnicastService implements ManagedUnicastService {
+
+  /**
+   * Returns a new unicast service builder.
+   *
+   * @return a new unicast service builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Netty unicast service builder.
+   */
+  public static class Builder implements UnicastService.Builder {
+    private Address address;
+
+    /**
+     * Sets the local address.
+     *
+     * @param address the local address
+     * @return the unicast service builder
+     */
+    public Builder withAddress(Address address) {
+      this.address = checkNotNull(address);
+      return this;
+    }
+
+    @Override
+    public ManagedUnicastService build() {
+      return new NettyUnicastService(address);
+    }
+  }
+
+  private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
+      .register(Namespaces.BASIC)
+      .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+      .register(Message.class)
+      .register(new AddressSerializer(), Address.class)
+      .build());
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final Address address;
+  private EventLoopGroup group;
+  private DatagramChannel channel;
+
+  private final Map<String, Map<BiConsumer<Address, byte[]>, Executor>> listeners = Maps.newConcurrentMap();
+  private final AtomicBoolean started = new AtomicBoolean();
+
+  public NettyUnicastService(Address address) {
+    this.address = address;
+  }
+
+  @Override
+  public void unicast(Address address, String subject, byte[] payload) {
+    Message message = new Message(this.address, subject, payload);
+    byte[] bytes = SERIALIZER.encode(message);
+    ByteBuf buf = channel.alloc().buffer(4 + bytes.length);
+    buf.writeInt(bytes.length).writeBytes(bytes);
+    channel.writeAndFlush(new DatagramPacket(buf, new InetSocketAddress(address.address(), address.port())));
+  }
+
+  @Override
+  public synchronized void addListener(String subject, BiConsumer<Address, byte[]> listener, Executor executor) {
+    listeners.computeIfAbsent(subject, s -> Maps.newConcurrentMap()).put(listener, executor);
+  }
+
+  @Override
+  public synchronized void removeListener(String subject, BiConsumer<Address, byte[]> listener) {
+    Map<BiConsumer<Address, byte[]>, Executor> listeners = this.listeners.get(subject);
+    if (listeners != null) {
+      listeners.remove(listener);
+      if (listeners.isEmpty()) {
+        this.listeners.remove(subject);
+      }
+    }
+  }
+
+  private CompletableFuture<Void> bootstrap() {
+    Bootstrap serverBootstrap = new Bootstrap()
+        .group(group)
+        .channel(NioDatagramChannel.class)
+        .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+          @Override
+          protected void channelRead0(ChannelHandlerContext context, DatagramPacket packet) throws Exception {
+            byte[] payload = new byte[packet.content().readInt()];
+            packet.content().readBytes(payload);
+            Message message = SERIALIZER.decode(payload);
+            Map<BiConsumer<Address, byte[]>, Executor> listeners = NettyUnicastService.this.listeners.get(message.subject());
+            if (listeners != null) {
+              listeners.forEach((consumer, executor) ->
+                  executor.execute(() -> consumer.accept(message.source(), message.payload())));
+            }
+          }
+        })
+        .option(ChannelOption.SO_BROADCAST, true)
+        .option(ChannelOption.SO_REUSEADDR, true);
+
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    serverBootstrap.bind(new InetSocketAddress(address.address(), address.port())).addListener((ChannelFutureListener) f -> {
+      if (f.isSuccess()) {
+        channel = (DatagramChannel) f.channel();
+        future.complete(null);
+      } else {
+        future.completeExceptionally(f.cause());
+      }
+    });
+    return future;
+  }
+
+  @Override
+  public CompletableFuture<UnicastService> start() {
+    group = new NioEventLoopGroup(0, namedThreads("netty-unicast-event-nio-client-%d", log));
+    return bootstrap()
+        .thenRun(() -> started.set(true))
+        .thenApply(v -> this);
+  }
+
+  @Override
+  public boolean isRunning() {
+    return started.get();
+  }
+
+  @Override
+  public CompletableFuture<Void> stop() {
+    if (channel != null) {
+      CompletableFuture<Void> future = new CompletableFuture<>();
+      channel.close().addListener(f -> {
+        started.set(false);
+        group.shutdownGracefully();
+        future.complete(null);
+      });
+      return future;
+    }
+    started.set(false);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  /**
+   * Internal unicast service message.
+   */
+  static class Message {
+    private final Address source;
+    private final String subject;
+    private final byte[] payload;
+
+    Message() {
+      this(null, null, null);
+    }
+
+    Message(Address source, String subject, byte[] payload) {
+      this.source = source;
+      this.subject = subject;
+      this.payload = payload;
+    }
+
+    Address source() {
+      return source;
+    }
+
+    String subject() {
+      return subject;
+    }
+
+    byte[] payload() {
+      return payload;
+    }
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipEvent.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/GroupMembershipEvent.java
@@ -18,6 +18,8 @@ package io.atomix.cluster.protocol;
 import io.atomix.cluster.Member;
 import io.atomix.utils.event.AbstractEvent;
 
+import java.util.Objects;
+
 /**
  * Group membership protocol event.
  */
@@ -63,5 +65,19 @@ public class GroupMembershipEvent extends AbstractEvent<GroupMembershipEvent.Typ
    */
   public Member member() {
     return subject();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type(), member());
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (object instanceof GroupMembershipEvent) {
+      GroupMembershipEvent that = (GroupMembershipEvent) object;
+      return this.type() == that.type() && this.member().equals(that.member());
+    }
+    return false;
   }
 }

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -247,6 +247,9 @@ public class SwimMembershipProtocol
           swimMember.setState(State.SUSPECT);
           LOGGER.debug("{} - Member unreachable {}", this.localMember.id(), swimMember);
           post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
+          if (config.isNotifySuspect()) {
+            gossip(swimMember, Lists.newArrayList(swimMember.copy()));
+          }
         }
         // If the state has been changed to DEAD, trigger a REACHABILITY_CHANGED event if necessary and then remove
         // the member from the members list and trigger a MEMBER_REMOVED event.
@@ -281,6 +284,9 @@ public class SwimMembershipProtocol
       if (member.state() == State.SUSPECT) {
         LOGGER.debug("{} - Member unreachable {}", this.localMember.id(), swimMember);
         post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, swimMember.copy()));
+        if (config.isNotifySuspect()) {
+          gossip(swimMember, Lists.newArrayList(swimMember.copy()));
+        }
       }
       // If the updated state is DEAD, post a REACHABILITY_CHANGED event if necessary, then post a MEMBER_REMOVED
       // event and record an update.

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -1,0 +1,856 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.atomix.cluster.BootstrapService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.NodeDiscoveryEvent;
+import io.atomix.cluster.discovery.NodeDiscoveryEventListener;
+import io.atomix.cluster.discovery.NodeDiscoveryService;
+import io.atomix.cluster.impl.AddressSerializer;
+import io.atomix.utils.Version;
+import io.atomix.utils.event.AbstractListenerManager;
+import io.atomix.utils.net.Address;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+import io.atomix.utils.serializer.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import static io.atomix.utils.concurrent.Threads.namedThreads;
+
+/**
+ * SWIM group membership protocol implementation.
+ */
+public class SwimMembershipProtocol
+    extends AbstractListenerManager<GroupMembershipEvent, GroupMembershipEventListener>
+    implements GroupMembershipProtocol {
+
+  public static final Type TYPE = new Type();
+
+  /**
+   * Creates a new bootstrap provider builder.
+   *
+   * @return a new bootstrap provider builder
+   */
+  public static SwimMembershipProtocolBuilder builder() {
+    return new SwimMembershipProtocolBuilder();
+  }
+
+  /**
+   * Bootstrap member location provider type.
+   */
+  public static class Type implements GroupMembershipProtocol.Type<SwimMembershipProtocolConfig> {
+    private static final String NAME = "bootstrap";
+
+    @Override
+    public String name() {
+      return NAME;
+    }
+
+    @Override
+    public SwimMembershipProtocolConfig newConfig() {
+      return new SwimMembershipProtocolConfig();
+    }
+
+    @Override
+    public GroupMembershipProtocol newProtocol(SwimMembershipProtocolConfig config) {
+      return new SwimMembershipProtocol(config);
+    }
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SwimMembershipProtocol.class);
+
+  private static final String MEMBERSHIP_GOSSIP = "atomix-membership-gossip";
+  private static final String MEMBERSHIP_PROBE = "atomix-membership-probe";
+  private static final String MEMBERSHIP_PROBE_REQUEST = "atomix-membership-probe-request";
+
+  private static final Serializer SERIALIZER = Serializer.using(
+      Namespace.builder()
+          .register(Namespaces.BASIC)
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
+          .register(MemberId.class)
+          .register(new AddressSerializer(), Address.class)
+          .register(ImmutableMember.class)
+          .register(State.class)
+          .build("ClusterMembershipService"));
+
+  private final BiFunction<Address, byte[], byte[]> probeHandler = (address, payload) ->
+      SERIALIZER.encode(handleProbe(SERIALIZER.decode(payload)));
+  private final BiConsumer<Address, byte[]> probeRequestHandler = (address, payload) ->
+      handleProbeRequest(SERIALIZER.decode(payload))
+          .thenApply(SERIALIZER::encode);
+  private final BiConsumer<Address, byte[]> gossipListener = (address, payload) ->
+      handleGossipUpdates(SERIALIZER.decode(payload));
+
+  private final SwimMembershipProtocolConfig config;
+  private NodeDiscoveryService discoveryService;
+  private BootstrapService bootstrapService;
+
+  private final AtomicBoolean started = new AtomicBoolean();
+  private SwimMember localMember;
+  private volatile Properties localProperties = new Properties();
+  private final Map<MemberId, SwimMember> members = Maps.newConcurrentMap();
+  private List<SwimMember> randomMembers = Lists.newCopyOnWriteArrayList();
+  private final Map<MemberId, Long> suspectTimestamps = Maps.newConcurrentMap();
+  private final NodeDiscoveryEventListener discoveryEventListener = this::handleDiscoveryEvent;
+  private final List<ImmutableMember> updates = Lists.newCopyOnWriteArrayList();
+
+  private final ScheduledExecutorService swimScheduler = Executors.newSingleThreadScheduledExecutor(
+      namedThreads("atomix-cluster-heartbeat-sender", LOGGER));
+  private final ExecutorService eventExecutor = Executors.newSingleThreadExecutor(
+      namedThreads("atomix-cluster-events", LOGGER));
+  private ScheduledFuture<?> gossipFuture;
+  private ScheduledFuture<?> probeFuture;
+
+  private final AtomicInteger probeCounter = new AtomicInteger();
+
+  SwimMembershipProtocol(SwimMembershipProtocolConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public SwimMembershipProtocolConfig config() {
+    return config;
+  }
+
+  @Override
+  public Set<Member> getMembers() {
+    return ImmutableSet.copyOf(members.values());
+  }
+
+  @Override
+  public Member getMember(MemberId memberId) {
+    return members.get(memberId);
+  }
+
+  @Override
+  protected void post(GroupMembershipEvent event) {
+    eventExecutor.execute(() -> super.post(event));
+  }
+
+  /**
+   * Checks the local member metadata for changes.
+   */
+  private void checkMetadata() {
+    if (!localMember.properties().equals(localProperties)) {
+      synchronized (this) {
+        if (!localMember.properties().equals(localProperties)) {
+          localProperties = localMember.properties();
+          localMember.setTerm(localMember.getTerm() + 1);
+          post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember));
+          recordUpdate(localMember.copy());
+        }
+      }
+    }
+  }
+
+  /**
+   * Updates the state for the given member.
+   *
+   * @param member the member for which to update the state
+   */
+  private void updateState(ImmutableMember member) {
+    // If the member matches the local member, ignore the update.
+    if (member.id().equals(localMember.id())) {
+      return;
+    }
+
+    SwimMember localMember = members.get(member.id());
+
+    // If the local member is not present, add the member in the ALIVE state.
+    if (localMember == null) {
+      localMember = new SwimMember(member);
+      members.put(localMember.id(), localMember);
+      randomMembers.add(localMember);
+      Collections.shuffle(randomMembers);
+      LOGGER.debug("{} - Member added {}", this.localMember.id(), localMember);
+      localMember.setState(State.ALIVE);
+      post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, localMember.copy()));
+      recordUpdate(localMember.copy());
+    }
+    // If the term has been increased, update the member and record a gossip event.
+    else if (member.term() > localMember.getTerm()) {
+      // If the member's version has changed, remove the old member and add the new member.
+      if (member.version().compareTo(localMember.version()) != 0) {
+        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, localMember.copy()));
+        randomMembers.remove(localMember);
+        localMember = new SwimMember(member);
+        localMember.setState(State.ALIVE);
+        members.put(member.id(), localMember);
+        randomMembers.add(localMember);
+        Collections.shuffle(randomMembers);
+        LOGGER.debug("{} - Evicted member for new version {}", localMember);
+        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, localMember.copy()));
+        recordUpdate(localMember.copy());
+      } else {
+        // Update the term for the local member.
+        localMember.setTerm(member.term());
+
+        // If the state has been changed to ALIVE, trigger a REACHABILITY_CHANGED event and then update metadata.
+        if (member.state() == State.ALIVE && localMember.getState() != State.ALIVE) {
+          localMember.setState(State.ALIVE);
+          LOGGER.debug("{} - Member reachable {}", this.localMember.id(), localMember);
+          post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, localMember.copy()));
+          if (!Objects.equals(member.properties(), localMember.properties())) {
+            localMember.properties().putAll(member.properties());
+            LOGGER.debug("{} - Member metadata changed {}", this.localMember.id(), localMember);
+            post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember.copy()));
+          }
+        }
+        // If the state has been changed to SUSPECT, update metadata and then trigger a REACHABILITY_CHANGED event.
+        else if (member.state() == State.SUSPECT && localMember.getState() != State.SUSPECT) {
+          if (!Objects.equals(member.properties(), localMember.properties())) {
+            localMember.properties().putAll(member.properties());
+            LOGGER.debug("{} - Member metadata changed {}", this.localMember.id(), localMember);
+            post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember.copy()));
+          }
+          localMember.setState(State.SUSPECT);
+          LOGGER.debug("{} - Member unreachable {}", this.localMember.id(), localMember);
+          post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, localMember.copy()));
+        }
+        // If the state has been changed to DEAD, trigger a REACHABILITY_CHANGED event if necessary and then remove
+        // the member from the members list and trigger a MEMBER_REMOVED event.
+        else if (member.state() == State.DEAD && localMember.getState() != State.DEAD) {
+          if (localMember.getState() == State.ALIVE) {
+            localMember.setState(State.SUSPECT);
+            LOGGER.debug("{} - Member unreachable {}", this.localMember.id(), localMember);
+            post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, localMember.copy()));
+          }
+          localMember.setState(State.DEAD);
+          members.remove(localMember.id());
+          randomMembers.remove(localMember);
+          Collections.shuffle(randomMembers);
+          LOGGER.debug("{} - Member removed {}", this.localMember.id(), localMember);
+          post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, localMember.copy()));
+        }
+
+        // Always enqueue an update for gossip when the term changes.
+        recordUpdate(localMember.copy());
+      }
+    }
+    // If the term remained the same but the state has progressed, update the state and trigger events.
+    else if (member.term() == localMember.getTerm() && member.state().ordinal() > localMember.getState().ordinal()) {
+      localMember.setState(member.state());
+
+      // If the updated state is SUSPECT, post a REACHABILITY_CHANGED event and record an update.
+      if (member.state() == State.SUSPECT) {
+        LOGGER.debug("{} - Member unreachable {}", this.localMember.id(), localMember);
+        post(new GroupMembershipEvent(GroupMembershipEvent.Type.REACHABILITY_CHANGED, localMember.copy()));
+      }
+      // If the updated state is DEAD, post a REACHABILITY_CHANGED event if necessary, then post a MEMBER_REMOVED
+      // event and record an update.
+      else if (member.state() == State.DEAD) {
+        members.remove(localMember.id());
+        randomMembers.remove(localMember);
+        Collections.shuffle(randomMembers);
+        LOGGER.debug("{} - Member removed {}", this.localMember.id(), localMember);
+        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, localMember.copy()));
+      }
+      recordUpdate(localMember.copy());
+    }
+  }
+
+  /**
+   * Records an update as an immutable member.
+   *
+   * @param member the updated member
+   */
+  private void recordUpdate(ImmutableMember member) {
+    updates.add(member);
+  }
+
+  /**
+   * Checks suspect nodes for failures.
+   */
+  private void checkFailures() {
+    Iterator<Map.Entry<MemberId, Long>> iterator = suspectTimestamps.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Map.Entry<MemberId, Long> entry = iterator.next();
+      SwimMember member = members.get(entry.getKey());
+      if (member != null && !member.isReachable()) {
+        if (System.currentTimeMillis() - entry.getValue() > config.getFailureTimeout().toMillis()) {
+          member.setState(State.DEAD);
+          updateState(member.copy());
+        }
+      }
+    }
+  }
+
+  /**
+   * Sends probes to all known members.
+   */
+  private void probeAll() {
+    probe(true);
+  }
+
+  /**
+   * Probes a random member.
+   */
+  private void probe() {
+    probe(false);
+  }
+
+  /**
+   * Sends probes to all members or to the next member in round robin fashion.
+   *
+   * @param all whether to send probes to all members
+   */
+  private void probe(boolean all) {
+    // First get a sorted list of discovery service nodes that are not present in the SWIM members.
+    // This is necessary to ensure we attempt to probe all nodes that are provided by the discovery provider.
+    List<SwimMember> probeMembers = Lists.newArrayList(discoveryService.getNodes().stream()
+        .map(node -> new SwimMember(MemberId.from(node.id().id()), node.address()))
+        .filter(member -> !members.containsKey(member.id()))
+        .sorted(Comparator.comparing(Member::id))
+        .collect(Collectors.toList()));
+
+    // Then add the randomly sorted list of SWIM members.
+    probeMembers.addAll(randomMembers);
+
+    // If there are members to probe, select the next member to probe using a counter for round robin probes.
+    if (!probeMembers.isEmpty()) {
+      if (all) {
+        for (SwimMember member : probeMembers) {
+          probe(member.copy());
+        }
+      } else {
+        SwimMember probeMember = probeMembers.get(Math.abs(probeCounter.incrementAndGet() % probeMembers.size()));
+        probe(probeMember.copy());
+      }
+    }
+
+    // Check suspect nodes for failure timeouts.
+    checkFailures();
+  }
+
+  /**
+   * Probes the given member.
+   *
+   * @param member the member to probe
+   */
+  private void probe(ImmutableMember member) {
+    LOGGER.trace("{} - Probing {}", localMember.id(), member);
+    bootstrapService.getMessagingService().sendAndReceive(member.address(), MEMBERSHIP_PROBE, SERIALIZER.encode(member))
+        .whenCompleteAsync((response, error) -> {
+          if (error == null) {
+            updateState(SERIALIZER.decode(response));
+          } else {
+            // Verify that the local member term has not changed and request probes from peers.
+            SwimMember localMember = members.get(member.id());
+            if (localMember != null && localMember.getTerm() == member.term()) {
+              LOGGER.debug("{} - Failed to probe {}", localMember.id(), member);
+              requestProbes(localMember.copy());
+            }
+          }
+        }, swimScheduler);
+  }
+
+  /**
+   * Handles a probe from another peer.
+   *
+   * @param member the probing member
+   * @return the current term
+   */
+  private ImmutableMember handleProbe(ImmutableMember member) {
+    LOGGER.trace("{} - Received probe from {}", localMember.id(), member);
+    // If the probe indicates a term greater than the local term, update the local term, increment and respond.
+    if (member.term() > localMember.getTerm()) {
+      localMember.setTerm(member.term() + 1);
+      if (config.isBroadcastDisputes()) {
+        broadcast(localMember.copy());
+      }
+    }
+    // If the probe indicates this member is suspect, increment the local term and respond.
+    else if (member.state() == State.SUSPECT) {
+      localMember.setTerm(localMember.getTerm() + 1);
+      if (config.isBroadcastDisputes()) {
+        broadcast(localMember.copy());
+      }
+    }
+    return localMember.copy();
+  }
+
+  /**
+   * Requests probes from n peers.
+   */
+  private void requestProbes(ImmutableMember suspect) {
+    Collection<SwimMember> members = selectRandomMembers(config.getSuspectProbes(), suspect);
+    AtomicInteger counter = new AtomicInteger();
+    AtomicBoolean succeeded = new AtomicBoolean();
+    for (SwimMember member : members) {
+      requestProbe(member, suspect).whenCompleteAsync((success, error) -> {
+        int count = counter.incrementAndGet();
+        if (error == null && success) {
+          succeeded.set(true);
+        }
+        // If the count is equal to the number of probe peers and no probe has succeeded, the node is unreachable.
+        else if (count == members.size() && !succeeded.get()) {
+          // Broadcast the unreachable change to all peers if necessary.
+          if (config.isBroadcastUpdates()) {
+            broadcast(suspect);
+          }
+        }
+      }, swimScheduler);
+    }
+  }
+
+  /**
+   * Requests a probe of the given suspect from the given member.
+   *
+   * @param member the member to perform the probe
+   * @param suspect the suspect member to probe
+   */
+  private CompletableFuture<Boolean> requestProbe(SwimMember member, ImmutableMember suspect) {
+    LOGGER.debug("{} - Requesting probe of {} from {}", this.localMember.id(), suspect, member);
+    return bootstrapService.getMessagingService().sendAndReceive(member.address(), MEMBERSHIP_PROBE_REQUEST, SERIALIZER.encode(suspect))
+        .thenApply(response -> {
+          boolean succeeded = SERIALIZER.decode(response);
+          LOGGER.debug("{} - Probe request of {} from {} {}", this.localMember.id(), succeeded, member, succeeded ? "succeeded" : "failed");
+          return succeeded;
+        });
+  }
+
+  /**
+   * Selects a set of random members, excluding the local member and a given member.
+   *
+   * @param count count the number of random members to select
+   * @param exclude the member to exclude
+   * @return members a set of random members
+   */
+  private Collection<SwimMember> selectRandomMembers(int count, ImmutableMember exclude) {
+    List<SwimMember> members = this.members.values().stream()
+        .filter(member -> !member.id().equals(localMember.id()) && !member.id().equals(exclude.id()))
+        .collect(Collectors.toList());
+    Collections.shuffle(members);
+    return members.subList(0, Math.min(members.size(), count));
+  }
+
+  /**
+   * Handles a probe request.
+   *
+   * @param member the member to probe
+   */
+  private CompletableFuture<Boolean> handleProbeRequest(ImmutableMember member) {
+    LOGGER.trace("{} - Probing {}", localMember.id(), member);
+    CompletableFuture<Boolean> future = new CompletableFuture<>();
+    bootstrapService.getMessagingService().sendAndReceive(member.address(), MEMBERSHIP_PROBE, SERIALIZER.encode(member))
+        .whenCompleteAsync((response, error) -> {
+          if (error != null) {
+            LOGGER.debug("{} - Failed to probe {}", localMember.id(), member);
+            future.complete(false);
+          } else {
+            future.complete(true);
+          }
+        }, swimScheduler);
+    return future;
+  }
+
+  /**
+   * Broadcasts the given update to all peers.
+   *
+   * @param update the update to broadcast
+   */
+  private void broadcast(ImmutableMember update) {
+    for (SwimMember member : members.values()) {
+      if (!localMember.id().equals(member.id())) {
+        unicast(member, update);
+      }
+    }
+  }
+
+  /**
+   * Unicasts the given update to the given member.
+   *
+   * @param member the member to which to unicast the update
+   * @param update the update to unicast
+   */
+  private void unicast(SwimMember member, ImmutableMember update) {
+    bootstrapService.getUnicastService().unicast(
+        member.address(),
+        MEMBERSHIP_GOSSIP,
+        SERIALIZER.encode(Lists.newArrayList(update)));
+  }
+
+  /**
+   * Gossips pending updates to the cluster.
+   */
+  private void gossip() {
+    // Check local metadata for changes.
+    checkMetadata();
+
+    // Copy and clear the list of pending updates.
+    if (!updates.isEmpty()) {
+      List<ImmutableMember> updates = Lists.newArrayList(this.updates);
+      this.updates.clear();
+
+      // Gossip the pending updates to peers.
+      gossip(updates);
+    }
+  }
+
+  /**
+   * Gossips this node's pending updates with a random set of peers.
+   *
+   * @param updates a collection of updated to gossip
+   */
+  private void gossip(Collection<ImmutableMember> updates) {
+    // Get a list of available peers. If peers are available, randomize the peer list and select a subset of
+    // peers with which to gossip updates.
+    List<SwimMember> members = Lists.newArrayList(this.members.values());
+    if (!members.isEmpty()) {
+      Collections.shuffle(members);
+      for (int i = 0; i < Math.min(members.size(), config.getGossipFanout()); i++) {
+        gossip(members.get(i), updates);
+      }
+    }
+  }
+
+  /**
+   * Gossips this node's pending updates with the given peer.
+   *
+   * @param member the peer with which to gossip this node's updates
+   * @param updates the updated members to gossip
+   */
+  private void gossip(SwimMember member, Collection<ImmutableMember> updates) {
+    LOGGER.trace("{} - Sending gossip updates {} to {}", localMember.id(), updates, member);
+    bootstrapService.getUnicastService().unicast(
+        member.address(),
+        MEMBERSHIP_GOSSIP,
+        SERIALIZER.encode(updates));
+  }
+
+  /**
+   * Handles a gossip message from a peer.
+   */
+  private void handleGossipUpdates(Collection<ImmutableMember> updates) {
+    for (ImmutableMember update : updates) {
+      updateState(update);
+    }
+  }
+
+  /**
+   * Handles a member location event.
+   *
+   * @param event the member location event
+   */
+  private void handleDiscoveryEvent(NodeDiscoveryEvent event) {
+    switch (event.type()) {
+      case JOIN:
+        handleJoinEvent(event.subject());
+        break;
+      case LEAVE:
+        handleLeaveEvent(event.subject());
+        break;
+      default:
+        throw new AssertionError();
+    }
+  }
+
+  /**
+   * Handles a node join event.
+   */
+  private void handleJoinEvent(Node node) {
+    SwimMember member = new SwimMember(MemberId.from(node.id().id()), node.address());
+    if (!members.containsKey(member.id())) {
+      probe(member.copy());
+    }
+  }
+
+  /**
+   * Handles a node leave event.
+   */
+  private void handleLeaveEvent(Node node) {
+    SwimMember member = members.get(MemberId.from(node.id().id()));
+    if (member != null && !member.isActive()) {
+      members.remove(member.id());
+    }
+  }
+
+  /**
+   * Registers message handlers for the SWIM protocol.
+   */
+  private void registerHandlers() {
+    // Register TCP message handlers.
+    bootstrapService.getMessagingService().registerHandler(MEMBERSHIP_PROBE, probeHandler, swimScheduler);
+    bootstrapService.getMessagingService().registerHandler(MEMBERSHIP_PROBE_REQUEST, probeRequestHandler, swimScheduler);
+
+    // Register UDP message listeners.
+    bootstrapService.getUnicastService().addListener(MEMBERSHIP_GOSSIP, gossipListener, swimScheduler);
+  }
+
+  /**
+   * Unregisters handlers for the SWIM protocol.
+   */
+  private void unregisterHandlers() {
+    // Unregister TCP message handlers.
+    bootstrapService.getMessagingService().unregisterHandler(MEMBERSHIP_PROBE);
+    bootstrapService.getMessagingService().unregisterHandler(MEMBERSHIP_PROBE_REQUEST);
+
+    // Unregister UDP message listeners.
+    bootstrapService.getUnicastService().removeListener(MEMBERSHIP_GOSSIP, gossipListener);
+  }
+
+  @Override
+  public CompletableFuture<Void> join(BootstrapService bootstrap, NodeDiscoveryService discovery, Member member) {
+    if (started.compareAndSet(false, true)) {
+      this.bootstrapService = bootstrap;
+      this.discoveryService = discovery;
+      this.localMember = new SwimMember(
+          member.id(),
+          member.address(),
+          member.zone(),
+          member.rack(),
+          member.host(),
+          member.properties(),
+          member.version());
+      discoveryService.addListener(discoveryEventListener);
+
+      LOGGER.info("{} - Member activated: {}", localMember.id(), localMember);
+      localMember.setState(State.ALIVE);
+      members.put(localMember.id(), localMember);
+      post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, localMember));
+
+      registerHandlers();
+      gossipFuture = swimScheduler.scheduleAtFixedRate(
+          this::gossip, 0, config.getGossipInterval().toMillis(), TimeUnit.MILLISECONDS);
+      probeFuture = swimScheduler.scheduleAtFixedRate(
+          this::probe, 0, config.getProbeInterval().toMillis(), TimeUnit.MILLISECONDS);
+      swimScheduler.execute(this::probeAll);
+      LOGGER.info("Started");
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> leave(Member member) {
+    if (started.compareAndSet(true, false)) {
+      discoveryService.removeListener(discoveryEventListener);
+      gossipFuture.cancel(false);
+      probeFuture.cancel(false);
+      swimScheduler.shutdownNow();
+      eventExecutor.shutdownNow();
+      LOGGER.info("{} - Member deactivated: {}", localMember.id(), localMember);
+      localMember.setState(State.DEAD);
+      members.clear();
+      unregisterHandlers();
+      LOGGER.info("Stopped");
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  /**
+   * Member states.
+   */
+  enum State {
+    ALIVE(true, true),
+    SUSPECT(true, false),
+    DEAD(false, false);
+
+    private final boolean active;
+    private final boolean reachable;
+
+    State(boolean active, boolean reachable) {
+      this.active = active;
+      this.reachable = reachable;
+    }
+
+    boolean isActive() {
+      return active;
+    }
+
+    boolean isReachable() {
+      return reachable;
+    }
+  }
+
+  /**
+   * Immutable member.
+   */
+  private static class ImmutableMember extends Member {
+    private final Version version;
+    private final State state;
+    private final long term;
+
+    ImmutableMember(MemberId id, Address address, String zone, String rack, String host, Properties properties, Version version, State state, long term) {
+      super(id, address, zone, rack, host, properties);
+      this.version = version;
+      this.state = state;
+      this.term = term;
+    }
+
+    /**
+     * Returns the member's version.
+     *
+     * @return the member's version
+     */
+    public Version version() {
+      return version;
+    }
+
+    /**
+     * Returns the member's state.
+     *
+     * @return the member's state
+     */
+    public State state() {
+      return state;
+    }
+
+    /**
+     * Returns the member's term.
+     *
+     * @return the member's term
+     */
+    public long term() {
+      return term;
+    }
+  }
+
+  /**
+   * Swim member.
+   */
+  private static class SwimMember extends Member {
+    private final Version version;
+    private volatile State state;
+    private volatile long term;
+
+    SwimMember(MemberId id, Address address) {
+      super(id, address);
+      this.version = null;
+    }
+
+    SwimMember(
+        MemberId id,
+        Address address,
+        String zone,
+        String rack,
+        String host,
+        Properties properties,
+        Version version) {
+      super(id, address, zone, rack, host, properties);
+      this.version = version;
+      term = System.currentTimeMillis();
+    }
+
+    SwimMember(ImmutableMember member) {
+      super(member.id(), member.address(), member.zone(), member.rack(), member.host(), member.properties());
+      this.version = member.version;
+      this.state = member.state;
+      this.term = member.term;
+    }
+
+    @Override
+    public Version version() {
+      return version;
+    }
+
+    /**
+     * Changes the member's state.
+     *
+     * @param state the member's state
+     * @return indicates whether the member's state was changed
+     */
+    synchronized boolean setState(State state) {
+      if (this.state != state) {
+        this.state = state;
+        return true;
+      }
+      return false;
+    }
+
+    /**
+     * Returns the member's state.
+     *
+     * @return the member's state
+     */
+    State getState() {
+      return state;
+    }
+
+    @Override
+    public boolean isActive() {
+      return state.isActive();
+    }
+
+    @Override
+    public boolean isReachable() {
+      return state.isReachable();
+    }
+
+    /**
+     * Returns the member logical timestamp.
+     *
+     * @return the member logical timestamp
+     */
+    public long getTerm() {
+      return term;
+    }
+
+    /**
+     * Sets the member's logical timestamp.
+     *
+     * @param term the member's logical timestamp
+     */
+    public void setTerm(long term) {
+      this.term = term;
+    }
+
+    /**
+     * Copies the member's state to a new object.
+     *
+     * @return the copied object
+     */
+    ImmutableMember copy() {
+      return new ImmutableMember(
+          id(),
+          address(),
+          zone(),
+          rack(),
+          host(),
+          properties(),
+          version(),
+          state,
+          term);
+    }
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolBuilder.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import java.time.Duration;
+
+/**
+ * SWIM membership protocol builder.
+ */
+public class SwimMembershipProtocolBuilder extends GroupMembershipProtocolBuilder {
+  private final SwimMembershipProtocolConfig config = new SwimMembershipProtocolConfig();
+
+  /**
+   * Sets whether to broadcast member updates to all peers.
+   *
+   * @param broadcastUpdates whether to broadcast member updates to all peers
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withBroadcastUpdates(boolean broadcastUpdates) {
+    config.setBroadcastUpdates(broadcastUpdates);
+    return this;
+  }
+
+  /**
+   * Sets whether to broadcast disputes to all peers.
+   *
+   * @param broadcastDisputes whether to broadcast disputes to all peers
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withBroadcastDisputes(boolean broadcastDisputes) {
+    config.setBroadcastDisputes(broadcastDisputes);
+    return this;
+  }
+
+  /**
+   * Sets the gossip interval.
+   *
+   * @param gossipInterval the gossip interval
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withGossipInterval(Duration gossipInterval) {
+    config.setGossipInterval(gossipInterval);
+    return this;
+  }
+
+  /**
+   * Sets the gossip fanout.
+   *
+   * @param gossipFanout the gossip fanout
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withGossipFanout(int gossipFanout) {
+    config.setGossipFanout(gossipFanout);
+    return this;
+  }
+
+  /**
+   * Sets the probe interval.
+   *
+   * @param probeInterval the probe interval
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withProbeInterval(Duration probeInterval) {
+    config.setProbeInterval(probeInterval);
+    return this;
+  }
+
+  /**
+   * Sets the number of probes to perform on suspect members.
+   *
+   * @param suspectProbes the number of probes to perform on suspect members
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withSuspectProbes(int suspectProbes) {
+    config.setSuspectProbes(suspectProbes);
+    return this;
+  }
+
+  /**
+   * Sets the failure timeout to use prior to phi failure detectors being populated.
+   *
+   * @param failureTimeout the failure timeout
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withFailureTimeout(Duration failureTimeout) {
+    config.setFailureTimeout(failureTimeout);
+    return this;
+  }
+
+  @Override
+  public GroupMembershipProtocol build() {
+    return new SwimMembershipProtocol(config);
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolBuilder.java
@@ -46,6 +46,17 @@ public class SwimMembershipProtocolBuilder extends GroupMembershipProtocolBuilde
   }
 
   /**
+   * Sets whether to notify a suspect node on state changes.
+   *
+   * @param notifySuspect whether to notify a suspect node on state changes
+   * @return the protocol builder
+   */
+  public SwimMembershipProtocolBuilder withNotifySuspect(boolean notifySuspect) {
+    config.setNotifySuspect(notifySuspect);
+    return this;
+  }
+
+  /**
    * Sets the gossip interval.
    *
    * @param gossipInterval the gossip interval

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolConfig.java
@@ -26,6 +26,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class SwimMembershipProtocolConfig extends GroupMembershipProtocolConfig {
   private static final boolean DEFAULT_BROADCAST_UPDATES = false;
   private static final boolean DEFAULT_BROADCAST_DISPUTES = true;
+  private static final boolean DEFAULT_NOTIFY_SUSPECT = false;
   private static final int DEFAULT_GOSSIP_INTERVAL = 250;
   private static final int DEFAULT_GOSSIP_FANOUT = 2;
   private static final int DEFAULT_PROBE_INTERVAL = 1000;
@@ -34,6 +35,7 @@ public class SwimMembershipProtocolConfig extends GroupMembershipProtocolConfig 
 
   private boolean broadcastUpdates = DEFAULT_BROADCAST_UPDATES;
   private boolean broadcastDisputes = DEFAULT_BROADCAST_DISPUTES;
+  private boolean notifySuspect = DEFAULT_NOTIFY_SUSPECT;
   private Duration gossipInterval = Duration.ofMillis(DEFAULT_GOSSIP_INTERVAL);
   private int gossipFanout = DEFAULT_GOSSIP_FANOUT;
   private Duration probeInterval = Duration.ofMillis(DEFAULT_PROBE_INTERVAL);
@@ -77,6 +79,26 @@ public class SwimMembershipProtocolConfig extends GroupMembershipProtocolConfig 
    */
   public SwimMembershipProtocolConfig setBroadcastDisputes(boolean broadcastDisputes) {
     this.broadcastDisputes = broadcastDisputes;
+    return this;
+  }
+
+  /**
+   * Returns whether to notify a suspect node on state changes.
+   *
+   * @return whether to notify a suspect node on state changes
+   */
+  public boolean isNotifySuspect() {
+    return notifySuspect;
+  }
+
+  /**
+   * Sets whether to notify a suspect node on state changes.
+   *
+   * @param notifySuspect whether to notify a suspect node on state changes
+   * @return the protocol configuration
+   */
+  public SwimMembershipProtocolConfig setNotifySuspect(boolean notifySuspect) {
+    this.notifySuspect = notifySuspect;
     return this;
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolConfig.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import java.time.Duration;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * SWIM membership protocol configuration.
+ */
+public class SwimMembershipProtocolConfig extends GroupMembershipProtocolConfig {
+  private static final boolean DEFAULT_BROADCAST_UPDATES = false;
+  private static final boolean DEFAULT_BROADCAST_DISPUTES = true;
+  private static final int DEFAULT_GOSSIP_INTERVAL = 250;
+  private static final int DEFAULT_GOSSIP_FANOUT = 2;
+  private static final int DEFAULT_PROBE_INTERVAL = 1000;
+  private static final int DEFAULT_SUSPECT_PROBES = 3;
+  private static final int DEFAULT_FAILURE_TIMEOUT = 10000;
+
+  private boolean broadcastUpdates = DEFAULT_BROADCAST_UPDATES;
+  private boolean broadcastDisputes = DEFAULT_BROADCAST_DISPUTES;
+  private Duration gossipInterval = Duration.ofMillis(DEFAULT_GOSSIP_INTERVAL);
+  private int gossipFanout = DEFAULT_GOSSIP_FANOUT;
+  private Duration probeInterval = Duration.ofMillis(DEFAULT_PROBE_INTERVAL);
+  private int suspectProbes = DEFAULT_SUSPECT_PROBES;
+  private Duration failureTimeout = Duration.ofMillis(DEFAULT_FAILURE_TIMEOUT);
+
+  /**
+   * Returns whether to broadcast member updates to all peers.
+   *
+   * @return whether to broadcast member updates to all peers
+   */
+  public boolean isBroadcastUpdates() {
+    return broadcastUpdates;
+  }
+
+  /**
+   * Sets whether to broadcast member updates to all peers.
+   *
+   * @param broadcastUpdates whether to broadcast member updates to all peers
+   * @return the protocol configuration
+   */
+  public SwimMembershipProtocolConfig setBroadcastUpdates(boolean broadcastUpdates) {
+    this.broadcastUpdates = broadcastUpdates;
+    return this;
+  }
+
+  /**
+   * Returns whether to broadcast disputes to all peers.
+   *
+   * @return whether to broadcast disputes to all peers
+   */
+  public boolean isBroadcastDisputes() {
+    return broadcastDisputes;
+  }
+
+  /**
+   * Sets whether to broadcast disputes to all peers.
+   *
+   * @param broadcastDisputes whether to broadcast disputes to all peers
+   * @return the protocol configuration
+   */
+  public SwimMembershipProtocolConfig setBroadcastDisputes(boolean broadcastDisputes) {
+    this.broadcastDisputes = broadcastDisputes;
+    return this;
+  }
+
+  /**
+   * Returns the gossip interval.
+   *
+   * @return the gossip interval
+   */
+  public Duration getGossipInterval() {
+    return gossipInterval;
+  }
+
+  /**
+   * Sets the gossip interval.
+   *
+   * @param gossipInterval the gossip interval
+   * @return the protocol configuration
+   */
+  public SwimMembershipProtocolConfig setGossipInterval(Duration gossipInterval) {
+    this.gossipInterval = gossipInterval;
+    return this;
+  }
+
+  /**
+   * Returns the gossip fanout.
+   *
+   * @return the gossip fanout
+   */
+  public int getGossipFanout() {
+    return gossipFanout;
+  }
+
+  /**
+   * Sets the gossip fanout.
+   *
+   * @param gossipFanout the gossip fanout
+   * @return the protocol configuration
+   */
+  public SwimMembershipProtocolConfig setGossipFanout(int gossipFanout) {
+    checkArgument(gossipFanout > 0, "gossipFanout must be positive");
+    this.gossipFanout = gossipFanout;
+    return this;
+  }
+
+  /**
+   * Returns the probe interval.
+   *
+   * @return the probe interval
+   */
+  public Duration getProbeInterval() {
+    return probeInterval;
+  }
+
+  /**
+   * Sets the probe interval.
+   *
+   * @param probeInterval the probe interval
+   * @return the membership configuration
+   */
+  public SwimMembershipProtocolConfig setProbeInterval(Duration probeInterval) {
+    checkNotNull(probeInterval, "probeInterval cannot be null");
+    checkArgument(!probeInterval.isNegative() && !probeInterval.isZero(), "probeInterval must be positive");
+    this.probeInterval = probeInterval;
+    return this;
+  }
+
+  /**
+   * Returns the number of probes to perform on suspect members.
+   *
+   * @return the number of probes to perform on suspect members
+   */
+  public int getSuspectProbes() {
+    return suspectProbes;
+  }
+
+  /**
+   * Sets the number of probes to perform on suspect members.
+   *
+   * @param suspectProbes the number of probes to perform on suspect members
+   * @return the membership configuration
+   */
+  public SwimMembershipProtocolConfig setSuspectProbes(int suspectProbes) {
+    checkArgument(suspectProbes > 0, "suspectProbes must be positive");
+    this.suspectProbes = suspectProbes;
+    return this;
+  }
+
+  /**
+   * Returns the base failure timeout.
+   *
+   * @return the base failure timeout
+   */
+  public Duration getFailureTimeout() {
+    return failureTimeout;
+  }
+
+  /**
+   * Sets the base failure timeout.
+   *
+   * @param failureTimeout the base failure timeout
+   * @return the group membership configuration
+   */
+  public SwimMembershipProtocolConfig setFailureTimeout(Duration failureTimeout) {
+    checkNotNull(failureTimeout, "failureTimeout cannot be null");
+    checkArgument(!failureTimeout.isNegative() && !failureTimeout.isZero(), "failureTimeout must be positive");
+    this.failureTimeout = checkNotNull(failureTimeout);
+    return this;
+  }
+
+  @Override
+  public GroupMembershipProtocol.Type getType() {
+    return SwimMembershipProtocol.TYPE;
+  }
+}

--- a/cluster/src/test/java/io/atomix/cluster/TestBootstrapService.java
+++ b/cluster/src/test/java/io/atomix/cluster/TestBootstrapService.java
@@ -17,22 +17,30 @@ package io.atomix.cluster;
 
 import io.atomix.cluster.messaging.BroadcastService;
 import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.cluster.messaging.UnicastService;
 
 /**
  * Test bootstrap service.
  */
 public class TestBootstrapService implements BootstrapService {
   private final MessagingService messagingService;
+  private final UnicastService unicastService;
   private final BroadcastService broadcastService;
 
-  public TestBootstrapService(MessagingService messagingService, BroadcastService broadcastService) {
+  public TestBootstrapService(MessagingService messagingService, UnicastService unicastService, BroadcastService broadcastService) {
     this.messagingService = messagingService;
+    this.unicastService = unicastService;
     this.broadcastService = broadcastService;
   }
 
   @Override
   public MessagingService getMessagingService() {
     return messagingService;
+  }
+
+  @Override
+  public UnicastService getUnicastService() {
+    return unicastService;
   }
 
   @Override

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
@@ -26,6 +26,7 @@ import io.atomix.cluster.TestBootstrapService;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.messaging.impl.TestBroadcastServiceFactory;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
+import io.atomix.cluster.messaging.impl.TestUnicastServiceFactory;
 import io.atomix.cluster.protocol.PhiMembershipProtocol;
 import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
 import io.atomix.utils.Version;
@@ -68,6 +69,7 @@ public class DefaultClusterMembershipServiceTest {
   @Test
   public void testClusterService() throws Exception {
     TestMessagingServiceFactory messagingServiceFactory = new TestMessagingServiceFactory();
+    TestUnicastServiceFactory unicastServiceFactory = new TestUnicastServiceFactory();
     TestBroadcastServiceFactory broadcastServiceFactory = new TestBroadcastServiceFactory();
 
     Collection<Node> bootstrapLocations = buildBootstrapNodes(3);
@@ -75,6 +77,7 @@ public class DefaultClusterMembershipServiceTest {
     Member localMember1 = buildMember(1);
     BootstrapService bootstrapService1 = new TestBootstrapService(
         messagingServiceFactory.newMessagingService(localMember1.address()).start().join(),
+        unicastServiceFactory.newUnicastService(localMember1.address()).start().join(),
         broadcastServiceFactory.newBroadcastService().start().join());
     ManagedClusterMembershipService clusterService1 = new DefaultClusterMembershipService(
         localMember1,
@@ -86,6 +89,7 @@ public class DefaultClusterMembershipServiceTest {
     Member localMember2 = buildMember(2);
     BootstrapService bootstrapService2 = new TestBootstrapService(
         messagingServiceFactory.newMessagingService(localMember2.address()).start().join(),
+        unicastServiceFactory.newUnicastService(localMember2.address()).start().join(),
         broadcastServiceFactory.newBroadcastService().start().join());
     ManagedClusterMembershipService clusterService2 = new DefaultClusterMembershipService(
         localMember2,
@@ -97,6 +101,7 @@ public class DefaultClusterMembershipServiceTest {
     Member localMember3 = buildMember(3);
     BootstrapService bootstrapService3 = new TestBootstrapService(
         messagingServiceFactory.newMessagingService(localMember3.address()).start().join(),
+        unicastServiceFactory.newUnicastService(localMember3.address()).start().join(),
         broadcastServiceFactory.newBroadcastService().start().join());
     ManagedClusterMembershipService clusterService3 = new DefaultClusterMembershipService(
         localMember3,
@@ -130,6 +135,7 @@ public class DefaultClusterMembershipServiceTest {
     Member anonymousMember = buildMember(4);
     BootstrapService ephemeralBootstrapService = new TestBootstrapService(
         messagingServiceFactory.newMessagingService(anonymousMember.address()).start().join(),
+        unicastServiceFactory.newUnicastService(anonymousMember.address()).start().join(),
         broadcastServiceFactory.newBroadcastService().start().join());
     ManagedClusterMembershipService ephemeralClusterService = new DefaultClusterMembershipService(
         anonymousMember,

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
@@ -70,6 +70,7 @@ public class DefaultClusterEventServiceTest {
   @Test
   public void testClusterEventService() throws Exception {
     TestMessagingServiceFactory messagingServiceFactory = new TestMessagingServiceFactory();
+    TestUnicastServiceFactory unicastServiceFactory = new TestUnicastServiceFactory();
     TestBroadcastServiceFactory broadcastServiceFactory = new TestBroadcastServiceFactory();
 
     Collection<Node> bootstrapLocations = buildBootstrapNodes(3);
@@ -78,6 +79,7 @@ public class DefaultClusterEventServiceTest {
     MessagingService messagingService1 = messagingServiceFactory.newMessagingService(localMember1.address()).start().join();
     BootstrapService bootstrapService1 = new TestBootstrapService(
         messagingService1,
+        unicastServiceFactory.newUnicastService(localMember1.address()).start().join(),
         broadcastServiceFactory.newBroadcastService().start().join());
     ManagedClusterMembershipService clusterService1 = new DefaultClusterMembershipService(
         localMember1,
@@ -93,6 +95,7 @@ public class DefaultClusterEventServiceTest {
     MessagingService messagingService2 = messagingServiceFactory.newMessagingService(localMember2.address()).start().join();
     BootstrapService bootstrapService2 = new TestBootstrapService(
         messagingService2,
+        unicastServiceFactory.newUnicastService(localMember2.address()).start().join(),
         broadcastServiceFactory.newBroadcastService().start().join());
     ManagedClusterMembershipService clusterService2 = new DefaultClusterMembershipService(
         localMember2,
@@ -108,6 +111,7 @@ public class DefaultClusterEventServiceTest {
     MessagingService messagingService3 = messagingServiceFactory.newMessagingService(localMember3.address()).start().join();
     BootstrapService bootstrapService3 = new TestBootstrapService(
         messagingService3,
+        unicastServiceFactory.newUnicastService(localMember1.address()).start().join(),
         broadcastServiceFactory.newBroadcastService().start().join());
     ManagedClusterMembershipService clusterService3 = new DefaultClusterMembershipService(
         localMember3,

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.atomix.cluster.messaging.ManagedUnicastService;
+import io.atomix.utils.net.Address;
+import net.jodah.concurrentunit.ConcurrentTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Netty unicast service test.
+ */
+public class NettyUnicastServiceTest extends ConcurrentTestCase {
+  private static final Logger LOGGER = getLogger(NettyBroadcastServiceTest.class);
+
+  ManagedUnicastService service1;
+  ManagedUnicastService service2;
+
+  Address address1;
+  Address address2;
+
+  @Test
+  public void testUnicast() throws Exception {
+    service1.addListener("test", (address, payload) -> {
+      assertEquals(address2, address);
+      assertArrayEquals("Hello world!".getBytes(), payload);
+      resume();
+    });
+
+    service2.unicast(address1, "test", "Hello world!".getBytes());
+    await(5000);
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    address1 = Address.from("127.0.0.1", findAvailablePort(5001));
+    address2 = Address.from("127.0.0.1", findAvailablePort(5002));
+
+    service1 = (ManagedUnicastService) NettyUnicastService.builder()
+        .withAddress(address1)
+        .build()
+        .start()
+        .join();
+
+    service2 = (ManagedUnicastService) NettyUnicastService.builder()
+        .withAddress(address2)
+        .build()
+        .start()
+        .join();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (service1 != null) {
+      try {
+        service1.stop().join();
+      } catch (Exception e) {
+        LOGGER.warn("Failed stopping netty1", e);
+      }
+    }
+
+    if (service2 != null) {
+      try {
+        service2.stop().join();
+      } catch (Exception e) {
+        LOGGER.warn("Failed stopping netty2", e);
+      }
+    }
+  }
+
+  private static int findAvailablePort(int defaultPort) {
+    try {
+      ServerSocket socket = new ServerSocket(0);
+      socket.setReuseAddress(true);
+      int port = socket.getLocalPort();
+      socket.close();
+      return port;
+    } catch (IOException ex) {
+      return defaultPort;
+    }
+  }
+}

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingServiceFactory.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingServiceFactory.java
@@ -16,8 +16,8 @@
 package io.atomix.cluster.messaging.impl;
 
 import com.google.common.collect.Maps;
-import io.atomix.utils.net.Address;
 import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.atomix.utils.net.Address;
 
 import java.util.Map;
 
@@ -26,6 +26,62 @@ import java.util.Map;
  */
 public class TestMessagingServiceFactory {
   private final Map<Address, TestMessagingService> services = Maps.newConcurrentMap();
+
+  /**
+   * Partitions the service at the given address.
+   *
+   * @param address the address of the service to partition
+   */
+  public void partition(Address address) {
+    TestMessagingService service = services.get(address);
+    services.values().stream()
+        .filter(s -> !s.address().equals(address))
+        .forEach(s -> {
+          service.partition(s.address());
+          s.partition(service.address());
+        });
+  }
+
+  /**
+   * Heals a partition of the service at the given address.
+   *
+   * @param address the address of the service to heal
+   */
+  public void heal(Address address) {
+    TestMessagingService service = services.get(address);
+    services.values().stream()
+        .filter(s -> !s.address().equals(address))
+        .forEach(s -> {
+          service.heal(s.address());
+          s.heal(service.address());
+        });
+  }
+
+  /**
+   * Creates a bi-directional partition between two services.
+   *
+   * @param address1 the first service
+   * @param address2 the second service
+   */
+  public void partition(Address address1, Address address2) {
+    TestMessagingService service1 = services.get(address1);
+    TestMessagingService service2 = services.get(address2);
+    service1.partition(service2.address());
+    service2.partition(service1.address());
+  }
+
+  /**
+   * Heals a bi-directional partition between two services.
+   *
+   * @param address1 the first service
+   * @param address2 the second service
+   */
+  public void heal(Address address1, Address address2) {
+    TestMessagingService service1 = services.get(address1);
+    TestMessagingService service2 = services.get(address2);
+    service1.heal(service2.address());
+    service2.heal(service1.address());
+  }
 
   /**
    * Returns a new test messaging service for the given address.

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestUnicastService.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestUnicastService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import com.google.common.collect.Maps;
+import io.atomix.cluster.messaging.ManagedUnicastService;
+import io.atomix.cluster.messaging.UnicastService;
+import io.atomix.utils.net.Address;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+
+/**
+ * Test unicast service.
+ */
+public class TestUnicastService implements ManagedUnicastService {
+  private final Address address;
+  private final Map<Address, TestUnicastService> services;
+  private final Map<String, Map<BiConsumer<Address, byte[]>, Executor>> listeners = Maps.newConcurrentMap();
+  private final AtomicBoolean started = new AtomicBoolean();
+
+  public TestUnicastService(Address address, Map<Address, TestUnicastService> services) {
+    this.address = address;
+    this.services = services;
+  }
+
+  @Override
+  public void unicast(Address address, String subject, byte[] message) {
+    TestUnicastService service = services.get(address);
+    if (service != null) {
+      Map<BiConsumer<Address, byte[]>, Executor> listeners = service.listeners.get(subject);
+      if (listeners != null) {
+        listeners.forEach((listener, executor) -> executor.execute(() -> listener.accept(this.address, message)));
+      }
+    }
+  }
+
+  @Override
+  public synchronized void addListener(String subject, BiConsumer<Address, byte[]> listener, Executor executor) {
+    listeners.computeIfAbsent(subject, s -> Maps.newConcurrentMap()).put(listener, executor);
+  }
+
+  @Override
+  public synchronized void removeListener(String subject, BiConsumer<Address, byte[]> listener) {
+    Map<BiConsumer<Address, byte[]>, Executor> listeners = this.listeners.get(subject);
+    if (listeners != null) {
+      listeners.remove(listener);
+      if (listeners.isEmpty()) {
+        this.listeners.remove(subject);
+      }
+    }
+  }
+
+  @Override
+  public CompletableFuture<UnicastService> start() {
+    services.put(address, this);
+    started.set(true);
+    return CompletableFuture.completedFuture(this);
+  }
+
+  @Override
+  public boolean isRunning() {
+    return started.get();
+  }
+
+  @Override
+  public CompletableFuture<Void> stop() {
+    services.remove(address);
+    started.set(false);
+    return CompletableFuture.completedFuture(null);
+  }
+}

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestUnicastServiceFactory.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestUnicastServiceFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import com.google.common.collect.Maps;
+import io.atomix.cluster.messaging.ManagedUnicastService;
+import io.atomix.utils.net.Address;
+
+import java.util.Map;
+
+/**
+ * Test unicast service factory.
+ */
+public class TestUnicastServiceFactory {
+  private final Map<Address, TestUnicastService> services = Maps.newConcurrentMap();
+
+  /**
+   * Returns a new test unicast service for the given endpoint.
+   *
+   * @param address the address to which to bind
+   * @return the unicast service for the given endpoint
+   */
+  public ManagedUnicastService newUnicastService(Address address) {
+    return new TestUnicastService(address, services);
+  }
+}

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestUnicastServiceFactory.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestUnicastServiceFactory.java
@@ -28,6 +28,62 @@ public class TestUnicastServiceFactory {
   private final Map<Address, TestUnicastService> services = Maps.newConcurrentMap();
 
   /**
+   * Partitions the service at the given address.
+   *
+   * @param address the address of the service to partition
+   */
+  public void partition(Address address) {
+    TestUnicastService service = services.get(address);
+    services.values().stream()
+        .filter(s -> !s.address().equals(address))
+        .forEach(s -> {
+          service.partition(s.address());
+          s.partition(service.address());
+        });
+  }
+
+  /**
+   * Heals a partition of the service at the given address.
+   *
+   * @param address the address of the service to heal
+   */
+  public void heal(Address address) {
+    TestUnicastService service = services.get(address);
+    services.values().stream()
+        .filter(s -> !s.address().equals(address))
+        .forEach(s -> {
+          service.heal(s.address());
+          s.heal(service.address());
+        });
+  }
+
+  /**
+   * Creates a bi-directional partition between two services.
+   *
+   * @param address1 the first service
+   * @param address2 the second service
+   */
+  public void partition(Address address1, Address address2) {
+    TestUnicastService service1 = services.get(address1);
+    TestUnicastService service2 = services.get(address2);
+    service1.partition(service2.address());
+    service2.partition(service1.address());
+  }
+
+  /**
+   * Heals a bi-directional partition between two services.
+   *
+   * @param address1 the first service
+   * @param address2 the second service
+   */
+  public void heal(Address address1, Address address2) {
+    TestUnicastService service1 = services.get(address1);
+    TestUnicastService service2 = services.get(address2);
+    service1.heal(service2.address());
+    service2.heal(service1.address());
+  }
+
+  /**
    * Returns a new test unicast service for the given endpoint.
    *
    * @param address the address to which to bind

--- a/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.protocol;
+
+import com.google.common.collect.Maps;
+import io.atomix.cluster.BootstrapService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.TestBootstrapService;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.discovery.NodeDiscoveryProvider;
+import io.atomix.cluster.discovery.NodeDiscoveryService;
+import io.atomix.cluster.impl.DefaultNodeDiscoveryService;
+import io.atomix.cluster.messaging.impl.TestBroadcastServiceFactory;
+import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
+import io.atomix.cluster.messaging.impl.TestUnicastServiceFactory;
+import io.atomix.utils.net.Address;
+import net.jodah.concurrentunit.ConcurrentTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * SWIM membership protocol test.
+ */
+public class SwimProtocolTest extends ConcurrentTestCase {
+  private TestMessagingServiceFactory messagingServiceFactory = new TestMessagingServiceFactory();
+  private TestUnicastServiceFactory unicastServiceFactory = new TestUnicastServiceFactory();
+  private TestBroadcastServiceFactory broadcastServiceFactory = new TestBroadcastServiceFactory();
+
+  private Member member1;
+  private Member member2;
+  private Member member3;
+  private Collection<Member> members;
+  private Collection<Node> nodes;
+
+  private Map<MemberId, TestGroupMembershipEventListener> listeners = Maps.newConcurrentMap();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void reset() {
+    messagingServiceFactory = new TestMessagingServiceFactory();
+    unicastServiceFactory = new TestUnicastServiceFactory();
+    broadcastServiceFactory = new TestBroadcastServiceFactory();
+
+    member1 = Member.builder()
+        .withId("1")
+        .withAddress(new Address("localhost", 5001))
+        .build();
+    member2 = Member.builder()
+        .withId("2")
+        .withAddress(new Address("localhost", 5002))
+        .build();
+    member3 = Member.builder()
+        .withId("3")
+        .withAddress(new Address("localhost", 5003))
+        .build();
+    members = Arrays.asList(member1, member2, member3);
+    nodes = (Collection) members;
+    listeners = Maps.newConcurrentMap();
+  }
+
+  @Test
+  public void testSwimProtocol() throws Exception {
+    SwimMembershipProtocol protocol1 = startProtocol(member1);
+    GroupMembershipEvent event1;
+
+    event1 = nextEvent(member1);
+    assertEquals(GroupMembershipEvent.Type.MEMBER_ADDED, event1.type());
+    assertEquals(member1, event1.member());
+
+    SwimMembershipProtocol protocol2 = startProtocol(member2);
+    GroupMembershipEvent event2;
+
+    event2 = nextEvent(member2);
+    assertEquals(GroupMembershipEvent.Type.MEMBER_ADDED, event2.type());
+    assertEquals(member2, event2.member());
+
+    event1 = nextEvent(member1);
+    assertEquals(GroupMembershipEvent.Type.MEMBER_ADDED, event1.type());
+    assertEquals(member2, event1.member());
+  }
+
+  private SwimMembershipProtocol startProtocol(Member member) {
+    SwimMembershipProtocol protocol = new SwimMembershipProtocol(new SwimMembershipProtocolConfig());
+    TestGroupMembershipEventListener listener = new TestGroupMembershipEventListener();
+    listeners.put(member.id(), listener);
+    protocol.addListener(listener);
+    BootstrapService bootstrap = new TestBootstrapService(
+        messagingServiceFactory.newMessagingService(member.address()).start().join(),
+        unicastServiceFactory.newUnicastService(member.address()).start().join(),
+        broadcastServiceFactory.newBroadcastService().start().join());
+    NodeDiscoveryProvider provider = new BootstrapDiscoveryProvider(nodes);
+    provider.join(bootstrap, member).join();
+    NodeDiscoveryService discovery = new DefaultNodeDiscoveryService(bootstrap, member, provider).start().join();
+    protocol.join(bootstrap, discovery, member).join();
+    return protocol;
+  }
+
+  private GroupMembershipEvent nextEvent(Member member) {
+    TestGroupMembershipEventListener listener = listeners.get(member.id());
+    return listener != null ? listener.nextEvent() : null;
+  }
+
+  private class TestGroupMembershipEventListener implements GroupMembershipEventListener {
+    private BlockingQueue<GroupMembershipEvent> queue = new ArrayBlockingQueue<>(10);
+
+    @Override
+    public void event(GroupMembershipEvent event) {
+      queue.add(event);
+    }
+
+    GroupMembershipEvent nextEvent() {
+      try {
+        return queue.poll(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        return null;
+      }
+    }
+  }
+}

--- a/tests/src/main/java/io/atomix/protocols/raft/test/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/test/RaftPerformanceTest.java
@@ -27,6 +27,7 @@ import io.atomix.cluster.impl.DefaultNodeDiscoveryService;
 import io.atomix.cluster.messaging.BroadcastService;
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.atomix.cluster.messaging.MessagingService;
+import io.atomix.cluster.messaging.UnicastService;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
 import io.atomix.cluster.protocol.PhiMembershipProtocol;
 import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
@@ -130,8 +131,10 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -495,6 +498,11 @@ public class RaftPerformanceTest implements Runnable {
       }
 
       @Override
+      public UnicastService getUnicastService() {
+        return new UnicastServiceAdapter();
+      }
+
+      @Override
       public BroadcastService getBroadcastService() {
         return new BroadcastServiceAdapter();
       }
@@ -715,6 +723,23 @@ public class RaftPerformanceTest implements Runnable {
     @Override
     public CompletableFuture<Void> remove() {
       return null;
+    }
+  }
+
+  private static class UnicastServiceAdapter implements UnicastService {
+    @Override
+    public void unicast(Address address, String subject, byte[] message) {
+
+    }
+
+    @Override
+    public void addListener(String subject, BiConsumer<Address, byte[]> listener, Executor executor) {
+
+    }
+
+    @Override
+    public void removeListener(String subject, BiConsumer<Address, byte[]> listener) {
+
     }
   }
 


### PR DESCRIPTION
This PR adds an implementation of the SWIM protocol for cluster membership as per #867 

The protocol is implemented per the [spec for the Atomix SWIM protocol](https://github.com/atomix/atomix-tlaplus/blob/master/SWIM/SWIM.pdf). The implementation is highly scalable, using UDP for gossip/broadcast and TCP for probing. The protocol works by nodes periodically probing random peers for failures. In the event a probe fails, the node requests additional probes from _n_ peers. If all probes fail, the member is marked `SUSPECT`. Once in the `SUSPECT` state, nodes have _s_ seconds to dispute their failure. Nodes are notified of their `SUSPECT` state either through gossip or probes. To dispute a `SUSPECT` state, nodes manage a logical clock (referred to as a term) and increment the term and gossip or broadcast their updated state to all nodes. When a node receives a greater term for any member, it always updates the member's state and triggers events. This provides a causal ordering of events with the gossip protocol.

The protocol provides several configuration options:
* `broadcastUpdates` broadcasts all state changes to all nodes for faster convergence
* `broadcastDisputes` broadcasts only disputes to all nodes to avoid false positives
* `notifySuspect` notifies a peer when any member receives an event indicating the peer is `SUSPECT`, allowing the peer to dispute the state change more quickly in a network partition
* `gossipInterval` is the interval at which nodes gossip with one another
* `gossipFanout` is the number of nodes to which to gossip changes in a single round of gossip
* `probeInterval` is the interval at which nodes probe a random peer
* `suspectProbes` is the number of additional probes to request for suspect members
* `failureTimeout` is the time after which a `SUSPECT` member should be marked `DEAD`