### PR TITLE
Transition Raft servers to candidate/leader immediately if single node cluster

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/CandidateRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/CandidateRole.java
@@ -57,6 +57,8 @@ public final class CandidateRole extends ActiveRole {
   public synchronized CompletableFuture<RaftRole> start() {
     if (raft.getCluster().getActiveMemberStates().isEmpty()) {
       log.debug("Single member cluster. Transitioning directly to leader.");
+      raft.setTerm(raft.getTerm() + 1);
+      raft.setLastVotedFor(raft.getCluster().getMember().memberId());
       raft.transition(RaftServer.Role.LEADER);
       return CompletableFuture.completedFuture(this);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/CandidateRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/CandidateRole.java
@@ -55,6 +55,11 @@ public final class CandidateRole extends ActiveRole {
 
   @Override
   public synchronized CompletableFuture<RaftRole> start() {
+    if (raft.getCluster().getActiveMemberStates().isEmpty()) {
+      log.debug("Single member cluster. Transitioning directly to leader.");
+      raft.transition(RaftServer.Role.LEADER);
+      return CompletableFuture.completedFuture(this);
+    }
     return super.start().thenRun(this::startElection).thenApply(v -> this);
   }
 
@@ -90,13 +95,6 @@ public final class CandidateRole extends ActiveRole {
 
     final AtomicBoolean complete = new AtomicBoolean();
     final Set<DefaultRaftMember> votingMembers = new HashSet<>(raft.getCluster().getActiveMemberStates().stream().map(RaftMemberContext::getMember).collect(Collectors.toList()));
-
-    // If there are no other members in the cluster, immediately transition to leader.
-    if (votingMembers.isEmpty()) {
-      log.debug("Single member cluster. Transitioning directly to leader.", raft.getCluster().getMember().memberId());
-      raft.transition(RaftServer.Role.LEADER);
-      return;
-    }
 
     // Send vote requests to all nodes. The vote request that is sent
     // to this node will be automatically successful.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -62,6 +62,11 @@ public final class FollowerRole extends ActiveRole {
 
   @Override
   public synchronized CompletableFuture<RaftRole> start() {
+    if (raft.getCluster().getActiveMemberStates().isEmpty()) {
+      log.debug("Single member cluster. Transitioning directly to candidate.");
+      raft.transition(RaftServer.Role.CANDIDATE);
+      return CompletableFuture.completedFuture(this);
+    }
     raft.getMembershipService().addListener(clusterListener);
     return super.start().thenRun(this::resetHeartbeatTimeout).thenApply(v -> this);
   }


### PR DESCRIPTION
Just a small optimization for startup time in a single node cluster.