### PR TITLE
Accept raft role listeners at raft partition server

### DIFF
--- a/core/src/test/java/io/atomix/core/AtomixTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixTest.java
@@ -15,6 +15,12 @@
  */
 package io.atomix.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import io.atomix.cluster.ClusterMembershipEvent;
 import io.atomix.cluster.ClusterMembershipEventListener;
 import io.atomix.cluster.Member;
@@ -53,22 +59,16 @@ import io.atomix.core.tree.AtomicDocumentTreeType;
 import io.atomix.core.value.AtomicValueType;
 import io.atomix.core.value.DistributedValueType;
 import io.atomix.core.workqueue.WorkQueueType;
-import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.impl.DefaultPartitionService;
 import io.atomix.primitive.protocol.ProxyProtocol;
 import io.atomix.protocols.log.DistributedLogProtocol;
 import io.atomix.protocols.log.partition.LogPartitionGroup;
 import io.atomix.protocols.raft.MultiRaftProtocol;
-import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.partition.RaftPartition;
 import io.atomix.protocols.raft.partition.RaftPartitionGroup;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.config.ConfigurationException;
 import io.atomix.utils.net.Address;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,10 +84,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Atomix test.
@@ -221,8 +220,7 @@ public class AtomixTest extends AbstractAtomixTest {
     final CompletableFuture<Void> roleChanged = new CompletableFuture<>();
 
     final CompletableFuture<Atomix> nodeOneFuture = startAtomix(1, Arrays.asList(1),
-        builder ->
-        {
+        builder -> {
           final RaftPartitionGroup partitionGroup = RaftPartitionGroup.builder("system")
               .withNumPartitions(1)
               .withMembers(String.valueOf(1))
@@ -238,11 +236,7 @@ public class AtomixTest extends AbstractAtomixTest {
           raftPartitionGroup.getPartitions().forEach(
               partition -> {
                 final RaftPartition raftPartition = (RaftPartition) partition;
-                raftPartition.addRoleChangeListener((role) ->
-                {
-                  roleChanged.complete(null);
-                  System.out.println(role.toString());
-                });
+                raftPartition.addRoleChangeListener((role) -> roleChanged.complete(null));
               });
           return atomix;
         });

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -87,20 +87,15 @@ public class RaftPartition implements Partition {
     return client != null ? client.leader() : null;
   }
 
-  public void addRoleChangeListener(Consumer<Role> listener)
-  {
-    if (server == null)
-    {
+  public void addRoleChangeListener(Consumer<Role> listener) {
+    if (server == null) {
       deferredRoleChangeListeners.add(listener);
-    }
-    else
-    {
+    } else {
       server.addRoleChangeListener(listener);
     }
   }
 
-  public void removeRoleChangeListener(Consumer<Role> listener)
-  {
+  public void removeRoleChangeListener(Consumer<Role> listener) {
     deferredRoleChangeListeners.remove(listener);
     server.removeRoleChangeListener(listener);
   }
@@ -214,8 +209,7 @@ public class RaftPartition implements Partition {
         managementService.getPrimitiveTypes(),
         threadContextFactory);
 
-    if (!deferredRoleChangeListeners.isEmpty())
-    {
+    if (!deferredRoleChangeListeners.isEmpty()) {
       deferredRoleChangeListeners.forEach(raftPartitionServer::addRoleChangeListener);
       deferredRoleChangeListeners.clear();
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -135,20 +135,15 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     return server.compact();
   }
 
-  public void addRoleChangeListener(Consumer<Role> listener)
-  {
-    if (server == null)
-    {
+  public void addRoleChangeListener(Consumer<Role> listener) {
+    if (server == null) {
       deferredRoleChangeListeners.add(listener);
-    }
-    else
-    {
+    } else {
       server.addRoleChangeListener(listener);
     }
   }
 
-  public void removeRoleChangeListener(Consumer<Role> listener)
-  {
+  public void removeRoleChangeListener(Consumer<Role> listener) {
     deferredRoleChangeListeners.remove(listener);
     server.removeRoleChangeListener(listener);
   }
@@ -202,8 +197,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .withThreadContextFactory(threadContextFactory)
         .build();
 
-    if (!deferredRoleChangeListeners.isEmpty())
-    {
+    if (!deferredRoleChangeListeners.isEmpty()) {
       deferredRoleChangeListeners.forEach(raftServer::addRoleChangeListener);
       deferredRoleChangeListeners.clear();
     }


### PR DESCRIPTION
This feature allows the user to add raft role change listeners to the RaftPartitionGroup.

Would be nice if we could have that, we have the use case where we need to know who is the leader and listen for then role changes (whether we becoming the leader or step down). We want to start processing on leader nodes and stop the processing on followers.