### PR TITLE
Fix memory leak in Raft member selectors

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionConnection.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionConnection.java
@@ -306,4 +306,11 @@ public class RaftSessionConnection {
       return currentNode;
     }
   }
+
+  /**
+   * Closes the connection.
+   */
+  public void close() {
+    selector.close();
+  }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
@@ -216,6 +216,8 @@ final class RaftSessionInvoker {
       attempt.fail(new PrimitiveException.ClosedSession("session closed"));
     }
     attempts.clear();
+    sessionConnection.close();
+    leaderConnection.close();
     return CompletableFuture.completedFuture(null);
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionListener.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionListener.java
@@ -140,6 +140,7 @@ final class RaftSessionListener {
    */
   public CompletableFuture<Void> close() {
     protocol.unregisterPublishListener(state.getSessionId());
+    memberSelector.close();
     return CompletableFuture.completedFuture(null);
   }
 }


### PR DESCRIPTION
This PR fixes a memory leak in Raft clients. When a Raft session is closed, the `MemberSelector`s used by the session are never unregistered from the `MemberSelectorManager`. This change simply removes the selectors when the session's state changes to `EXPIRED` or `CLOSED`.