### PR TITLE
SonarQube - String Literals on the left on comparisons

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/event/Events.java
+++ b/primitive/src/main/java/io/atomix/primitive/event/Events.java
@@ -52,7 +52,7 @@ public final class Events {
     for (Method method : type.getDeclaredMethods()) {
       Event event = method.getAnnotation(Event.class);
       if (event != null) {
-        String name = event.value().equals("") ? method.getName() : event.value();
+        String name = "".equals(event.value()) ? method.getName() : event.value();
         events.put(method, EventType.from(name));
       }
     }
@@ -94,7 +94,7 @@ public final class Events {
     for (Method method : type.getDeclaredMethods()) {
       Event event = method.getAnnotation(Event.class);
       if (event != null) {
-        String name = event.value().equals("") ? method.getName() : event.value();
+        String name = "".equals(event.value()) ? method.getName() : event.value();
         events.put(EventType.from(name), method);
       }
     }

--- a/primitive/src/main/java/io/atomix/primitive/operation/Operations.java
+++ b/primitive/src/main/java/io/atomix/primitive/operation/Operations.java
@@ -117,17 +117,17 @@ public final class Operations {
   private static OperationId getOperationId(Method method) {
     Command command = method.getAnnotation(Command.class);
     if (command != null) {
-      String name = command.value().equals("") ? method.getName() : command.value();
+      String name = "".equals(command.value()) ? method.getName() : command.value();
       return OperationId.from(name, OperationType.COMMAND);
     }
     Query query = method.getAnnotation(Query.class);
     if (query != null) {
-      String name = query.value().equals("") ? method.getName() : query.value();
+      String name = "".equals(query.value()) ? method.getName() : query.value();
       return OperationId.from(name, OperationType.QUERY);
     }
     Operation operation = method.getAnnotation(Operation.class);
     if (operation != null) {
-      String name = operation.value().equals("") ? method.getName() : operation.value();
+      String name = "".equals(operation.value()) ? method.getName() : operation.value();
       return OperationId.from(name, operation.type());
     }
     return null;

--- a/utils/src/main/java/io/atomix/utils/Version.java
+++ b/utils/src/main/java/io/atomix/utils/Version.java
@@ -237,7 +237,7 @@ public final class Version implements Comparable<Version> {
       String format(int version) {
         if (name == null) {
           return null;
-        } else if (name.equals("snapshot")) {
+        } else if ("snapshot".equals(name)) {
           return "SNAPSHOT";
         } else {
           return String.format("%s%d", name, version);

--- a/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
+++ b/utils/src/main/java/io/atomix/utils/config/ConfigMapper.java
@@ -211,7 +211,7 @@ public class ConfigMapper {
         String configPropName = propertyNames.remove(descriptor.name);
         if (configPropName == null) {
           if ((Named.class.isAssignableFrom(clazz) || NamedConfig.class.isAssignableFrom(clazz))
-              && descriptor.setter.getParameterTypes()[0] == String.class && name != null && descriptor.name.equals("name")) {
+              && descriptor.setter.getParameterTypes()[0] == String.class && name != null && "name".equals(descriptor.name)) {
             if (descriptor.deprecated) {
               if (path == null) {
                 LOGGER.warn("{} is deprecated!", name);
@@ -254,7 +254,7 @@ public class ConfigMapper {
 
         String configPropName = propertyNames.remove(descriptor.name);
         if (configPropName == null) {
-          if (Named.class.isAssignableFrom(clazz) && field.getType() == String.class && name != null && descriptor.name.equals("name")) {
+          if (Named.class.isAssignableFrom(clazz) && field.getType() == String.class && name != null && "name".equals(descriptor.name)) {
             if (descriptor.deprecated) {
               LOGGER.warn("{}.{} is deprecated!", path, name);
             }
@@ -535,7 +535,7 @@ public class ConfigMapper {
       String name = method.getName();
       if (method.getParameterTypes().length == 1
           && name.length() > 3
-          && name.substring(0, 3).equals("set")
+          && "set".equals(name.substring(0, 3))
           && name.charAt(3) >= 'A'
           && name.charAt(3) <= 'Z') {
 


### PR DESCRIPTION
Transforming from `someString.equals("string")`  to `"string".equals(someString)`. This avoids checking for `null` and also prevents `NullPointerException` being thrown.

This PR fixes SonarQube violations of the rule: [Strings literals should be placed on the left side when checking for equality](https://rules.sonarsource.com/java/RSPEC-1132)