### PR TITLE
Return exception on unmatched partition group for primitive protocol

### DIFF
--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -50,7 +50,9 @@ import io.atomix.core.value.AtomicValueType;
 import io.atomix.core.value.DistributedValueType;
 import io.atomix.core.workqueue.WorkQueueType;
 import io.atomix.primitive.protocol.ProxyProtocol;
+import io.atomix.protocols.raft.MultiRaftProtocol;
 import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.config.ConfigurationException;
 import io.atomix.utils.net.Address;
 import org.junit.After;
 import org.junit.Before;
@@ -550,6 +552,24 @@ public class AtomixTest extends AbstractAtomixTest {
     //}
 
     atomix.start().get(30, TimeUnit.SECONDS);
+
+    try {
+      atomix.mapBuilder("foo")
+          .withProtocol(MultiRaftProtocol.builder("wrong").build())
+          .get();
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof ConfigurationException);
+    }
+
+    try {
+      atomix.mapBuilder("bar")
+          .withProtocol(MultiRaftProtocol.builder("wrong").build())
+          .build();
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof ConfigurationException);
+    }
 
     assertEquals(AtomicCounterType.instance(), atomix.getPrimitive("atomic-counter", AtomicCounterType.instance()).type());
     assertEquals("atomic-counter", atomix.getAtomicCounter("atomic-counter").name());

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionService.java
@@ -71,6 +71,7 @@ public interface PartitionService {
       if (systemGroup != null && systemGroup.name().equals(protocol.group())) {
         return systemGroup;
       }
+      return null;
     }
 
     for (PartitionGroup partitionGroup : getPartitionGroups()) {

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/MultiPrimaryProtocol.java
@@ -16,6 +16,7 @@
 package io.atomix.protocols.backup;
 
 import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionService;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.protocol.ProxyProtocol;
@@ -24,6 +25,7 @@ import io.atomix.primitive.proxy.impl.DefaultProxyClient;
 import io.atomix.primitive.service.ServiceConfig;
 import io.atomix.primitive.session.SessionClient;
 import io.atomix.protocols.backup.partition.PrimaryBackupPartition;
+import io.atomix.utils.config.ConfigurationException;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -104,9 +106,12 @@ public class MultiPrimaryProtocol implements ProxyProtocol {
 
   @Override
   public <S> ProxyClient<S> newProxy(String primitiveName, PrimitiveType primitiveType, Class<S> serviceType, ServiceConfig serviceConfig, PartitionService partitionService) {
-    Collection<SessionClient> partitions = partitionService.getPartitionGroup(this)
-        .getPartitions()
-        .stream()
+    PartitionGroup partitionGroup = partitionService.getPartitionGroup(this);
+    if (partitionGroup == null) {
+      throw new ConfigurationException("No Raft partition group matching the configured protocol exists");
+    }
+
+    Collection<SessionClient> partitions = partitionGroup.getPartitions().stream()
         .map(partition -> ((PrimaryBackupPartition) partition).getClient()
             .sessionBuilder(primitiveName, primitiveType, serviceConfig)
             .withConsistency(config.getConsistency())


### PR DESCRIPTION
This PR adds a `ConfigurationException` to attempts to `build()` or `get()` a primitive when the configured protocol does not match a partition group.