### PR TITLE
Ensure pending commands are immediately drained on commit

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -651,10 +651,11 @@ public final class LeaderRole extends ActiveRole {
                   .build());
       }
     }
-    // Otherwise, commit the command and update the request sequence number.
+    // Otherwise, commit the command and update the request sequence number, then drain pending commands.
     else {
       commitCommand(request, future);
       session.setRequestSequence(sequenceNumber);
+      drainCommands(sequenceNumber, session);
     }
 
     return future.thenApply(this::logResponse);


### PR DESCRIPTION
This PR fixes a bug in the Raft leader that can prevent out of order commands from being quickly appended to the Raft log. When two commands are received out of order - e.g. sequence `2` and then sequence `1` - the append of the older command does not currently drain pending commands to the Raft log. This PR ensures next commands are drained after an append to the Raft log.