### PR TITLE
Use G1 GC in Atomix agent by default

### DIFF
--- a/dist/src/main/resources/bin/atomix-agent
+++ b/dist/src/main/resources/bin/atomix-agent
@@ -14,7 +14,8 @@ fi
 ATOMIX_ROOT="$(dirname "$(dirname "$0")")"
 
 java \
-  -XX:+UseConcMarkSweepGC \
+  -XX:+UseG1GC \
+  -XX:MaxGCPauseMillis=200 \
   $JAVA_OPTS \
   -Datomix.root="$ATOMIX_ROOT" \
   -Datomix.data="$ATOMIX_ROOT/data" \


### PR DESCRIPTION
We've seen significant improvements in stability in production using G1 rather than CMS. It pretty reliably keeps GC pauses below the threshold of default Raft leader election timeouts. This PR enables G1 with a 200ms pause goal.