### PR TITLE
Make cluster membership protocol configurable via Atomix builder

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -17,6 +17,7 @@ package io.atomix.cluster;
 
 import com.google.common.collect.Lists;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
+import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
 import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
 import io.atomix.utils.Builder;
@@ -406,6 +407,22 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
     if (protocolConfig instanceof PhiMembershipProtocolConfig) {
       ((PhiMembershipProtocolConfig) protocolConfig).setFailureTimeout(timeout);
     }
+    return this;
+  }
+
+  /**
+   * Sets the cluster membership protocol.
+   * <p>
+   * The membership protocol is responsible for determining the active set of members in the cluster, replicating
+   * member metadata, and detecting failures. The default is {@link io.atomix.cluster.protocol.PhiMembershipProtocol}.
+   *
+   * @param protocol the cluster membership protocol
+   * @return the cluster builder
+   * @see io.atomix.cluster.protocol.PhiMembershipProtocol
+   * @see io.atomix.cluster.protocol.SwimMembershipProtocol
+   */
+  public AtomixClusterBuilder withMembershipProtocol(GroupMembershipProtocol protocol) {
+    config.setProtocolConfig(protocol.config());
     return this;
   }
 

--- a/core/src/main/java/io/atomix/core/AtomixBuilder.java
+++ b/core/src/main/java/io/atomix/core/AtomixBuilder.java
@@ -18,6 +18,7 @@ package io.atomix.core;
 import io.atomix.cluster.AtomixClusterBuilder;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
+import io.atomix.cluster.protocol.GroupMembershipProtocol;
 import io.atomix.core.profile.Profile;
 import io.atomix.primitive.partition.ManagedPartitionGroup;
 import io.atomix.utils.net.Address;
@@ -402,6 +403,12 @@ public class AtomixBuilder extends AtomixClusterBuilder {
   @Override
   public AtomixBuilder withMulticastAddress(Address address) {
     super.withMulticastAddress(address);
+    return this;
+  }
+
+  @Override
+  public AtomixClusterBuilder withMembershipProtocol(GroupMembershipProtocol protocol) {
+    super.withMembershipProtocol(protocol);
     return this;
   }
 


### PR DESCRIPTION
Just adding the `GroupMembershipProtocol` to `AtomixClusterBuilder` and `AtomixBuilder` for programmatic configuration.