### PR TITLE
Reduce DEBUG logging in service executor to TRACE

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
@@ -136,7 +136,7 @@ public class DefaultServiceExecutor implements ServiceExecutor {
     checkNotNull(operationId, "operationId cannot be null");
     checkNotNull(callback, "callback cannot be null");
     operations.put(operationId.id(), callback);
-    log.debug("Registered operation callback {}", operationId);
+    log.trace("Registered operation callback {}", operationId);
   }
 
   @Override


### PR DESCRIPTION
This can be too verbose when many, many primitives are created as is done in ONOS.