### PR TITLE
Local AtomicMap implementation

### DIFF
--- a/core/src/main/java/io/atomix/core/map/impl/CachedAsyncAtomicMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/CachedAsyncAtomicMap.java
@@ -1,0 +1,622 @@
+/*
+ * Copyright 2019-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.map.impl;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.google.common.collect.Maps;
+import io.atomix.core.collection.AsyncDistributedCollection;
+import io.atomix.core.collection.CollectionEvent;
+import io.atomix.core.collection.CollectionEventListener;
+import io.atomix.core.collection.DistributedCollection;
+import io.atomix.core.collection.impl.BlockingDistributedCollection;
+import io.atomix.core.iterator.AsyncIterator;
+import io.atomix.core.map.AsyncAtomicMap;
+import io.atomix.core.map.AtomicMapEventListener;
+import io.atomix.core.set.AsyncDistributedSet;
+import io.atomix.core.set.DistributedSet;
+import io.atomix.core.set.impl.AsyncDistributedJavaSet;
+import io.atomix.core.set.impl.BlockingDistributedSet;
+import io.atomix.core.set.impl.SetUpdate;
+import io.atomix.core.transaction.TransactionId;
+import io.atomix.core.transaction.TransactionLog;
+import io.atomix.primitive.PrimitiveState;
+import io.atomix.primitive.PrimitiveType;
+import io.atomix.primitive.protocol.PrimitiveProtocol;
+import io.atomix.utils.concurrent.Futures;
+import io.atomix.utils.time.Versioned;
+
+/**
+ * Implementation of {@link io.atomix.core.map.AsyncAtomicMap} that caches the entire map locally, allowing for
+ * e.g. local iteration.
+ */
+public class CachedAsyncAtomicMap<K, V> extends DelegatingAsyncAtomicMap<K, V> {
+  private final AsyncAtomicMap<K, V> map;
+  private final Map<K, Supplier<CompletableFuture<Versioned<V>>>> cache = new ConcurrentHashMap<>();
+  private final Map<AtomicMapEventListener<K, V>, Executor> eventListeners = new ConcurrentHashMap<>();
+  private final AtomicMapEventListener<K, V> cacheUpdater = event -> {
+    Versioned<V> newValue = event.newValue();
+    if (newValue == null) {
+      cache.remove(event.key());
+    } else {
+      cache.put(event.key(), () -> CompletableFuture.completedFuture(newValue));
+    }
+    eventListeners.forEach((listener, executor) -> executor.execute(() -> listener.event(event)));
+  };
+  private final Consumer<PrimitiveState> stateListener = status -> {
+    if (status == PrimitiveState.CONNECTED) {
+      create();
+    }
+  };
+
+  public CachedAsyncAtomicMap(AsyncAtomicMap<K, V> delegate) {
+    super(delegate);
+    this.map = delegate;
+    map.addStateChangeListener(stateListener);
+  }
+
+  /**
+   * Creates the cache.
+   *
+   * @return a future to be completed once the cache has been created
+   */
+  CompletableFuture<AsyncAtomicMap<K, V>> create() {
+    return map.addListener(cacheUpdater)
+        .thenCompose(v -> create(map.entrySet().iterator()));
+  }
+
+  private CompletableFuture<AsyncAtomicMap<K, V>> create(AsyncIterator<Map.Entry<K, Versioned<V>>> iterator) {
+    CompletableFuture<AsyncAtomicMap<K, V>> future = new CompletableFuture<>();
+    create(iterator, future);
+    return future;
+  }
+
+  private void create(
+      AsyncIterator<Map.Entry<K, Versioned<V>>> iterator,
+      CompletableFuture<AsyncAtomicMap<K, V>> future) {
+    iterator.hasNext().whenComplete((hasNext, hasNextError) -> {
+      if (hasNextError == null) {
+        if (hasNext) {
+          iterator.next().whenComplete((entry, nextError) -> {
+            if (nextError == null) {
+              cache.put(entry.getKey(), () -> CompletableFuture.completedFuture(entry.getValue()));
+              create(iterator, future);
+            } else {
+              future.completeExceptionally(nextError);
+            }
+          });
+        } else {
+          future.complete(this);
+        }
+      } else {
+        future.completeExceptionally(hasNextError);
+      }
+    });
+  }
+
+  private <T> CompletableFuture<T> runOnCache(Supplier<T> supplier) {
+    return CompletableFuture.completedFuture(supplier.get());
+  }
+
+  @Override
+  public CompletableFuture<Integer> size() {
+    return runOnCache(cache::size);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> containsKey(K key) {
+    return runOnCache(() -> cache.containsKey(key));
+  }
+
+  @Override
+  public CompletableFuture<Boolean> containsValue(V value) {
+    CompletableFuture<Boolean> future = new CompletableFuture<>();
+    containsValue(value, cache.values().iterator(), future);
+    return future;
+  }
+
+  private void containsValue(V value, Iterator<Supplier<CompletableFuture<Versioned<V>>>> iterator, CompletableFuture<Boolean> future) {
+    if (iterator.hasNext()) {
+      iterator.next().get().whenComplete((result, error) -> {
+        if (error == null) {
+          if (Objects.equals(value, result.value())) {
+            future.complete(true);
+          } else {
+            containsValue(value, iterator, future);
+          }
+        } else {
+          future.completeExceptionally(error);
+        }
+      });
+    } else {
+      future.complete(false);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Versioned<V>> get(K key) {
+    return cache.getOrDefault(key, () -> CompletableFuture.completedFuture(null)).get();
+  }
+
+  @Override
+  public CompletableFuture<Map<K, Versioned<V>>> getAllPresent(Iterable<K> keys) {
+    CompletableFuture<Map<K, Versioned<V>>> future = new CompletableFuture<>();
+    getAllPresent(keys.iterator(), new HashMap<>(), future);
+    return future;
+  }
+
+  private void getAllPresent(Iterator<K> iterator, Map<K, Versioned<V>> map, CompletableFuture<Map<K, Versioned<V>>> future) {
+    if (iterator.hasNext()) {
+      K key = iterator.next();
+      Supplier<CompletableFuture<Versioned<V>>> value = cache.get(key);
+      if (value != null) {
+        value.get().whenComplete((result, error) -> {
+          if (error == null) {
+            if (result != null) {
+              map.put(key, result);
+            }
+            getAllPresent(iterator, map, future);
+          } else {
+            future.completeExceptionally(error);
+          }
+        });
+      } else {
+        getAllPresent(iterator, map, future);
+      }
+    } else {
+      future.complete(map);
+    }
+  }
+
+  @Override
+  public CompletableFuture<Versioned<V>> getOrDefault(K key, V defaultValue) {
+    return cache.getOrDefault(key, () -> CompletableFuture.completedFuture(new Versioned<>(defaultValue, 0))).get();
+  }
+
+  @Override
+  public CompletableFuture<Versioned<V>> put(K key, V value, Duration ttl) {
+    return super.put(key, value, ttl)
+        .thenApply(result -> {
+          cache.put(key, () -> map.get(key));
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Versioned<V>> putAndGet(K key, V value, Duration ttl) {
+    return super.putAndGet(key, value, ttl)
+        .thenApply(result -> {
+          cache.put(key, () -> CompletableFuture.completedFuture(result));
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Versioned<V>> putIfAbsent(K key, V value, Duration ttl) {
+    return super.putIfAbsent(key, value, ttl)
+        .thenApply(result -> {
+          cache.put(key, () -> map.get(key));
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Versioned<V>> remove(K key) {
+    return super.remove(key)
+        .thenApply(result -> {
+          cache.remove(key);
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Boolean> remove(K key, V value) {
+    return super.remove(key, value)
+        .thenApply(result -> {
+          if (result) {
+            cache.remove(key);
+          }
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Boolean> remove(K key, long version) {
+    return super.remove(key, version)
+        .thenApply(result -> {
+          if (result) {
+            cache.remove(key);
+          }
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Versioned<V>> replace(K key, V value) {
+    return super.replace(key, value)
+        .thenApply(result -> {
+          cache.put(key, () -> map.get(key));
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Boolean> replace(K key, V oldValue, V newValue) {
+    return super.replace(key, oldValue, newValue)
+        .thenApply(result -> {
+          if (result) {
+            cache.put(key, () -> map.get(key));
+          }
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Boolean> replace(K key, long oldVersion, V newValue) {
+    return super.replace(key, oldVersion, newValue)
+        .thenApply(result -> {
+          if (result) {
+            cache.put(key, () -> map.get(key));
+          }
+          return result;
+        });
+  }
+
+  @Override
+  public CompletableFuture<Void> clear() {
+    return super.clear().thenRun(() -> cache.clear());
+  }
+
+  @Override
+  public AsyncDistributedSet<K> keySet() {
+    return new AsyncDistributedJavaSet<>(name(), protocol(), cache.keySet());
+  }
+
+  @Override
+  public AsyncDistributedCollection<Versioned<V>> values() {
+    return new Values();
+  }
+
+  @Override
+  public AsyncDistributedSet<Map.Entry<K, Versioned<V>>> entrySet() {
+    return new EntrySet();
+  }
+
+  @Override
+  public CompletableFuture<Void> addListener(AtomicMapEventListener<K, V> listener, Executor executor) {
+    eventListeners.put(listener, executor);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Void> removeListener(AtomicMapEventListener<K, V> listener) {
+    eventListeners.remove(listener);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private class Values implements AsyncDistributedCollection<Versioned<V>> {
+    private final Map<CollectionEventListener<Versioned<V>>, AtomicMapEventListener<K, V>> listenerMap = new ConcurrentHashMap<>();
+
+    @Override
+    public String name() {
+      return CachedAsyncAtomicMap.this.name();
+    }
+
+    @Override
+    public PrimitiveType type() {
+      return CachedAsyncAtomicMap.this.type();
+    }
+
+    @Override
+    public PrimitiveProtocol protocol() {
+      return CachedAsyncAtomicMap.this.protocol();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> add(Versioned<V> element) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> remove(Versioned<V> element) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Integer> size() {
+      return CachedAsyncAtomicMap.this.size();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isEmpty() {
+      return CachedAsyncAtomicMap.this.isEmpty();
+    }
+
+    @Override
+    public CompletableFuture<Void> clear() {
+      return CachedAsyncAtomicMap.this.clear();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> contains(Versioned<V> element) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> addAll(Collection<? extends Versioned<V>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> containsAll(Collection<? extends Versioned<V>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> retainAll(Collection<? extends Versioned<V>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> removeAll(Collection<? extends Versioned<V>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Void> addListener(CollectionEventListener<Versioned<V>> listener, Executor executor) {
+      AtomicMapEventListener<K, V> mapListener = event -> {
+        switch (event.type()) {
+          case INSERT:
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.ADD, event.newValue()));
+            break;
+          case UPDATE:
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.REMOVE, event.oldValue()));
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.ADD, event.newValue()));
+            break;
+          case REMOVE:
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.REMOVE, event.oldValue()));
+            break;
+        }
+      };
+      if (listenerMap.putIfAbsent(listener, mapListener) == null) {
+        return CachedAsyncAtomicMap.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeListener(CollectionEventListener<Versioned<V>> listener) {
+      AtomicMapEventListener<K, V> mapListener = listenerMap.remove(listener);
+      if (mapListener != null) {
+        return CachedAsyncAtomicMap.this.removeListener(mapListener);
+      }
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public DistributedCollection<Versioned<V>> sync(Duration operationTimeout) {
+      return new BlockingDistributedCollection<>(this, operationTimeout.toMillis());
+    }
+
+    @Override
+    public AsyncIterator<Versioned<V>> iterator() {
+      return new ValuesIterator();
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+      return CachedAsyncAtomicMap.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return CachedAsyncAtomicMap.this.delete();
+    }
+  }
+
+  private class ValuesIterator implements AsyncIterator<Versioned<V>> {
+    private final Iterator<Supplier<CompletableFuture<Versioned<V>>>> iterator;
+
+    private ValuesIterator() {
+      this.iterator = cache.values().iterator();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> hasNext() {
+      return CompletableFuture.completedFuture(iterator.hasNext());
+    }
+
+    @Override
+    public CompletableFuture<Versioned<V>> next() {
+      return iterator.next().get();
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+      return CompletableFuture.completedFuture(null);
+    }
+  }
+
+  private class EntrySet implements AsyncDistributedSet<Map.Entry<K, Versioned<V>>> {
+    private final Map<CollectionEventListener<Map.Entry<K, Versioned<V>>>, AtomicMapEventListener<K, V>> listenerMap = new ConcurrentHashMap<>();
+
+    @Override
+    public String name() {
+      return CachedAsyncAtomicMap.this.name();
+    }
+
+    @Override
+    public PrimitiveType type() {
+      return CachedAsyncAtomicMap.this.type();
+    }
+
+    @Override
+    public PrimitiveProtocol protocol() {
+      return CachedAsyncAtomicMap.this.protocol();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> add(Map.Entry<K, Versioned<V>> element) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> remove(Map.Entry<K, Versioned<V>> element) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Integer> size() {
+      return CachedAsyncAtomicMap.this.size();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> isEmpty() {
+      return CachedAsyncAtomicMap.this.isEmpty();
+    }
+
+    @Override
+    public CompletableFuture<Void> clear() {
+      return CachedAsyncAtomicMap.this.clear();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> contains(Map.Entry<K, Versioned<V>> element) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> addAll(Collection<? extends Map.Entry<K, Versioned<V>>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> containsAll(Collection<? extends Map.Entry<K, Versioned<V>>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> retainAll(Collection<? extends Map.Entry<K, Versioned<V>>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> removeAll(Collection<? extends Map.Entry<K, Versioned<V>>> c) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Void> addListener(CollectionEventListener<Map.Entry<K, Versioned<V>>> listener, Executor executor) {
+      AtomicMapEventListener<K, V> mapListener = event -> {
+        switch (event.type()) {
+          case INSERT:
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.ADD, Maps.immutableEntry(event.key(), event.newValue())));
+            break;
+          case UPDATE:
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.REMOVE, Maps.immutableEntry(event.key(), event.oldValue())));
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.ADD, Maps.immutableEntry(event.key(), event.newValue())));
+            break;
+          case REMOVE:
+            listener.event(new CollectionEvent<>(CollectionEvent.Type.REMOVE, Maps.immutableEntry(event.key(), event.oldValue())));
+            break;
+        }
+      };
+      if (listenerMap.putIfAbsent(listener, mapListener) == null) {
+        return CachedAsyncAtomicMap.this.addListener(mapListener, executor);
+      }
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeListener(CollectionEventListener<Map.Entry<K, Versioned<V>>> listener) {
+      AtomicMapEventListener<K, V> mapListener = listenerMap.remove(listener);
+      if (mapListener != null) {
+        return CachedAsyncAtomicMap.this.removeListener(mapListener);
+      }
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public AsyncIterator<Map.Entry<K, Versioned<V>>> iterator() {
+      return new EntrySetIterator();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> prepare(TransactionLog<SetUpdate<Map.Entry<K, Versioned<V>>>> transactionLog) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Void> commit(TransactionId transactionId) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Void> rollback(TransactionId transactionId) {
+      return Futures.exceptionalFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+      return CachedAsyncAtomicMap.this.close();
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+      return CachedAsyncAtomicMap.this.delete();
+    }
+
+    @Override
+    public DistributedSet<Map.Entry<K, Versioned<V>>> sync(Duration operationTimeout) {
+      return new BlockingDistributedSet<>(this, operationTimeout.toMillis());
+    }
+  }
+
+  private class EntrySetIterator implements AsyncIterator<Map.Entry<K, Versioned<V>>> {
+    private final Iterator<Map.Entry<K, Supplier<CompletableFuture<Versioned<V>>>>> iterator;
+
+    EntrySetIterator() {
+      this.iterator = cache.entrySet().iterator();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> hasNext() {
+      return CompletableFuture.completedFuture(iterator.hasNext());
+    }
+
+    @Override
+    public CompletableFuture<Map.Entry<K, Versioned<V>>> next() {
+      Map.Entry<K, Supplier<CompletableFuture<Versioned<V>>>> entry = iterator.next();
+      return entry.getValue().get()
+          .thenApply(value -> Maps.immutableEntry(entry.getKey(), value));
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+      return CompletableFuture.completedFuture(null);
+    }
+  }
+}

--- a/core/src/main/java/io/atomix/core/map/impl/CachingAsyncAtomicMap.java
+++ b/core/src/main/java/io/atomix/core/map/impl/CachingAsyncAtomicMap.java
@@ -26,6 +26,7 @@ import io.atomix.primitive.PrimitiveState;
 import io.atomix.utils.time.Versioned;
 import org.slf4j.Logger;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -134,20 +135,20 @@ public class CachingAsyncAtomicMap<K, V> extends DelegatingAsyncAtomicMap<K, V> 
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> put(K key, V value) {
-    return super.put(key, value)
+  public CompletableFuture<Versioned<V>> put(K key, V value, Duration ttl) {
+    return super.put(key, value, ttl)
         .whenComplete((r, e) -> cache.invalidate(key));
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putAndGet(K key, V value) {
-    return super.putAndGet(key, value)
+  public CompletableFuture<Versioned<V>> putAndGet(K key, V value, Duration ttl) {
+    return super.putAndGet(key, value, ttl)
         .whenComplete((r, e) -> cache.invalidate(key));
   }
 
   @Override
-  public CompletableFuture<Versioned<V>> putIfAbsent(K key, V value) {
-    return super.putIfAbsent(key, value)
+  public CompletableFuture<Versioned<V>> putIfAbsent(K key, V value, Duration ttl) {
+    return super.putIfAbsent(key, value, ttl)
         .whenComplete((r, e) -> cache.invalidate(key));
   }
 

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
@@ -58,23 +58,29 @@ public class DefaultDistributedMapBuilder<K, V> extends DistributedMapBuilder<K,
           .thenCompose(proxy -> new AtomicMapProxy((ProxyClient) proxy, managementService.getPrimitiveRegistry()).connect())
           .thenApply(rawMap -> {
             Serializer serializer = serializer();
-            AsyncAtomicMap<K, V> map = new TranscodingAsyncAtomicMap<K, V, String, byte[]>(
+            return new TranscodingAsyncAtomicMap<K, V, String, byte[]>(
                 rawMap,
                 key -> BaseEncoding.base16().encode(serializer.encode(key)),
                 string -> serializer.decode(BaseEncoding.base16().decode(string)),
                 value -> serializer.encode(value),
                 bytes -> serializer.decode(bytes));
-
+          }).thenApply(map -> {
             if (!config.isNullValues()) {
-              map = new NotNullAsyncAtomicMap<>(map);
+              return new NotNullAsyncAtomicMap<>(map);
             }
-
+            return map;
+          }).thenCompose(map -> {
             if (config.getCacheConfig().isEnabled()) {
-              map = new CachingAsyncAtomicMap<>(map, config.getCacheConfig());
+              if (config.getCacheConfig().getSize() == -1) {
+                return new CachedAsyncAtomicMap<>(map).create();
+              } else {
+                return CompletableFuture.completedFuture(new CachingAsyncAtomicMap<>(map, config.getCacheConfig()));
+              }
             }
-
+            return CompletableFuture.completedFuture(map);
+          }).thenApply(map -> {
             if (config.isReadOnly()) {
-              map = new UnmodifiableAsyncAtomicMap<>(map);
+              return new UnmodifiableAsyncAtomicMap<>(map);
             }
             return map;
           }).thenApply(atomicMap -> new DelegatingAsyncDistributedMap<>(atomicMap).sync());

--- a/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
+++ b/core/src/main/java/io/atomix/core/map/impl/DefaultDistributedMapBuilder.java
@@ -16,7 +16,6 @@
 package io.atomix.core.map.impl;
 
 import com.google.common.io.BaseEncoding;
-import io.atomix.core.map.AsyncAtomicMap;
 import io.atomix.core.map.AsyncDistributedMap;
 import io.atomix.core.map.DistributedMap;
 import io.atomix.core.map.DistributedMapBuilder;

--- a/core/src/test/java/io/atomix/core/map/AtomicMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/AtomicMapTest.java
@@ -88,14 +88,14 @@ public class AtomicMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testSimpleMap() throws Throwable {
-    testMap(atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
+    testMap(atomix().<String, String>atomicMapBuilder("testSimpleMap")
         .withProtocol(protocol())
         .build());
   }
 
   @Test
   public void testCachedMap() throws Throwable {
-    testMap(atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
+    testMap(atomix().<String, String>atomicMapBuilder("testCachedMap")
         .withProtocol(protocol())
         .withCacheEnabled()
         .build());
@@ -103,11 +103,32 @@ public class AtomicMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testLocalMap() throws Throwable {
-    testMap(atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
+    testMap(atomix().<String, String>atomicMapBuilder("testLocalMap")
         .withProtocol(protocol())
         .withCacheEnabled()
         .withCacheSize(-1)
         .build());
+  }
+
+  @Test
+  public void testLocalMapInitialization() throws Exception {
+    AtomicMap<String, String> map1 = atomix().<String, String>atomicMapBuilder("testLocalMapInitialization")
+        .withProtocol(protocol())
+        .withCacheEnabled()
+        .withCacheSize(-1)
+        .build();
+
+    map1.put("foo", "bar");
+    map1.put("bar", "baz");
+
+    AtomicMap<String, String> map2 = atomix().<String, String>atomicMapBuilder("testLocalMapInitialization")
+        .withProtocol(protocol())
+        .withCacheEnabled()
+        .withCacheSize(-1)
+        .build();
+
+    assertEquals("bar", map2.get("foo").value());
+    assertEquals("baz", map2.get("bar").value());
   }
 
   private void testMap(AtomicMap<String, String> map) throws Exception {

--- a/core/src/test/java/io/atomix/core/map/AtomicMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/AtomicMapTest.java
@@ -87,13 +87,32 @@ public class AtomicMapTest extends AbstractPrimitiveTest {
   }
 
   @Test
-  public void testBasicMapOperations() throws Throwable {
+  public void testSimpleMap() throws Throwable {
+    testMap(atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .build());
+  }
+
+  @Test
+  public void testCachedMap() throws Throwable {
+    testMap(atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .withCacheEnabled()
+        .build());
+  }
+
+  @Test
+  public void testLocalMap() throws Throwable {
+    testMap(atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .withCacheEnabled()
+        .withCacheSize(-1)
+        .build());
+  }
+
+  private void testMap(AtomicMap<String, String> map) throws Exception {
     final String fooValue = "Hello foo!";
     final String barValue = "Hello bar!";
-
-    AtomicMap<String, String> map = atomix().<String, String>atomicMapBuilder("testBasicMapOperationMap")
-        .withProtocol(protocol())
-        .build();
 
     assertTrue(map.isEmpty());
     assertNull(map.put("foo", fooValue));

--- a/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
@@ -69,14 +69,14 @@ public class DistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testSimpleMap() throws Throwable {
-    testBasicMapOperations(atomix().<String, String>mapBuilder("testBasicMapOperationMap")
+    testBasicMapOperations(atomix().<String, String>mapBuilder("testSimpleMap")
         .withProtocol(protocol())
         .build());
   }
 
   @Test
   public void testCachedMap() throws Throwable {
-    testBasicMapOperations(atomix().<String, String>mapBuilder("testBasicMapOperationMap")
+    testBasicMapOperations(atomix().<String, String>mapBuilder("testCachedMap")
         .withProtocol(protocol())
         .withCacheEnabled()
         .build());
@@ -84,7 +84,7 @@ public class DistributedMapTest extends AbstractPrimitiveTest {
 
   @Test
   public void testLocalMap() throws Throwable {
-    testBasicMapOperations(atomix().<String, String>mapBuilder("testBasicMapOperationMap")
+    testBasicMapOperations(atomix().<String, String>mapBuilder("testLocalMap")
         .withProtocol(protocol())
         .withCacheEnabled()
         .withCacheSize(-1)

--- a/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
+++ b/core/src/test/java/io/atomix/core/map/DistributedMapTest.java
@@ -68,13 +68,32 @@ public class DistributedMapTest extends AbstractPrimitiveTest {
   }
 
   @Test
-  public void testBasicMapOperations() throws Throwable {
+  public void testSimpleMap() throws Throwable {
+    testBasicMapOperations(atomix().<String, String>mapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .build());
+  }
+
+  @Test
+  public void testCachedMap() throws Throwable {
+    testBasicMapOperations(atomix().<String, String>mapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .withCacheEnabled()
+        .build());
+  }
+
+  @Test
+  public void testLocalMap() throws Throwable {
+    testBasicMapOperations(atomix().<String, String>mapBuilder("testBasicMapOperationMap")
+        .withProtocol(protocol())
+        .withCacheEnabled()
+        .withCacheSize(-1)
+        .build());
+  }
+
+  private void testBasicMapOperations(DistributedMap<String, String> map) throws Throwable {
     final String fooValue = "Hello foo!";
     final String barValue = "Hello bar!";
-
-    DistributedMap<String, String> map = atomix().<String, String>mapBuilder("testBasicMapOperationMap")
-        .withProtocol(protocol())
-        .build();
 
     assertTrue(map.isEmpty());
     assertNull(map.put("foo", fooValue));


### PR DESCRIPTION
This PR adds experimental support for a fully locally cached `AtomicMap` and `DistributedMap`. This essentially amounts to replication to the client, and it relies on consistency guarantees of map events to maintain the local map. Maintaining a map locally means the entire data set can be iterated without remote calls. This feature is needed for a performance optimization in ONOS.