### PR TITLE
Fix race condition in cluster membership test

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/PhiMembershipProtocol.java
@@ -209,13 +209,9 @@ public class PhiMembershipProtocol
    */
   private void checkMetadata() {
     if (!localMember.properties().equals(localProperties)) {
-      synchronized (this) {
-        if (!localMember.properties().equals(localProperties)) {
-          localProperties = new Properties();
-          localProperties.putAll(localMember.properties());
-          post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember));
-        }
-      }
+      localProperties = new Properties();
+      localProperties.putAll(localMember.properties());
+      post(new GroupMembershipEvent(GroupMembershipEvent.Type.METADATA_CHANGED, localMember));
     }
   }
 
@@ -228,7 +224,9 @@ public class PhiMembershipProtocol
           if (error == null) {
             Collection<GossipMember> remoteMembers = SERIALIZER.decode(response);
             for (GossipMember remoteMember : remoteMembers) {
-              updateMember(remoteMember, remoteMember.id().equals(member.id()));
+              if (!remoteMember.id().equals(localMember.id())) {
+                updateMember(remoteMember, remoteMember.id().equals(member.id()));
+              }
             }
           } else {
             LOGGER.debug("{} - Sending heartbeat to {} failed", localMember.id(), member, error);


### PR DESCRIPTION
This PR fixes a bug in the `ClusterMembershipService` tests as well as in the `ClusterMembershipService` itself. The bug in the test was a race condition that could result in incorrect events being asserted. The bug in the service itself was also a race condition that could prevent metadata changes from being detected when performed closely together.