### PR TITLE
3.0

### DIFF
--- a/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapService.java
+++ b/core/src/main/java/io/atomix/core/map/impl/AbstractAtomicMapService.java
@@ -125,6 +125,9 @@ public abstract class AbstractAtomicMapService<K> extends AbstractPrimitiveServi
         });
       }
     });
+    listeners = listeners.stream()
+            .filter(each -> getSession(each) != null && getSession(each).getState().active())
+            .collect(Collectors.toSet());
   }
 
   @Override
@@ -893,7 +896,8 @@ public abstract class AbstractAtomicMapService<K> extends AbstractPrimitiveServi
    * @param events list of map event to publish
    */
   private void publish(List<AtomicMapEvent<K, byte[]>> events) {
-    listeners.forEach(listener -> events.forEach(event -> getSession(listener).accept(client -> client.change(event))));
+    listeners.stream().filter(each->getSession(each) != null && getSession(each).getState().active())
+            .forEach(listener -> events.forEach(event -> getSession(listener).accept(client -> client.change(event))));
   }
 
   @Override

--- a/core/src/main/java/io/atomix/core/multimap/impl/AbstractAtomicMultimapService.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/AbstractAtomicMultimapService.java
@@ -107,6 +107,9 @@ public abstract class AbstractAtomicMultimapService extends AbstractPrimitiveSer
   public void restore(BackupInput reader) {
     globalVersion = new AtomicLong(reader.readLong());
     listeners = reader.readObject();
+    listeners = listeners.stream()
+            .filter(each -> getSession(each) != null && getSession(each).getState().active())
+            .collect(Collectors.toSet());
     backingMap = reader.readObject();
   }
 

--- a/core/src/main/java/io/atomix/core/value/impl/AbstractAtomicValueService.java
+++ b/core/src/main/java/io/atomix/core/value/impl/AbstractAtomicValueService.java
@@ -28,6 +28,7 @@ import io.atomix.utils.serializer.Serializer;
 
 import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Abstract atomic value service.
@@ -67,6 +68,9 @@ public abstract class AbstractAtomicValueService extends AbstractPrimitiveServic
       value = null;
     }
     listeners = reader.readObject();
+    listeners = listeners.stream()
+            .filter(each -> getSession(each) != null && getSession(each).getState().active())
+            .collect(Collectors.toSet());
   }
 
   private byte[] updateAndNotify(byte[] value) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -435,12 +435,12 @@ public class RaftSession extends AbstractSession {
   public void publish(PrimitiveEvent event) {
     // Store volatile state in a local variable.
     State state = this.state;
-    if (state == State.EXPIRED) {
+    // If the sessions's state is not active, just ignore the event.
+    if (!state.active()) {
       return;
     }
-    if (state == State.CLOSED) {
-      return;
-    }
+
+    // If the event is being published during a read operation, throw an exception.
     checkState(context.currentOperation() == OperationType.COMMAND, "session events can only be published during command execution");
 
     // If the client acked an index greater than the current event sequence number since we know the

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -435,8 +435,14 @@ public class RaftSession extends AbstractSession {
   public void publish(PrimitiveEvent event) {
     // Store volatile state in a local variable.
     State state = this.state;
-    checkState(state != State.EXPIRED, "session is expired");
-    checkState(state != State.CLOSED, "session is closed");
+    if (state == State.EXPIRED) {
+      log.warn("session is expired");
+      return;
+    }
+    if (state == State.CLOSED) {
+      log.warn("session is closed");
+      return;
+    }
     checkState(context.currentOperation() == OperationType.COMMAND, "session events can only be published during command execution");
 
     // If the client acked an index greater than the current event sequence number since we know the

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -436,11 +436,9 @@ public class RaftSession extends AbstractSession {
     // Store volatile state in a local variable.
     State state = this.state;
     if (state == State.EXPIRED) {
-      log.warn("session {} is expired", this.sessionId());
       return;
     }
     if (state == State.CLOSED) {
-      log.warn("session {} is closed", this.sessionId());
       return;
     }
     checkState(context.currentOperation() == OperationType.COMMAND, "session events can only be published during command execution");

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/RaftSession.java
@@ -436,11 +436,11 @@ public class RaftSession extends AbstractSession {
     // Store volatile state in a local variable.
     State state = this.state;
     if (state == State.EXPIRED) {
-      log.warn("session is expired");
+      log.warn("session {} is expired", this.sessionId());
       return;
     }
     if (state == State.CLOSED) {
-      log.warn("session is closed");
+      log.warn("session {} is closed", this.sessionId());
       return;
     }
     checkState(context.currentOperation() == OperationType.COMMAND, "session events can only be published during command execution");


### PR DESCRIPTION
10:02:56.624 [raft-server-raft-partition-2-state] WARN i.a.p.s.impl.DefaultServiceExecutor - PrimitiveService{56}{type=AtomicValueType{name=atomic-value}, name=onos-apps-activation-topic} - State machine operation failed: java.lang.reflect.InvocationTargetException
10:02:56.627 [raft-server-raft-partition-2-state] WARN i.a.p.s.impl.DefaultServiceExecutor - PrimitiveService{56}{type=AtomicValueType{name=atomic-value}, name=onos-apps-activation-topic} - State machine operation failed: java.lang.reflect.InvocationTargetException
10:02:56.647 [raft-server-raft-partition-2] WARN i.a.protocols.raft.roles.LeaderRole - RaftServer{raft-partition-2}{role=LEADER} - An application error occurred: {}
io.atomix.primitive.PrimitiveException$ServiceException: java.lang.reflect.InvocationTargetException
at io.atomix.primitive.service.AbstractPrimitiveService.lambda$configure$2(AbstractPrimitiveService.java:151) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at io.atomix.primitive.service.impl.DefaultServiceExecutor.lambda$register$1(DefaultServiceExecutor.java:154) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at io.atomix.primitive.service.impl.DefaultServiceExecutor.apply(DefaultServiceExecutor.java:182) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at io.atomix.primitive.service.AbstractPrimitiveService.apply(AbstractPrimitiveService.java:113) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at io.atomix.protocols.raft.service.RaftServiceContext.applyCommand(RaftServiceContext.java:520) ~[atomix-raft-3.0.9-SNAPSHOT.jar:na]
at io.atomix.protocols.raft.service.RaftServiceContext.executeCommand(RaftServiceContext.java:492) ~[atomix-raft-3.0.9-SNAPSHOT.jar:na]
at io.atomix.protocols.raft.impl.RaftServiceManager.applyCommand(RaftServiceManager.java:807) ~[atomix-raft-3.0.9-SNAPSHOT.jar:na]
at io.atomix.protocols.raft.impl.RaftServiceManager.lambda$apply$12(RaftServiceManager.java:424) ~[atomix-raft-3.0.9-SNAPSHOT.jar:na]
at io.atomix.utils.concurrent.SingleThreadContext$1.lambda$execute$0(SingleThreadContext.java:53) ~[atomix-utils-3.0.9-SNAPSHOT.jar:na]
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_171]
at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_171]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[na:1.8.0_171]
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[na:1.8.0_171]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_171]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_171]
at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_171]
Caused by: java.lang.reflect.InvocationTargetException: null
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_171]
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_171]
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_171]
at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_171]
at io.atomix.primitive.service.AbstractPrimitiveService.lambda$configure$2(AbstractPrimitiveService.java:149) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
... 15 common frames omitted
Caused by: java.lang.IllegalStateException: session is expired
at com.google.common.base.Preconditions.checkState(Preconditions.java:456) ~[guava-22.0.jar:na]
at io.atomix.protocols.raft.session.RaftSession.publish(RaftSession.java:438) ~[atomix-raft-3.0.9-SNAPSHOT.jar:na]
at io.atomix.primitive.session.impl.AbstractSession.publish(AbstractSession.java:101) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at io.atomix.primitive.session.impl.ClientSession$SessionProxyHandler.invoke(ClientSession.java:127) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at com.sun.proxy.$Proxy9.change(Unknown Source) ~[na:na]
at io.atomix.core.value.impl.AbstractAtomicValueService.lambda$null$0(AbstractAtomicValueService.java:75) ~[atomix-3.0.9-SNAPSHOT.jar:na]
at io.atomix.primitive.session.impl.ClientSession$SessionProxy.accept(ClientSession.java:107) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at io.atomix.primitive.session.impl.ClientSession.accept(ClientSession.java:84) ~[atomix-primitive-3.0.9-SNAPSHOT.jar:na]
at io.atomix.core.value.impl.AbstractAtomicValueService.lambda$updateAndNotify$1(AbstractAtomicValueService.java:75) ~[atomix-3.0.9-SNAPSHOT.jar:na]
at java.lang.Iterable.forEach(Iterable.java:75) ~[na:1.8.0_171]
at io.atomix.core.value.impl.AbstractAtomicValueService.updateAndNotify(AbstractAtomicValueService.java:75) ~[atomix-3.0.9-SNAPSHOT.jar:na]
at io.atomix.core.value.impl.AbstractAtomicValueService.set(AbstractAtomicValueService.java:82) ~[atomix-3.0.9-SNAPSHOT.jar:na]
... 20 common frames omitted
10:02:56.653 [raft-server-raft-partition-2-state] WARN i.a.p.s.impl.DefaultServiceExecutor - PrimitiveService{56}{type=AtomicValueType{name=atomic-value}, name=onos-apps-activation-topic} - State machine operation failed: java.lang.reflect.InvocationTargetException