### PR TITLE
Use temporary connections when probing peers in SWIM protocol

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/messaging/MessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/MessagingService.java
@@ -44,7 +44,21 @@ public interface MessagingService {
    * @param payload message payload bytes.
    * @return future that is completed when the message is sent
    */
-  CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload);
+  default CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload) {
+    return sendAsync(address, type, payload, true);
+  }
+
+  /**
+   * Sends a message asynchronously to the specified communication address.
+   * The message is specified using the type and payload.
+   *
+   * @param address   address to send the message to.
+   * @param type      type of message.
+   * @param payload   message payload bytes.
+   * @param keepAlive whether to keep the connection alive after usage
+   * @return future that is completed when the message is sent
+   */
+  CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload, boolean keepAlive);
 
   /**
    * Sends a message asynchronously and expects a response.
@@ -54,7 +68,20 @@ public interface MessagingService {
    * @param payload message payload.
    * @return a response future
    */
-  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload);
+  default CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload) {
+    return sendAndReceive(address, type, payload, true);
+  }
+
+  /**
+   * Sends a message asynchronously and expects a response.
+   *
+   * @param address   address to send the message to.
+   * @param type      type of message.
+   * @param payload   message payload.
+   * @param keepAlive whether to keep the connection alive after usage
+   * @return a response future
+   */
+  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive);
 
   /**
    * Sends a message synchronously and expects a response.
@@ -65,7 +92,21 @@ public interface MessagingService {
    * @param executor executor over which any follow up actions after completion will be executed.
    * @return a response future
    */
-  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Executor executor);
+  default CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Executor executor) {
+    return sendAndReceive(address, type, payload, true, executor);
+  }
+
+  /**
+   * Sends a message synchronously and expects a response.
+   *
+   * @param address   address to send the message to.
+   * @param type      type of message.
+   * @param payload   message payload.
+   * @param keepAlive whether to keep the connection alive after usage
+   * @param executor  executor over which any follow up actions after completion will be executed.
+   * @return a response future
+   */
+  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Executor executor);
 
   /**
    * Sends a message asynchronously and expects a response.
@@ -76,7 +117,21 @@ public interface MessagingService {
    * @param timeout response timeout
    * @return a response future
    */
-  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout);
+  default CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout) {
+    return sendAndReceive(address, type, payload, true, timeout);
+  }
+
+  /**
+   * Sends a message asynchronously and expects a response.
+   *
+   * @param address   address to send the message to.
+   * @param type      type of message.
+   * @param payload   message payload.
+   * @param keepAlive whether to keep the connection alive after usage
+   * @param timeout   response timeout
+   * @return a response future
+   */
+  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Duration timeout);
 
   /**
    * Sends a message synchronously and expects a response.
@@ -84,11 +139,26 @@ public interface MessagingService {
    * @param address  address to send the message to.
    * @param type     type of message.
    * @param payload  message payload.
-   * @param timeout response timeout
+   * @param timeout  response timeout
    * @param executor executor over which any follow up actions after completion will be executed.
    * @return a response future
    */
-  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout, Executor executor);
+  default CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout, Executor executor) {
+    return sendAndReceive(address, type, payload, true, timeout, executor);
+  }
+
+  /**
+   * Sends a message synchronously and expects a response.
+   *
+   * @param address   address to send the message to.
+   * @param type      type of message.
+   * @param payload   message payload.
+   * @param keepAlive whether to keep the connection alive after usage
+   * @param timeout   response timeout
+   * @param executor  executor over which any follow up actions after completion will be executed.
+   * @return a response future
+   */
+  CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Duration timeout, Executor executor);
 
   /**
    * Registers a new message handler for message type.

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/TestMessagingService.java
@@ -105,7 +105,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload) {
+  public CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload, boolean keepAlive) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -113,7 +113,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -121,7 +121,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Executor executor) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Executor executor) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -131,7 +131,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Duration timeout) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -139,7 +139,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout, Executor executor) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Duration timeout, Executor executor) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }

--- a/core/src/test/java/io/atomix/core/test/messaging/TestMessagingService.java
+++ b/core/src/test/java/io/atomix/core/test/messaging/TestMessagingService.java
@@ -105,7 +105,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload) {
+  public CompletableFuture<Void> sendAsync(Address address, String type, byte[] payload, boolean keepAlive) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -113,7 +113,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -121,7 +121,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Executor executor) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Executor executor) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -131,7 +131,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Duration timeout) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }
@@ -139,7 +139,7 @@ public class TestMessagingService implements ManagedMessagingService {
   }
 
   @Override
-  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, Duration timeout, Executor executor) {
+  public CompletableFuture<byte[]> sendAndReceive(Address address, String type, byte[] payload, boolean keepAlive, Duration timeout, Executor executor) {
     if (isPartitioned(address)) {
       return Futures.exceptionalFuture(new ConnectException());
     }


### PR DESCRIPTION
This PR adds support for temporary connections used when probing peers in the SWIM protocol. Using temporary connections reduces the explosion of sockets in clusters with a large number of clients that don't otherwise talk to each other. It also fixes a bug in probe request handling in the SWIM protocol.