### PR TITLE
Sort primary election candidates by member group ID

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/partition/PrimaryTerm.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PrimaryTerm.java
@@ -87,7 +87,7 @@ public class PrimaryTerm {
    * @return an ordered list of backup members
    */
   public List<GroupMember> backups(int numBackups) {
-    if (primary == null) {
+    if (primary == null || candidates.isEmpty()) {
       return Collections.emptyList();
     }
     return candidates.subList(1, Math.min(candidates.size(), numBackups + 1));

--- a/primitive/src/main/java/io/atomix/primitive/partition/PrimaryTerm.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PrimaryTerm.java
@@ -15,12 +15,9 @@
  */
 package io.atomix.primitive.partition;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
@@ -93,35 +90,7 @@ public class PrimaryTerm {
     if (primary == null) {
       return Collections.emptyList();
     }
-
-    List<GroupMember> backups = new ArrayList<>();
-    Set<MemberGroupId> groups = new HashSet<>();
-
-    // Add the primary group to the set of groups to avoid assigning a backup in the same group.
-    groups.add(primary.groupId());
-
-    // First populate backups with members from a unique set of groups.
-    int i = 0;
-    for (int j = 0; j < numBackups; j++) {
-      while (i < candidates.size()) {
-        GroupMember member = candidates.get(i++);
-        if (groups.add(member.groupId())) {
-          backups.add(member);
-          break;
-        }
-      }
-    }
-
-    // If there are still not enough backups, add duplicate groups.
-    for (int j = backups.size(); j < numBackups; j++) {
-      for (GroupMember candidate : candidates) {
-        if (!candidate.equals(primary) && !backups.contains(candidate)) {
-          backups.add(candidate);
-          break;
-        }
-      }
-    }
-    return backups;
+    return candidates.subList(1, Math.min(candidates.size(), numBackups + 1));
   }
 
   @Override

--- a/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorService.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/impl/PrimaryElectorService.java
@@ -18,6 +18,8 @@ package io.atomix.primitive.partition.impl;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +34,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.atomix.primitive.partition.GroupMember;
+import io.atomix.primitive.partition.MemberGroupId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PrimaryElectionEvent;
 import io.atomix.primitive.partition.PrimaryTerm;
@@ -380,7 +383,9 @@ public class PrimaryElectorService extends AbstractPrimitiveService {
           updatedRegistrations.add(registration);
         }
 
-        Registration firstRegistration = updatedRegistrations.get(0);
+        List<Registration> sortedRegistrations = sortRegistrations(updatedRegistrations);
+
+        Registration firstRegistration = sortedRegistrations.get(0);
         Registration leader = this.primary;
         long term = this.term;
         long termStartTime = this.termStartTime;
@@ -391,13 +396,48 @@ public class PrimaryElectorService extends AbstractPrimitiveService {
         }
         return new ElectionState(
             partitionId,
-            updatedRegistrations,
+            sortedRegistrations,
             leader,
             term,
             termStartTime,
             elections);
       }
       return this;
+    }
+
+    List<Registration> sortRegistrations(List<Registration> registrations) {
+      // Count the number of distinct groups in the registrations list.
+      int groupCount = (int) registrations.stream()
+          .map(r -> r.member().groupId())
+          .distinct()
+          .count();
+
+      Set<MemberGroupId> groups = new HashSet<>();
+      List<Registration> sortedRegistrations = new LinkedList<>();
+
+      // Loop until all registrations have been sorted.
+      while (!registrations.isEmpty()) {
+        // Clear the list of consumed groups.
+        groups.clear();
+
+        // For each registration, check if it can be added to the registrations list.
+        Iterator<Registration> iterator = registrations.iterator();
+        while (iterator.hasNext()) {
+          Registration registration = iterator.next();
+
+          // If the registration's group has not been added to the list, add the registration.
+          if (groups.add(registration.member().groupId())) {
+            sortedRegistrations.add(registration);
+            iterator.remove();
+
+            // If an instance of a registration from each group has been added, reset the list of registrations.
+            if (groups.size() == groupCount) {
+              groups.clear();
+            }
+          }
+        }
+      }
+      return sortedRegistrations;
     }
 
     int countPrimaries(Registration registration) {

--- a/primitive/src/test/java/io/atomix/primitive/partition/PrimaryTermTest.java
+++ b/primitive/src/test/java/io/atomix/primitive/partition/PrimaryTermTest.java
@@ -31,6 +31,7 @@ public class PrimaryTermTest {
   public void testPrimaryTerm() throws Exception {
     GroupMember primary = new GroupMember(MemberId.from("1"), MemberGroupId.from("1"));
     List<GroupMember> candidates = Arrays.asList(
+        new GroupMember(MemberId.from("1"), MemberGroupId.from("1")),
         new GroupMember(MemberId.from("2"), MemberGroupId.from("2")),
         new GroupMember(MemberId.from("3"), MemberGroupId.from("2")),
         new GroupMember(MemberId.from("4"), MemberGroupId.from("3")),
@@ -41,10 +42,10 @@ public class PrimaryTermTest {
     assertEquals(candidates, term.candidates());
 
     assertEquals(Arrays.asList(), term.backups(0));
-    assertEquals(Arrays.asList(candidates.get(0)), term.backups(1));
-    assertEquals(Arrays.asList(candidates.get(0), candidates.get(2)), term.backups(2));
-    assertEquals(Arrays.asList(candidates.get(0), candidates.get(2), candidates.get(1)), term.backups(3));
-    assertEquals(Arrays.asList(candidates.get(0), candidates.get(2), candidates.get(1), candidates.get(3)), term.backups(4));
-    assertEquals(Arrays.asList(candidates.get(0), candidates.get(2), candidates.get(1), candidates.get(3)), term.backups(5));
+    assertEquals(Arrays.asList(candidates.get(1)), term.backups(1));
+    assertEquals(Arrays.asList(candidates.get(1), candidates.get(2)), term.backups(2));
+    assertEquals(Arrays.asList(candidates.get(1), candidates.get(2), candidates.get(3)), term.backups(3));
+    assertEquals(Arrays.asList(candidates.get(1), candidates.get(2), candidates.get(3), candidates.get(4)), term.backups(4));
+    assertEquals(Arrays.asList(candidates.get(1), candidates.get(2), candidates.get(3), candidates.get(4)), term.backups(5));
   }
 }

--- a/primitive/src/test/java/io/atomix/primitive/partition/PrimaryTermTest.java
+++ b/primitive/src/test/java/io/atomix/primitive/partition/PrimaryTermTest.java
@@ -19,14 +19,27 @@ import io.atomix.cluster.MemberId;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Primary term test.
  */
 public class PrimaryTermTest {
+  @Test
+  public void testEmptyTerm() throws Exception {
+    PrimaryTerm term = new PrimaryTerm(1, null, Collections.emptyList());
+    assertNull(term.primary());
+    assertTrue(term.candidates().isEmpty());
+    assertTrue(term.backups(0).isEmpty());
+    assertTrue(term.backups(1).isEmpty());
+    assertTrue(term.backups(2).isEmpty());
+  }
+
   @Test
   public void testPrimaryTerm() throws Exception {
     GroupMember primary = new GroupMember(MemberId.from("1"), MemberGroupId.from("1"));

--- a/primitive/src/test/java/io/atomix/primitive/partition/impl/PrimaryElectorServiceTest.java
+++ b/primitive/src/test/java/io/atomix/primitive/partition/impl/PrimaryElectorServiceTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.primitive.partition.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.event.EventType;
+import io.atomix.primitive.event.PrimitiveEvent;
+import io.atomix.primitive.operation.OperationType;
+import io.atomix.primitive.partition.GroupMember;
+import io.atomix.primitive.partition.MemberGroupId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PrimaryTerm;
+import io.atomix.primitive.partition.impl.PrimaryElectorOperations.Enter;
+import io.atomix.primitive.partition.impl.PrimaryElectorOperations.GetTerm;
+import io.atomix.primitive.service.Commit;
+import io.atomix.primitive.service.ServiceConfig;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.service.impl.DefaultCommit;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.utils.time.LogicalClock;
+import io.atomix.utils.time.WallClock;
+import io.atomix.utils.time.WallClockTimestamp;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PrimaryElectorServiceTest {
+  static long sessionNum = 0;
+
+  @Test
+  public void testEnterSinglePartition() {
+    PartitionId partition = new PartitionId("test", 1);
+    PrimaryElectorService elector = newService();
+    PrimaryTerm term;
+
+    // 1st member to enter should be primary.
+    GroupMember m1 = createGroupMember("node1", "group1");
+    Session<?> s1 = createSession(m1);
+    term = elector.enter(createEnterOp(partition, m1, s1));
+    assertEquals(1L, term.term());
+    assertEquals(m1, term.primary());
+    assertEquals(1, term.candidates().size());
+
+    // 2nd member to enter should be added to candidates.
+    GroupMember m2 = createGroupMember("node2", "group1");
+    Session<?> s2 = createSession(m2);
+    term = elector.enter(createEnterOp(partition, m2, s2));
+    assertEquals(1L, term.term());
+    assertEquals(m1, term.primary());
+    assertEquals(2, term.candidates().size());
+    assertEquals(m2, term.candidates().get(1));
+  }
+
+  @Test
+  public void testEnterSeveralPartitions() {
+    PrimaryElectorService elector = newService();
+    PrimaryTerm term = null;
+    int numParts = 10;
+    int numMembers = 20;
+
+    List<List<GroupMember>> allMembers = new ArrayList<>();
+    List<PrimaryTerm> terms = new ArrayList<>();
+    for (int p = 0; p < numParts; p++) {
+      PartitionId partId = new PartitionId("test", p);
+      allMembers.add(new ArrayList<>());
+
+      // Add all members in same group.
+      for (int i = 0; i < numMembers; i++) {
+        GroupMember m = createGroupMember("node" + i, "group1");
+        allMembers.get(p).add(m);
+        Session<?> s = createSession(m);
+        term = elector.enter(createEnterOp(partId, m, s));
+      }
+
+      if (term != null) {
+        terms.add(term);
+      }
+    }
+
+    // Check primary and candidates in each partition.
+    for (int p = 0; p < numParts; p++) {
+      assertEquals(1L, terms.get(p).term());
+      assertEquals(allMembers.get(p).get(0), terms.get(p).primary());
+      assertEquals(numMembers, terms.get(p).candidates().size());
+      for (int i = 0; i < numMembers; i++) {
+        assertEquals(allMembers.get(p).get(i), terms.get(p).candidates().get(i));
+      }
+    }
+  }
+
+  @Test
+  public void testEnterSinglePartitionWithGroups() {
+    PrimaryElectorService elector = newService();
+    PartitionId partId = new PartitionId("test", 1);
+    PrimaryTerm term = null;
+    int numMembers = 9;
+
+    // Add 9 members in 3 different groups.
+    List<GroupMember> members = new ArrayList<>();
+    for (int i = 0; i < numMembers; i++) {
+      GroupMember m = createGroupMember("node" + i, "group" + (i / 3));
+      members.add(m);
+      Session<?> s = createSession(m);
+      term = elector.enter(createEnterOp(partId, m, s));
+    }
+
+    // Check primary and candidates.
+    assertEquals(1L, term.term());
+    assertEquals(members.get(0), term.primary());
+    assertEquals(numMembers, term.candidates().size());
+
+    // Check backups are selected in different groups.
+    List<GroupMember> backups2 = term.backups(2);
+    assertEquals(members.get(3), backups2.get(0));
+    assertEquals(members.get(6), backups2.get(1));
+
+    List<GroupMember> backups3 = term.backups(3);
+    assertEquals(members.get(3), backups3.get(0));
+    assertEquals(members.get(6), backups3.get(1));
+    assertEquals(members.get(1), backups3.get(2));
+  }
+
+  @Test
+  public void testEnterAndExpireSessions() {
+    PrimaryElectorService elector = newService();
+    PartitionId partId = new PartitionId("test", 1);
+    PrimaryTerm term = null;
+    int numMembers = 9;
+
+    // Add 9 members in 3 different groups.
+    List<Session<?>> sessions = new ArrayList<>();
+    List<GroupMember> members = new ArrayList<>();
+    for (int i = 0; i < numMembers; i++) {
+      GroupMember m = createGroupMember("node" + i, "group" + (i / 3));
+      members.add(m);
+      Session<?> s = createSession(m);
+      sessions.add(s);
+      term = elector.enter(createEnterOp(partId, m, s));
+    }
+
+    // Check current primary.
+    assertEquals(1L, term.term());
+    assertEquals(members.get(0), term.primary());
+    assertEquals(numMembers, term.candidates().size());
+    List<GroupMember> backups1 = term.backups(2);
+    assertEquals(members.get(3), backups1.get(0));
+    assertEquals(members.get(6), backups1.get(1));
+
+    // Expire session of primary and check new term.
+    // New primary should be the first of the old backups.
+    elector.onExpire(sessions.get(0));
+    term = elector.getTerm(createGetTermOp(partId, members.get(3), sessions.get(3)));
+    assertEquals(2L, term.term());
+    assertEquals(members.get(3), term.primary());
+    assertEquals(numMembers - 1, term.candidates().size());
+    List<GroupMember> backups2 = term.backups(2);
+    assertEquals(members.get(6), backups2.get(0));
+    assertEquals(members.get(1), backups2.get(1));
+
+    // Expire session of backup and check term updated.
+    elector.onExpire(sessions.get(6));
+    term = elector.getTerm(createGetTermOp(partId, members.get(5), sessions.get(5)));
+    assertEquals(2L, term.term());
+    assertEquals(members.get(3), term.primary());
+    assertEquals(numMembers - 2, term.candidates().size());
+    List<GroupMember> backups3 = term.backups(2);
+    assertEquals(members.get(1), backups3.get(0));
+    assertEquals(members.get(4), backups3.get(1));
+  }
+
+  Commit<Enter> createEnterOp(PartitionId partition, GroupMember member, Session<?> session) {
+    Enter enter = new Enter(partition, member);
+    return new DefaultCommit<>(0, null, enter, session, System.currentTimeMillis());
+  }
+
+  Commit<GetTerm> createGetTermOp(PartitionId partition, GroupMember member, Session<?> session) {
+    GetTerm getTerm = new GetTerm(partition);
+    return new DefaultCommit<>(0, null, getTerm, session, System.currentTimeMillis());
+  }
+
+  GroupMember createGroupMember(String id, String groupId) {
+    return new GroupMember(MemberId.from(id), MemberGroupId.from(groupId));
+  }
+
+  PrimaryElectorService newService() {
+    PrimaryElectorService elector = new PrimaryElectorService();
+    elector.init(new ServiceContext() {
+      @Override
+      public PrimitiveId serviceId() {
+        return PrimitiveId.from(1L);
+      }
+
+      @Override
+      public String serviceName() {
+        return "test-primary-elector";
+      }
+
+      @SuppressWarnings("rawtypes")
+      @Override
+      public PrimitiveType serviceType() {
+        return PrimaryElectorType.instance();
+      }
+
+      @Override
+      public MemberId localMemberId() {
+        return null;
+      }
+
+      @Override
+      public <C extends ServiceConfig> C serviceConfig() {
+        return null;
+      }
+
+      @Override
+      public long currentIndex() {
+        return 0;
+      }
+
+      @Override
+      public Session<?> currentSession() {
+        return null;
+      }
+
+      @Override
+      public OperationType currentOperation() {
+        return null;
+      }
+
+      @Override
+      public LogicalClock logicalClock() {
+        return null;
+      }
+
+      @Override
+      public WallClock wallClock() {
+        return null;
+      }
+    });
+    elector.tick(WallClockTimestamp.from(System.currentTimeMillis()));
+    return elector;
+  }
+
+  @SuppressWarnings("rawtypes")
+  Session<?> createSession(final GroupMember member) {
+    return new Session() {
+      long sessionId = sessionNum++;
+
+      @Override
+      public SessionId sessionId() {
+        return SessionId.from(sessionId);
+      }
+
+      @Override
+      public String primitiveName() {
+        return null; // not used in test
+      }
+
+      @Override
+      public PrimitiveType primitiveType() {
+        return null; // not used in test
+      }
+
+      @Override
+      public MemberId memberId() {
+        return member.memberId();
+      }
+
+      @Override
+      public State getState() {
+        return State.OPEN;
+      }
+
+      @Override
+      public void publish(EventType eventType, Object event) {
+        // not used in test
+      }
+
+      @Override
+      public void publish(PrimitiveEvent event) {
+        // not used in test
+      }
+
+      @Override
+      public void accept(Consumer event) {
+        // not used in test
+      }
+
+      @Override
+      public String toString() {
+        return "Session " + sessionId;
+      }
+    };
+  }
+}

--- a/primitive/src/test/java/io/atomix/primitive/partition/impl/PrimaryElectorServiceTest.java
+++ b/primitive/src/test/java/io/atomix/primitive/partition/impl/PrimaryElectorServiceTest.java
@@ -191,7 +191,6 @@ public class PrimaryElectorServiceTest {
   @Test
   public void testSortCandidatesByGroup() {
     PrimaryElectorService elector = newService();
-    PartitionId partId = new PartitionId("test", 1);
     PrimaryTerm term = null;
 
     term = enter("node1", "group1", elector);
@@ -238,6 +237,26 @@ public class PrimaryElectorServiceTest {
     assertEquals("node3", term.candidates().get(5).memberId().id());
   }
 
+  @Test
+  public void testSortCandidatesWithoutGroup() {
+    PrimaryElectorService elector = newService();
+    PrimaryTerm term = null;
+
+    term = enter("node1", "node1", elector);
+    term = enter("node2", "node2", elector);
+    term = enter("node3", "node3", elector);
+    term = enter("node4", "node4", elector);
+    term = enter("node5", "node5", elector);
+    term = enter("node6", "node6", elector);
+
+    assertEquals("node1", term.candidates().get(0).memberId().id());
+    assertEquals("node2", term.candidates().get(1).memberId().id());
+    assertEquals("node3", term.candidates().get(2).memberId().id());
+    assertEquals("node4", term.candidates().get(3).memberId().id());
+    assertEquals("node5", term.candidates().get(4).memberId().id());
+    assertEquals("node6", term.candidates().get(5).memberId().id());
+  }
+
   private PrimaryTerm enter(String nodeId, String groupId, PrimaryElectorService elector) {
     PartitionId partId = new PartitionId("test", 1);
     GroupMember member = createGroupMember(nodeId, groupId);
@@ -256,7 +275,7 @@ public class PrimaryElectorServiceTest {
   }
 
   GroupMember createGroupMember(String id, String groupId) {
-    return new GroupMember(MemberId.from(id), MemberGroupId.from(groupId));
+    return new GroupMember(MemberId.from(id), groupId != null ? MemberGroupId.from(groupId) : null);
   }
 
   PrimaryElectorService newService() {

--- a/primitive/src/test/java/io/atomix/primitive/partition/impl/PrimaryElectorServiceTest.java
+++ b/primitive/src/test/java/io/atomix/primitive/partition/impl/PrimaryElectorServiceTest.java
@@ -188,6 +188,63 @@ public class PrimaryElectorServiceTest {
     assertEquals(members.get(4), backups3.get(1));
   }
 
+  @Test
+  public void testSortCandidatesByGroup() {
+    PrimaryElectorService elector = newService();
+    PartitionId partId = new PartitionId("test", 1);
+    PrimaryTerm term = null;
+
+    term = enter("node1", "group1", elector);
+    assertEquals("node1", term.primary().memberId().id());
+
+    term = enter("node2", "group1", elector);
+    assertEquals("node1", term.primary().memberId().id());
+    assertEquals("node2", term.candidates().get(1).memberId().id());
+    assertEquals("node2", term.backups(2).get(0).memberId().id());
+
+    term = enter("node3", "group1", elector);
+    assertEquals("node1", term.primary().memberId().id());
+    assertEquals("node2", term.candidates().get(1).memberId().id());
+    assertEquals("node2", term.backups(2).get(0).memberId().id());
+    assertEquals("node3", term.candidates().get(2).memberId().id());
+    assertEquals("node3", term.backups(2).get(1).memberId().id());
+
+    term = enter("node4", "group2", elector);
+    assertEquals("node1", term.primary().memberId().id());
+    assertEquals("node4", term.candidates().get(1).memberId().id());
+    assertEquals("node4", term.backups(2).get(0).memberId().id());
+    assertEquals("node2", term.candidates().get(2).memberId().id());
+    assertEquals("node2", term.backups(2).get(1).memberId().id());
+
+    term = enter("node5", "group3", elector);
+    assertEquals("node1", term.primary().memberId().id());
+    assertEquals("node4", term.candidates().get(1).memberId().id());
+    assertEquals("node4", term.backups(2).get(0).memberId().id());
+    assertEquals("node5", term.candidates().get(2).memberId().id());
+    assertEquals("node5", term.backups(2).get(1).memberId().id());
+
+    term = enter("node6", "group3", elector);
+    assertEquals("node1", term.primary().memberId().id());
+    assertEquals("node4", term.candidates().get(1).memberId().id());
+    assertEquals("node4", term.backups(2).get(0).memberId().id());
+    assertEquals("node5", term.candidates().get(2).memberId().id());
+    assertEquals("node5", term.backups(2).get(1).memberId().id());
+
+    assertEquals("node1", term.candidates().get(0).memberId().id());
+    assertEquals("node4", term.candidates().get(1).memberId().id());
+    assertEquals("node5", term.candidates().get(2).memberId().id());
+    assertEquals("node2", term.candidates().get(3).memberId().id());
+    assertEquals("node6", term.candidates().get(4).memberId().id());
+    assertEquals("node3", term.candidates().get(5).memberId().id());
+  }
+
+  private PrimaryTerm enter(String nodeId, String groupId, PrimaryElectorService elector) {
+    PartitionId partId = new PartitionId("test", 1);
+    GroupMember member = createGroupMember(nodeId, groupId);
+    Session session = createSession(member);
+    return elector.enter(createEnterOp(partId, member, session));
+  }
+
   Commit<Enter> createEnterOp(PartitionId partition, GroupMember member, Session<?> session) {
     Enter enter = new Enter(partition, member);
     return new DefaultCommit<>(0, null, enter, session, System.currentTimeMillis());


### PR DESCRIPTION
This PR is a follow up on #863

The fix is to sort primary election candidates by group ID inside the primary elector service. This is done by iterating through candidates and ensuring each group is assigned before proceeding on to the next iteration.