### PR TITLE
Support arbitrary configuration overrides via command line arguments

### DIFF
--- a/agent/src/test/resources/test.conf
+++ b/agent/src/test/resources/test.conf
@@ -1,22 +1,24 @@
 cluster {
-  cluster-id: test
+  clusterId: test
+  node.id: test-1
+  node.address: "localhost:5679"
   multicast.enabled: true
 }
 
 managementGroup {
   type: raft
-  storage-level: memory
   partitions: 1
-  data-directory: target/test-logs/system
+  storage.level: disk
+  storage.directory: target/test-logs/system
   members: [node1, node2, node3]
 }
 
 partitionGroups.raft {
   type: raft
-  storage-level: memory
   partitions: 7
-  partition-size: 3
-  data-directory: target/test-logs/raft
+  partitionSize: 3
+  storage.level: disk
+  storage.directory: target/test-logs/raft
   members: [node1, node2, node3]
 }
 

--- a/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
+++ b/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
@@ -78,21 +78,13 @@ public class ConfigMapper {
       return loadResources(type, resources);
     }
 
-    Config config = null;
+    Config config = ConfigFactory.systemProperties();
     for (File file : files) {
-      if (config == null) {
-        config = ConfigFactory.parseFile(file, ConfigParseOptions.defaults().setAllowMissing(false));
-      } else {
-        config = config.withFallback(ConfigFactory.parseFile(file, ConfigParseOptions.defaults().setAllowMissing(false)));
-      }
+      config = config.withFallback(ConfigFactory.parseFile(file, ConfigParseOptions.defaults().setAllowMissing(false)));
     }
 
     for (String resource : resources) {
-      if (config == null) {
-        config = ConfigFactory.load(classLoader, resource);
-      } else {
-        config = config.withFallback(ConfigFactory.load(classLoader, resource));
-      }
+      config = config.withFallback(ConfigFactory.load(classLoader, resource));
     }
     return map(checkNotNull(config, "config cannot be null").resolve(), type);
   }


### PR DESCRIPTION
This PR introduces support for arbitrary configuration overrides via the command line. This can be done by simply specifying an arbitrary option name:
```
./bin/atomix-agent -c atomix.conf --cluster.node.id member-1 --cluster.node.address=localhost:5679
```