### PR TITLE
Initialize session with monotonically increasing service timestamp

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/service/RaftServiceContext.java
@@ -329,7 +329,7 @@ public class RaftServiceContext implements ServiceContext {
     // Update the state machine index/timestamp.
     tick(index, timestamp);
 
-    // Update the state machine index/ timestamp .
+    // Set the session timestamp to the current service timestamp.
     session.setLastUpdated(currentTimestamp);
 
     // Expire sessions that have timed out.


### PR DESCRIPTION
This PR fixes a bug in how session timestamps are initialized. Currently, it's possible for a session to be immediately expired if a leader change occurs and the new leader has a clock that's behind the prior leader's last committed timestamp by more than the session timeout. This can result in the session being expired and then registered with the service.