### PR TITLE
Ensure transaction participants are closed on commit

### DIFF
--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
@@ -127,7 +127,9 @@ public class DefaultTransaction implements AsyncTransaction {
             : transactionService.aborting(transactionId)
             .thenCompose(v -> rollback(participants))
             .thenApply(v -> CommitStatus.FAILURE));
-    return status.thenCompose(v -> transactionService.complete(transactionId).thenApply(u -> v));
+    return status.thenCompose(v -> transactionService.complete(transactionId)
+        .thenRun(() -> participants.forEach(p -> p.close().exceptionally(e -> null)))
+        .thenApply(u -> v));
   }
 
   private CompletableFuture<Boolean> prepare(Set<TransactionParticipant<?>> participants) {


### PR DESCRIPTION
This PR fixes a bug in transactions. Currently, transaction participants' sessions are not closed when a transaction is committed.