### PR TITLE
Make Netty connection pool size configurable

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -150,6 +150,22 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   }
 
   /**
+   * Sets the messaging connection pool size.
+   * <p>
+   * The node will create {@code connectionPoolSize} connections to each peer with which it regularly communicates
+   * over TCP. Periodic heartbeats from cluster membership protocols will not consume pool connections. Thus, if
+   * a node does not communicate with one of its peers for replication or application communication, the pool for
+   * that peer should remain empty.
+   *
+   * @param connectionPoolSize the connection pool size
+   * @return the cluster builder
+   */
+  public AtomixClusterBuilder withConnectionPoolSize(int connectionPoolSize) {
+    config.getMessagingConfig().setConnectionPoolSize(connectionPoolSize);
+    return this;
+  }
+
+  /**
    * Sets the member address.
    * <p>
    * The constructed {@link AtomixCluster} will bind to the given address for intra-cluster communication. The format

--- a/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -27,6 +27,7 @@ import java.util.List;
 public class MessagingConfig implements Config {
   private List<String> interfaces = new ArrayList<>();
   private Integer port;
+  private int connectionPoolSize = 8;
   private Duration connectTimeout = Duration.ofSeconds(10);
   private TlsConfig tlsConfig = new TlsConfig();
 
@@ -67,6 +68,26 @@ public class MessagingConfig implements Config {
    */
   public MessagingConfig setPort(Integer port) {
     this.port = port;
+    return this;
+  }
+
+  /**
+   * Returns the connection pool size.
+   *
+   * @return the connection pool size
+   */
+  public int getConnectionPoolSize() {
+    return connectionPoolSize;
+  }
+
+  /**
+   * Sets the connection pool size.
+   *
+   * @param connectionPoolSize the connection pool size
+   * @return the messaging configuration
+   */
+  public MessagingConfig setConnectionPoolSize(int connectionPoolSize) {
+    this.connectionPoolSize = connectionPoolSize;
     return this;
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -102,8 +102,7 @@ public class NettyMessagingService implements ManagedMessagingService {
   private volatile LocalClientConnection localConnection;
   private final Map<Channel, RemoteClientConnection> connections = Maps.newConcurrentMap();
   private final AtomicLong messageIdGenerator = new AtomicLong(0);
-
-  private final ChannelPool channelPool = new ChannelPool(this::openChannel, CHANNEL_POOL_SIZE);
+  private final ChannelPool channelPool;
 
   private EventLoopGroup serverGroup;
   private EventLoopGroup clientGroup;
@@ -121,6 +120,7 @@ public class NettyMessagingService implements ManagedMessagingService {
     this.preamble = cluster.hashCode();
     this.returnAddress = address;
     this.config = config;
+    this.channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
   }
 
   @Override

--- a/dist/src/main/resources/examples/reference.conf
+++ b/dist/src/main/resources/examples/reference.conf
@@ -176,6 +176,11 @@ cluster {
     # The bind port indicates the port to which to bind the node.
     port: null
 
+    # The number of connections per peer. Persistent connections will typically only be created for connections
+    # between a client and server node primitive client and all nodes in the primitive's partition group). Nodes
+    # that do not communicate with each other directly will not maintain persistent connections to one another.
+    connectionPoolSize: 8
+
     # The timeout for TCP connection attempts to other nodes.
     # The format allows the interval to be specified in ms, s, m, h, d, etc.
     connectTimeout: 10s


### PR DESCRIPTION
This PR makes the number of connections per peer configurable via the `cluster.messaging.connectionPoolSize` configuration option