### PR TITLE
Primitive partition connections

### DIFF
--- a/core/src/main/java/io/atomix/core/barrier/impl/DistributedCyclicBarrierProxy.java
+++ b/core/src/main/java/io/atomix/core/barrier/impl/DistributedCyclicBarrierProxy.java
@@ -118,6 +118,7 @@ public class DistributedCyclicBarrierProxy
   @Override
   public CompletableFuture<AsyncDistributedCyclicBarrier> connect() {
     return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
         .thenCompose(v -> getProxyClient().acceptBy(name(), service -> service.join()))
         .thenApply(v -> this);
   }

--- a/core/src/main/java/io/atomix/core/collection/impl/DistributedCollectionProxy.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/DistributedCollectionProxy.java
@@ -149,6 +149,7 @@ public abstract class DistributedCollectionProxy<A extends AsyncDistributedColle
   @Override
   public CompletableFuture<A> connect() {
     return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
         .thenRun(() -> {
           ProxySession<S> partition = getProxyClient().getPartition(name());
           partition.addStateChangeListener(state -> {

--- a/core/src/main/java/io/atomix/core/collection/impl/PartitionedDistributedCollectionProxy.java
+++ b/core/src/main/java/io/atomix/core/collection/impl/PartitionedDistributedCollectionProxy.java
@@ -28,6 +28,7 @@ import io.atomix.primitive.PrimitiveRegistry;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.proxy.ProxyClient;
+import io.atomix.primitive.proxy.ProxySession;
 import io.atomix.utils.concurrent.Futures;
 
 import java.util.Collection;
@@ -176,6 +177,7 @@ public abstract class PartitionedDistributedCollectionProxy<A extends AsyncDistr
   @Override
   public CompletableFuture<A> connect() {
     return super.connect()
+        .thenCompose(v -> Futures.allOf(getProxyClient().getPartitions().stream().map(ProxySession::connect)))
         .thenRun(() -> getProxyClient().getPartitions().forEach(partition -> {
           partition.addStateChangeListener(state -> {
             if (state == PrimitiveState.CONNECTED && isListening()) {

--- a/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterProxy.java
+++ b/core/src/main/java/io/atomix/core/counter/impl/AtomicCounterProxy.java
@@ -78,6 +78,13 @@ public class AtomicCounterProxy extends AbstractAsyncPrimitive<AsyncAtomicCounte
   }
 
   @Override
+  public CompletableFuture<AsyncAtomicCounter> connect() {
+    return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
+        .thenApply(v -> this);
+  }
+
+  @Override
   public AtomicCounter sync(Duration operationTimeout) {
     return new BlockingAtomicCounter(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectionProxy.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectionProxy.java
@@ -104,6 +104,7 @@ public class LeaderElectionProxy
   @Override
   public CompletableFuture<AsyncLeaderElection<byte[]>> connect() {
     return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
         .thenRun(() -> getProxyClient().getPartitions().forEach(partition -> {
           partition.addStateChangeListener(state -> {
             if (state == PrimitiveState.CONNECTED && isListening()) {

--- a/core/src/main/java/io/atomix/core/list/impl/DistributedListProxy.java
+++ b/core/src/main/java/io/atomix/core/list/impl/DistributedListProxy.java
@@ -73,6 +73,13 @@ public class DistributedListProxy extends DistributedCollectionProxy<AsyncDistri
   }
 
   @Override
+  public CompletableFuture<AsyncDistributedList<String>> connect() {
+    return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
+        .thenApply(v -> this);
+  }
+
+  @Override
   public DistributedList<String> sync(Duration operationTimeout) {
     return new BlockingDistributedList<>(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapProxy.java
@@ -307,6 +307,7 @@ public abstract class AbstractAtomicMapProxy<P extends AsyncPrimitive, S extends
   @Override
   public CompletableFuture<P> connect() {
     return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
         .thenRun(() -> getProxyClient().getPartition(name()).addStateChangeListener(state -> {
           if (state == PrimitiveState.CONNECTED && isListening()) {
             getProxyClient().getPartition(name()).accept(service -> service.listen());

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicCounterMapProxy.java
@@ -20,6 +20,8 @@ import io.atomix.core.map.AtomicCounterMap;
 import io.atomix.primitive.AbstractAsyncPrimitive;
 import io.atomix.primitive.PrimitiveRegistry;
 import io.atomix.primitive.proxy.ProxyClient;
+import io.atomix.primitive.proxy.ProxySession;
+import io.atomix.utils.concurrent.Futures;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -110,6 +112,13 @@ public class AtomicCounterMapProxy
   @Override
   public CompletableFuture<Void> clear() {
     return getProxyClient().acceptAll(service -> service.clear());
+  }
+
+  @Override
+  public CompletableFuture<AsyncAtomicCounterMap<String>> connect() {
+    return super.connect()
+        .thenCompose(v -> Futures.allOf(getProxyClient().getPartitions().stream().map(ProxySession::connect)))
+        .thenApply(v -> this);
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AtomicNavigableMapProxy.java
@@ -68,102 +68,74 @@ public class AtomicNavigableMapProxy<K extends Comparable<K>> extends AbstractAt
     super(proxy, registry);
   }
 
-  protected K greaterKey(K a, K b) {
-    return a.compareTo(b) > 0 ? a : b;
-  }
-
-  protected K lesserKey(K a, K b) {
-    return a.compareTo(b) < 0 ? a : b;
-  }
-
-  protected Map.Entry<K, Versioned<byte[]>> greaterEntry(Map.Entry<K, Versioned<byte[]>> a, Map.Entry<K, Versioned<byte[]>> b) {
-    return a.getKey().compareTo(b.getKey()) > 0 ? a : b;
-  }
-
-  protected Map.Entry<K, Versioned<byte[]>> lesserEntry(Map.Entry<K, Versioned<byte[]>> a, Map.Entry<K, Versioned<byte[]>> b) {
-    return a.getKey().compareTo(b.getKey()) < 0 ? a : b;
-  }
-
   @Override
   public CompletableFuture<K> firstKey() {
-    return getProxyClient().applyAll(service -> service.firstKey())
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::lesserKey).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.firstKey());
   }
 
   @Override
   public CompletableFuture<K> lastKey() {
-    return getProxyClient().applyAll(service -> service.lastKey())
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::greaterKey).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.lastKey());
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> ceilingEntry(K key) {
-    return getProxyClient().applyAll(service -> service.ceilingEntry(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::lesserEntry).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.ceilingEntry(key));
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> floorEntry(K key) {
-    return getProxyClient().applyAll(service -> service.floorEntry(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::greaterEntry).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.floorEntry(key));
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> higherEntry(K key) {
-    return getProxyClient().applyAll(service -> service.higherEntry(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::lesserEntry).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.higherEntry(key));
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> lowerEntry(K key) {
-    return getProxyClient().applyAll(service -> service.lowerEntry(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::greaterEntry).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.lowerEntry(key));
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> firstEntry() {
-    return getProxyClient().applyAll(service -> service.firstEntry())
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::lesserEntry).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.firstEntry());
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> lastEntry() {
-    return getProxyClient().applyAll(service -> service.lastEntry())
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::greaterEntry).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.lastEntry());
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> pollFirstEntry() {
-    return Futures.exceptionalFuture(new UnsupportedOperationException());
+    return getProxyClient().applyBy(name(), service -> service.pollFirstEntry());
   }
 
   @Override
   public CompletableFuture<Map.Entry<K, Versioned<byte[]>>> pollLastEntry() {
-    return Futures.exceptionalFuture(new UnsupportedOperationException());
+    return getProxyClient().applyBy(name(), service -> service.pollLastEntry());
   }
 
   @Override
   public CompletableFuture<K> lowerKey(K key) {
-    return getProxyClient().applyAll(service -> service.lowerKey(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::greaterKey).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.lowerKey(key));
   }
 
   @Override
   public CompletableFuture<K> floorKey(K key) {
-    return getProxyClient().applyAll(service -> service.floorKey(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::greaterKey).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.floorKey(key));
   }
 
   @Override
   public CompletableFuture<K> ceilingKey(K key) {
-    return getProxyClient().applyAll(service -> service.ceilingKey(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::lesserKey).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.ceilingKey(key));
   }
 
   @Override
   public CompletableFuture<K> higherKey(K key) {
-    return getProxyClient().applyAll(service -> service.higherKey(key))
-        .thenApply(results -> results.filter(Objects::nonNull).reduce(this::lesserKey).orElse(null));
+    return getProxyClient().applyBy(name(), service -> service.higherKey(key));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/map/impl/PartitionedAtomicMapProxy.java
+++ b/core/src/main/java/io/atomix/core/map/impl/PartitionedAtomicMapProxy.java
@@ -46,6 +46,7 @@ import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
+import io.atomix.primitive.proxy.ProxySession;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.time.Versioned;
 
@@ -343,6 +344,7 @@ public abstract class PartitionedAtomicMapProxy<P extends AsyncPrimitive, S exte
   @Override
   public CompletableFuture<P> connect() {
     return super.connect()
+        .thenCompose(v -> Futures.allOf(getProxyClient().getPartitions().stream().map(ProxySession::connect)))
         .thenRun(() -> getProxyClient().getPartitions().forEach(partition -> {
           partition.addStateChangeListener(state -> {
             if (state == PrimitiveState.CONNECTED && isListening()) {

--- a/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/AtomicMultimapProxy.java
@@ -56,6 +56,7 @@ import io.atomix.primitive.PrimitiveType;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.protocol.PrimitiveProtocol;
 import io.atomix.primitive.proxy.ProxyClient;
+import io.atomix.primitive.proxy.ProxySession;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.time.Versioned;
 
@@ -213,6 +214,7 @@ public class AtomicMultimapProxy
   @Override
   public CompletableFuture<AsyncAtomicMultimap<String, byte[]>> connect() {
     return super.connect()
+        .thenCompose(v -> Futures.allOf(getProxyClient().getPartitions().stream().map(ProxySession::connect)))
         .thenRun(() -> getProxyClient().getPartitionIds().forEach(partition -> {
           getProxyClient().getPartition(partition).addStateChangeListener(state -> {
             if (state == PrimitiveState.CONNECTED && isListening()) {

--- a/core/src/main/java/io/atomix/core/semaphore/impl/AtomicSemaphoreProxy.java
+++ b/core/src/main/java/io/atomix/core/semaphore/impl/AtomicSemaphoreProxy.java
@@ -153,6 +153,13 @@ public class AtomicSemaphoreProxy
   }
 
   @Override
+  public CompletableFuture<AsyncAtomicSemaphore> connect() {
+    return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
+        .thenApply(v -> this);
+  }
+
+  @Override
   public AtomicSemaphore sync(Duration operationTimeout) {
     return new BlockingAtomicSemaphore(this, operationTimeout);
   }

--- a/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
+++ b/core/src/main/java/io/atomix/core/tree/impl/AtomicDocumentTreeProxy.java
@@ -196,6 +196,7 @@ public class AtomicDocumentTreeProxy
   @Override
   public CompletableFuture<AsyncAtomicDocumentTree<byte[]>> connect() {
     return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
         .thenRun(() -> getProxyClient().getPartition(name()).addStateChangeListener(state -> {
           if (state == PrimitiveState.CONNECTED && isListening()) {
             getProxyClient().acceptBy(name(), service -> service.listen(root()));

--- a/core/src/main/java/io/atomix/core/value/impl/AtomicValueProxy.java
+++ b/core/src/main/java/io/atomix/core/value/impl/AtomicValueProxy.java
@@ -82,6 +82,13 @@ public class AtomicValueProxy extends AbstractAsyncPrimitive<AsyncAtomicValue<by
   }
 
   @Override
+  public CompletableFuture<AsyncAtomicValue<byte[]>> connect() {
+    return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
+        .thenApply(v -> this);
+  }
+
+  @Override
   public AtomicValue<byte[]> sync(Duration operationTimeout) {
     return new BlockingAtomicValue<>(this, operationTimeout.toMillis());
   }

--- a/core/src/main/java/io/atomix/core/workqueue/impl/WorkQueueProxy.java
+++ b/core/src/main/java/io/atomix/core/workqueue/impl/WorkQueueProxy.java
@@ -142,6 +142,7 @@ public class WorkQueueProxy
   @Override
   public CompletableFuture<AsyncWorkQueue<byte[]>> connect() {
     return super.connect()
+        .thenCompose(v -> getProxyClient().getPartition(name()).connect())
         .thenRun(() -> getProxyClient().getPartition(name()).addStateChangeListener(state -> {
           if (state == PrimitiveState.CONNECTED && isRegistered.get()) {
             getProxyClient().acceptBy(name(), service -> service.register());

--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -328,7 +328,6 @@ public class AtomixTest extends AbstractAtomixTest {
 
     assertEquals(1, counter1.incrementAndGet());
     assertEquals(1, counter1.get());
-    assertEquals(0, counter2.get());
     Thread.sleep(1000);
     assertEquals(1, counter2.get());
     assertEquals(2, counter2.incrementAndGet());

--- a/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
+++ b/primitive/src/main/java/io/atomix/primitive/proxy/impl/DefaultProxySession.java
@@ -231,8 +231,7 @@ public class DefaultProxySession<S> implements ProxySession<S> {
     public Object invoke(Object object, Method method, Object[] args) throws Throwable {
       OperationId operationId = operations.get(method);
       if (operationId != null) {
-        future.set(connect()
-            .thenCompose(v -> session.execute(PrimitiveOperation.operation(operationId, encode(args))))
+        future.set(session.execute(PrimitiveOperation.operation(operationId, encode(args)))
             .thenApply(DefaultProxySession.this::decode));
       } else {
         throw new PrimitiveException("Unknown primitive operation: " + method.getName());


### PR DESCRIPTION
This PR changes the logic for connecting to partitions in all primitives. Currently, primitives connect lazily to partitions when they're accessed. But primitives know which partitions they are going to use, so they should establish sessions when constructed. This avoids consistency issues that we've seen in the log-based primitive tests.

This change also exposed some bugs in the `AtomicNavigableMapProxy` implementation which are fixed.