### PR TITLE
Ensure primary election listener is added to underlying primitive

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPrimaryElection.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/DefaultPrimaryElection.java
@@ -63,6 +63,7 @@ public class DefaultPrimaryElection implements ManagedPrimaryElection {
         listeners.forEach(l -> l.event(event));
       }
     };
+    service.addListener(eventListener);
   }
 
   @Override
@@ -87,7 +88,6 @@ public class DefaultPrimaryElection implements ManagedPrimaryElection {
 
   @Override
   public CompletableFuture<PrimaryElection> start() {
-    service.addListener(eventListener);
     started.set(true);
     return CompletableFuture.completedFuture(this);
   }


### PR DESCRIPTION
This PR fixes a bug in the primary election service. Election listeners were not being properly added, leading some primary change events to be lost.