### PR TITLE
Ensure global leader change event listeners are re-registered

### DIFF
--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxy.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxy.java
@@ -137,7 +137,7 @@ public class LeaderElectorProxy
   }
 
   private boolean isListening() {
-    return !topicListeners.isEmpty();
+    return !leadershipChangeListeners.isEmpty() && !topicListeners.isEmpty();
   }
 
   @Override


### PR DESCRIPTION
This PR fixes a bug in the `LeaderElector` implementation. When a partition session is suspended and then re-`CONNECTED`, the leader elector re-registers listeners with the partition service. However, if only global leadership change listeners have been added to the leader elector, the leader elector does not properly re-register the listeners. Thus, if the leader elector's session is expired and then recreated, it may miss later change events. This PR ensures both the global event listeners and per-topic event listeners are used to determine whether the elector needs to re-register listeners.