### PR TITLE
Rename phi membership protocol to 'heartbeat'

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -18,7 +18,8 @@ package io.atomix.cluster;
 import com.google.common.collect.Lists;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
 import io.atomix.cluster.protocol.GroupMembershipProtocol;
-import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocol;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocolConfig;
 import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
 import io.atomix.utils.Builder;
 import io.atomix.utils.net.Address;
@@ -332,8 +333,8 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   @Deprecated
   public AtomixClusterBuilder setBroadcastInterval(Duration interval) {
     GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
-    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
-      ((PhiMembershipProtocolConfig) protocolConfig).setHeartbeatInterval(interval);
+    if (protocolConfig instanceof HeartbeatMembershipProtocolConfig) {
+      ((HeartbeatMembershipProtocolConfig) protocolConfig).setHeartbeatInterval(interval);
     }
     return this;
   }
@@ -349,8 +350,8 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   @Deprecated
   public AtomixClusterBuilder withBroadcastInterval(Duration interval) {
     GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
-    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
-      ((PhiMembershipProtocolConfig) protocolConfig).setHeartbeatInterval(interval);
+    if (protocolConfig instanceof HeartbeatMembershipProtocolConfig) {
+      ((HeartbeatMembershipProtocolConfig) protocolConfig).setHeartbeatInterval(interval);
     }
     return this;
   }
@@ -368,8 +369,8 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   @Deprecated
   public AtomixClusterBuilder setReachabilityThreshold(int threshold) {
     GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
-    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
-      ((PhiMembershipProtocolConfig) protocolConfig).setFailureThreshold(threshold);
+    if (protocolConfig instanceof HeartbeatMembershipProtocolConfig) {
+      ((HeartbeatMembershipProtocolConfig) protocolConfig).setPhiFailureThreshold(threshold);
     }
     return this;
   }
@@ -386,8 +387,8 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   @Deprecated
   public AtomixClusterBuilder withReachabilityThreshold(int threshold) {
     GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
-    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
-      ((PhiMembershipProtocolConfig) protocolConfig).setFailureThreshold(threshold);
+    if (protocolConfig instanceof HeartbeatMembershipProtocolConfig) {
+      ((HeartbeatMembershipProtocolConfig) protocolConfig).setPhiFailureThreshold(threshold);
     }
     return this;
   }
@@ -404,8 +405,8 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   @Deprecated
   public AtomixClusterBuilder withReachabilityTimeout(Duration timeout) {
     GroupMembershipProtocolConfig protocolConfig = config.getProtocolConfig();
-    if (protocolConfig instanceof PhiMembershipProtocolConfig) {
-      ((PhiMembershipProtocolConfig) protocolConfig).setFailureTimeout(timeout);
+    if (protocolConfig instanceof HeartbeatMembershipProtocolConfig) {
+      ((HeartbeatMembershipProtocolConfig) protocolConfig).setFailureTimeout(timeout);
     }
     return this;
   }
@@ -414,11 +415,11 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * Sets the cluster membership protocol.
    * <p>
    * The membership protocol is responsible for determining the active set of members in the cluster, replicating
-   * member metadata, and detecting failures. The default is {@link io.atomix.cluster.protocol.PhiMembershipProtocol}.
+   * member metadata, and detecting failures. The default is {@link HeartbeatMembershipProtocol}.
    *
    * @param protocol the cluster membership protocol
    * @return the cluster builder
-   * @see io.atomix.cluster.protocol.PhiMembershipProtocol
+   * @see HeartbeatMembershipProtocol
    * @see io.atomix.cluster.protocol.SwimMembershipProtocol
    */
   public AtomixClusterBuilder withMembershipProtocol(GroupMembershipProtocol protocol) {

--- a/cluster/src/main/java/io/atomix/cluster/protocol/HeartbeatMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/HeartbeatMembershipProtocol.java
@@ -57,7 +57,7 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
 /**
  * Gossip based group membership protocol.
  */
-public class PhiMembershipProtocol
+public class HeartbeatMembershipProtocol
     extends AbstractListenerManager<GroupMembershipEvent, GroupMembershipEventListener>
     implements GroupMembershipProtocol {
 
@@ -68,15 +68,15 @@ public class PhiMembershipProtocol
    *
    * @return a new bootstrap provider builder
    */
-  public static PhiMembershipProtocolBuilder builder() {
-    return new PhiMembershipProtocolBuilder();
+  public static HeartbeatMembershipProtocolBuilder builder() {
+    return new HeartbeatMembershipProtocolBuilder();
   }
 
   /**
    * Bootstrap member location provider type.
    */
-  public static class Type implements GroupMembershipProtocol.Type<PhiMembershipProtocolConfig> {
-    private static final String NAME = "phi";
+  public static class Type implements GroupMembershipProtocol.Type<HeartbeatMembershipProtocolConfig> {
+    private static final String NAME = "heartbeat";
 
     @Override
     public String name() {
@@ -84,19 +84,19 @@ public class PhiMembershipProtocol
     }
 
     @Override
-    public PhiMembershipProtocolConfig newConfig() {
-      return new PhiMembershipProtocolConfig();
+    public HeartbeatMembershipProtocolConfig newConfig() {
+      return new HeartbeatMembershipProtocolConfig();
     }
 
     @Override
-    public GroupMembershipProtocol newProtocol(PhiMembershipProtocolConfig config) {
-      return new PhiMembershipProtocol(config);
+    public GroupMembershipProtocol newProtocol(HeartbeatMembershipProtocolConfig config) {
+      return new HeartbeatMembershipProtocol(config);
     }
   }
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(PhiMembershipProtocol.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatMembershipProtocol.class);
 
-  private final PhiMembershipProtocolConfig config;
+  private final HeartbeatMembershipProtocolConfig config;
 
   private static final String HEARTBEAT_MESSAGE = "atomix-cluster-membership";
 
@@ -125,7 +125,7 @@ public class PhiMembershipProtocol
       namedThreads("atomix-cluster-events", LOGGER));
   private ScheduledFuture<?> heartbeatFuture;
 
-  public PhiMembershipProtocol(PhiMembershipProtocolConfig config) {
+  public HeartbeatMembershipProtocol(HeartbeatMembershipProtocolConfig config) {
     this.config = config;
   }
 
@@ -237,7 +237,7 @@ public class PhiMembershipProtocol
 
             PhiAccrualFailureDetector failureDetector = failureDetectors.computeIfAbsent(member.id(), n -> new PhiAccrualFailureDetector());
             double phi = failureDetector.phi();
-            if (phi >= config.getFailureThreshold()
+            if (phi >= config.getPhiFailureThreshold()
                 || (phi == 0.0 && System.currentTimeMillis() - failureDetector.lastUpdated() > config.getFailureTimeout().toMillis())) {
               if (members.remove(member.id()) != null) {
                 failureDetectors.remove(member.id());

--- a/cluster/src/main/java/io/atomix/cluster/protocol/HeartbeatMembershipProtocolBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/HeartbeatMembershipProtocolBuilder.java
@@ -20,8 +20,8 @@ import java.time.Duration;
 /**
  * Gossip based group membership protocol builder.
  */
-public class PhiMembershipProtocolBuilder extends GroupMembershipProtocolBuilder {
-  private final PhiMembershipProtocolConfig config = new PhiMembershipProtocolConfig();
+public class HeartbeatMembershipProtocolBuilder extends GroupMembershipProtocolBuilder {
+  private final HeartbeatMembershipProtocolConfig config = new HeartbeatMembershipProtocolConfig();
 
   /**
    * Sets the failure detection heartbeat interval.
@@ -29,7 +29,7 @@ public class PhiMembershipProtocolBuilder extends GroupMembershipProtocolBuilder
    * @param heartbeatInterval the failure detection heartbeat interval
    * @return the location provider builder
    */
-  public PhiMembershipProtocolBuilder withHeartbeatInterval(Duration heartbeatInterval) {
+  public HeartbeatMembershipProtocolBuilder withHeartbeatInterval(Duration heartbeatInterval) {
     config.setHeartbeatInterval(heartbeatInterval);
     return this;
   }
@@ -40,8 +40,8 @@ public class PhiMembershipProtocolBuilder extends GroupMembershipProtocolBuilder
    * @param failureThreshold the phi accrual failure threshold
    * @return the location provider builder
    */
-  public PhiMembershipProtocolBuilder withFailureThreshold(int failureThreshold) {
-    config.setFailureThreshold(failureThreshold);
+  public HeartbeatMembershipProtocolBuilder withFailureThreshold(int failureThreshold) {
+    config.setPhiFailureThreshold(failureThreshold);
     return this;
   }
 
@@ -51,13 +51,13 @@ public class PhiMembershipProtocolBuilder extends GroupMembershipProtocolBuilder
    * @param failureTimeout the failure timeout
    * @return the location provider builder
    */
-  public PhiMembershipProtocolBuilder withFailureTimeout(Duration failureTimeout) {
+  public HeartbeatMembershipProtocolBuilder withFailureTimeout(Duration failureTimeout) {
     config.setFailureTimeout(failureTimeout);
     return this;
   }
 
   @Override
   public GroupMembershipProtocol build() {
-    return new PhiMembershipProtocol(config);
+    return new HeartbeatMembershipProtocol(config);
   }
 }

--- a/cluster/src/main/java/io/atomix/cluster/protocol/HeartbeatMembershipProtocolConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/HeartbeatMembershipProtocolConfig.java
@@ -22,18 +22,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Gossip group membership protocol configuration.
  */
-public class PhiMembershipProtocolConfig extends GroupMembershipProtocolConfig {
+public class HeartbeatMembershipProtocolConfig extends GroupMembershipProtocolConfig {
   private static final int DEFAULT_HEARTBEAT_INTERVAL = 1000;
   private static final int DEFAULT_FAILURE_TIMEOUT = 10000;
   private static final int DEFAULT_PHI_FAILURE_THRESHOLD = 10;
 
   private Duration heartbeatInterval = Duration.ofMillis(DEFAULT_HEARTBEAT_INTERVAL);
-  private int failureThreshold = DEFAULT_PHI_FAILURE_THRESHOLD;
+  private int phiFailureThreshold = DEFAULT_PHI_FAILURE_THRESHOLD;
   private Duration failureTimeout = Duration.ofMillis(DEFAULT_FAILURE_TIMEOUT);
 
   @Override
   public GroupMembershipProtocol.Type getType() {
-    return PhiMembershipProtocol.TYPE;
+    return HeartbeatMembershipProtocol.TYPE;
   }
 
   /**
@@ -51,7 +51,7 @@ public class PhiMembershipProtocolConfig extends GroupMembershipProtocolConfig {
    * @param heartbeatInterval the heartbeat interval
    * @return the group membership configuration
    */
-  public PhiMembershipProtocolConfig setHeartbeatInterval(Duration heartbeatInterval) {
+  public HeartbeatMembershipProtocolConfig setHeartbeatInterval(Duration heartbeatInterval) {
     this.heartbeatInterval = checkNotNull(heartbeatInterval);
     return this;
   }
@@ -61,18 +61,18 @@ public class PhiMembershipProtocolConfig extends GroupMembershipProtocolConfig {
    *
    * @return the failure detector threshold
    */
-  public int getFailureThreshold() {
-    return failureThreshold;
+  public int getPhiFailureThreshold() {
+    return phiFailureThreshold;
   }
 
   /**
    * Sets the failure detector threshold.
    *
-   * @param failureThreshold the failure detector threshold
+   * @param phiFailureThreshold the failure detector threshold
    * @return the group membership configuration
    */
-  public PhiMembershipProtocolConfig setFailureThreshold(int failureThreshold) {
-    this.failureThreshold = failureThreshold;
+  public HeartbeatMembershipProtocolConfig setPhiFailureThreshold(int phiFailureThreshold) {
+    this.phiFailureThreshold = phiFailureThreshold;
     return this;
   }
 
@@ -91,7 +91,7 @@ public class PhiMembershipProtocolConfig extends GroupMembershipProtocolConfig {
    * @param failureTimeout the base failure timeout
    * @return the group membership configuration
    */
-  public PhiMembershipProtocolConfig setFailureTimeout(Duration failureTimeout) {
+  public HeartbeatMembershipProtocolConfig setFailureTimeout(Duration failureTimeout) {
     this.failureTimeout = checkNotNull(failureTimeout);
     return this;
   }

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
@@ -27,8 +27,8 @@ import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.messaging.impl.TestBroadcastServiceFactory;
 import io.atomix.cluster.messaging.impl.TestMessagingServiceFactory;
 import io.atomix.cluster.messaging.impl.TestUnicastServiceFactory;
-import io.atomix.cluster.protocol.PhiMembershipProtocol;
-import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocol;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocolConfig;
 import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import org.junit.Test;
@@ -85,7 +85,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService1, localMember1, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService1,
-        new PhiMembershipProtocol(new PhiMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
+        new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
 
     Member localMember2 = buildMember(2);
     BootstrapService bootstrapService2 = new TestBootstrapService(
@@ -97,7 +97,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService2, localMember2, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService2,
-        new PhiMembershipProtocol(new PhiMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
+        new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
 
     Member localMember3 = buildMember(3);
     BootstrapService bootstrapService3 = new TestBootstrapService(
@@ -109,7 +109,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.0.1"),
         new DefaultNodeDiscoveryService(bootstrapService3, localMember3, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService3,
-        new PhiMembershipProtocol(new PhiMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
+        new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
 
     assertNull(clusterService1.getMember(MemberId.from("1")));
     assertNull(clusterService1.getMember(MemberId.from("2")));
@@ -143,7 +143,7 @@ public class DefaultClusterMembershipServiceTest {
         Version.from("1.1.0"),
         new DefaultNodeDiscoveryService(ephemeralBootstrapService, anonymousMember, new BootstrapDiscoveryProvider(bootstrapLocations)),
         ephemeralBootstrapService,
-        new PhiMembershipProtocol(new PhiMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
+        new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig().setFailureTimeout(Duration.ofSeconds(2))));
 
     assertFalse(ephemeralClusterService.getLocalMember().isActive());
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
@@ -28,8 +28,8 @@ import io.atomix.cluster.impl.DefaultNodeDiscoveryService;
 import io.atomix.cluster.messaging.ClusterEventService;
 import io.atomix.cluster.messaging.ManagedClusterEventService;
 import io.atomix.cluster.messaging.MessagingService;
-import io.atomix.cluster.protocol.PhiMembershipProtocol;
-import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocol;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocolConfig;
 import io.atomix.utils.Version;
 import io.atomix.utils.net.Address;
 import io.atomix.utils.serializer.Namespaces;
@@ -86,7 +86,7 @@ public class DefaultClusterEventServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService1, localMember1, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService1,
-        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
+        new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig()));
     ClusterMembershipService clusterMembershipService1 = clusterService1.start().join();
     ManagedClusterEventService clusterEventingService1 = new DefaultClusterEventService(clusterMembershipService1, messagingService1);
     ClusterEventService eventService1 = clusterEventingService1.start().join();
@@ -102,7 +102,7 @@ public class DefaultClusterEventServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService2, localMember2, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService2,
-        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
+        new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig()));
     ClusterMembershipService clusterMembershipService2 = clusterService2.start().join();
     ManagedClusterEventService clusterEventingService2 = new DefaultClusterEventService(clusterMembershipService2, messagingService2);
     ClusterEventService eventService2 = clusterEventingService2.start().join();
@@ -118,7 +118,7 @@ public class DefaultClusterEventServiceTest {
         Version.from("1.0.0"),
         new DefaultNodeDiscoveryService(bootstrapService3, localMember3, new BootstrapDiscoveryProvider(bootstrapLocations)),
         bootstrapService3,
-        new PhiMembershipProtocol(new PhiMembershipProtocolConfig()));
+        new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig()));
     ClusterMembershipService clusterMembershipService3 = clusterService3.start().join();
     ManagedClusterEventService clusterEventingService3 = new DefaultClusterEventService(clusterMembershipService3, messagingService3);
     ClusterEventService eventService3 = clusterEventingService3.start().join();

--- a/core/src/main/java/io/atomix/core/utils/config/PolymorphicTypeMapper.java
+++ b/core/src/main/java/io/atomix/core/utils/config/PolymorphicTypeMapper.java
@@ -17,6 +17,7 @@ package io.atomix.core.utils.config;
 
 import io.atomix.core.AtomixRegistry;
 import io.atomix.utils.ConfiguredType;
+import io.atomix.utils.NamedType;
 import io.atomix.utils.config.TypedConfig;
 
 /**
@@ -64,11 +65,15 @@ public class PolymorphicTypeMapper {
    * Returns the concrete configuration class.
    *
    * @param registry the Atomix type registry
-   * @param type     the type name
+   * @param typeName the type name
    * @return the concrete configuration class
    */
   @SuppressWarnings("unchecked")
-  public Class<? extends TypedConfig<?>> getConcreteClass(AtomixRegistry registry, String type) {
-    return (Class<? extends TypedConfig<?>>) registry.getType(typeClass, type).newConfig().getClass();
+  public Class<? extends TypedConfig<?>> getConcreteClass(AtomixRegistry registry, String typeName) {
+    ConfiguredType type = registry.getType(typeClass, typeName);
+    if (type == null) {
+      return null;
+    }
+    return (Class<? extends TypedConfig<?>>) type.newConfig().getClass();
   }
 }

--- a/core/src/test/java/io/atomix/core/AtomixConfigTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixConfigTest.java
@@ -22,7 +22,7 @@ import io.atomix.cluster.MulticastConfig;
 import io.atomix.cluster.discovery.MulticastDiscoveryConfig;
 import io.atomix.cluster.discovery.MulticastDiscoveryProvider;
 import io.atomix.cluster.messaging.MessagingConfig;
-import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocolConfig;
 import io.atomix.core.map.AtomicMapConfig;
 import io.atomix.core.profile.ConsensusProfile;
 import io.atomix.core.profile.ConsensusProfileConfig;
@@ -81,9 +81,9 @@ public class AtomixConfigTest {
     assertEquals("230.0.1.1", multicast.getGroup().getHostAddress());
     assertEquals(56789, multicast.getPort());
 
-    PhiMembershipProtocolConfig protocol = (PhiMembershipProtocolConfig) cluster.getProtocolConfig();
+    HeartbeatMembershipProtocolConfig protocol = (HeartbeatMembershipProtocolConfig) cluster.getProtocolConfig();
     assertEquals(Duration.ofMillis(200), protocol.getHeartbeatInterval());
-    assertEquals(12, protocol.getFailureThreshold());
+    assertEquals(12, protocol.getPhiFailureThreshold());
     assertEquals(Duration.ofSeconds(15), protocol.getFailureTimeout());
 
     MembershipConfig membership = cluster.getMembershipConfig();

--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -17,9 +17,9 @@ cluster {
     port: 56789
   }
   protocol {
-    type: phi
+    type: heartbeat
     heartbeatInterval: 200ms
-    failureThreshold: 12
+    phiFailureThreshold: 12
     failureTimeout: 15s
   }
   membership {

--- a/dist/src/main/resources/examples/reference.conf
+++ b/dist/src/main/resources/examples/reference.conf
@@ -117,9 +117,9 @@ cluster {
     # The format allows the interval to be specified in ms, s, m, h, d, etc.
     heartbeatInterval: 1s
 
-    # The 'failureThreshold' is the phi value threshold at which to consider a peer dead.
+    # The 'phiFailureThreshold' is the phi value threshold at which to consider a peer dead.
     # Typical values range from 8 to 12.
-    failureThreshold: 10
+    phiFailureThreshold: 10
 
     # The 'failureTimeout' is the maximum amount of time that may pass without hearing from a peer before
     # marking it dead. This is used when not enough heartbeats have been recorded to reliably detect

--- a/tests/src/main/java/io/atomix/protocols/raft/test/RaftPerformanceTest.java
+++ b/tests/src/main/java/io/atomix/protocols/raft/test/RaftPerformanceTest.java
@@ -30,8 +30,8 @@ import io.atomix.cluster.messaging.MessagingConfig;
 import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.cluster.messaging.UnicastService;
 import io.atomix.cluster.messaging.impl.NettyMessagingService;
-import io.atomix.cluster.protocol.PhiMembershipProtocol;
-import io.atomix.cluster.protocol.PhiMembershipProtocolConfig;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocol;
+import io.atomix.cluster.protocol.HeartbeatMembershipProtocolConfig;
 import io.atomix.primitive.PrimitiveBuilder;
 import io.atomix.primitive.PrimitiveManagementService;
 import io.atomix.primitive.PrimitiveType;
@@ -515,7 +515,7 @@ public class RaftPerformanceTest implements Runnable {
             Version.from("1.0.0"),
             new DefaultNodeDiscoveryService(bootstrapService, member, new BootstrapDiscoveryProvider(members)),
             bootstrapService,
-            new PhiMembershipProtocol(new PhiMembershipProtocolConfig())))
+            new HeartbeatMembershipProtocol(new HeartbeatMembershipProtocolConfig())))
         .withStorage(RaftStorage.builder()
             .withStorageLevel(StorageLevel.DISK)
             .withDirectory(new File(String.format("target/perf-logs/%s", member.id())))


### PR DESCRIPTION
This PR renames the `phi` protocol to `heartbeat`, updates associated configuration options, and adds additional information to configuration mappers to help users locate the correct configuration options.