### PR TITLE
Ensure connection callbacks are executed in program order after connect

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -27,6 +27,7 @@ import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.cluster.messaging.MessagingService;
 import io.atomix.utils.AtomixRuntimeException;
 import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.concurrent.OrderedFuture;
 import io.atomix.utils.net.Address;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
@@ -519,7 +520,7 @@ public class NettyMessagingService implements ManagedMessagingService {
   }
 
   private CompletableFuture<Channel> bootstrapClient(Address address) {
-    CompletableFuture<Channel> future = new CompletableFuture<>();
+    CompletableFuture<Channel> future = new OrderedFuture<>();
     Bootstrap bootstrap = new Bootstrap();
     bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
     bootstrap.option(ChannelOption.WRITE_BUFFER_WATER_MARK,


### PR DESCRIPTION
This PR adds an `OrderedFuture` to Netty connection futures to ensure multiple callbacks waiting for the same connection are called in the order in which they were added. This fixes an ordering bug that can occur when initially establishing a connection to a peer.