### PR TITLE
Replace WARN level configuration messages with DEBUG

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
@@ -350,9 +350,9 @@ abstract class AbstractAppender implements AutoCloseable {
           handleConfigureResponse(member, request, response, timestamp);
         } else {
           if (log.isTraceEnabled()) {
-            log.warn("Failed to configure {}", member.getMember().memberId(), error);
+            log.debug("Failed to configure {}", member.getMember().memberId(), error);
           } else {
-            log.warn("Failed to configure {}", member.getMember().memberId());
+            log.debug("Failed to configure {}", member.getMember().memberId());
           }
           handleConfigureResponseFailure(member, request, error);
         }


### PR DESCRIPTION
Many users have asked what the warnings mean, and they're typically benign unless repeating. The configuration protocol is stable enough that they can be changed to DEBUG level messages.