### PR TITLE
Fix unstable log primitives test

### DIFF
--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -328,7 +328,6 @@ public class AtomixTest extends AbstractAtomixTest {
 
     assertEquals(1, counter1.incrementAndGet());
     assertEquals(1, counter1.get());
-    assertEquals(0, counter2.get());
     Thread.sleep(1000);
     assertEquals(1, counter2.get());
     assertEquals(2, counter2.incrementAndGet());


### PR DESCRIPTION
Fixes a race condition in the distributed log primitives test. When the counter is created, if the counter receives log events prior to the value check then the value may not be `0`.