### PR TITLE
Handle 0 readable bytes when reading compact int/long in Netty decoder

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageDecoderV1.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessageDecoderV1.java
@@ -224,6 +224,9 @@ class MessageDecoderV1 extends ByteToMessageDecoder {
   }
 
   static int readIntSlow(ByteBuf buffer) {
+    if (buffer.readableBytes() == 0) {
+      throw ESCAPE;
+    }
     buffer.markReaderIndex();
     int b = buffer.readByte();
     int result = b & 0x7F;
@@ -309,6 +312,9 @@ class MessageDecoderV1 extends ByteToMessageDecoder {
   }
 
   static long readLongSlow(ByteBuf buffer) {
+    if (buffer.readableBytes() == 0) {
+      throw ESCAPE;
+    }
     buffer.markReaderIndex();
     int b = buffer.readByte();
     long result = b & 0x7F;


### PR DESCRIPTION
This PR fixes a bug in compact int/long readers in the Netty V1 decoder. The `readableBytes` is not checked on the first `readByte` and thus can lead to an `IndexOutOfBoundsException` when no bytes are available to read. This PR simply adds the initial check to the slow read methods.