### PR TITLE
Fix node catch up after log compaction

### DIFF
--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -68,6 +68,7 @@ import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Serializer;
 import net.jodah.concurrentunit.ConcurrentTestCase;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -473,6 +474,42 @@ public class RaftTest extends ConcurrentTestCase {
   @Test
   public void testTwoOfThreeNodeSubmitCommand() throws Throwable {
     testSubmitCommand(2, 3);
+  }
+
+  @Test
+  public void testNodeCatchUpAfterCompaction() throws Throwable
+  {
+    // given
+    createServers(3);
+
+    servers.get(0).shutdown();
+    RaftClient client = createClient();
+    TestPrimitive primitive = createPrimitive(client);
+
+    final int entries = 10;
+    final int entrySize = 1024;
+    final String entry = RandomStringUtils.random(entrySize);
+    for (int i = 0; i < entries; i++)
+    {
+      primitive.write(entry)
+               .get(1_000, TimeUnit.MILLISECONDS);
+    }
+
+    // when
+    CompletableFuture
+        .allOf(servers.get(1).compact(),
+               servers.get(2).compact())
+        .get(15_000, TimeUnit.MILLISECONDS);
+
+    // then
+    final RaftServer server = createServer(members.get(0).memberId());
+    List<MemberId> members =
+        this.members
+            .stream()
+            .map(RaftMember::memberId)
+            .collect(Collectors.toList());
+
+    server.join(members).get(15_000, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -1271,6 +1308,7 @@ public class RaftTest extends ConcurrentTestCase {
             .build());
 
     RaftServer server = builder.build();
+
     servers.add(server);
     return server;
   }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -477,8 +477,7 @@ public class RaftTest extends ConcurrentTestCase {
   }
 
   @Test
-  public void testNodeCatchUpAfterCompaction() throws Throwable
-  {
+  public void testNodeCatchUpAfterCompaction() throws Throwable {
     // given
     createServers(3);
 
@@ -489,8 +488,7 @@ public class RaftTest extends ConcurrentTestCase {
     final int entries = 10;
     final int entrySize = 1024;
     final String entry = RandomStringUtils.random(entrySize);
-    for (int i = 0; i < entries; i++)
-    {
+    for (int i = 0; i < entries; i++) {
       primitive.write(entry)
                .get(1_000, TimeUnit.MILLISECONDS);
     }

--- a/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentWriter.java
+++ b/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentWriter.java
@@ -323,8 +323,7 @@ class FileChannelJournalSegmentWriter<E> implements JournalWriter<E> {
   @Override
   public void flush() {
     try {
-      if (channel.isOpen())
-      {
+      if (channel.isOpen()) {
         channel.force(true);
       }
     } catch (IOException e) {

--- a/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentWriter.java
+++ b/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentWriter.java
@@ -323,7 +323,10 @@ class FileChannelJournalSegmentWriter<E> implements JournalWriter<E> {
   @Override
   public void flush() {
     try {
-      channel.force(true);
+      if (channel.isOpen())
+      {
+        channel.force(true);
+      }
     } catch (IOException e) {
       throw new StorageException(e);
     }

--- a/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
+++ b/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalWriter.java
@@ -50,7 +50,6 @@ public class SegmentedJournalWriter<E> implements JournalWriter<E> {
   @Override
   public void reset(long index) {
     if (index > currentSegment.index()) {
-      currentWriter.close();
       currentSegment.release();
       currentSegment = journal.resetSegments(index);
       currentSegment.acquire();

--- a/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -92,8 +92,7 @@ public abstract class AbstractJournalTest {
   }
 
   @Test
-  public void testCloseMultipleTimes()
-  {
+  public void testCloseMultipleTimes() {
     // given
     final Journal<TestEntry> journal = createJournal();
 

--- a/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -92,6 +92,19 @@ public abstract class AbstractJournalTest {
   }
 
   @Test
+  public void testCloseMultipleTimes()
+  {
+    // given
+    final Journal<TestEntry> journal = createJournal();
+
+    // when
+    journal.close();
+
+    // then
+    journal.close();
+  }
+
+  @Test
   @SuppressWarnings("unchecked")
   public void testWriteRead() throws Exception {
     try (Journal<TestEntry> journal = createJournal()) {


### PR DESCRIPTION
Hey,

I hope this PR is conform to your contribution guidelines, unfortunately I didn't found them.

This PR fixes the problem described in #978 (might be more an easy fix, maybe you need to have an look why this segment is closed twice). I was able to reproduce the problem with the an unit test in the RaftTest, but after fixing this issue I would like to assert in the test that all nodes have the same state and log, but I don't know how to test that. But maybe it is also fine if the join was completed without any problems.

closes #978