### PR TITLE
fix(cluster): do not send requests to unresolvable hosts

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -20,6 +20,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.net.InetAddress;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.MessageDigest;
@@ -470,6 +471,13 @@ public class NettyMessagingService implements ManagedMessagingService {
    */
   private CompletableFuture<Channel> bootstrapClient(Address address) {
     CompletableFuture<Channel> future = new OrderedFuture<>();
+    final InetAddress resolvedAddress = address.address(true);
+    if (resolvedAddress == null) {
+      future.completeExceptionally(new IllegalStateException("Failed to bootstrap client (address "
+          + address.toString() + " cannot be resolved)"));
+      return future;
+    }
+
     Bootstrap bootstrap = new Bootstrap();
     bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
     bootstrap.option(ChannelOption.WRITE_BUFFER_WATER_MARK,
@@ -483,7 +491,7 @@ public class NettyMessagingService implements ManagedMessagingService {
     // TODO: Make this faster:
     // http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#37.0
     bootstrap.channel(clientChannelClass);
-    bootstrap.remoteAddress(address.address(true), address.port());
+    bootstrap.remoteAddress(resolvedAddress, address.port());
     if (enableNettyTls) {
       try {
         bootstrap.handler(new SslClientChannelInitializer(future, address));

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -40,6 +40,7 @@ import io.netty.channel.socket.nio.NioDatagramChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.Map;
@@ -54,6 +55,7 @@ import static io.atomix.utils.concurrent.Threads.namedThreads;
  * Netty unicast service.
  */
 public class NettyUnicastService implements ManagedUnicastService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(NettyUnicastService.class);
   private static final Serializer SERIALIZER = Serializer.using(Namespace.builder()
       .register(Namespaces.BASIC)
       .nextId(Namespaces.BEGIN_USER_CUSTOM_ID)
@@ -78,11 +80,17 @@ public class NettyUnicastService implements ManagedUnicastService {
 
   @Override
   public void unicast(Address address, String subject, byte[] payload) {
+    final InetAddress resolvedAddress = address.address();
+    if (resolvedAddress == null) {
+      LOGGER.debug("Failed sending unicast message (destination address {} cannot be resolved)", address);
+      return;
+    }
+
     Message message = new Message(this.address, subject, payload);
     byte[] bytes = SERIALIZER.encode(message);
     ByteBuf buf = channel.alloc().buffer(4 + bytes.length);
     buf.writeInt(bytes.length).writeBytes(bytes);
-    channel.writeAndFlush(new DatagramPacket(buf, new InetSocketAddress(address.address(), address.port())));
+    channel.writeAndFlush(new DatagramPacket(buf, new InetSocketAddress(resolvedAddress, address.port())));
   }
 
   @Override

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -126,6 +126,14 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
+  public void testSendAsyncToUnresolvable() {
+    final Address unresolvable = Address.from("unknown.local", address1.port());
+    final String subject = nextSubject();
+    final CompletableFuture<Void> response = netty1.sendAsync(unresolvable, subject, "hello world".getBytes());
+    assertTrue(response.isCompletedExceptionally());
+  }
+
+  @Test
   public void testSendAsync() {
     String subject = nextSubject();
     CountDownLatch latch1 = new CountDownLatch(1);


### PR DESCRIPTION
Solves the issue mentioned in #1017, and prevents `NettyUnicastService` from mistakenly sending messages to itself when trying to send to an address which cannot be resolved. It's also possible there are other usages of `Address#address()` which are not handling the case where it's null.