### PR TITLE
Ignore events published on expired sessions

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -435,8 +435,13 @@ public class RaftSession extends AbstractSession {
   public void publish(PrimitiveEvent event) {
     // Store volatile state in a local variable.
     State state = this.state;
-    checkState(state != State.EXPIRED, "session is expired");
-    checkState(state != State.CLOSED, "session is closed");
+
+    // If the sessions's state is not active, just ignore the event.
+    if (!state.active()) {
+      return;
+    }
+
+    // If the event is being published during a read operation, throw an exception.
     checkState(context.currentOperation() == OperationType.COMMAND, "session events can only be published during command execution");
 
     // If the client acked an index greater than the current event sequence number since we know the


### PR DESCRIPTION
This PR changes the behavior of Raft sessions when events are published to an expired or closed session. Currently, publishing an event to an expired session results in an exception, and that exception is propagated back to the client. Rather than throwing an exception, this change ignores the published event to ensure the command that produced it can still succeed.

Separately, a race condition exists that allows expired sessions to be registered when the Raft log clock is significantly skewed. This will be resolved in a separate PR.