### PR TITLE
Add programmatic API for force snapshot of Raft partition group

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -495,6 +495,13 @@ public interface RaftServer {
   CompletableFuture<RaftServer> promote();
 
   /**
+   * Compacts server logs.
+   *
+   * @return a future to be completed once the server's logs have been compacted
+   */
+  CompletableFuture<Void> compact();
+
+  /**
    * Returns a boolean indicating whether the server is running.
    *
    * @return Indicates whether the server is running.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -82,6 +82,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public CompletableFuture<Void> compact() {
+    return context.compact();
+  }
+
+  @Override
   public CompletableFuture<RaftServer> bootstrap(Collection<MemberId> cluster) {
     return start(() -> cluster().bootstrap(cluster));
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -50,10 +50,10 @@ import io.atomix.protocols.raft.storage.snapshot.SnapshotStore;
 import io.atomix.protocols.raft.storage.system.MetaStore;
 import io.atomix.protocols.raft.utils.LoadMonitor;
 import io.atomix.storage.StorageException;
+import io.atomix.utils.concurrent.ComposableFuture;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.concurrent.ThreadContextFactory;
-import io.atomix.utils.concurrent.ThreadModel;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import org.slf4j.Logger;
@@ -655,6 +655,17 @@ public class RaftContext implements AutoCloseable {
    */
   public SnapshotStore getSnapshotStore() {
     return snapshotStore;
+  }
+
+  /**
+   * Compacts the server logs.
+   *
+   * @return a future to be completed once the logs have been compacted
+   */
+  public CompletableFuture<Void> compact() {
+    ComposableFuture<Void> future = new ComposableFuture<>();
+    threadContext.execute(() -> stateMachine.compact().whenComplete(future));
+    return future;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -107,6 +107,19 @@ public class RaftPartition implements Partition {
     return dataDirectory;
   }
 
+  /**
+   * Takes a snapshot of the partition.
+   *
+   * @return a future to be completed once the snapshot is complete
+   */
+  public CompletableFuture<Void> snapshot() {
+    RaftPartitionServer server = this.server;
+    if (server != null) {
+      return server.snapshot();
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
   @Override
   public RaftPartitionClient getClient() {
     return client;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -122,6 +122,15 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   }
 
   /**
+   * Takes a snapshot of the partition server.
+   *
+   * @return a future to be completed once the snapshot has been taken
+   */
+  public CompletableFuture<Void> snapshot() {
+    return server.compact();
+  }
+
+  /**
    * Deletes the server.
    */
   public void delete() {


### PR DESCRIPTION
This PR adds a programmatic API for force snapshotting Raft partitions. This feature is primarily needed for deterministic system tests, but can also be useful for administration.