### PR TITLE
Avoid filtering all Raft sessions when iterating service sessions

### DIFF
--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionRegistryTest.java
@@ -45,11 +45,10 @@ public class RaftSessionRegistryTest {
     RaftSessionContext session = createSession(1);
     sessionManager.addSession(session);
     assertNotNull(sessionManager.getSession(1));
-    assertEquals(0, sessionManager.getSessions(ServiceId.from(1)).size());
-    session.open();
     assertEquals(1, sessionManager.getSessions(ServiceId.from(1)).size());
     sessionManager.removeSession(SessionId.from(1));
     assertNull(sessionManager.getSession(1));
+    assertEquals(0, sessionManager.getSessions(ServiceId.from(1)).size());
   }
 
   private RaftSessionContext createSession(long sessionId) {


### PR DESCRIPTION
When profiling an ONOS cluster, we discovered session management was consuming a lot of CPU time in Raft state machines. This PR modifies the `RaftSessionRegistry` to maintain two separate maps for sessions - one for all sessions and one for sessions registered to a specific service. This eliminates the need to filter all sessions for the current service's sessions when checking for session expiration, committing events, etc.