### PR TITLE
Fix session/memory leak in transactions

### DIFF
--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
@@ -128,7 +128,7 @@ public class DefaultTransaction implements AsyncTransaction {
             .thenCompose(v -> rollback(participants))
             .thenApply(v -> CommitStatus.FAILURE));
     return status.thenCompose(v -> transactionService.complete(transactionId)
-        .thenRun(() -> participants.forEach(p -> p.close().exceptionally(e -> null)))
+        .thenRun(() -> this.participants.forEach(p -> p.close().exceptionally(e -> null)))
         .thenApply(u -> v));
   }
 

--- a/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
+++ b/core/src/main/java/io/atomix/core/transaction/impl/DefaultTransaction.java
@@ -128,7 +128,7 @@ public class DefaultTransaction implements AsyncTransaction {
             .thenCompose(v -> rollback(participants))
             .thenApply(v -> CommitStatus.FAILURE));
     return status.thenCompose(v -> transactionService.complete(transactionId)
-        .thenRun(() -> this.participants.forEach(p -> p.close().exceptionally(e -> null)))
+        .whenComplete((r, e) -> this.participants.forEach(p -> p.close()))
         .thenApply(u -> v));
   }
 

--- a/core/src/test/java/io/atomix/core/transaction/TransactionalMapTest.java
+++ b/core/src/test/java/io/atomix/core/transaction/TransactionalMapTest.java
@@ -42,7 +42,7 @@ public abstract class TransactionalMapTest extends AbstractPrimitiveTest<ProxyPr
         .build();
     transaction2.begin();
 
-    TransactionalMap<String, String> map2 = transaction1.<String, String>mapBuilder("test-map")
+    TransactionalMap<String, String> map2 = transaction2.<String, String>mapBuilder("test-map")
         .withProtocol(protocol())
         .build();
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/DefaultRaftSessionClient.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/DefaultRaftSessionClient.java
@@ -221,8 +221,10 @@ public class DefaultRaftSessionClient implements RaftSessionClient {
 
           selectorManager.addLeaderChangeListener(leaderChangeListener);
           state.addStateChangeListener(s -> {
-            if (s == PrimitiveState.CLOSED) {
+            if (s == PrimitiveState.EXPIRED || s == PrimitiveState.CLOSED) {
               selectorManager.removeLeaderChangeListener(leaderChangeListener);
+              proxyListener.close();
+              proxyInvoker.close();
             }
           });
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
@@ -369,14 +369,14 @@ final class RaftSessionInvoker {
         // If the client is unknown by the cluster, close the session and complete the operation exceptionally.
         else if (response.error().type() == RaftError.Type.UNKNOWN_CLIENT
             || response.error().type() == RaftError.Type.UNKNOWN_SESSION) {
-          state.setState(PrimitiveState.EXPIRED);
           complete(response.error().createException());
+          state.setState(PrimitiveState.EXPIRED);
         }
         // If the service is unknown by the cluster or the session was explicitly closed, set the session state to CLOSED.
         else if (response.error().type() == RaftError.Type.UNKNOWN_SERVICE
             || response.error().type() == RaftError.Type.CLOSED_SESSION) {
-          state.setState(PrimitiveState.CLOSED);
           complete(response.error().createException());
+          state.setState(PrimitiveState.CLOSED);
         }
         // For all other errors, use fibonacci backoff to resubmit the command.
         else {
@@ -437,12 +437,12 @@ final class RaftSessionInvoker {
           complete(response);
         } else if (response.error().type() == RaftError.Type.UNKNOWN_CLIENT
             || response.error().type() == RaftError.Type.UNKNOWN_SESSION) {
-          state.setState(PrimitiveState.EXPIRED);
           complete(response.error().createException());
+          state.setState(PrimitiveState.EXPIRED);
         } else if (response.error().type() == RaftError.Type.UNKNOWN_SERVICE
             || response.error().type() == RaftError.Type.CLOSED_SESSION) {
-          state.setState(PrimitiveState.CLOSED);
           complete(response.error().createException());
+          state.setState(PrimitiveState.CLOSED);
         } else {
           complete(response.error().createException());
         }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionManager.java
@@ -223,7 +223,7 @@ public class RaftSessionManager {
       return Futures.exceptionalFuture(new RaftException.UnknownSession("Unknown session: " + sessionId));
     }
 
-    log.info("Closing session {}", sessionId);
+    log.debug("Closing session {}", sessionId);
     CloseSessionRequest request = CloseSessionRequest.builder()
         .withSession(sessionId.id())
         .withDelete(delete)
@@ -231,9 +231,9 @@ public class RaftSessionManager {
 
     CompletableFuture<Void> future = new CompletableFuture<>();
     connection.closeSession(request).whenComplete((response, error) -> {
+      sessions.remove(sessionId.id());
       if (error == null) {
         if (response.status() == RaftResponse.Status.OK) {
-          sessions.remove(sessionId.id());
           future.complete(null);
         } else {
           future.completeExceptionally(response.error().createException());

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1168,7 +1168,7 @@ public class RaftTest extends ConcurrentTestCase {
       resume();
     });
     primitive2.read().whenComplete((result, error) -> {
-      threadAssertTrue(error.getCause() instanceof PrimitiveException.UnknownService);
+      threadAssertTrue(error.getCause() instanceof PrimitiveException.ClosedSession);
       resume();
     });
     await(5000, 2);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1167,11 +1167,7 @@ public class RaftTest extends ConcurrentTestCase {
       threadAssertTrue(error.getCause() instanceof PrimitiveException.UnknownService);
       resume();
     });
-    primitive2.read().whenComplete((result, error) -> {
-      threadAssertTrue(error.getCause() instanceof PrimitiveException.ClosedSession);
-      resume();
-    });
-    await(5000, 2);
+    await(5000);
 
     primitive2.read().whenComplete((result, error) -> {
       threadAssertTrue(error.getCause() instanceof PrimitiveException.ClosedSession);


### PR DESCRIPTION
This PR fixes a memory leak in transactions. When a transaction is created, the primitives used in the transaction may be created specifically for the transaction. When the transaction is committed or aborted, those primitives will be `close`d. However, currently only primitives that changed will be closed during a `commit`. This can leave open sessions.

Secondly, when a Raft session is closed, some client-side message handlers are not properly cleaned up. This PR ensures session event handlers are removed from the underlying messaging service when closed.