### PR TITLE
Use Java API links in Javadoc configuration to avoid build errors in JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,15 @@
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <!-- workaround for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+              <javaApiLinks>
+                <property>
+                  <name>foo</name>
+                  <value>bar</value>
+                </property>
+              </javaApiLinks>
+            </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Testing a fix for build errors in Java 11 builds.