### PR TITLE
SWIM: Ignore suspected members when updating membership list

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -204,15 +204,18 @@ public class SwimMembershipProtocol
 
     // If the local member is not present, add the member in the ALIVE state.
     if (swimMember == null) {
-      swimMember = new SwimMember(member);
-      members.put(swimMember.id(), swimMember);
-      randomMembers.add(swimMember);
-      Collections.shuffle(randomMembers);
-      LOGGER.debug("{} - Member added {}", this.localMember.id(), swimMember);
-      swimMember.setState(State.ALIVE);
-      post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, swimMember.copy()));
-      recordUpdate(swimMember.copy());
-      return true;
+      if (member.state() == State.ALIVE) {
+        swimMember = new SwimMember(member);
+        members.put(swimMember.id(), swimMember);
+        randomMembers.add(swimMember);
+        Collections.shuffle(randomMembers);
+        LOGGER.debug("{} - Member added {}", this.localMember.id(), swimMember);
+        swimMember.setState(State.ALIVE);
+        post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_ADDED, swimMember.copy()));
+        recordUpdate(swimMember.copy());
+        return true;
+      }
+      return false;
     }
     // If the term has been increased, update the member and record a gossip event.
     else if (member.incarnationNumber() > swimMember.getIncarnationNumber()) {
@@ -331,6 +334,7 @@ public class SwimMembershipProtocol
         Collections.shuffle(randomMembers);
         LOGGER.debug("{} - Member removed {}", this.localMember.id(), member);
         post(new GroupMembershipEvent(GroupMembershipEvent.Type.MEMBER_REMOVED, member.copy()));
+        recordUpdate(member.copy());
       }
     }
   }


### PR DESCRIPTION
This PR fixes a couple bugs in the SWIM protocol implementation that can result in members not being removed from the membership list in certain cases.
* Enqueue updates for gossip when a `DEAD` member is removed
* Only add members in the `ALIVE` state

The problem is, an update indicating a member is `SUSPECT`ed can result in that member being added on nodes that have already removed it. In large clusters, this can make it more difficult to ultimately remove a member from all the nodes. This change only allows `ALIVE` members to be added, meaning the message must come from a running member or from a gossip message that resulted from a probe from a running member.