### PR TITLE
chore(raft): get leader/term from server if available

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,4 +81,19 @@ spec:
       }
     }
   }
+
+  post {
+      always {
+          // Retrigger the build if the node disconnected
+          script {
+              if (nodeDisconnected()) {
+                  build job: currentBuild.projectName, propagate: false, quietPeriod: 60, wait: false
+              }
+          }
+      }
+  }
+}
+
+boolean nodeDisconnected() {
+  return currentBuild.rawBuild.getLog(500).join('') ==~ /.*(ChannelClosedException|KubernetesClientException|ClosedChannelException).*/
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ spec:
     stage('Build') {
       steps {
         container('maven') {
-            sh 'mvn install -B -s settings.xml -Ddockerfile.skip -Dmaven.test.redirectTestOutputToFile'
+            sh 'mvn install -B -s settings.xml -Ddockerfile.skip -Dmaven.test.redirectTestOutputToFile -Dsurefire.rerunFailingTestsCount=3'
         }
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,84 @@
+pipeline {
+
+  agent {
+    kubernetes {
+      cloud 'zeebe-ci'
+      label "zeebe-ci-build_${env.JOB_BASE_NAME}-${env.BUILD_ID}"
+      defaultContainer 'jnlp'
+      yaml '''\
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    agent: zeebe-ci-build
+spec:
+  nodeSelector:
+    cloud.google.com/gke-nodepool: slaves
+  tolerations:
+    - key: "slaves"
+      operator: "Exists"
+      effect: "NoSchedule"
+  containers:
+    - name: maven
+      image: maven:3.6.0-jdk-8
+      command: ["cat"]
+      tty: true
+      env:
+        - name: JAVA_TOOL_OPTIONS
+          value: |
+            -XX:+UnlockExperimentalVMOptions
+            -XX:+UseCGroupMemoryLimitForHeap
+      resources:
+        limits:
+          cpu: 2
+          memory: 8Gi
+        requests:
+          cpu: 1
+          memory: 4Gi
+'''
+    }
+  }
+
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+    timestamps()
+    timeout(time: 45, unit: 'MINUTES')
+  }
+
+  environment {
+    NEXUS = credentials("camunda-nexus")
+  }
+
+  stages {
+    stage('Prepare') {
+      steps {
+        container('maven') {
+            sh 'mvn clean install -B -s settings.xml -DskipTests -Dmaven.test.skip -Dmaven.javadoc.skip -Ddockerfile.skip'
+        }
+      }
+    }
+
+    stage('Build') {
+      steps {
+        container('maven') {
+            sh 'mvn install -B -s settings.xml -Ddockerfile.skip -Dmaven.test.redirectTestOutputToFile'
+        }
+      }
+
+      post {
+        always {
+            junit testResults: "**/*/TEST-*.xml", keepLongStdio: true
+        }
+      }
+    }
+
+    stage('Upload') {
+      when { branch 'zeebe' }
+      steps {
+        container('maven') {
+            sh 'mvn -B -s settings.xml generate-sources source:jar javadoc:jar deploy -DskipTests -Ddockerfile.skip'
+        }
+      }
+    }
+  }
+}

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,32 +28,32 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-raft</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-log</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-gossip</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primary-backup</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-rest</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,7 @@
+status = [
+  "continuous-integration/jenkins/branch"
+]
+
+required_approvals = 0
+
+delete_merged_branches = true

--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,7 +28,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -20,6 +20,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.net.InetAddress;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.MessageDigest;
@@ -470,6 +471,14 @@ public class NettyMessagingService implements ManagedMessagingService {
    */
   private CompletableFuture<Channel> bootstrapClient(Address address) {
     CompletableFuture<Channel> future = new OrderedFuture<>();
+    final InetAddress resolvedAddress = address.address(true);
+    if (resolvedAddress == null) {
+      final String errorMessage = String.format("Cannot bootstrap client for address %s as it cannot be resolved",
+              address.toString());
+      future.completeExceptionally(new IllegalStateException(errorMessage));
+      return future;
+    }
+
     Bootstrap bootstrap = new Bootstrap();
     bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
     bootstrap.option(ChannelOption.WRITE_BUFFER_WATER_MARK,
@@ -483,7 +492,7 @@ public class NettyMessagingService implements ManagedMessagingService {
     // TODO: Make this faster:
     // http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html#37.0
     bootstrap.channel(clientChannelClass);
-    bootstrap.remoteAddress(address.address(true), address.port());
+    bootstrap.remoteAddress(resolvedAddress, address.port());
     if (enableNettyTls) {
       try {
         bootstrap.handler(new SslClientChannelInitializer(future, address));

--- a/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -126,6 +126,14 @@ public class NettyMessagingServiceTest {
   }
 
   @Test
+  public void testSendAsyncToUnresolvable() {
+    final Address unresolvable = Address.from("unknown.local", address1.port());
+    final String subject = nextSubject();
+    final CompletableFuture<Void> response = netty1.sendAsync(unresolvable, subject, "hello world".getBytes());
+    assertTrue(response.isCompletedExceptionally());
+  }
+
+  @Test
   public void testSendAsync() {
     String subject = nextSubject();
     CountDownLatch latch1 = new CountDownLatch(1);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,41 +28,41 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-cluster</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primitive</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-gossip</artifactId>
       <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-raft</artifactId>
       <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primary-backup</artifactId>
       <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-log</artifactId>
       <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/core/src/main/java/io/atomix/core/utils/config/PolymorphicConfigMapper.java
+++ b/core/src/main/java/io/atomix/core/utils/config/PolymorphicConfigMapper.java
@@ -25,6 +25,7 @@ import io.atomix.utils.config.TypedConfig;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -97,7 +98,7 @@ public class PolymorphicConfigMapper extends ConfigMapper {
         .filter(propertyName -> !isPolymorphicType(clazz) || !polymorphicTypes.stream().anyMatch(type -> Objects.equals(type.getTypePath(), propertyName)))
         .map(propertyName -> toPath(path, propertyName))
         .filter(propertyName -> !properties.containsKey(propertyName))
-        .filter(propertyName -> properties.entrySet().stream().noneMatch(entry -> entry.getKey().toString().startsWith(propertyName + ".")))
+        .filter(propertyName -> new HashSet<>(properties.entrySet()).stream().noneMatch(entry -> entry.getKey().toString().startsWith(propertyName + ".")))
         .sorted()
         .collect(Collectors.toList());
     if (!cleanNames.isEmpty()) {

--- a/core/src/test/java/io/atomix/core/AtomixConfigTest.java
+++ b/core/src/test/java/io/atomix/core/AtomixConfigTest.java
@@ -117,6 +117,9 @@ public class AtomixConfigTest {
     RaftPartitionGroupConfig managementGroup = (RaftPartitionGroupConfig) config.getManagementGroup();
     assertEquals(RaftPartitionGroup.TYPE, managementGroup.getType());
     assertEquals(1, managementGroup.getPartitions());
+    assertEquals(Duration.ofSeconds(5), managementGroup.getElectionTimeout());
+    assertEquals(Duration.ofMillis(500), managementGroup.getHeartbeatInterval());
+    assertEquals(Duration.ofSeconds(10), managementGroup.getDefaultSessionTimeout());
     assertEquals(new MemorySize(1024 * 1024 * 16), managementGroup.getStorageConfig().getSegmentSize());
 
     RaftPartitionGroupConfig groupOne = (RaftPartitionGroupConfig) config.getPartitionGroups().get("one");

--- a/core/src/test/resources/test.conf
+++ b/core/src/test/resources/test.conf
@@ -51,6 +51,9 @@ cluster {
 managementGroup {
   type: raft
   partitions: 1
+  electionTimeout: 5s
+  heartbeatInterval: 500ms
+  defaultSessionTimeout: 10s
   storage.segmentSize: 16M
   storage.level: memory
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -27,7 +27,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-agent</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <version>7</version>
   </parent>
 
-  <groupId>io.atomix</groupId>
+  <groupId>io.zeebe</groupId>
   <artifactId>atomix-parent</artifactId>
   <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
@@ -167,14 +167,14 @@
   </developers>
 
   <scm>
-    <connection>scm:git:git@github.com:atomix/atomix.git</connection>
-    <developerConnection>scm:git:git@github.com:atomix/atomix.git</developerConnection>
-    <url>git@github.com:atomix/atomix.git</url>
+    <connection>scm:git:git@github.com:zeebe-io/atomix.git</connection>
+    <developerConnection>scm:git:git@github.com:zeebe-io/atomix.git</developerConnection>
+    <url>git@github.com:zeebe-io/atomix.git</url>
   </scm>
 
   <issueManagement>
     <system>GitHub</system>
-    <url>http://github.com/atomix/atomix/issues</url>
+    <url>http://github.com/zeebe-io/atomix/issues</url>
   </issueManagement>
 
   <modules>
@@ -456,4 +456,44 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>zeebe-nexus</id>
+      <name>Zeebe Repository</name>
+      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+
+    <repository>
+      <id>zeebe-snapshots-nexus</id>
+      <name>Zeebe Snapshot Repository</name>
+      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>camunda-nexus</id>
+      <name>Zeebe Snapshots Repository</name>
+      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+    </snapshotRepository>
+    <repository>
+      <id>camunda-nexus</id>
+      <name>Zeebe Release Repository</name>
+      <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+    </repository>
+  </distributionManagement>
+
 </project>

--- a/primitive/pom.xml
+++ b/primitive/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,17 +28,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-cluster</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-storage</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/protocols/gossip/pom.xml
+++ b/protocols/gossip/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-protocols-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,7 +28,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primitive</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/protocols/log/pom.xml
+++ b/protocols/log/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-protocols-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,7 +28,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primitive</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/protocols/pom.xml
+++ b/protocols/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>

--- a/protocols/primary-backup/pom.xml
+++ b/protocols/primary-backup/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-protocols-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,12 +28,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primitive</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/protocols/raft/pom.xml
+++ b/protocols/raft/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-protocols-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,7 +28,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primitive</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -289,6 +289,13 @@ public interface RaftServer {
   Role getRole();
 
   /**
+   * Returns the server's term.
+   *
+   * @return the server's term
+   */
+  long getTerm();
+
+  /**
    * Returns whether the server is the leader.
    *
    * @return whether the server is the leader

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -72,6 +72,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public long getTerm() {
+    return context.getTerm();
+  }
+
+  @Override
   public void addRoleChangeListener(Consumer<Role> listener) {
     context.addRoleChangeListener(listener);
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -20,6 +20,7 @@ import io.atomix.primitive.partition.Partition;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionManagementService;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.partition.impl.RaftClientCommunicator;
 import io.atomix.protocols.raft.partition.impl.RaftNamespaces;
 import io.atomix.protocols.raft.partition.impl.RaftPartitionClient;
@@ -30,7 +31,10 @@ import io.atomix.utils.serializer.Serializer;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -43,6 +47,7 @@ public class RaftPartition implements Partition {
   private final RaftPartitionGroupConfig config;
   private final File dataDirectory;
   private final ThreadContextFactory threadContextFactory;
+  private final Set<Consumer<Role>> deferredRoleChangeListeners = new CopyOnWriteArraySet<>();
   private PartitionMetadata partition;
   private RaftPartitionClient client;
   private RaftPartitionServer server;
@@ -80,6 +85,19 @@ public class RaftPartition implements Partition {
   @Override
   public MemberId primary() {
     return client != null ? client.leader() : null;
+  }
+
+  public void addRoleChangeListener(Consumer<Role> listener) {
+    if (server == null) {
+      deferredRoleChangeListeners.add(listener);
+    } else {
+      server.addRoleChangeListener(listener);
+    }
+  }
+
+  public void removeRoleChangeListener(Consumer<Role> listener) {
+    deferredRoleChangeListeners.remove(listener);
+    server.removeRoleChangeListener(listener);
   }
 
   @Override
@@ -132,7 +150,7 @@ public class RaftPartition implements Partition {
     this.partition = metadata;
     this.client = createClient(managementService);
     if (partition.members().contains(managementService.getMembershipService().getLocalMember().id())) {
-      server = createServer(managementService);
+      initServer(managementService);
       return server.start()
           .thenCompose(v -> client.start())
           .thenApply(v -> null);
@@ -146,7 +164,7 @@ public class RaftPartition implements Partition {
    */
   CompletableFuture<Void> update(PartitionMetadata metadata, PartitionManagementService managementService) {
     if (server == null && metadata.members().contains(managementService.getMembershipService().getLocalMember().id())) {
-      server = createServer(managementService);
+      initServer(managementService);
       return server.join(metadata.members());
     } else if (server != null && !metadata.members().contains(managementService.getMembershipService().getLocalMember().id())) {
       return server.leave().thenRun(() -> server = null);
@@ -190,6 +208,15 @@ public class RaftPartition implements Partition {
         managementService.getMessagingService(),
         managementService.getPrimitiveTypes(),
         threadContextFactory);
+  }
+
+  private void initServer(final PartitionManagementService managementService) {
+    server = createServer(managementService);
+
+    if (!deferredRoleChangeListeners.isEmpty()) {
+      deferredRoleChangeListeners.forEach(server::addRoleChangeListener);
+      deferredRoleChangeListeners.clear();
+    }
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -79,12 +79,16 @@ public class RaftPartition implements Partition {
 
   @Override
   public long term() {
-    return client != null ? client.term() : 0;
+    return server != null ? server.getTerm() : 0;
   }
 
   @Override
   public MemberId primary() {
     return client != null ? client.leader() : null;
+  }
+
+  public Role getRole() {
+    return server != null ? server.getRole() : null;
   }
 
   public void addRoleChangeListener(Consumer<Role> listener) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroup.java
@@ -376,6 +376,39 @@ public class RaftPartitionGroup implements ManagedPartitionGroup {
     }
 
     /**
+     * Sets the leader election timeout.
+     *
+     * @param electionTimeout the leader election timeout
+     * @return the Raft partition group configuration
+     */
+    public Builder withElectionTimeout(Duration electionTimeout) {
+      config.setElectionTimeout(electionTimeout);
+      return this;
+    }
+
+    /**
+     * Sets the heartbeat interval.
+     *
+     * @param heartbeatInterval the heartbeat interval
+     * @return the Raft partition group configuration
+     */
+    public Builder withHeartbeatInterval(Duration heartbeatInterval) {
+      config.setHeartbeatInterval(heartbeatInterval);
+      return this;
+    }
+
+    /**
+     * Sets the default session timeout.
+     *
+     * @param defaultSessionTimeout the default session timeout
+     * @return the Raft partition group configuration
+     */
+    public Builder withDefaultSessionTimeout(Duration defaultSessionTimeout) {
+      config.setDefaultSessionTimeout(defaultSessionTimeout);
+      return this;
+    }
+
+    /**
      * Sets the storage level.
      *
      * @param storageLevel the storage level

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
@@ -18,6 +18,7 @@ package io.atomix.protocols.raft.partition;
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,9 +27,15 @@ import java.util.Set;
  */
 public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartitionGroupConfig> {
   private static final int DEFAULT_PARTITIONS = 7;
+  private static final Duration DEFAULT_ELECTION_TIMEOUT = Duration.ofMillis(2500);
+  private static final Duration DEFAULT_HEARTBEAT_INTERVAL = Duration.ofMillis(250);
+  private static final Duration DEFAULT_DEFAULT_SESSION_TIMEOUT = Duration.ofMillis(5000);
 
   private Set<String> members = new HashSet<>();
   private int partitionSize;
+  private Duration electionTimeout = DEFAULT_ELECTION_TIMEOUT;
+  private Duration heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+  private Duration defaultSessionTimeout = DEFAULT_DEFAULT_SESSION_TIMEOUT;
   private RaftStorageConfig storageConfig = new RaftStorageConfig();
   private RaftCompactionConfig compactionConfig = new RaftCompactionConfig();
 
@@ -79,6 +86,66 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
    */
   public RaftPartitionGroupConfig setPartitionSize(int partitionSize) {
     this.partitionSize = partitionSize;
+    return this;
+  }
+
+  /**
+   * Returns the Raft leader election timeout.
+   *
+   * @return the Raft leader election timeout
+   */
+  public Duration getElectionTimeout() {
+    return electionTimeout;
+  }
+
+  /**
+   * Sets the leader election timeout.
+   *
+   * @param electionTimeout the leader election timeout
+   * @return the Raft partition group configuration
+   */
+  public RaftPartitionGroupConfig setElectionTimeout(Duration electionTimeout) {
+    this.electionTimeout = electionTimeout;
+    return this;
+  }
+
+  /**
+   * Returns the heartbeat interval.
+   *
+   * @return the heartbeat interval
+   */
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  /**
+   * Sets the heartbeat interval.
+   *
+   * @param heartbeatInterval the heartbeat interval
+   * @return the Raft partition group configuration
+   */
+  public RaftPartitionGroupConfig setHeartbeatInterval(Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+    return this;
+  }
+
+  /**
+   * Returns the default session timeout.
+   *
+   * @return the default session timeout
+   */
+  public Duration getDefaultSessionTimeout() {
+    return defaultSessionTimeout;
+  }
+
+  /**
+   * Sets the default session timeout.
+   *
+   * @param defaultSessionTimeout the default session timeout
+   * @return the Raft partition group configuration
+   */
+  public RaftPartitionGroupConfig setDefaultSessionTimeout(Duration defaultSessionTimeout) {
+    this.defaultSessionTimeout = defaultSessionTimeout;
     return this;
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -21,6 +21,7 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.Partition;
 import io.atomix.protocols.raft.RaftServer;
+import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.partition.RaftPartition;
 import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
 import io.atomix.protocols.raft.storage.RaftStorage;
@@ -29,6 +30,9 @@ import io.atomix.utils.Managed;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.serializer.Serializer;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -60,6 +64,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   private final ClusterCommunicationService clusterCommunicator;
   private final PrimitiveTypeRegistry primitiveTypes;
   private final ThreadContextFactory threadContextFactory;
+  private final Set<Consumer<Role>> deferredRoleChangeListeners = new CopyOnWriteArraySet<>();
   private RaftServer server;
 
   public RaftPartitionServer(
@@ -89,7 +94,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
       }
       synchronized (this) {
         try {
-          server = buildServer();
+          initServer();
         } catch (StorageException e) {
           return Futures.exceptionalFuture(e);
         }
@@ -128,6 +133,19 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
    */
   public CompletableFuture<Void> snapshot() {
     return server.compact();
+  }
+
+  public void addRoleChangeListener(Consumer<Role> listener) {
+    if (server == null) {
+      deferredRoleChangeListeners.add(listener);
+    } else {
+      server.addRoleChangeListener(listener);
+    }
+  }
+
+  public void removeRoleChangeListener(Consumer<Role> listener) {
+    deferredRoleChangeListeners.remove(listener);
+    server.removeRoleChangeListener(listener);
   }
 
   /**
@@ -180,9 +198,18 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         .build();
   }
 
+  private void initServer() {
+    server = buildServer();
+
+    if (!deferredRoleChangeListeners.isEmpty()) {
+      deferredRoleChangeListeners.forEach(server::addRoleChangeListener);
+      deferredRoleChangeListeners.clear();
+    }
+  }
+
   public CompletableFuture<Void> join(Collection<MemberId> otherMembers) {
     log.info("Joining partition {} ({})", partition.id(), partition.name());
-    server = buildServer();
+    initServer();
     return server.join(otherMembers).whenComplete((r, e) -> {
       if (e == null) {
         log.debug("Successfully joined partition {} ({})", partition.id(), partition.name());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -135,6 +135,14 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     return server.compact();
   }
 
+  public Role getRole() {
+    return server.getRole();
+  }
+
+  public long getTerm() {
+    return server.getTerm();
+  }
+
   public void addRoleChangeListener(Consumer<Role> listener) {
     if (server == null) {
       deferredRoleChangeListeners.add(listener);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -62,6 +62,11 @@ public final class FollowerRole extends ActiveRole {
 
   @Override
   public synchronized CompletableFuture<RaftRole> start() {
+    if (raft.getCluster().getActiveMemberStates().isEmpty()) {
+      log.debug("Single member cluster. Transitioning directly to candidate.");
+      raft.transition(RaftServer.Role.CANDIDATE);
+      return CompletableFuture.completedFuture(this);
+    }
     raft.getMembershipService().addListener(clusterListener);
     return super.start().thenRun(this::resetHeartbeatTimeout).thenApply(v -> this);
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionConnection.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionConnection.java
@@ -306,4 +306,11 @@ public class RaftSessionConnection {
       return currentNode;
     }
   }
+
+  /**
+   * Closes the connection.
+   */
+  public void close() {
+    selector.close();
+  }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
@@ -216,6 +216,8 @@ final class RaftSessionInvoker {
       attempt.fail(new PrimitiveException.ClosedSession("session closed"));
     }
     attempts.clear();
+    sessionConnection.close();
+    leaderConnection.close();
     return CompletableFuture.completedFuture(null);
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionListener.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionListener.java
@@ -140,6 +140,7 @@ final class RaftSessionListener {
    */
   public CompletableFuture<Void> close() {
     protocol.unregisterPublishListener(state.getSessionId());
+    memberSelector.close();
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,18 +28,18 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-raft</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-primary-backup</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>camunda-nexus</id>
+      <username>${env.NEXUS_USR}</username>
+      <password>${env.NEXUS_PSW}</password>
+    </server>
+    <server>
+      <id>central</id>
+      <username>${env.MAVEN_CENTRAL_USR}</username>
+      <password>${env.MAVEN_CENTRAL_PSW}</password>
+    </server>
+  </servers>
+  <mirrors>
+    <mirror>
+      <id>camunda-nexus</id>
+      <mirrorOf>*</mirrorOf>
+      <name>Camunda Nexus</name>
+      <!-- uncomment to use DC Nexus locally
+      <url>https://app.camunda.com/nexus/content/groups/internal</url>
+      -->
+      <!-- use CI proxy nexus -->
+      <url>http://repository-ci-camunda-cloud.nexus:8081/content/groups/internal/</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,7 +28,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>
@@ -28,12 +28,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.atomix</groupId>
+      <groupId>io.zeebe</groupId>
       <artifactId>atomix-raft</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -17,7 +17,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.atomix</groupId>
+    <groupId>io.zeebe</groupId>
     <artifactId>atomix-parent</artifactId>
     <version>3.2.0-SNAPSHOT</version>
   </parent>


### PR DESCRIPTION
- exposes the current raft leader/term of a given partition through the server instead of client
- fixes issue where the client is out of date with the current leader
- fixes issue where the client term is always 0