### PR TITLE
Detect multiple metadata changes on local node

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
+++ b/cluster/src/main/java/io/atomix/cluster/impl/DefaultClusterMembershipService.java
@@ -177,7 +177,8 @@ public class DefaultClusterMembershipService
     if (!localMember.properties().equals(localProperties)) {
       synchronized (this) {
         if (!localMember.properties().equals(localProperties)) {
-          localProperties = localMember.properties();
+          localProperties = new Properties();
+          localProperties.putAll(localMember.properties());
           post(new ClusterMembershipEvent(ClusterMembershipEvent.Type.METADATA_CHANGED, localMember));
           broadcastMetadata();
         }

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
@@ -198,6 +198,14 @@ public class DefaultClusterMembershipServiceTest {
     assertEquals(ClusterMembershipEvent.Type.METADATA_CHANGED, event.type());
     assertEquals("bar", event.subject().properties().get("foo"));
 
+    TestClusterMembershipEventListener eventListener3 = new TestClusterMembershipEventListener();
+    clusterService3.addListener(eventListener3);
+    clusterService3.getLocalMember().properties().put("foo", "baz");
+
+    ClusterMembershipEvent event3 = eventListener3.nextEvent();
+    assertEquals(ClusterMembershipEvent.Type.METADATA_CHANGED, event3.type());
+    assertEquals("baz", event3.subject().properties().get("foo"));
+
     CompletableFuture.allOf(new CompletableFuture[]{clusterService1.stop(), clusterService2.stop(),
         clusterService3.stop()}).join();
   }


### PR DESCRIPTION
This PR fixes a bug in detecting local metadata changes and triggering events. Because the `DefaultClusterMembershipService` stores a reference to the updated metadata object, future equality checks are unsuccessful even if metadata has changed. 