### PR TITLE
Don't commit non replicated entries in old leader upon reconnecting

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -117,6 +117,7 @@ public class RaftContext implements AutoCloseable {
   private long commitIndex;
   private volatile long firstCommitIndex;
   private volatile long lastApplied;
+  private volatile long lastAppliedTerm;
 
   @SuppressWarnings("unchecked")
   public RaftContext(
@@ -526,10 +527,11 @@ public class RaftContext implements AutoCloseable {
   /**
    * Sets the last applied index.
    *
-   * @param lastApplied the last applied index
+   * @param lastApplied the last applied index and the last applied term
    */
-  public void setLastApplied(long lastApplied) {
+  public void setLastApplied(long lastApplied, long lastAppliedTerm) {
     this.lastApplied = Math.max(this.lastApplied, lastApplied);
+    this.lastAppliedTerm = Math.max(this.lastAppliedTerm, lastAppliedTerm);
     if (state == State.ACTIVE) {
       threadContext.execute(() -> {
         if (state == State.ACTIVE && this.lastApplied >= firstCommitIndex) {
@@ -547,6 +549,15 @@ public class RaftContext implements AutoCloseable {
    */
   public long getLastApplied() {
     return lastApplied;
+  }
+
+  /**
+   * Returns the term of the last applied entry.
+   *
+   * @return the last applied index
+   */
+  public long getLastAppliedTerm() {
+    return lastAppliedTerm;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/InstallRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/InstallRequest.java
@@ -49,13 +49,14 @@ public class InstallRequest extends AbstractRaftRequest {
   private final long term;
   private final MemberId leader;
   private final long index;
+  private final long snapshotTerm;
   private final long timestamp;
   private final int version;
   private final int offset;
   private final byte[] data;
   private final boolean complete;
 
-  public InstallRequest(long term, MemberId leader, long index, long timestamp, int version, int offset, byte[] data, boolean complete) {
+  public InstallRequest(long term, MemberId leader, long index, long snapshotTerm, long timestamp, int version, int offset, byte[] data, boolean complete) {
     this.term = term;
     this.leader = leader;
     this.index = index;
@@ -64,6 +65,7 @@ public class InstallRequest extends AbstractRaftRequest {
     this.offset = offset;
     this.data = data;
     this.complete = complete;
+    this.snapshotTerm = snapshotTerm;
   }
 
   /**
@@ -73,6 +75,15 @@ public class InstallRequest extends AbstractRaftRequest {
    */
   public long term() {
     return term;
+  }
+
+  /**
+   * Returns the term of the last applied entry in the snapshot.
+   *
+   * @return The snapshot term.
+   */
+  public long snapshotTerm() {
+    return snapshotTerm;
   }
 
   /**
@@ -140,7 +151,7 @@ public class InstallRequest extends AbstractRaftRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), term, leader, index, offset, complete, data);
+    return Objects.hash(getClass(), term, leader, index, offset, complete, data, snapshotTerm);
   }
 
   @Override
@@ -152,6 +163,7 @@ public class InstallRequest extends AbstractRaftRequest {
           && request.index == index
           && request.offset == offset
           && request.complete == complete
+          && request.snapshotTerm == snapshotTerm
           && Arrays.equals(request.data, data);
     }
     return false;
@@ -163,6 +175,7 @@ public class InstallRequest extends AbstractRaftRequest {
         .add("term", term)
         .add("leader", leader)
         .add("index", index)
+        .add("snapshotTerm", snapshotTerm)
         .add("timestamp", timestamp)
         .add("version", version)
         .add("offset", offset)
@@ -183,6 +196,7 @@ public class InstallRequest extends AbstractRaftRequest {
     private int offset;
     private byte[] data;
     private boolean complete;
+    private long snapshotTerm;
 
     /**
      * Sets the request term.
@@ -206,6 +220,12 @@ public class InstallRequest extends AbstractRaftRequest {
      */
     public Builder withLeader(MemberId leader) {
       this.leader = checkNotNull(leader, "leader cannot be null");
+      return this;
+    }
+
+    public Builder withSnapshotTerm(long term) {
+      checkArgument(term > 0, "snapshotTerm must be positive");
+      this.snapshotTerm = term;
       return this;
     }
 
@@ -286,6 +306,7 @@ public class InstallRequest extends AbstractRaftRequest {
       checkArgument(term > 0, "term must be positive");
       checkNotNull(leader, "leader cannot be null");
       checkArgument(index >= 0, "index must be positive");
+      checkArgument(snapshotTerm > 0, "snapshotTerm must be positive");
       checkArgument(offset >= 0, "offset must be positive");
       checkNotNull(data, "data cannot be null");
     }
@@ -296,7 +317,7 @@ public class InstallRequest extends AbstractRaftRequest {
     @Override
     public InstallRequest build() {
       validate();
-      return new InstallRequest(term, leader, index, timestamp, version, offset, data, complete);
+      return new InstallRequest(term, leader, index,  snapshotTerm, timestamp, version, offset, data, complete);
     }
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
@@ -57,7 +57,7 @@ final class MemorySnapshot extends Snapshot {
   @Override
   public Snapshot persist() {
     if (store.storage.storageLevel() != StorageLevel.MEMORY) {
-      try (Snapshot newSnapshot = store.newSnapshot(index(), timestamp())) {
+      try (Snapshot newSnapshot = store.newSnapshot(index(), term(), timestamp())) {
         try (SnapshotWriter newSnapshotWriter = newSnapshot.openWriter()) {
           buffer.flip().skip(SnapshotDescriptor.BYTES);
           newSnapshotWriter.write(buffer.array(), buffer.position(), buffer.remaining());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
@@ -75,6 +75,10 @@ public abstract class Snapshot implements AutoCloseable {
     return descriptor.index();
   }
 
+  public long term() {
+    return descriptor.term();
+  }
+
   /**
    * Returns the snapshot timestamp.
    * <p>

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptor.java
@@ -30,7 +30,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class SnapshotDescriptor implements AutoCloseable {
   public static final int BYTES = 64;
-  public static final int VERSION = 1;
+
+  // Current snapshot version.
+  private static final int VERSION = 1;
+
+  // The lengths of each field in the header.
+  private static final int INDEX_LENGTH = Long.BYTES;          // 64-bit signed integer
+  private static final int TIMESTAMP_LENGTH = Long.BYTES;      // 64-bit signed integer
+  private static final int VERSION_LENGTH = Integer.BYTES;     // 32-bit signed integer
+  private static final int LOCKED_LENGTH = 1;                  // 8-bit signed byte
+  private static final int TERM_LENGTH = Long.BYTES;           // 64-bit signed integer
+
+  // The positions of each field in the header.
+  private static final int INDEX_POSITION = 0;                                           // 0
+  private static final int TIMESTAMP_POSITION = INDEX_POSITION + INDEX_LENGTH;           // 8
+  private static final int VERSION_POSITION = TIMESTAMP_POSITION + TIMESTAMP_LENGTH;     // 16
+  private static final int LOCKED_POSITION = VERSION_POSITION + VERSION_LENGTH;          // 20
+  private static final int TERM_POSITION = LOCKED_POSITION + LOCKED_LENGTH;              // 21
 
   /**
    * Returns a descriptor builder.
@@ -57,6 +73,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
   private Buffer buffer;
   private final long index;
   private final long timestamp;
+  private final long term;
   private boolean locked;
   private int version;
 
@@ -69,6 +86,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
     this.timestamp = buffer.readLong();
     this.version = buffer.readInt();
     this.locked = buffer.readBoolean();
+    this.term = buffer.readLong();
     buffer.skip(BYTES - buffer.position());
   }
 
@@ -99,6 +117,10 @@ public final class SnapshotDescriptor implements AutoCloseable {
     return version;
   }
 
+  public long term() {
+    return term;
+  }
+
   /**
    * Returns whether the snapshot has been locked by commitment.
    * <p>
@@ -115,7 +137,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
    */
   public void lock() {
     buffer.flush()
-        .writeBoolean(20, true)
+        .writeBoolean(LOCKED_POSITION, true)
         .flush();
     locked = true;
   }
@@ -129,6 +151,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
         .writeLong(timestamp)
         .writeInt(version)
         .writeBoolean(locked)
+        .writeLong(term)
         .skip(BYTES - buffer.position())
         .flush();
     return this;
@@ -165,7 +188,12 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The snapshot builder.
      */
     public Builder withIndex(long index) {
-      buffer.writeLong(0, index);
+      buffer.writeLong(INDEX_POSITION, index);
+      return this;
+    }
+
+    public Builder withTerm(long term) {
+      buffer.writeLong(TERM_POSITION, term);
       return this;
     }
 
@@ -176,7 +204,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The snapshot builder.
      */
     public Builder withTimestamp(long timestamp) {
-      buffer.writeLong(8, timestamp);
+      buffer.writeLong(TIMESTAMP_POSITION, timestamp);
       return this;
     }
 
@@ -186,7 +214,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The built snapshot descriptor.
      */
     public SnapshotDescriptor build() {
-      return new SnapshotDescriptor(buffer.writeInt(16, VERSION));
+      return new SnapshotDescriptor(buffer.writeInt(VERSION_POSITION, VERSION));
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
@@ -153,9 +153,10 @@ public class SnapshotStore implements AutoCloseable {
    * @param timestamp The snapshot timestamp.
    * @return The snapshot.
    */
-  public Snapshot newTemporarySnapshot(long index, WallClockTimestamp timestamp) {
+  public Snapshot newTemporarySnapshot(long index, long term, WallClockTimestamp timestamp) {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(index)
+        .withTerm(term)
         .withTimestamp(timestamp.unixTimestamp())
         .build();
     return newSnapshot(descriptor, StorageLevel.MEMORY);
@@ -168,9 +169,10 @@ public class SnapshotStore implements AutoCloseable {
    * @param timestamp The snapshot timestamp.
    * @return The snapshot.
    */
-  public Snapshot newSnapshot(long index, WallClockTimestamp timestamp) {
+  public Snapshot newSnapshot(long index, long term, WallClockTimestamp timestamp) {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(index)
+        .withTerm(term)
         .withTimestamp(timestamp.unixTimestamp())
         .build();
     return newSnapshot(descriptor, storage.storageLevel());

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -57,7 +57,6 @@ import io.atomix.protocols.raft.impl.RaftContext;
 import io.atomix.protocols.raft.protocol.InstallResponse;
 import io.atomix.protocols.raft.protocol.TestPartitionableRaftProtocolFactory;
 import io.atomix.protocols.raft.protocol.TestRaftProtocolFactory;
-import io.atomix.protocols.raft.protocol.TestRaftServerProtocol;
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.protocols.raft.storage.log.RaftLog;
 import io.atomix.protocols.raft.storage.log.RaftLogReader;
@@ -1442,11 +1441,10 @@ public class RaftTest extends ConcurrentTestCase {
   }
 
   private RaftServer createServer(MemberId memberId, Function<RaftServer.Builder, RaftServer.Builder> configurator) {
-    final TestRaftServerProtocol raftServerProtocol = protocolFactory.newServerProtocol(memberId);
     final RaftServer.Builder defaults =
         RaftServer.builder(memberId)
             .withMembershipService(mock(ClusterMembershipService.class))
-            .withProtocol(raftServerProtocol);
+            .withProtocol(protocolFactory.newServerProtocol(memberId));
     final RaftServer server = configurator.apply(defaults).build();
 
     servers.add(server);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
@@ -51,8 +52,15 @@ import io.atomix.primitive.session.SessionMetadata;
 import io.atomix.protocols.raft.cluster.RaftClusterEvent;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.protocols.raft.impl.DefaultRaftServer;
+import io.atomix.protocols.raft.impl.RaftContext;
+import io.atomix.protocols.raft.protocol.InstallResponse;
+import io.atomix.protocols.raft.protocol.TestPartitionableRaftProtocolFactory;
 import io.atomix.protocols.raft.protocol.TestRaftProtocolFactory;
+import io.atomix.protocols.raft.protocol.TestRaftServerProtocol;
 import io.atomix.protocols.raft.storage.RaftStorage;
+import io.atomix.protocols.raft.storage.log.RaftLog;
+import io.atomix.protocols.raft.storage.log.RaftLogReader;
 import io.atomix.protocols.raft.storage.log.entry.CloseSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.CommandEntry;
 import io.atomix.protocols.raft.storage.log.entry.ConfigurationEntry;
@@ -61,12 +69,16 @@ import io.atomix.protocols.raft.storage.log.entry.KeepAliveEntry;
 import io.atomix.protocols.raft.storage.log.entry.MetadataEntry;
 import io.atomix.protocols.raft.storage.log.entry.OpenSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.QueryEntry;
+import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.protocols.raft.storage.system.Configuration;
 import io.atomix.storage.StorageLevel;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.storage.journal.JournalReader.Mode;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Serializer;
+import java.lang.reflect.Field;
 import net.jodah.concurrentunit.ConcurrentTestCase;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
@@ -89,6 +101,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -96,11 +109,15 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -1221,6 +1238,117 @@ public class RaftTest extends ConcurrentTestCase {
     await(5000);
   }
 
+  @Test
+  public void testLeaderTruncate() throws Throwable {
+    TestPartitionableRaftProtocolFactory partitionableProtocolFactory =
+        new TestPartitionableRaftProtocolFactory(protocolFactory);
+    final List<RaftMember> members =
+        Lists.newArrayList(createMember(), createMember(), createMember());
+    List<MemberId> memberIds =
+        members.stream().map(RaftMember::memberId).collect(Collectors.toList());
+    final Map<MemberId, RaftStorage> storages =
+        memberIds.stream().collect(Collectors.toMap(Function.identity(), this::createStorage));
+    final Map<MemberId, RaftServer> servers =
+        members.stream()
+            .collect(
+                Collectors.toMap(
+                    member -> member.memberId(),
+                    member ->
+                        createServer(
+                            member.memberId(),
+                            builder ->
+                                builder
+                                    .withStorage(storages.get(member.memberId()))
+                                    .withProtocol(partitionableProtocolFactory.newServerProtocol(member.memberId())))));
+
+    partitionableProtocolFactory.connectAll();
+    // wait for cluster to start
+    startCluster(servers);
+
+    MemberId leaderId = members.stream().filter(m -> servers.get(m.memberId()).isLeader()).findFirst().get().memberId();
+    List<MemberId> followers =
+        memberIds.stream().filter(m -> !m.equals(leaderId)).collect(Collectors.toList());
+
+    final RaftClient client = createClient(members);
+    final TestPrimitive primitive = createPrimitive(client);
+    final String entry = RandomStringUtils.randomAscii(1024);
+    primitive.write(entry).get(5, TimeUnit.SECONDS);
+
+    // partition leader from other members
+    partitionableProtocolFactory.partition(leaderId, followers.get(0));
+    partitionableProtocolFactory.partition(leaderId, followers.get(1));
+    primitive.write("ShouldNotBeCommitted");
+
+    client.close();
+
+    long lastNonReplicatedEntryIndex = getLastLogEntryIndex(storages.get(leaderId), Mode.ALL);
+    final long committedIndex =
+        Math.max(
+            getLastLogEntryIndex(storages.get(followers.get(0)), Mode.ALL),
+            getLastLogEntryIndex(storages.get(followers.get(1)), Mode.ALL));
+    assumeTrue(committedIndex < lastNonReplicatedEntryIndex); // verify that leader has non replicated entries in the log.
+
+    // write and compact log
+    final RaftClient client1 =
+        createClient(members.stream().filter(m -> !m.memberId().equals(leaderId)).collect(Collectors.toList()));
+    final TestPrimitive primitive1 = createPrimitive(client1);
+    fillSegment(primitive1);
+    final List<CompletableFuture<Void>> compactFutures =
+        memberIds.stream().map(m -> servers.get(m).compact()).collect(Collectors.toList());
+    compactFutures.get(0).get(15_000, TimeUnit.MILLISECONDS);
+    compactFutures.get(1).get(15_000, TimeUnit.MILLISECONDS);
+
+    final CompletableFuture<Void> rejoined = new CompletableFuture();
+    partitionableProtocolFactory.getServer(leaderId).registerInstallHandler(request -> {
+      rejoined.complete(null);
+      CompletableFuture<InstallResponse> response = new CompletableFuture<>();
+      response.completeExceptionally(new RuntimeException());
+      return response;
+    });
+
+    // heal partition to old leader
+    partitionableProtocolFactory.heal(leaderId, followers.get(0));
+    partitionableProtocolFactory.heal(leaderId, followers.get(1));
+
+    rejoined.get(15_000, TimeUnit.SECONDS);
+
+    final RaftLogReader reader = getRaftLog((DefaultRaftServer) servers.get(leaderId)).openReader(0, Mode.COMMITS);
+    while (reader.hasNext()) {
+      final Indexed<RaftLogEntry> next = reader.next();
+      assertNotEquals(lastNonReplicatedEntryIndex, next.index());
+    }
+  }
+
+  private RaftLog getRaftLog(DefaultRaftServer server) {
+    try {
+      final Field context = DefaultRaftServer.class.getDeclaredField("context");
+      context.setAccessible(true);
+      final RaftContext raft = (RaftContext) context.get(server);
+      final Field raftLog = RaftContext.class.getDeclaredField("raftLog");
+      raftLog.setAccessible(true);
+      final RaftLog log = (RaftLog) raftLog.get(raft);
+      raftLog.setAccessible(false);
+      context.setAccessible(false);
+      return log;
+    } catch (IllegalAccessException | NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private long getLastLogEntryIndex(RaftStorage storage, Mode mode) {
+    final RaftLogReader reader = storage.openLog().openReader(0, mode);
+    while (reader.hasNext()) {
+      reader.next();
+    }
+    return reader.getCurrentEntry().index();
+  }
+
+  private void fillSegment(TestPrimitive primitive) throws InterruptedException, ExecutionException, TimeoutException {
+    final String entry = RandomStringUtils.randomAscii(1024);
+    primitive.write(entry).get(5, TimeUnit.SECONDS);
+    IntStream.range(0, 10 - 1).forEach(i -> primitive.write(entry).join());
+  }
+
   /**
    * Returns the next unique member identifier.
    *
@@ -1290,38 +1418,76 @@ public class RaftTest extends ConcurrentTestCase {
     return servers;
   }
 
+  private RaftMember createMember() {
+    final RaftMember member = nextMember(RaftMember.Type.ACTIVE);
+    members.add(member);
+
+    return member;
+  }
+
+  private void startCluster(Map<MemberId, RaftServer> servers) throws TimeoutException {
+    final List<MemberId> members = new ArrayList<>(servers.keySet());
+    final CompletableFuture[] bootstrapped = new CompletableFuture[members.size()];
+    servers.values().stream().map(s -> s.bootstrap(members)).collect(Collectors.toList()).toArray(bootstrapped);
+
+    CompletableFuture.allOf(bootstrapped).thenRun(this::resume);
+    await(30000);
+  }
+
   /**
    * Creates a Raft server.
    */
   private RaftServer createServer(MemberId memberId) {
-    RaftServer.Builder builder = RaftServer.builder(memberId)
-        .withMembershipService(mock(ClusterMembershipService.class))
-        .withProtocol(protocolFactory.newServerProtocol(memberId))
-        .withStorage(RaftStorage.builder()
-            .withStorageLevel(StorageLevel.DISK)
-            .withDirectory(new File(String.format("target/test-logs/%s", memberId)))
-            .withNamespace(NAMESPACE)
-            .withMaxSegmentSize(1024 * 10)
-            .withMaxEntriesPerSegment(10)
-            .build());
+    return createServer(memberId, b -> b.withStorage(createStorage(memberId)));
+  }
 
-    RaftServer server = builder.build();
+  private RaftServer createServer(MemberId memberId, Function<RaftServer.Builder, RaftServer.Builder> configurator) {
+    final TestRaftServerProtocol raftServerProtocol = protocolFactory.newServerProtocol(memberId);
+    final RaftServer.Builder defaults =
+        RaftServer.builder(memberId)
+            .withMembershipService(mock(ClusterMembershipService.class))
+            .withProtocol(raftServerProtocol);
+    final RaftServer server = configurator.apply(defaults).build();
 
     servers.add(server);
     return server;
+  }
+
+  private RaftServer createServer(Map.Entry<MemberId, RaftStorage> entry) {
+    return createServer(entry.getKey(), b -> b.withStorage(entry.getValue()));
+  }
+
+  private RaftStorage createStorage(MemberId memberId) {
+    return createStorage(memberId, Function.identity());
+  }
+
+  private RaftStorage createStorage(MemberId memberId, Function<RaftStorage.Builder, RaftStorage.Builder> configurator) {
+    final RaftStorage.Builder defaults =
+        RaftStorage.builder()
+            .withStorageLevel(StorageLevel.DISK)
+            .withDirectory(new File(String.format("target/test-logs/%s", memberId)))
+            .withMaxEntriesPerSegment(10)
+            .withMaxSegmentSize(1024 * 10)
+            .withNamespace(NAMESPACE);
+    return configurator.apply(defaults).build();
   }
 
   /**
    * Creates a Raft client.
    */
   private RaftClient createClient() throws Throwable {
-    MemberId memberId = nextNodeId();
-    RaftClient client = RaftClient.builder()
-        .withMemberId(memberId)
-        .withPartitionId(PartitionId.from("test", 1))
-        .withProtocol(protocolFactory.newClientProtocol(memberId))
-        .build();
-    client.connect(members.stream().map(RaftMember::memberId).collect(Collectors.toList())).thenRun(this::resume);
+    return createClient(members);
+  }
+
+  private RaftClient createClient(List<RaftMember> members) throws Throwable {
+    final MemberId memberId = nextNodeId();
+    final List<MemberId> memberIds = members.stream().map(RaftMember::memberId).collect(Collectors.toList());
+    final RaftClient client = RaftClient.builder()
+            .withMemberId(memberId)
+            .withPartitionId(PartitionId.from("test", 1))
+            .withProtocol(protocolFactory.newClientProtocol(memberId))
+            .build();
+    client.connect(memberIds).thenRun(this::resume);
     await(30000);
     clients.add(client);
     return client;

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestPartitionableRaftProtocolFactory.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestPartitionableRaftProtocolFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.protocol;
+
+import com.google.common.collect.Maps;
+import io.atomix.cluster.MemberId;
+import io.atomix.utils.concurrent.ThreadContext;
+import java.util.Map;
+
+public class TestPartitionableRaftProtocolFactory {
+
+  private final Map<MemberId, Map<MemberId, TestRaftServerProtocol>> serverConnections =
+      Maps.newConcurrentMap();
+  private final Map<MemberId, TestRaftClientProtocol> clients;
+  private final Map<MemberId, TestRaftServerProtocol> servers;
+  private final ThreadContext context;
+
+  public TestPartitionableRaftProtocolFactory(TestRaftProtocolFactory protocolFactory) {
+    this.context = protocolFactory.context;
+    this.servers = protocolFactory.servers;
+    this.clients = protocolFactory.clients;
+  }
+
+  public TestRaftServerProtocol newServerProtocol(MemberId memberId) {
+    final TestRaftServerProtocol protocol =
+        new TestRaftServerProtocol(memberId, getConnections(memberId), clients, context);
+    servers.put(memberId, protocol);
+    return protocol;
+  }
+
+  public void connectAll() {
+    servers.forEach((member, protocol) -> connectAll(member));
+  }
+
+  private void connectAll(MemberId server) {
+    servers.forEach((member, protocol) -> connect(server, member));
+  }
+
+  private Map<MemberId, TestRaftServerProtocol> getConnections(MemberId memberId) {
+    return serverConnections.computeIfAbsent(memberId, m -> Maps.newConcurrentMap());
+  }
+
+  public void partition(MemberId server1, MemberId server2) {
+    disconnect(server1, server2);
+    disconnect(server2, server1);
+  }
+
+  public void heal(MemberId server1, MemberId server2) {
+    connect(server1, server2);
+    connect(server2, server1);
+  }
+
+  private void disconnect(MemberId source, MemberId dest) {
+    getConnections(source).remove(dest);
+  }
+
+  private void connect(MemberId source, MemberId dest) {
+    getConnections(source).put(dest, servers.get(dest));
+  }
+
+  public TestRaftServerProtocol getServer(MemberId memberId) {
+    return servers.get(memberId);
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftProtocol.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftProtocol.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeoutException;
  * Base class for Raft protocol.
  */
 public abstract class TestRaftProtocol {
-  private final Map<MemberId, TestRaftServerProtocol> servers;
+  protected final Map<MemberId, TestRaftServerProtocol> servers;
   private final Map<MemberId, TestRaftClientProtocol> clients;
   private final ThreadContext context;
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftProtocolFactory.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/protocol/TestRaftProtocolFactory.java
@@ -25,9 +25,9 @@ import java.util.Map;
  * Test Raft protocol factory.
  */
 public class TestRaftProtocolFactory {
-  private final Map<MemberId, TestRaftServerProtocol> servers = Maps.newConcurrentMap();
-  private final Map<MemberId, TestRaftClientProtocol> clients = Maps.newConcurrentMap();
-  private final ThreadContext context;
+  final Map<MemberId, TestRaftServerProtocol> servers = Maps.newConcurrentMap();
+  final Map<MemberId, TestRaftClientProtocol> clients = Maps.newConcurrentMap();
+  final ThreadContext context;
 
   public TestRaftProtocolFactory(ThreadContext context) {
     this.context = context;
@@ -39,7 +39,7 @@ public class TestRaftProtocolFactory {
    * @param memberId the client member identifier
    * @return a new test client protocol
    */
-  public RaftClientProtocol newClientProtocol(MemberId memberId) {
+  public TestRaftClientProtocol newClientProtocol(MemberId memberId) {
     return new TestRaftClientProtocol(memberId, servers, clients, context);
   }
 
@@ -49,7 +49,7 @@ public class TestRaftProtocolFactory {
    * @param memberId the server member identifier
    * @return a new test server protocol
    */
-  public RaftServerProtocol newServerProtocol(MemberId memberId) {
+  public TestRaftServerProtocol newServerProtocol(MemberId memberId) {
     return new TestRaftServerProtocol(memberId, servers, clients, context);
   }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/AbstractSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/AbstractSnapshotStoreTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractSnapshotStoreTest {
   public void testWriteSnapshotChunks() {
     SnapshotStore store = createSnapshotStore();
     WallClockTimestamp timestamp = new WallClockTimestamp();
-    Snapshot snapshot = store.newSnapshot(2, timestamp);
+    Snapshot snapshot = store.newSnapshot(2, 1, timestamp);
     assertEquals(2, snapshot.index());
     assertEquals(timestamp, snapshot.timestamp());
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
@@ -64,7 +64,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testStoreLoadSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newSnapshot(2, new WallClockTimestamp());
+    Snapshot snapshot = store.newSnapshot(2, 3, new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       writer.writeLong(10);
     }
@@ -75,6 +75,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     store = createSnapshotStore();
     assertNotNull(store.getSnapshot(2));
     assertEquals(2, store.getSnapshot(2).index());
+    assertEquals(3, store.getSnapshot(2).term());
 
     try (SnapshotReader reader = snapshot.openReader()) {
       assertEquals(10, reader.readLong());
@@ -88,7 +89,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testPersistLoadSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newTemporarySnapshot(2, new WallClockTimestamp());
+    Snapshot snapshot = store.newTemporarySnapshot(2, 3, new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       writer.writeLong(10);
     }
@@ -111,6 +112,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     store = createSnapshotStore();
     assertNotNull(store.getSnapshot(2));
     assertEquals(2, store.getSnapshot(2).index());
+    assertEquals(3, store.getSnapshot(2).term());
 
     snapshot = store.getSnapshot(2);
     try (SnapshotReader reader = snapshot.openReader()) {
@@ -125,7 +127,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testStreamSnapshot() throws Exception {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newSnapshot(1, new WallClockTimestamp());
+    Snapshot snapshot = store.newSnapshot(1, 1, new WallClockTimestamp());
     for (long i = 1; i <= 10; i++) {
       try (SnapshotWriter writer = snapshot.openWriter()) {
         writer.writeLong(i);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptorTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptorTest.java
@@ -31,9 +31,11 @@ public class SnapshotDescriptorTest {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(2)
         .withTimestamp(3)
+        .withTerm(4)
         .build();
     assertEquals(2, descriptor.index());
     assertEquals(3, descriptor.timestamp());
+    assertEquals(4, descriptor.term());
     assertEquals(1, descriptor.version());
   }
 
@@ -42,6 +44,7 @@ public class SnapshotDescriptorTest {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(2)
         .withTimestamp(3)
+        .withTerm(4)
         .build();
     Buffer buffer = HeapBuffer.allocate(SnapshotDescriptor.BYTES);
     descriptor.copyTo(buffer);
@@ -49,6 +52,7 @@ public class SnapshotDescriptorTest {
     descriptor = new SnapshotDescriptor(buffer);
     assertEquals(2, descriptor.index());
     assertEquals(3, descriptor.timestamp());
+    assertEquals(4, descriptor.term());
     assertEquals(1, descriptor.version());
   }
 


### PR DESCRIPTION
This PR fixes #1036 
 * added a test to verify that non replicated events can get committed when old leader reconnects after a network partition.

To fix the issue, following changes are made to the raft implementation:
 * previous term is 0 only for the first entry in the log
 * if there is no previous entry in the log after compaction, use the existing snapshot as previous entry.
 * reset follower's next index when install response is success.
 * reset log after receiving a snapshot from leader.
 * include the last applied entry's term in the snapshot
 * replaces SnapshotDescriptor positions and lengths with constants
       similar to JournalSegmentDescriptor
