### PR TITLE
Add utilities to Docker image for fault injection testing

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM java:8
 
+RUN apt-get update -y && apt-get install -y iptables stress
+
 ARG VERSION
 RUN mkdir -p /opt/atomix
 COPY target/atomix.tar.gz /opt/atomix/atomix.tar.gz


### PR DESCRIPTION
Add `iptables` and `stress` to the Docker image for use in fault injection and stress testing respectively.