### PR TITLE
Refactor NettyMessagingService

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import com.google.common.collect.Maps;
+import io.atomix.cluster.messaging.MessagingException;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.descriptive.SynchronizedDescriptiveStatistics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.ConnectException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Base class for client-side connections. Manages request futures and timeouts.
+ */
+abstract class AbstractClientConnection implements ClientConnection {
+  private static final int WINDOW_SIZE = 10;
+  private static final int MIN_SAMPLES = 50;
+  private static final int TIMEOUT_FACTOR = 5;
+  private static final long MIN_TIMEOUT_MILLIS = 100;
+  private static final long MAX_TIMEOUT_MILLIS = 5000;
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  private final ScheduledExecutorService executorService;
+  private final Map<Long, Callback> callbacks = Maps.newConcurrentMap();
+
+  private final Map<String, DescriptiveStatistics> replySamples = new ConcurrentHashMap<>();
+
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
+  AbstractClientConnection(ScheduledExecutorService executorService) {
+    this.executorService = executorService;
+  }
+
+  @Override
+  public void dispatch(ProtocolReply message) {
+    Callback callback = callbacks.remove(message.id());
+    if (callback != null) {
+      if (message.status() == ProtocolReply.Status.OK) {
+        callback.complete(message.payload());
+      } else if (message.status() == ProtocolReply.Status.ERROR_NO_HANDLER) {
+        callback.completeExceptionally(new MessagingException.NoRemoteHandler());
+      } else if (message.status() == ProtocolReply.Status.ERROR_HANDLER_EXCEPTION) {
+        callback.completeExceptionally(new MessagingException.RemoteHandlerFailure());
+      } else if (message.status() == ProtocolReply.Status.PROTOCOL_EXCEPTION) {
+        callback.completeExceptionally(new MessagingException.ProtocolException());
+      }
+    } else {
+      log.debug("Received a reply for message id:[{}] but was unable to locate the request handle", message.id());
+    }
+  }
+
+  /**
+   * Adds a reply time to the history.
+   *
+   * @param type      the message type
+   * @param replyTime the reply time to add to the history
+   */
+  private void addReplyTime(String type, long replyTime) {
+    DescriptiveStatistics samples = replySamples.get(type);
+    if (samples == null) {
+      samples = replySamples.computeIfAbsent(type, t -> new SynchronizedDescriptiveStatistics(WINDOW_SIZE));
+    }
+    samples.addValue(replyTime);
+  }
+
+  /**
+   * Returns the timeout in milliseconds for the given timeout duration
+   *
+   * @param type    the message type
+   * @param timeout the timeout duration or {@code null} if the timeout is dynamic
+   * @return the timeout in milliseconds
+   */
+  private long getTimeoutMillis(String type, Duration timeout) {
+    return timeout != null ? timeout.toMillis() : computeTimeoutMillis(type);
+  }
+
+  /**
+   * Computes the timeout for the next request.
+   *
+   * @param type the message type
+   * @return the computed timeout for the next request
+   */
+  private long computeTimeoutMillis(String type) {
+    DescriptiveStatistics samples = replySamples.get(type);
+    if (samples == null || samples.getN() < MIN_SAMPLES) {
+      return MAX_TIMEOUT_MILLIS;
+    }
+    return Math.min(Math.max((int) samples.getMax() * TIMEOUT_FACTOR, MIN_TIMEOUT_MILLIS), MAX_TIMEOUT_MILLIS);
+  }
+
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) {
+      for (Callback callback : callbacks.values()) {
+        callback.completeExceptionally(new ConnectException());
+      }
+    }
+  }
+
+  /**
+   * Client connection callback.
+   */
+  final class Callback {
+    private final long id;
+    private final String type;
+    private final long time = System.currentTimeMillis();
+    private final long timeout;
+    private final ScheduledFuture<?> scheduledFuture;
+    private final CompletableFuture<byte[]> replyFuture;
+
+    Callback(long id, String type, Duration timeout, CompletableFuture<byte[]> future) {
+      this.id = id;
+      this.type = type;
+      this.timeout = getTimeoutMillis(type, timeout);
+      this.scheduledFuture = executorService.schedule(this::timeout, this.timeout, TimeUnit.MILLISECONDS);
+      this.replyFuture = future;
+      future.thenRun(() -> addReplyTime(type, System.currentTimeMillis() - time));
+      callbacks.put(id, this);
+    }
+
+    /**
+     * Returns the callback message type.
+     *
+     * @return the message type
+     */
+    String type() {
+      return type;
+    }
+
+    /**
+     * Fails the callback future with a timeout exception.
+     */
+    private void timeout() {
+      replyFuture.completeExceptionally(new TimeoutException("Request type " + type + " timed out in " + timeout + " milliseconds"));
+      callbacks.remove(id);
+    }
+
+    /**
+     * Completes the callback with the given value.
+     *
+     * @param value the value with which to complete the callback
+     */
+    void complete(byte[] value) {
+      scheduledFuture.cancel(false);
+      replyFuture.complete(value);
+    }
+
+    /**
+     * Completes the callback exceptionally.
+     *
+     * @param error the callback exception
+     */
+    void completeExceptionally(Throwable error) {
+      scheduledFuture.cancel(false);
+      replyFuture.completeExceptionally(error);
+      callbacks.remove(id);
+    }
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractServerConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractServerConnection.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+/**
+ * Base class for server-side connections. Manages dispatching requests to message handlers.
+ */
+abstract class AbstractServerConnection implements ServerConnection {
+  private final Logger log = LoggerFactory.getLogger(getClass());
+  private final HandlerRegistry handlers;
+
+  AbstractServerConnection(HandlerRegistry handlers) {
+    this.handlers = handlers;
+  }
+
+  @Override
+  public void dispatch(ProtocolRequest message) {
+    BiConsumer<ProtocolRequest, ServerConnection> handler = handlers.get(message.subject());
+    if (handler != null) {
+      log.trace("Received message type {} from {}", message.subject(), message.sender());
+      handler.accept(message, this);
+    } else {
+      log.debug("No handler for message type {} from {}", message.subject(), message.sender());
+      reply(message, ProtocolReply.Status.ERROR_NO_HANDLER, Optional.empty());
+    }
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.atomix.utils.net.Address;
+import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Internal Netty channel pool.
+ */
+class ChannelPool {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ChannelPool.class);
+
+  private final Function<Address, CompletableFuture<Channel>> factory;
+  private final int size;
+  private final Map<Address, List<CompletableFuture<Channel>>> channels = Maps.newConcurrentMap();
+
+  ChannelPool(Function<Address, CompletableFuture<Channel>> factory, int size) {
+    this.factory = factory;
+    this.size = size;
+  }
+
+  /**
+   * Returns the channel pool for the given address.
+   *
+   * @param address the address for which to return the channel pool
+   * @return the channel pool for the given address
+   */
+  private List<CompletableFuture<Channel>> getChannelPool(Address address) {
+    List<CompletableFuture<Channel>> channelPool = channels.get(address);
+    if (channelPool != null) {
+      return channelPool;
+    }
+    return channels.computeIfAbsent(address, e -> {
+      List<CompletableFuture<Channel>> defaultList = new ArrayList<>(size);
+      for (int i = 0; i < size; i++) {
+        defaultList.add(null);
+      }
+      return Lists.newCopyOnWriteArrayList(defaultList);
+    });
+  }
+
+  /**
+   * Returns the channel offset for the given message type.
+   *
+   * @param messageType the message type for which to return the channel offset
+   * @return the channel offset for the given message type
+   */
+  private int getChannelOffset(String messageType) {
+    return Math.abs(messageType.hashCode() % size);
+  }
+
+  /**
+   * Gets or creates a pooled channel to the given address for the given message type.
+   *
+   * @param address     the address for which to get the channel
+   * @param messageType the message type for which to get the channel
+   * @return a future to be completed with a channel from the pool
+   */
+  CompletableFuture<Channel> getChannel(Address address, String messageType) {
+    List<CompletableFuture<Channel>> channelPool = getChannelPool(address);
+    int offset = getChannelOffset(messageType);
+
+    CompletableFuture<Channel> channelFuture = channelPool.get(offset);
+    if (channelFuture == null || channelFuture.isCompletedExceptionally()) {
+      synchronized (channelPool) {
+        channelFuture = channelPool.get(offset);
+        if (channelFuture == null || channelFuture.isCompletedExceptionally()) {
+          LOGGER.debug("Connecting to {}", address);
+          channelFuture = factory.apply(address);
+          channelFuture.whenComplete((channel, error) -> {
+            if (error == null) {
+              LOGGER.debug("Connected to {}", channel.remoteAddress());
+            } else {
+              LOGGER.debug("Failed to connect to {}", address, error);
+            }
+          });
+          channelPool.set(offset, channelFuture);
+        }
+      }
+    }
+
+    final CompletableFuture<Channel> future = new CompletableFuture<>();
+    final CompletableFuture<Channel> finalFuture = channelFuture;
+    finalFuture.whenComplete((channel, error) -> {
+      if (error == null) {
+        if (!channel.isActive()) {
+          CompletableFuture<Channel> currentFuture;
+          synchronized (channelPool) {
+            currentFuture = channelPool.get(offset);
+            if (currentFuture == finalFuture) {
+              channelPool.set(offset, null);
+            } else if (currentFuture == null) {
+              currentFuture = factory.apply(address);
+              currentFuture.whenComplete((c, e) -> {
+                if (e == null) {
+                  LOGGER.debug("Connected to {}", channel.remoteAddress());
+                } else {
+                  LOGGER.debug("Failed to connect to {}", channel.remoteAddress(), e);
+                }
+              });
+              channelPool.set(offset, currentFuture);
+            }
+          }
+
+          if (currentFuture == finalFuture) {
+            getChannel(address, messageType).whenComplete((recursiveResult, recursiveError) -> {
+              if (recursiveError == null) {
+                future.complete(recursiveResult);
+              } else {
+                future.completeExceptionally(recursiveError);
+              }
+            });
+          } else {
+            currentFuture.whenComplete((recursiveResult, recursiveError) -> {
+              if (recursiveError == null) {
+                future.complete(recursiveResult);
+              } else {
+                future.completeExceptionally(recursiveError);
+              }
+            });
+          }
+        } else {
+          future.complete(channel);
+        }
+      } else {
+        future.completeExceptionally(error);
+      }
+    });
+    return future;
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/ClientConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/ClientConnection.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Client-side connection interface which handles sending messages.
+ */
+interface ClientConnection extends Connection<ProtocolReply> {
+
+  /**
+   * Sends a message to the other side of the connection.
+   *
+   * @param message the message to send
+   * @return a completable future to be completed once the message has been sent
+   */
+  CompletableFuture<Void> sendAsync(ProtocolRequest message);
+
+  /**
+   * Sends a message to the other side of the connection, awaiting a reply.
+   *
+   * @param message the message to send
+   * @param timeout the response timeout
+   * @return a completable future to be completed once a reply is received or the request times out
+   */
+  CompletableFuture<byte[]> sendAndReceive(ProtocolRequest message, Duration timeout);
+
+  /**
+   * Closes the connection.
+   */
+  default void close() {
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/Connection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/Connection.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+interface Connection<M extends ProtocolMessage> {
+  /**
+   * Dispatches a message received on the connection.
+   *
+   * @param message the message to dispatch
+   */
+  void dispatch(M message);
+
+  /**
+   * Closes the connection.
+   */
+  default void close() {
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/HandlerRegistry.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/HandlerRegistry.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+/**
+ * Messaging handler registry.
+ */
+final class HandlerRegistry {
+  private final Map<String, BiConsumer<ProtocolRequest, ServerConnection>> handlers = new ConcurrentHashMap<>();
+
+  /**
+   * Registers a message type handler.
+   *
+   * @param type    the message type
+   * @param handler the message handler
+   */
+  void register(String type, BiConsumer<ProtocolRequest, ServerConnection> handler) {
+    handlers.put(type, handler);
+  }
+
+  /**
+   * Unregisters a message type handler.
+   *
+   * @param type the message type
+   */
+  void unregister(String type) {
+    handlers.remove(type);
+  }
+
+  /**
+   * Looks up a message type handler.
+   *
+   * @param type the message type
+   * @return the message handler or {@code null} if no handler of the given type is registered
+   */
+  BiConsumer<ProtocolRequest, ServerConnection> get(String type) {
+    return handlers.get(type);
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalClientConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalClientConnection.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Local client-side connection.
+ */
+final class LocalClientConnection extends AbstractClientConnection {
+  private final LocalServerConnection serverConnection;
+
+  LocalClientConnection(ScheduledExecutorService executorService, HandlerRegistry handlers) {
+    super(executorService);
+    this.serverConnection = new LocalServerConnection(handlers, this);
+  }
+
+  @Override
+  public CompletableFuture<Void> sendAsync(ProtocolRequest message) {
+    serverConnection.dispatch(message);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<byte[]> sendAndReceive(ProtocolRequest message, Duration timeout) {
+    CompletableFuture<byte[]> future = new CompletableFuture<>();
+    new Callback(message.id(), message.subject(), timeout, future);
+    serverConnection.dispatch(message);
+    return future;
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    serverConnection.close();
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalServerConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/LocalServerConnection.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import java.util.Optional;
+
+/**
+ * Local server-side connection.
+ */
+final class LocalServerConnection extends AbstractServerConnection {
+  private static final byte[] EMPTY_PAYLOAD = new byte[0];
+
+  private volatile LocalClientConnection clientConnection;
+
+  LocalServerConnection(HandlerRegistry handlers, LocalClientConnection clientConnection) {
+    super(handlers);
+    this.clientConnection = clientConnection;
+  }
+
+  @Override
+  public void reply(ProtocolRequest message, ProtocolReply.Status status, Optional<byte[]> payload) {
+    LocalClientConnection clientConnection = this.clientConnection;
+    if (clientConnection != null) {
+      clientConnection.dispatch(new ProtocolReply(message.id(), payload.orElse(EMPTY_PAYLOAD), status));
+    }
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -698,19 +698,23 @@ public class NettyMessagingService implements ManagedMessagingService {
      * @return the read protocol version
      */
     Optional<ProtocolVersion> readProtocolVersion(ChannelHandlerContext context, ByteBuf buffer) {
-      int preamble = buffer.readInt();
-      if (preamble != NettyMessagingService.this.preamble) {
-        log.warn("Received invalid handshake, closing connection");
-        context.close();
-        return Optional.empty();
-      }
+      try {
+        int preamble = buffer.readInt();
+        if (preamble != NettyMessagingService.this.preamble) {
+          log.warn("Received invalid handshake, closing connection");
+          context.close();
+          return Optional.empty();
+        }
 
-      int version = buffer.readShort();
-      ProtocolVersion protocolVersion = ProtocolVersion.valueOf(version);
-      if (protocolVersion == null) {
-        context.close();
+        int version = buffer.readShort();
+        ProtocolVersion protocolVersion = ProtocolVersion.valueOf(version);
+        if (protocolVersion == null) {
+          context.close();
+        }
+        return Optional.ofNullable(protocolVersion);
+      } finally {
+        buffer.release();
       }
-      return Optional.ofNullable(protocolVersion);
     }
 
     /**

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteClientConnection.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.netty.channel.Channel;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Client-side Netty remote connection.
+ */
+final class RemoteClientConnection extends AbstractClientConnection {
+  private final Channel channel;
+
+  RemoteClientConnection(ScheduledExecutorService executorService, Channel channel) {
+    super(executorService);
+    this.channel = channel;
+  }
+
+  @Override
+  public CompletableFuture<Void> sendAsync(ProtocolRequest message) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    channel.writeAndFlush(message).addListener(channelFuture -> {
+      if (!channelFuture.isSuccess()) {
+        future.completeExceptionally(channelFuture.cause());
+      } else {
+        future.complete(null);
+      }
+    });
+    return future;
+  }
+
+  @Override
+  public CompletableFuture<byte[]> sendAndReceive(ProtocolRequest message, Duration timeout) {
+    CompletableFuture<byte[]> future = new CompletableFuture<>();
+    Callback callback = new Callback(message.id(), message.subject(), timeout, future);
+    channel.writeAndFlush(message).addListener(channelFuture -> {
+      if (!channelFuture.isSuccess()) {
+        callback.completeExceptionally(channelFuture.cause());
+      }
+    });
+    return future;
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteServerConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/RemoteServerConnection.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.netty.channel.Channel;
+
+import java.util.Optional;
+
+/**
+ * Remote server connection manages messaging on the server side of a Netty connection.
+ */
+final class RemoteServerConnection extends AbstractServerConnection {
+  private static final byte[] EMPTY_PAYLOAD = new byte[0];
+
+  private final Channel channel;
+
+  RemoteServerConnection(HandlerRegistry handlers, Channel channel) {
+    super(handlers);
+    this.channel = channel;
+  }
+
+  @Override
+  public void reply(ProtocolRequest message, ProtocolReply.Status status, Optional<byte[]> payload) {
+    ProtocolReply response = new ProtocolReply(
+        message.id(),
+        payload.orElse(EMPTY_PAYLOAD),
+        status);
+    channel.writeAndFlush(response, channel.voidPromise());
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/ServerConnection.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/ServerConnection.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import java.util.Optional;
+
+/**
+ * Server-side connection interface which handles replying to messages.
+ */
+interface ServerConnection extends Connection<ProtocolRequest> {
+
+  /**
+   * Sends a reply to the other side of the connection.
+   *
+   * @param message the message to which to reply
+   * @param status  the reply status
+   * @param payload the response payload
+   */
+  void reply(ProtocolRequest message, ProtocolReply.Status status, Optional<byte[]> payload);
+
+  /**
+   * Closes the connection.
+   */
+  default void close() {
+  }
+}

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -389,10 +389,10 @@ public class SwimMembershipProtocol
           if (error == null) {
             updateState(SERIALIZER.decode(response));
           } else {
+            LOGGER.debug("{} - Failed to probe {}", this.localMember.id(), member, error);
             // Verify that the local member term has not changed and request probes from peers.
             SwimMember swimMember = members.get(member.id());
             if (swimMember != null && swimMember.getIncarnationNumber() == member.incarnationNumber()) {
-              LOGGER.debug("{} - Failed to probe {}", this.localMember.id(), member);
               requestProbes(swimMember.copy());
             }
           }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -97,9 +97,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -1166,7 +1164,8 @@ public class RaftTest extends ConcurrentTestCase {
       resume();
     });
     primitive2.read().whenComplete((result, error) -> {
-      threadAssertTrue(error.getCause() instanceof PrimitiveException.UnknownService);
+      threadAssertTrue(error.getCause() instanceof PrimitiveException.ClosedSession
+          || error.getCause() instanceof PrimitiveException.UnknownService);
       resume();
     });
     await(5000, 2);


### PR DESCRIPTION
This PR refactors the `NettyMessagingService` to clean up the implementation and reduce the overhead of dynamic timeouts. 

* Many of the classes that were previously internal to the `NettyMessagingService` are now moved to package private classes since the class was getting a bit unwieldy
* The channel pool is moved to a separate `ChannelPool` class
* Local and remote client and server connections share a base interface and class through which they share a lot of logic
* Compute dynamic message timeouts before request to allow timeout scheduling at the start of the request. This reduces the currently significant overhead from constantly recomputing timeouts while messages are in flight.
* Use `ScheduledExecutorService` directly for static and dynamic message timeouts
* Use a simple max-based algorithm for computing dynamic timeouts