### PR TITLE
SonarQube - Replacing String comparison from '!=' to '!.equals()'

### DIFF
--- a/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
@@ -580,7 +580,7 @@ public final class Namespace implements KryoFactory, KryoPool {
 
   @Override
   public String toString() {
-    if (friendlyName != NO_NAME) {
+    if (!NO_NAME.equals(friendlyName)) {
       return MoreObjects.toStringHelper(getClass())
           .omitNullValues()
           .add("friendlyName", friendlyName)


### PR DESCRIPTION
SonarQube rule states that is almost always a mistake to compare two instances of `String` with `==`, because it compares location in memory. `equals()` should be used.

Here is the link for the rule: [Strings and Boxed types should be compared using "equals()"](https://rules.sonarsource.com/java/RSPEC-4973)