### PR TITLE
Ignore keep-alives for deleted Raft services

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
@@ -333,10 +333,9 @@ public class RaftServiceContext implements ServiceContext {
    * @param eventIndex The session event index.
    */
   public boolean keepAlive(long index, long timestamp, RaftSession session, long commandSequence, long eventIndex) {
-    // If the service has been deleted then throw an unknown service exception.
+    // If the service has been deleted, just return false to ignore the keep-alive.
     if (deleted) {
-      log.warn("Service {} has been deleted by another process", serviceName);
-      throw new RaftException.UnknownService("Service " + serviceName + " has been deleted");
+      return false;
     }
 
     // Update the state machine index/timestamp.


### PR DESCRIPTION
This PR fixes a bug in the `RaftServiceManager`. When a service is deleted, a later keep-alive for that service can be failed with an `UNKNOWN_SERVICE` error. That's fine, but the problem is other services' keep-alives are carried in the same request, so an `UnknownService` exception can prevent a keep-alive from completing. Clients will then attempt to recreate their sessions, placing additional load on the Raft partitions.

To fix this issue, we simply ignore keep-alives for services that have been marked deleted.