### PR TITLE
Support singleton transactional primitives

### DIFF
--- a/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalMap.java
@@ -1,0 +1,87 @@
+package io.atomix.core.transaction.impl;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import io.atomix.core.map.impl.MapUpdate;
+import io.atomix.core.transaction.AsyncTransactionalMap;
+import io.atomix.core.transaction.TransactionLog;
+import io.atomix.core.transaction.TransactionalMap;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.ProxyProtocol;
+
+/**
+ * Delegating transactional map.
+ */
+public class DelegatingTransactionalMap<K, V> implements AsyncTransactionalMap<K, V> {
+  private final AsyncTransactionalMap<K, V> map;
+
+  public DelegatingTransactionalMap(AsyncTransactionalMap<K, V> map) {
+    this.map = map;
+  }
+
+  @Override
+  public String name() {
+    return map.name();
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return map.type();
+  }
+
+  @Override
+  public ProxyProtocol protocol() {
+    return (ProxyProtocol) map.protocol();
+  }
+
+  @Override
+  public CompletableFuture<V> get(K key) {
+    return map.get(key);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> containsKey(K key) {
+    return map.containsKey(key);
+  }
+
+  @Override
+  public CompletableFuture<V> put(K key, V value) {
+    return map.put(key, value);
+  }
+
+  @Override
+  public CompletableFuture<V> remove(K key) {
+    return map.remove(key);
+  }
+
+  @Override
+  public CompletableFuture<V> putIfAbsent(K key, V value) {
+    return map.putIfAbsent(key, value);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> remove(K key, V value) {
+    return map.remove(key, value);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> replace(K key, V oldValue, V newValue) {
+    return map.replace(key, oldValue, newValue);
+  }
+
+  @Override
+  public CompletableFuture<Void> close() {
+    return map.close();
+  }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    return map.delete();
+  }
+
+  @Override
+  public TransactionalMap<K, V> sync(Duration operationTimeout) {
+    return new BlockingTransactionalMap<>(this, operationTimeout.toMillis());
+  }
+}

--- a/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalMap.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atomix.core.transaction.impl;
 
 import java.time.Duration;

--- a/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalSet.java
@@ -1,0 +1,65 @@
+package io.atomix.core.transaction.impl;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import io.atomix.core.transaction.AsyncTransactionalSet;
+import io.atomix.core.transaction.TransactionalSet;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.ProxyProtocol;
+
+/**
+ * Delegating transactional set.
+ */
+public abstract class DelegatingTransactionalSet<E> implements AsyncTransactionalSet<E> {
+  private final AsyncTransactionalSet<E> set;
+
+  public DelegatingTransactionalSet(AsyncTransactionalSet<E> set) {
+    this.set = set;
+  }
+
+  @Override
+  public String name() {
+    return set.name();
+  }
+
+  @Override
+  public PrimitiveType type() {
+    return set.type();
+  }
+
+  @Override
+  public ProxyProtocol protocol() {
+    return (ProxyProtocol) set.protocol();
+  }
+
+  @Override
+  public CompletableFuture<Boolean> add(E e) {
+    return set.add(e);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> remove(E e) {
+    return set.remove(e);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> contains(E e) {
+    return set.contains(e);
+  }
+
+  @Override
+  public CompletableFuture<Void> close() {
+    return set.close();
+  }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    return set.delete();
+  }
+
+  @Override
+  public TransactionalSet<E> sync(Duration operationTimeout) {
+    return new BlockingTransactionalSet<>(set, operationTimeout.toMillis());
+  }
+}

--- a/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DelegatingTransactionalSet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atomix.core.transaction.impl;
 
 import java.time.Duration;

--- a/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalMap.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atomix.core.transaction.impl;
 
 import java.util.concurrent.CompletableFuture;

--- a/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalMap.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalMap.java
@@ -1,0 +1,49 @@
+package io.atomix.core.transaction.impl;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.atomix.core.map.impl.MapUpdate;
+import io.atomix.core.transaction.TransactionLog;
+import io.atomix.core.transaction.TransactionParticipant;
+
+/**
+ * Singleton transactional map.
+ */
+public class SingletonTransactionalMap<K, V> extends DelegatingTransactionalMap<K, V> implements TransactionParticipant<MapUpdate<K, V>> {
+  private final TransactionalMapParticipant<K, V> map;
+
+  public SingletonTransactionalMap(TransactionalMapParticipant<K, V> map) {
+    super(map);
+    this.map = map;
+  }
+
+  @Override
+  public TransactionLog<MapUpdate<K, V>> log() {
+    return map.log();
+  }
+
+  @Override
+  public CompletableFuture<Boolean> prepare() {
+    return map.prepare();
+  }
+
+  @Override
+  public CompletableFuture<Void> commit() {
+    return map.commit();
+  }
+
+  @Override
+  public CompletableFuture<Void> rollback() {
+    return map.rollback();
+  }
+
+  @Override
+  public CompletableFuture<Void> close() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    return CompletableFuture.completedFuture(null);
+  }
+}

--- a/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalSet.java
@@ -1,0 +1,49 @@
+package io.atomix.core.transaction.impl;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.atomix.core.set.impl.SetUpdate;
+import io.atomix.core.transaction.TransactionLog;
+import io.atomix.core.transaction.TransactionParticipant;
+
+/**
+ * Singleton transactional set.
+ */
+public class SingletonTransactionalSet<E> extends DelegatingTransactionalSet<E> implements TransactionParticipant<SetUpdate<E>> {
+  private final TransactionalSetParticipant<E> set;
+
+  public SingletonTransactionalSet(TransactionalSetParticipant<E> set) {
+    super(set);
+    this.set = set;
+  }
+
+  @Override
+  public TransactionLog<SetUpdate<E>> log() {
+    return set.log();
+  }
+
+  @Override
+  public CompletableFuture<Boolean> prepare() {
+    return set.prepare();
+  }
+
+  @Override
+  public CompletableFuture<Void> commit() {
+    return set.commit();
+  }
+
+  @Override
+  public CompletableFuture<Void> rollback() {
+    return set.rollback();
+  }
+
+  @Override
+  public CompletableFuture<Void> close() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> delete() {
+    return CompletableFuture.completedFuture(null);
+  }
+}

--- a/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalSet.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/SingletonTransactionalSet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.atomix.core.transaction.impl;
 
 import java.util.concurrent.CompletableFuture;


### PR DESCRIPTION
This PR implements the correct behavior for `get()` when using transactional primitives. SIngleton transactional primitives are implemented by exposing a wrapped primitive to the `Transaction` to prevent it from closing the primitive sessions at the end of the transaction.