### PR TITLE
Add join timestamp to cluster members

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -203,6 +203,15 @@ public class Member extends Node {
     return null;
   }
 
+  /**
+   * Returns the member timestamp.
+   *
+   * @return the member timestamp
+   */
+  public long timestamp() {
+    return 0;
+  }
+
   @Override
   public MemberConfig config() {
     return new MemberConfig()

--- a/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/protocol/SwimProtocolTest.java
@@ -80,7 +80,8 @@ public class SwimProtocolTest extends ConcurrentTestCase {
         null,
         null,
         new Properties(),
-        version);
+        version,
+        System.currentTimeMillis());
   }
 
   @Before


### PR DESCRIPTION
This PR adds a timestamp to cluster `Member`s. The timestamp can be used to determine the oldest member in the cluster e.g. for eventually consistent leaders.