### PR TITLE
Fix improper condition for adding listeners to LeaderElector

### DIFF
--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxy.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxy.java
@@ -137,7 +137,7 @@ public class LeaderElectorProxy
   }
 
   private boolean isListening() {
-    return !leadershipChangeListeners.isEmpty() && !topicListeners.isEmpty();
+    return !leadershipChangeListeners.isEmpty() || !topicListeners.isEmpty();
   }
 
   @Override


### PR DESCRIPTION
Fix incorrect condition for adding listeners to `LeaderElector` primitive.