### PR TITLE
Separate host and port from Address object in config and APIs

### DIFF
--- a/agent/src/main/java/io/atomix/agent/AtomixAgent.java
+++ b/agent/src/main/java/io/atomix/agent/AtomixAgent.java
@@ -322,13 +322,13 @@ public class AtomixAgent {
     }
 
     if (host != null) {
-      config.getClusterConfig().getNodeConfig().setHost(host);
+      config.getClusterConfig().getNodeConfig().setHostId(host);
     }
     if (rack != null) {
-      config.getClusterConfig().getNodeConfig().setRack(rack);
+      config.getClusterConfig().getNodeConfig().setRackId(rack);
     }
     if (zone != null) {
-      config.getClusterConfig().getNodeConfig().setZone(zone);
+      config.getClusterConfig().getNodeConfig().setZoneId(zone);
     }
 
     if (bootstrap != null && !bootstrap.isEmpty()) {

--- a/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
+++ b/agent/src/test/java/io/atomix/agent/AtomixAgentTest.java
@@ -108,13 +108,15 @@ public class AtomixAgentTest {
 
     Atomix client1 = Atomix.builder(path)
         .withMemberId("client1")
-        .withAddress("localhost:5003")
+        .withHost("localhost")
+        .withPort(5003)
         .build();
     client1.start().join();
 
     Atomix client2 = Atomix.builder(path)
         .withMemberId("client2")
-        .withAddress("localhost:5004")
+        .withHost("localhost")
+        .withPort(5004)
         .build();
     client2.start().join();
 

--- a/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -432,9 +432,9 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
     Member localMember = Member.builder()
         .withId(config.getNodeConfig().getId())
         .withAddress(config.getNodeConfig().getAddress())
-        .withHost(config.getNodeConfig().getHost())
-        .withRack(config.getNodeConfig().getRack())
-        .withZone(config.getNodeConfig().getZone())
+        .withHostId(config.getNodeConfig().getHostId())
+        .withRackId(config.getNodeConfig().getRackId())
+        .withZoneId(config.getNodeConfig().getZoneId())
         .withProperties(config.getNodeConfig().getProperties())
         .build();
     return new DefaultClusterMembershipService(

--- a/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -138,6 +138,7 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * @param address a host:port tuple
    * @return the cluster builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withHost(String)} and/or {@link #withPort(int)} instead
    */
   @Deprecated
   public AtomixClusterBuilder withAddress(String address) {
@@ -154,6 +155,7 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * @param port the port number
    * @return the cluster builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withHost(String)} and {@link #withPort(int)} instead
    */
   @Deprecated
   public AtomixClusterBuilder withAddress(String host, int port) {
@@ -168,6 +170,7 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    * @param port the port number
    * @return the cluster builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withPort(int)} instead
    */
   @Deprecated
   public AtomixClusterBuilder withAddress(int port) {
@@ -210,6 +213,7 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    *
    * @param zone the zone to which the member belongs
    * @return the cluster builder
+   * @deprecated since 3.1. Use {@link #withZoneId(String)} instead
    */
   @Deprecated
   public AtomixClusterBuilder withZone(String zone) {
@@ -239,6 +243,7 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    *
    * @param rack the rack to which the member belongs
    * @return the cluster builder
+   * @deprecated since 3.1. Use {@link #withRackId(String)} instead
    */
   @Deprecated
   public AtomixClusterBuilder withRack(String rack) {

--- a/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/AtomixClusterBuilder.java
@@ -18,9 +18,9 @@ package io.atomix.cluster;
 import com.google.common.collect.Lists;
 import io.atomix.cluster.discovery.NodeDiscoveryProvider;
 import io.atomix.cluster.protocol.GroupMembershipProtocol;
+import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
 import io.atomix.cluster.protocol.HeartbeatMembershipProtocol;
 import io.atomix.cluster.protocol.HeartbeatMembershipProtocolConfig;
-import io.atomix.cluster.protocol.GroupMembershipProtocolConfig;
 import io.atomix.utils.Builder;
 import io.atomix.utils.net.Address;
 
@@ -108,6 +108,191 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
   }
 
   /**
+   * Sets the member host.
+   *
+   * @param host the member host
+   * @return the cluster builder
+   */
+  public AtomixClusterBuilder withHost(String host) {
+    config.getNodeConfig().setHost(host);
+    return this;
+  }
+
+  /**
+   * Sets the member port.
+   *
+   * @param port the member port
+   * @return the cluster builder
+   */
+  public AtomixClusterBuilder withPort(int port) {
+    config.getNodeConfig().setPort(port);
+    return this;
+  }
+
+  /**
+   * Sets the member address.
+   * <p>
+   * The constructed {@link AtomixCluster} will bind to the given address for intra-cluster communication. The format
+   * of the address can be {@code host:port} or just {@code host}.
+   *
+   * @param address a host:port tuple
+   * @return the cluster builder
+   * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   */
+  @Deprecated
+  public AtomixClusterBuilder withAddress(String address) {
+    return withAddress(Address.from(address));
+  }
+
+  /**
+   * Sets the member host/port.
+   * <p>
+   * The constructed {@link AtomixCluster} will bind to the given host/port for intra-cluster communication. The
+   * provided host should be visible to other nodes in the cluster.
+   *
+   * @param host the host name
+   * @param port the port number
+   * @return the cluster builder
+   * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   */
+  @Deprecated
+  public AtomixClusterBuilder withAddress(String host, int port) {
+    return withAddress(Address.from(host, port));
+  }
+
+  /**
+   * Sets the member address using local host.
+   * <p>
+   * The constructed {@link AtomixCluster} will bind to the given port for intra-cluster communication.
+   *
+   * @param port the port number
+   * @return the cluster builder
+   * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   */
+  @Deprecated
+  public AtomixClusterBuilder withAddress(int port) {
+    return withAddress(Address.from(port));
+  }
+
+  /**
+   * Sets the member address.
+   * <p>
+   * The constructed {@link AtomixCluster} will bind to the given address for intra-cluster communication. The
+   * provided address should be visible to other nodes in the cluster.
+   *
+   * @param address the member address
+   * @return the cluster builder
+   */
+  public AtomixClusterBuilder withAddress(Address address) {
+    config.getNodeConfig().setAddress(address);
+    return this;
+  }
+
+  /**
+   * Sets the zone to which the member belongs.
+   * <p>
+   * The zone attribute can be used to enable zone-awareness in replication for certain primitive protocols. It is an
+   * arbitrary string that should be used to group multiple nodes together by their physical location.
+   *
+   * @param zoneId the zone to which the member belongs
+   * @return the cluster builder
+   */
+  public AtomixClusterBuilder withZoneId(String zoneId) {
+    config.getNodeConfig().setZoneId(zoneId);
+    return this;
+  }
+
+  /**
+   * Sets the zone to which the member belongs.
+   * <p>
+   * The zone attribute can be used to enable zone-awareness in replication for certain primitive protocols. It is an
+   * arbitrary string that should be used to group multiple nodes together by their physical location.
+   *
+   * @param zone the zone to which the member belongs
+   * @return the cluster builder
+   */
+  @Deprecated
+  public AtomixClusterBuilder withZone(String zone) {
+    config.getNodeConfig().setZoneId(zone);
+    return this;
+  }
+
+  /**
+   * Sets the rack to which the member belongs.
+   * <p>
+   * The rack attribute can be used to enable rack-awareness in replication for certain primitive protocols. It is an
+   * arbitrary string that should be used to group multiple nodes together by their physical location.
+   *
+   * @param rackId the rack to which the member belongs
+   * @return the cluster builder
+   */
+  public AtomixClusterBuilder withRackId(String rackId) {
+    config.getNodeConfig().setRackId(rackId);
+    return this;
+  }
+
+  /**
+   * Sets the rack to which the member belongs.
+   * <p>
+   * The rack attribute can be used to enable rack-awareness in replication for certain primitive protocols. It is an
+   * arbitrary string that should be used to group multiple nodes together by their physical location.
+   *
+   * @param rack the rack to which the member belongs
+   * @return the cluster builder
+   */
+  @Deprecated
+  public AtomixClusterBuilder withRack(String rack) {
+    config.getNodeConfig().setRackId(rack);
+    return this;
+  }
+
+  /**
+   * Sets the host to which the member belongs.
+   * <p>
+   * The host attribute can be used to enable host-awareness in replication for certain primitive protocols. It is an
+   * arbitrary string that should be used to group multiple nodes together by their physical location. Typically this
+   * attribute only applies to containerized clusters.
+   *
+   * @param hostId the host to which the member belongs
+   * @return the cluster builder
+   */
+  public AtomixClusterBuilder withHostId(String hostId) {
+    config.getNodeConfig().setHostId(hostId);
+    return this;
+  }
+
+  /**
+   * Sets the member properties.
+   * <p>
+   * The properties are arbitrary settings that will be replicated along with this node's member information. Properties
+   * can be used to enable other nodes to determine metadata about this node.
+   *
+   * @param properties the member properties
+   * @return the cluster builder
+   * @throws NullPointerException if the properties are null
+   */
+  public AtomixClusterBuilder withProperties(Properties properties) {
+    config.getNodeConfig().setProperties(properties);
+    return this;
+  }
+
+  /**
+   * Sets a property of the member.
+   * <p>
+   * The properties are arbitrary settings that will be replicated along with this node's member information. Properties
+   * can be used to enable other nodes to determine metadata about this node.
+   *
+   * @param key   the property key to set
+   * @param value the property value to set
+   * @return the cluster builder
+   * @throws NullPointerException if the property is null
+   */
+  public AtomixClusterBuilder withProperty(String key, String value) {
+    config.getNodeConfig().setProperty(key, value);
+    return this;
+  }
+
+  /**
    * Sets the interface to which to bind the instance.
    *
    * @param iface the interface to which to bind the instance
@@ -162,136 +347,6 @@ public class AtomixClusterBuilder implements Builder<AtomixCluster> {
    */
   public AtomixClusterBuilder withConnectionPoolSize(int connectionPoolSize) {
     config.getMessagingConfig().setConnectionPoolSize(connectionPoolSize);
-    return this;
-  }
-
-  /**
-   * Sets the member address.
-   * <p>
-   * The constructed {@link AtomixCluster} will bind to the given address for intra-cluster communication. The format
-   * of the address can be {@code host:port} or just {@code host}.
-   *
-   * @param address a host:port tuple
-   * @return the cluster builder
-   * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
-   */
-  public AtomixClusterBuilder withAddress(String address) {
-    return withAddress(Address.from(address));
-  }
-
-  /**
-   * Sets the member host/port.
-   * <p>
-   * The constructed {@link AtomixCluster} will bind to the given host/port for intra-cluster communication. The
-   * provided host should be visible to other nodes in the cluster.
-   *
-   * @param host the host name
-   * @param port the port number
-   * @return the cluster builder
-   * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
-   */
-  public AtomixClusterBuilder withAddress(String host, int port) {
-    return withAddress(Address.from(host, port));
-  }
-
-  /**
-   * Sets the member address using local host.
-   * <p>
-   * The constructed {@link AtomixCluster} will bind to the given port for intra-cluster communication.
-   *
-   * @param port the port number
-   * @return the cluster builder
-   * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
-   */
-  public AtomixClusterBuilder withAddress(int port) {
-    return withAddress(Address.from(port));
-  }
-
-  /**
-   * Sets the member address.
-   * <p>
-   * The constructed {@link AtomixCluster} will bind to the given address for intra-cluster communication. The
-   * provided address should be visible to other nodes in the cluster.
-   *
-   * @param address the member address
-   * @return the cluster builder
-   */
-  public AtomixClusterBuilder withAddress(Address address) {
-    config.getNodeConfig().setAddress(address);
-    return this;
-  }
-
-  /**
-   * Sets the zone to which the member belongs.
-   * <p>
-   * The zone attribute can be used to enable zone-awareness in replication for certain primitive protocols. It is an
-   * arbitrary string that should be used to group multiple nodes together by their physical location.
-   *
-   * @param zone the zone to which the member belongs
-   * @return the cluster builder
-   */
-  public AtomixClusterBuilder withZone(String zone) {
-    config.getNodeConfig().setZone(zone);
-    return this;
-  }
-
-  /**
-   * Sets the rack to which the member belongs.
-   * <p>
-   * The rack attribute can be used to enable rack-awareness in replication for certain primitive protocols. It is an
-   * arbitrary string that should be used to group multiple nodes together by their physical location.
-   *
-   * @param rack the rack to which the member belongs
-   * @return the cluster builder
-   */
-  public AtomixClusterBuilder withRack(String rack) {
-    config.getNodeConfig().setRack(rack);
-    return this;
-  }
-
-  /**
-   * Sets the host to which the member belongs.
-   * <p>
-   * The host attribute can be used to enable host-awareness in replication for certain primitive protocols. It is an
-   * arbitrary string that should be used to group multiple nodes together by their physical location. Typically this
-   * attribute only applies to containerized clusters.
-   *
-   * @param host the host to which the member belongs
-   * @return the cluster builder
-   */
-  public AtomixClusterBuilder withHost(String host) {
-    config.getNodeConfig().setHost(host);
-    return this;
-  }
-
-  /**
-   * Sets the member properties.
-   * <p>
-   * The properties are arbitrary settings that will be replicated along with this node's member information. Properties
-   * can be used to enable other nodes to determine metadata about this node.
-   *
-   * @param properties the member properties
-   * @return the cluster builder
-   * @throws NullPointerException if the properties are null
-   */
-  public AtomixClusterBuilder withProperties(Properties properties) {
-    config.getNodeConfig().setProperties(properties);
-    return this;
-  }
-
-  /**
-   * Sets a property of the member.
-   * <p>
-   * The properties are arbitrary settings that will be replicated along with this node's member information. Properties
-   * can be used to enable other nodes to determine metadata about this node.
-   *
-   * @param key   the property key to set
-   * @param value the property value to set
-   * @return the cluster builder
-   * @throws NullPointerException if the property is null
-   */
-  public AtomixClusterBuilder withProperty(String key, String value) {
-    config.getNodeConfig().setProperty(key, value);
     return this;
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -115,9 +115,9 @@ public class Member extends Node {
   public Member(MemberConfig config) {
     super(config);
     this.id = config.getId();
-    this.zone = config.getZone();
-    this.rack = config.getRack();
-    this.host = config.getHost();
+    this.zone = config.getZoneId();
+    this.rack = config.getRackId();
+    this.host = config.getHostId();
     this.properties = new Properties();
     properties.putAll(config.getProperties());
   }
@@ -217,9 +217,9 @@ public class Member extends Node {
     return new MemberConfig()
         .setId(id())
         .setAddress(address())
-        .setZone(zone())
-        .setRack(rack())
-        .setHost(host())
+        .setZoneId(zone())
+        .setRackId(rack())
+        .setHostId(host())
         .setProperties(properties());
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/MemberBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/MemberBuilder.java
@@ -53,6 +53,18 @@ public class MemberBuilder extends NodeBuilder {
     return this;
   }
 
+  @Override
+  public MemberBuilder withHost(String host) {
+    super.withHost(host);
+    return this;
+  }
+
+  @Override
+  public MemberBuilder withPort(int port) {
+    super.withPort(port);
+    return this;
+  }
+
   /**
    * Sets the member address.
    *
@@ -60,6 +72,7 @@ public class MemberBuilder extends NodeBuilder {
    * @return the member builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
    */
+  @Deprecated
   public MemberBuilder withAddress(String address) {
     return withAddress(Address.from(address));
   }
@@ -72,6 +85,7 @@ public class MemberBuilder extends NodeBuilder {
    * @return the member builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
    */
+  @Deprecated
   public MemberBuilder withAddress(String host, int port) {
     return withAddress(Address.from(host, port));
   }
@@ -83,6 +97,7 @@ public class MemberBuilder extends NodeBuilder {
    * @return the member builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
    */
+  @Deprecated
   public MemberBuilder withAddress(int port) {
     return withAddress(Address.from(port));
   }
@@ -101,11 +116,23 @@ public class MemberBuilder extends NodeBuilder {
   /**
    * Sets the zone to which the member belongs.
    *
+   * @param zoneId the zone to which the member belongs
+   * @return the member builder
+   */
+  public MemberBuilder withZoneId(String zoneId) {
+    config.setZoneId(zoneId);
+    return this;
+  }
+
+  /**
+   * Sets the zone to which the member belongs.
+   *
    * @param zone the zone to which the member belongs
    * @return the member builder
    */
+  @Deprecated
   public MemberBuilder withZone(String zone) {
-    config.setZone(zone);
+    config.setZoneId(zone);
     return this;
   }
 
@@ -115,19 +142,31 @@ public class MemberBuilder extends NodeBuilder {
    * @param rack the rack to which the member belongs
    * @return the member builder
    */
+  public MemberBuilder withRackId(String rack) {
+    config.setRackId(rack);
+    return this;
+  }
+
+  /**
+   * Sets the rack to which the member belongs.
+   *
+   * @param rack the rack to which the member belongs
+   * @return the member builder
+   */
+  @Deprecated
   public MemberBuilder withRack(String rack) {
-    config.setRack(rack);
+    config.setRackId(rack);
     return this;
   }
 
   /**
    * Sets the host to which the member belongs.
    *
-   * @param host the host to which the member belongs
+   * @param hostId the host to which the member belongs
    * @return the member builder
    */
-  public MemberBuilder withHost(String host) {
-    config.setHost(host);
+  public MemberBuilder withHostId(String hostId) {
+    config.setHostId(hostId);
     return this;
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/MemberBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/MemberBuilder.java
@@ -71,6 +71,7 @@ public class MemberBuilder extends NodeBuilder {
    * @param address a host:port tuple
    * @return the member builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withHost(String)} and/or {@link #withPort(int)} instead
    */
   @Deprecated
   public MemberBuilder withAddress(String address) {
@@ -84,6 +85,7 @@ public class MemberBuilder extends NodeBuilder {
    * @param port the port number
    * @return the member builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withHost(String)} and {@link #withPort(int)} instead
    */
   @Deprecated
   public MemberBuilder withAddress(String host, int port) {
@@ -96,6 +98,7 @@ public class MemberBuilder extends NodeBuilder {
    * @param port the port number
    * @return the member builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withPort(int)} instead
    */
   @Deprecated
   public MemberBuilder withAddress(int port) {
@@ -129,6 +132,7 @@ public class MemberBuilder extends NodeBuilder {
    *
    * @param zone the zone to which the member belongs
    * @return the member builder
+   * @deprecated since 3.1. Use {@link #withZoneId(String)} instead
    */
   @Deprecated
   public MemberBuilder withZone(String zone) {
@@ -152,6 +156,7 @@ public class MemberBuilder extends NodeBuilder {
    *
    * @param rack the rack to which the member belongs
    * @return the member builder
+   * @deprecated since 3.1. Use {@link #withRackId(String)} instead
    */
   @Deprecated
   public MemberBuilder withRack(String rack) {

--- a/cluster/src/main/java/io/atomix/cluster/MemberConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/MemberConfig.java
@@ -25,9 +25,9 @@ import java.util.Properties;
  */
 public class MemberConfig extends NodeConfig {
   private MemberId id = MemberId.anonymous();
-  private String zone;
-  private String rack;
-  private String host;
+  private String zoneId;
+  private String rackId;
+  private String hostId;
   private Properties properties = new Properties();
 
   /**
@@ -65,32 +65,19 @@ public class MemberConfig extends NodeConfig {
     return this;
   }
 
-  /**
-   * Returns the member address.
-   *
-   * @return the member address
-   */
-  public Address getAddress() {
-    return super.getAddress();
+  @Override
+  public MemberConfig setPort(int port) {
+    super.setPort(port);
+    return this;
   }
 
-  /**
-   * Sets the member address.
-   *
-   * @param address the member address
-   * @return the member configuration
-   */
+  @Override
   public MemberConfig setAddress(String address) {
     super.setAddress(address);
     return this;
   }
 
-  /**
-   * Sets the member address.
-   *
-   * @param address the member address
-   * @return the member configuration
-   */
+  @Override
   public MemberConfig setAddress(Address address) {
     super.setAddress(address);
     return this;
@@ -101,8 +88,19 @@ public class MemberConfig extends NodeConfig {
    *
    * @return the member zone
    */
-  public String getZone() {
-    return zone;
+  public String getZoneId() {
+    return zoneId;
+  }
+
+  /**
+   * Sets the member zone.
+   *
+   * @param zoneId the member zone
+   * @return the member configuration
+   */
+  public MemberConfig setZoneId(String zoneId) {
+    this.zoneId = zoneId;
+    return this;
   }
 
   /**
@@ -112,8 +110,7 @@ public class MemberConfig extends NodeConfig {
    * @return the member configuration
    */
   public MemberConfig setZone(String zone) {
-    this.zone = zone;
-    return this;
+    return setZoneId(zone);
   }
 
   /**
@@ -121,8 +118,19 @@ public class MemberConfig extends NodeConfig {
    *
    * @return the member rack
    */
-  public String getRack() {
-    return rack;
+  public String getRackId() {
+    return rackId;
+  }
+
+  /**
+   * Sets the member rack.
+   *
+   * @param rackId the member rack
+   * @return the member configuration
+   */
+  public MemberConfig setRackId(String rackId) {
+    this.rackId = rackId;
+    return this;
   }
 
   /**
@@ -132,8 +140,7 @@ public class MemberConfig extends NodeConfig {
    * @return the member configuration
    */
   public MemberConfig setRack(String rack) {
-    this.rack = rack;
-    return this;
+    return setRackId(rack);
   }
 
   /**
@@ -141,18 +148,25 @@ public class MemberConfig extends NodeConfig {
    *
    * @return the member host
    */
-  public String getHost() {
-    return host;
+  public String getHostId() {
+    return hostId;
   }
 
   /**
    * Sets the member host.
    *
-   * @param host the member host
+   * @param hostId the member host
    * @return the member configuration
    */
+  public MemberConfig setHostId(String hostId) {
+    this.hostId = hostId;
+    return this;
+  }
+
+  @Override
   public MemberConfig setHost(String host) {
-    this.host = host;
+    super.setHost(host);
+    setHostId(host);
     return this;
   }
 

--- a/cluster/src/main/java/io/atomix/cluster/NodeBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/NodeBuilder.java
@@ -78,6 +78,7 @@ public class NodeBuilder implements Builder<Node> {
    * @param address a host:port tuple
    * @return the node builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withHost(String)} and/or {@link #withPort(int)} instead
    */
   @Deprecated
   public NodeBuilder withAddress(String address) {
@@ -91,6 +92,7 @@ public class NodeBuilder implements Builder<Node> {
    * @param port the port number
    * @return the node builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withHost(String)} and {@link #withPort(int)} instead
    */
   @Deprecated
   public NodeBuilder withAddress(String host, int port) {
@@ -103,6 +105,7 @@ public class NodeBuilder implements Builder<Node> {
    * @param port the port number
    * @return the node builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
+   * @deprecated since 3.1. Use {@link #withPort(int)} instead
    */
   @Deprecated
   public NodeBuilder withAddress(int port) {

--- a/cluster/src/main/java/io/atomix/cluster/NodeBuilder.java
+++ b/cluster/src/main/java/io/atomix/cluster/NodeBuilder.java
@@ -51,12 +51,35 @@ public class NodeBuilder implements Builder<Node> {
   }
 
   /**
+   * Sets the node host.
+   *
+   * @param host the node host
+   * @return the node builder
+   */
+  public NodeBuilder withHost(String host) {
+    config.setHost(host);
+    return this;
+  }
+
+  /**
+   * Sets the node port.
+   *
+   * @param port the node port
+   * @return the node builder
+   */
+  public NodeBuilder withPort(int port) {
+    config.setPort(port);
+    return this;
+  }
+
+  /**
    * Sets the node address.
    *
    * @param address a host:port tuple
    * @return the node builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
    */
+  @Deprecated
   public NodeBuilder withAddress(String address) {
     return withAddress(Address.from(address));
   }
@@ -69,6 +92,7 @@ public class NodeBuilder implements Builder<Node> {
    * @return the node builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
    */
+  @Deprecated
   public NodeBuilder withAddress(String host, int port) {
     return withAddress(Address.from(host, port));
   }
@@ -80,6 +104,7 @@ public class NodeBuilder implements Builder<Node> {
    * @return the node builder
    * @throws io.atomix.utils.net.MalformedAddressException if a valid {@link Address} cannot be constructed from the arguments
    */
+  @Deprecated
   public NodeBuilder withAddress(int port) {
     return withAddress(Address.from(port));
   }

--- a/cluster/src/main/java/io/atomix/cluster/NodeConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/NodeConfig.java
@@ -23,7 +23,8 @@ import io.atomix.utils.net.Address;
  */
 public class NodeConfig implements Config {
   private NodeId id = NodeId.anonymous();
-  private Address address;
+  private String host = "localhost";
+  private int port = 5679;
 
   /**
    * Returns the node identifier.
@@ -56,12 +57,52 @@ public class NodeConfig implements Config {
   }
 
   /**
+   * Returns the node hostname.
+   *
+   * @return the node hostname
+   */
+  public String getHost() {
+    return host;
+  }
+
+  /**
+   * Sets the node hostname.
+   *
+   * @param host the node hostname
+   * @return the node configuration
+   */
+  public NodeConfig setHost(String host) {
+    this.host = host;
+    return this;
+  }
+
+  /**
+   * Returns the node port.
+   *
+   * @return the node port
+   */
+  public int getPort() {
+    return port;
+  }
+
+  /**
+   * Sets the node port.
+   *
+   * @param port the node port
+   * @return the node configuration
+   */
+  public NodeConfig setPort(int port) {
+    this.port = port;
+    return this;
+  }
+
+  /**
    * Returns the node address.
    *
    * @return the node address
    */
   public Address getAddress() {
-    return address;
+    return Address.from(host, port);
   }
 
   /**
@@ -70,6 +111,7 @@ public class NodeConfig implements Config {
    * @param address the node address
    * @return the node configuration
    */
+  @Deprecated
   public NodeConfig setAddress(String address) {
     return setAddress(Address.from(address));
   }
@@ -80,8 +122,10 @@ public class NodeConfig implements Config {
    * @param address the node address
    * @return the node configuration
    */
+  @Deprecated
   public NodeConfig setAddress(Address address) {
-    this.address = address;
+    this.host = address.host();
+    this.port = address.port();
     return this;
   }
 }

--- a/cluster/src/main/java/io/atomix/cluster/discovery/DnsDiscoveryProvider.java
+++ b/cluster/src/main/java/io/atomix/cluster/discovery/DnsDiscoveryProvider.java
@@ -135,7 +135,8 @@ public class DnsDiscoveryProvider
 
         Node node = Node.builder()
             .withId(id)
-            .withAddress(host, Integer.parseInt(port))
+            .withHost(host)
+            .withPort(Integer.parseInt(port))
             .build();
 
         if (nodes.putIfAbsent(node.id(), node) == null) {

--- a/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/AtomixClusterTest.java
@@ -46,7 +46,8 @@ public class AtomixClusterTest {
 
     AtomixCluster cluster1 = AtomixCluster.builder()
         .withMemberId("foo")
-        .withAddress("localhost:5000")
+        .withHost("localhost")
+        .withPort(5000)
         .withMembershipProvider(BootstrapDiscoveryProvider.builder()
             .withNodes(bootstrapLocations)
             .build())
@@ -57,7 +58,8 @@ public class AtomixClusterTest {
 
     AtomixCluster cluster2 = AtomixCluster.builder()
         .withMemberId("bar")
-        .withAddress("localhost:5001")
+        .withHost("localhost")
+        .withPort(5001)
         .withMembershipProvider(BootstrapDiscoveryProvider.builder()
             .withNodes(bootstrapLocations)
             .build())
@@ -68,7 +70,8 @@ public class AtomixClusterTest {
 
     AtomixCluster cluster3 = AtomixCluster.builder()
         .withMemberId("baz")
-        .withAddress("localhost:5002")
+        .withHost("localhost")
+        .withPort(5002)
         .withMembershipProvider(BootstrapDiscoveryProvider.builder()
             .withNodes(bootstrapLocations)
             .build())
@@ -89,17 +92,20 @@ public class AtomixClusterTest {
   @Test
   public void testDiscovery() throws Exception {
     AtomixCluster cluster1 = AtomixCluster.builder()
-        .withAddress("localhost:5000")
+        .withHost("localhost")
+        .withPort(5000)
         .withMulticastEnabled()
         .withMembershipProvider(new MulticastDiscoveryProvider())
         .build();
     AtomixCluster cluster2 = AtomixCluster.builder()
-        .withAddress("localhost:5001")
+        .withHost("localhost")
+        .withPort(5001)
         .withMulticastEnabled()
         .withMembershipProvider(new MulticastDiscoveryProvider())
         .build();
     AtomixCluster cluster3 = AtomixCluster.builder()
-        .withAddress("localhost:5002")
+        .withHost("localhost")
+        .withPort(5002)
         .withMulticastEnabled()
         .withMembershipProvider(new MulticastDiscoveryProvider())
         .build();

--- a/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/impl/DefaultClusterMembershipServiceTest.java
@@ -42,10 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Default cluster service test.
@@ -54,7 +51,8 @@ public class DefaultClusterMembershipServiceTest {
 
   private Member buildMember(int memberId) {
     return Member.builder(String.valueOf(memberId))
-        .withAddress("localhost", memberId)
+        .withHost("localhost")
+        .withPort(memberId)
         .build();
   }
 

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/DefaultClusterEventServiceTest.java
@@ -54,7 +54,8 @@ public class DefaultClusterEventServiceTest {
 
   private Member buildNode(int memberId) {
     return Member.builder(String.valueOf(memberId))
-        .withAddress("localhost", memberId)
+        .withHost("localhost")
+        .withPort(memberId)
         .build();
   }
 

--- a/core/src/main/java/io/atomix/core/Atomix.java
+++ b/core/src/main/java/io/atomix/core/Atomix.java
@@ -121,7 +121,7 @@ import static com.google.common.base.Preconditions.checkState;
  *   {@code
  *   Atomix atomix = Atomix.builder()
  *     .withMemberId("member-1")
- *     .withAddress("localhost:5000")
+ *     .withHost("192.168.10.2")
  *     .build();
  *   }
  * </pre>
@@ -141,7 +141,7 @@ import static com.google.common.base.Preconditions.checkState;
  * create and configure primitives in code:
  * <pre>
  *   {@code
- *   AtomicMap<String, String> map = atomix.mapBuilder("my-map")
+ *   DistributedMap<String, String> map = atomix.mapBuilder("my-map")
  *     .withProtocol(MultiRaftProtocol.builder("raft")
  *       .withReadConsistency(ReadConsistency.SEQUENTIAL)
  *       .build())

--- a/core/src/main/java/io/atomix/core/AtomixBuilder.java
+++ b/core/src/main/java/io/atomix/core/AtomixBuilder.java
@@ -311,6 +311,89 @@ public class AtomixBuilder extends AtomixClusterBuilder {
   }
 
   @Override
+  public AtomixBuilder withHost(String host) {
+    super.withHost(host);
+    return this;
+  }
+
+  @Override
+  public AtomixBuilder withPort(int port) {
+    super.withPort(port);
+    return this;
+  }
+
+  @Override
+  @Deprecated
+  public AtomixBuilder withAddress(String address) {
+    super.withAddress(address);
+    return this;
+  }
+
+  @Override
+  @Deprecated
+  public AtomixBuilder withAddress(String host, int port) {
+    super.withAddress(host, port);
+    return this;
+  }
+
+  @Override
+  @Deprecated
+  public AtomixBuilder withAddress(int port) {
+    super.withAddress(port);
+    return this;
+  }
+
+  @Override
+  public AtomixBuilder withAddress(Address address) {
+    super.withAddress(address);
+    return this;
+  }
+
+  @Override
+  @Deprecated
+  public AtomixBuilder withZone(String zone) {
+    super.withZone(zone);
+    return this;
+  }
+
+  @Override
+  public AtomixBuilder withZoneId(String zoneId) {
+    super.withZoneId(zoneId);
+    return this;
+  }
+
+  @Override
+  @Deprecated
+  public AtomixBuilder withRack(String rack) {
+    super.withRack(rack);
+    return this;
+  }
+
+  @Override
+  public AtomixBuilder withRackId(String rackId) {
+    super.withRackId(rackId);
+    return this;
+  }
+
+  @Override
+  public AtomixBuilder withHostId(String hostId) {
+    super.withHostId(hostId);
+    return this;
+  }
+
+  @Override
+  public AtomixBuilder withProperties(Properties properties) {
+    super.withProperties(properties);
+    return this;
+  }
+
+  @Override
+  public AtomixBuilder withProperty(String key, String value) {
+    super.withProperty(key, value);
+    return this;
+  }
+
+  @Override
   public AtomixBuilder withMessagingInterface(String iface) {
     super.withMessagingInterface(iface);
     return this;
@@ -335,56 +418,8 @@ public class AtomixBuilder extends AtomixClusterBuilder {
   }
 
   @Override
-  public AtomixBuilder withAddress(String address) {
-    super.withAddress(address);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withAddress(String host, int port) {
-    super.withAddress(host, port);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withAddress(int port) {
-    super.withAddress(port);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withAddress(Address address) {
-    super.withAddress(address);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withZone(String zone) {
-    super.withZone(zone);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withRack(String rack) {
-    super.withRack(rack);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withHost(String host) {
-    super.withHost(host);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withProperties(Properties properties) {
-    super.withProperties(properties);
-    return this;
-  }
-
-  @Override
-  public AtomixBuilder withProperty(String key, String value) {
-    super.withProperty(key, value);
+  public AtomixBuilder withConnectionPoolSize(int connectionPoolSize) {
+    super.withConnectionPoolSize(connectionPoolSize);
     return this;
   }
 
@@ -407,7 +442,7 @@ public class AtomixBuilder extends AtomixClusterBuilder {
   }
 
   @Override
-  public AtomixClusterBuilder withMembershipProtocol(GroupMembershipProtocol protocol) {
+  public AtomixBuilder withMembershipProtocol(GroupMembershipProtocol protocol) {
     super.withMembershipProtocol(protocol);
     return this;
   }

--- a/core/src/main/java/io/atomix/core/AtomixBuilder.java
+++ b/core/src/main/java/io/atomix/core/AtomixBuilder.java
@@ -46,7 +46,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *   {@code
  *   Atomix atomix = Atomix.builder()
  *     .withMemberId("member-1")
- *     .withAddress("localhost", 5000)
+ *     .withHost("192.168.10.2")
+ *     .withPort(5000)
  *     .build();
  *   }
  * </pre>
@@ -517,7 +518,8 @@ public class AtomixBuilder extends AtomixClusterBuilder {
    *   {@code
    *   Atomix atomix = Atomix.builder()
    *     .withMemberId("member-1")
-   *     .withAddress("localhost", 5000)
+   *     .withHost("192.168.10.2")
+   *     .withPort(5000)
    *     .build();
    *   atomix.start().join();
    *   }

--- a/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AbstractAtomixTest.java
@@ -56,7 +56,8 @@ public abstract class AbstractAtomixTest {
     return Atomix.builder()
         .withClusterId("test")
         .withMemberId(String.valueOf(id))
-        .withAddress("localhost", BASE_PORT + id)
+        .withHost("localhost")
+        .withPort(BASE_PORT + id)
         .withProperties(properties)
         .withMulticastEnabled()
         .withMembershipProvider(new MulticastDiscoveryProvider());
@@ -76,7 +77,8 @@ public abstract class AbstractAtomixTest {
     return Atomix.builder()
         .withClusterId("test")
         .withMemberId(String.valueOf(id))
-        .withAddress("localhost", BASE_PORT + id)
+        .withHost("localhost")
+        .withPort(BASE_PORT + id)
         .withProperties(properties)
         .withMulticastEnabled()
         .withMembershipProvider(!nodes.isEmpty() ? new BootstrapDiscoveryProvider(nodes) : new MulticastDiscoveryProvider());

--- a/core/src/test/java/io/atomix/core/AtomixConfigTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixConfigTest.java
@@ -70,9 +70,9 @@ public class AtomixConfigTest {
     MemberConfig node = cluster.getNodeConfig();
     assertEquals("one", node.getId().id());
     assertEquals("localhost:5000", node.getAddress().toString());
-    assertEquals("foo", node.getZone());
-    assertEquals("bar", node.getRack());
-    assertEquals("baz", node.getHost());
+    assertEquals("foo", node.getZoneId());
+    assertEquals("bar", node.getRackId());
+    assertEquals("baz", node.getHostId());
     assertEquals("bar", node.getProperties().getProperty("foo"));
     assertEquals("baz", node.getProperties().getProperty("bar"));
 

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -532,7 +532,8 @@ public class AtomixTest extends AbstractAtomixTest {
     IntStream.range(1, 4).forEach(i ->
         instances.add(Atomix.builder(getClass().getResource("/primitives.conf").getFile())
             .withMemberId(String.valueOf(i))
-            .withAddress("localhost", 5000 + i)
+            .withHost("localhost")
+            .withPort(5000 + i)
             .withProfiles(ConsensusProfile.builder()
                 .withMembers("1", "2", "3")
                 .withDataPath(new File(new File(DATA_DIR, "primitive-getters"), String.valueOf(i)))
@@ -541,7 +542,8 @@ public class AtomixTest extends AbstractAtomixTest {
     Futures.allOf(instances.stream().map(Atomix::start)).get(30, TimeUnit.SECONDS);
 
     Atomix atomix = Atomix.builder(getClass().getResource("/primitives.conf").getFile())
-        .withAddress("localhost:5000")
+        .withHost("localhost")
+        .withPort(5000)
         .build();
     instances.add(atomix);
 

--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -2,10 +2,11 @@ cluster {
   clusterId: test
   node {
     id: one
-    address: "localhost:5000"
-    zone: "foo"
-    rack: "bar"
-    host: "baz"
+    host: localhost
+    port: 5000
+    zoneId: "foo"
+    rackId: "bar"
+    hostId: "baz"
     properties {
       foo: "bar"
       bar: "baz"

--- a/dist/src/main/resources/examples/reference.conf
+++ b/dist/src/main/resources/examples/reference.conf
@@ -32,18 +32,26 @@ cluster {
     # node identifier is required.
     id: (uuid)
 
+    # The host is the hostname for the local node to broadcast to peers. This should be the IP or hostname
+    # through which peers can connect to this node.
+    host: localhost
+
+    # The port is the port number for the local node to broadcast to peers. This should be the port through
+    # which peers can connect to this node. Defaults to 5679.
+    port: 5679
+
     # The address is the address through which other nodes can reach this node for cluster membership and general
     # communication. The address is a host:port tuple and supports DNS lookups.
     address: "localhost:5679"
 
-    # The 'zone' is metadata that may be used for zone-aware partitioning in certain protocols.
-    zone: null
+    # The 'zoneId' is metadata that may be used for zone-aware partitioning in certain protocols.
+    zoneId: null
 
-    # The 'rack' is metadata that may be used for zone-aware partitioning in certain protocols.
-    rack: null
+    # The 'rackId' is metadata that may be used for zone-aware partitioning in certain protocols.
+    rackId: null
 
-    # The 'host' is metadata that may be used for zone-aware partitioning in certain protocols.
-    host: null
+    # The 'hostId' is metadata that may be used for zone-aware partitioning in certain protocols.
+    hostId: null
 
     # Properties is an arbitrary mutable mapping of node properties that will be replicated to all peers.
     properties {
@@ -75,15 +83,18 @@ cluster {
     # for the node to successfully join the cluster.
     nodes.1 {
       id: atomix-1
-      address: "10.192.19.171:5679"
+      host: 10.192.19.171
+      port: 5679
     }
     nodes.2 {
       id: atomix-2
-      address: "10.192.19.172:5679"
+      host: 10.192.19.172
+      port: 5679
     }
     nodes.3 {
       id: atomix-3
-      address: "10.192.19.173:5679"
+      host: 10.192.19.173
+      port: 5679
     }
   }
 
@@ -298,7 +309,7 @@ partitionGroups.data {
 
   # Defines how partitions are distributed among the cluster members. Backups for a partition will be
   # distributed first among distinct groups. For example, to distribute backups among nodes on different
-  # racks, configure the 'cluster.node.rack' for each node and use the 'rack-aware' strategy.
+  # racks, configure the 'cluster.node.rackId' for each node and use the 'rack-aware' strategy.
   # The value may be one of 'node-aware', 'host-aware', 'rack-aware', or 'zone-aware'.
   memberGroupStrategy: node-aware
 }

--- a/rest/src/test/java/io/atomix/rest/impl/VertxRestServiceTest.java
+++ b/rest/src/test/java/io/atomix/rest/impl/VertxRestServiceTest.java
@@ -30,7 +30,6 @@ import io.restassured.filter.log.RequestLoggingFilter;
 import io.restassured.filter.log.ResponseLoggingFilter;
 import io.restassured.http.ContentType;
 import io.restassured.specification.RequestSpecification;
-import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +48,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -451,20 +449,24 @@ public class VertxRestServiceTest {
     return Atomix.builder()
         .withClusterId("test")
         .withMemberId(String.valueOf(memberId))
-        .withAddress(Address.from("localhost", 5000 + memberId))
+        .withHost("localhost")
+        .withPort(5000 + memberId)
         .withMulticastEnabled()
         .withMembershipProvider(new BootstrapDiscoveryProvider(
             Node.builder()
                 .withId("1")
-                .withAddress("localhost", 5001)
+                .withHost("localhost")
+                .withPort(5001)
                 .build(),
             Node.builder()
                 .withId("2")
-                .withAddress("localhost", 5002)
+                .withHost("localhost")
+                .withPort(5002)
                 .build(),
             Node.builder()
                 .withId("3")
-                .withAddress("localhost", 5003)
+                .withHost("localhost")
+                .withPort(5003)
                 .build()))
         .withManagementGroup(PrimaryBackupPartitionGroup.builder("system")
             .withNumPartitions(1)


### PR DESCRIPTION
This PR separates the host and port from the `Address` object when supplied in configuration files and when configuring nodes via builders.

`withAddress` methods are changed to `withHost` and `withPort`:

```java
Atomix atomix = Atomix.builder()
  .withHost("localhost")
  .withPort(54321)
  ...
  .build();
```

This especially simplifies configuration files where IPs and ports no longer need to be quoted:

```
cluster {
  node {
    id: member-1
    host: 192.168.1.50
    port: 5679
  }
}
```

The default port remains `5679` and the default host `localhost`. The `withAddress(Address)` is retained but rest of the `withAddress` builder methods are `@Deprecated`.