### PR TITLE
Deprecate the MEMORY storage level

### DIFF
--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -51,6 +51,7 @@ management-group {
   type: raft
   partitions: 1
   storage.segmentSize: 16M
+  storage.level: memory
 }
 
 partition-groups.one {

--- a/storage/src/main/java/io/atomix/storage/StorageLevel.java
+++ b/storage/src/main/java/io/atomix/storage/StorageLevel.java
@@ -23,6 +23,7 @@ public enum StorageLevel {
   /**
    * Stores data in memory only.
    */
+  @Deprecated
   MEMORY,
 
   /**

--- a/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
+++ b/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
@@ -335,8 +335,16 @@ public class ConfigMapper {
       }
     } else if (parameterClass.isEnum()) {
       String value = config.getString(configPropName);
+      String enumName = value.replace("-", "_").toUpperCase();
       @SuppressWarnings("unchecked")
-      Enum enumValue = Enum.valueOf((Class<Enum>) parameterClass, value.replace("-", "_").toUpperCase());
+      Enum enumValue = Enum.valueOf((Class<Enum>) parameterClass, enumName);
+      try {
+        Deprecated deprecated = enumValue.getDeclaringClass().getField(enumName).getAnnotation(Deprecated.class);
+        if (deprecated != null) {
+          LOGGER.warn("{}.{} = {} is deprecated!", configPath, configPropName, value);
+        }
+      } catch (NoSuchFieldException e) {
+      }
       return enumValue;
     } else {
       return map(config.getConfig(configPropName), configPath, configPropName, parameterClass);


### PR DESCRIPTION
`MEMORY` is deprecated in 3.1, which supports only `MAPPED` and `DISK` storage.