### PR TITLE
Use given mode when opening log reader

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -61,7 +61,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
   @Override
   public RaftLogReader openReader(long index, RaftLogReader.Mode mode) {
-    return new RaftLogReader(journal.openReader(index), this, mode);
+    return new RaftLogReader(journal.openReader(index, mode));
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLogReader.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLogReader.java
@@ -23,7 +23,7 @@ import io.atomix.storage.journal.SegmentedJournalReader;
  * Raft log reader.
  */
 public class RaftLogReader extends DelegatingJournalReader<RaftLogEntry> {
-  public RaftLogReader(SegmentedJournalReader<RaftLogEntry> reader, RaftLog log, Mode mode) {
+  public RaftLogReader(SegmentedJournalReader<RaftLogEntry> reader) {
     super(reader);
   }
 }


### PR DESCRIPTION
Being able to specify the mode of the Raft log is useful especially for tests. But the specified mode was ignored. 