### PR TITLE
fix(raft): fixes issues with concurrent snapshot writers

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
@@ -17,10 +17,12 @@ package io.atomix.protocols.raft.storage.snapshot;
 
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.FileBuffer;
+import io.atomix.utils.AtomixIOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -42,7 +44,9 @@ final class FileSnapshot extends Snapshot {
   @Override
   public synchronized SnapshotWriter openWriter() {
     checkWriter();
-    Buffer buffer = FileBuffer.allocate(file.file(), SnapshotDescriptor.BYTES);
+    checkState(!file.file().exists(), "cannot write to completed snapshot");
+    checkNotNull(file.temporaryFile(), "missing temporary snapshot file for writing");
+    Buffer buffer = FileBuffer.allocate(file.temporaryFile(), SnapshotDescriptor.BYTES);
     descriptor.copyTo(buffer);
 
     int length = buffer.position(SnapshotDescriptor.BYTES).readInt();
@@ -66,17 +70,36 @@ final class FileSnapshot extends Snapshot {
   }
 
   @Override
-  public boolean isPersisted() {
-    return true;
-  }
-
-  @Override
   public Snapshot complete() {
-    Buffer buffer = FileBuffer.allocate(file.file(), SnapshotDescriptor.BYTES);
+    checkNotNull(file.temporaryFile(), "no temporary snapshot file to read from");
+
+    Buffer buffer = FileBuffer.allocate(file.temporaryFile(), SnapshotDescriptor.BYTES);
     try (SnapshotDescriptor descriptor = new SnapshotDescriptor(buffer)) {
       descriptor.lock();
     }
+
+    try {
+      Files.move(file.temporaryFile().toPath(), file.file().toPath());
+    } catch (FileAlreadyExistsException e) {
+      LOGGER.debug("Snapshot {} was already previously completed", this);
+    } catch (IOException e) {
+      throw new AtomixIOException(e);
+    }
+
+    file.clearTemporaryFile();
     return super.complete();
+  }
+
+  /**
+   * Deletes the temporary file
+   */
+  @Override
+  public void close() {
+    super.close();
+
+    if (file.temporaryFile() != null) {
+      deleteFileSilently(file.temporaryFile().toPath());
+    }
   }
 
   /**
@@ -86,11 +109,17 @@ final class FileSnapshot extends Snapshot {
   public void delete() {
     LOGGER.debug("Deleting {}", this);
     Path path = file.file().toPath();
+
     if (Files.exists(path)) {
-      try {
-        Files.delete(file.file().toPath());
-      } catch (IOException e) {
-      }
+      deleteFileSilently(path);
+    }
+  }
+
+  private void deleteFileSilently(Path path) {
+    try {
+      Files.delete(path);
+    } catch (IOException e) {
+      LOGGER.debug("Failed to delete snapshot file {}", path, e);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
@@ -16,7 +16,6 @@
 package io.atomix.protocols.raft.storage.snapshot;
 
 import io.atomix.utils.time.WallClockTimestamp;
-
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -174,24 +173,6 @@ public abstract class Snapshot implements AutoCloseable {
   }
 
   /**
-   * Persists the snapshot to disk if necessary.
-   * <p>
-   * If the snapshot store is backed by disk, the snapshot will be persisted.
-   *
-   * @return The persisted snapshot.
-   */
-  public Snapshot persist() {
-    return this;
-  }
-
-  /**
-   * Returns whether the snapshot is persisted.
-   *
-   * @return Whether the snapshot is persisted.
-   */
-  public abstract boolean isPersisted();
-
-  /**
    * Closes the snapshot.
    */
   @Override
@@ -202,6 +183,7 @@ public abstract class Snapshot implements AutoCloseable {
    * Deletes the snapshot.
    */
   public void delete() {
+
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotFile.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotFile.java
@@ -16,8 +16,10 @@
 package io.atomix.protocols.raft.storage.snapshot;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.atomix.utils.AtomixIOException;
 
 import java.io.File;
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,6 +31,7 @@ public final class SnapshotFile {
   private static final char EXTENSION_SEPARATOR = '.';
   private static final String EXTENSION = "snapshot";
   private final File file;
+  private File temporaryFile;
 
   /**
    * Returns a boolean value indicating whether the given file appears to be a parsable snapshot file.
@@ -91,6 +94,19 @@ public final class SnapshotFile {
   }
 
   /**
+   * Creates a temporary file for writing snapshots.
+   */
+  static File createTemporaryFile(File base) {
+    try {
+      final File file = File.createTempFile(base.getName(), null);
+      file.deleteOnExit();
+      return file;
+    } catch (IOException e) {
+      throw new AtomixIOException(e);
+    }
+  }
+
+  /**
    * Creates a snapshot file name from the given parameters.
    */
   @VisibleForTesting
@@ -102,10 +118,29 @@ public final class SnapshotFile {
   }
 
   /**
-   * @throws IllegalArgumentException if {@code file} is not a valid snapshot file
+   * Creates a new SnapshotFile with references to a permanent snapshot file (for reading)
+   * and a temporary snapshot file (for writing). The temporary file can be null if the snapshot
+   * is already completed and should not be written to.
+   *
+   * @param file the snapshot file which is used for reading
+   * @param temporaryFile the snapshot file which is used for writing
    */
-  SnapshotFile(File file) {
+  SnapshotFile(File file, File temporaryFile) {
     this.file = file;
+    this.temporaryFile = temporaryFile;
+  }
+
+  /**
+   * Returns the snapshot lock file name.
+   *
+   * @return the snapshot lock file name
+   */
+  File temporaryFile() {
+    return temporaryFile;
+  }
+
+  void clearTemporaryFile() {
+    temporaryFile = null;
   }
 
   /**
@@ -130,5 +165,4 @@ public final class SnapshotFile {
   static String parseName(String fileName) {
     return fileName.substring(0, fileName.lastIndexOf(PART_SEPARATOR, fileName.lastIndexOf(PART_SEPARATOR) - 1));
   }
-
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotFile.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotFile.java
@@ -96,11 +96,9 @@ public final class SnapshotFile {
   /**
    * Creates a temporary file for writing snapshots.
    */
-  static File createTemporaryFile(File base) {
+  static File createTemporaryFile(File directory, File base) {
     try {
-      final File file = File.createTempFile(base.getName(), null);
-      file.deleteOnExit();
-      return file;
+      return File.createTempFile(base.getName(), null, directory);
     } catch (IOException e) {
       throw new AtomixIOException(e);
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
@@ -180,7 +180,7 @@ public class SnapshotStore implements AutoCloseable {
             storage.directory(),
             storage.prefix(),
             descriptor.index());
-    File temporaryFile = SnapshotFile.createTemporaryFile(snapshotFile);
+    File temporaryFile = SnapshotFile.createTemporaryFile(storage.directory(), snapshotFile);
 
     SnapshotFile file = new SnapshotFile(snapshotFile, temporaryFile);
     Snapshot snapshot = new FileSnapshot(file, descriptor, this);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
@@ -40,10 +40,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * to the configured {@link RaftStorage#storageLevel() storage level}. Each server with a snapshottable state machine
  * persists the state machine state to allow commands to be removed from disk.
  * <p>
- * When a snapshot store is {@link RaftStorage#openSnapshotStore() created}, the store will load any
- * existing snapshots from disk and make them available for reading. Only snapshots that have been
- * written and {@link Snapshot#complete() completed} will be read from disk. Incomplete snapshots are
- * automatically deleted from disk when the snapshot store is opened.
+ * When a snapshot store is {@link RaftStorage#openSnapshotStore() created} with a non-memory storage level, the store
+ * will load any existing snapshots from disk and make them available for reading. Only snapshots that have been
+ * written and {@link Snapshot#complete() completed} will be read from disk.
  * <p>
  * <pre>
  *   {@code
@@ -83,8 +82,11 @@ public class SnapshotStore implements AutoCloseable {
    * Opens the snapshot manager.
    */
   private void open() {
-    for (Snapshot snapshot : loadSnapshots()) {
-      completeSnapshot(snapshot);
+    // load persisted snapshots only if storage level is persistent
+    if (storage.storageLevel() != StorageLevel.MEMORY) {
+      for (Snapshot snapshot : loadSnapshots()) {
+        completeSnapshot(snapshot);
+      }
     }
   }
 
@@ -124,7 +126,7 @@ public class SnapshotStore implements AutoCloseable {
 
       // If the file looks like a segment file, attempt to load the segment.
       if (SnapshotFile.isSnapshotFile(file)) {
-        SnapshotFile snapshotFile = new SnapshotFile(file);
+        SnapshotFile snapshotFile = new SnapshotFile(file, null);
         SnapshotDescriptor descriptor = new SnapshotDescriptor(FileBuffer.allocate(file, SnapshotDescriptor.BYTES));
 
         // Valid segments will have been locked. Segments that resulting from failures during log cleaning will be
@@ -134,31 +136,10 @@ public class SnapshotStore implements AutoCloseable {
           snapshots.add(new FileSnapshot(snapshotFile, descriptor, this));
           descriptor.close();
         }
-        // If the segment descriptor wasn't locked, close and delete the descriptor.
-        else {
-          log.debug("Deleting partial snapshot: {} ({})", descriptor.index(), snapshotFile.file().getName());
-          descriptor.close();
-          descriptor.delete();
-        }
       }
     }
 
     return snapshots;
-  }
-
-  /**
-   * Creates a temporary in-memory snapshot.
-   *
-   * @param index     The snapshot index.
-   * @param timestamp The snapshot timestamp.
-   * @return The snapshot.
-   */
-  public Snapshot newTemporarySnapshot(long index, WallClockTimestamp timestamp) {
-    SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
-        .withIndex(index)
-        .withTimestamp(timestamp.unixTimestamp())
-        .build();
-    return newSnapshot(descriptor, StorageLevel.MEMORY);
   }
 
   /**
@@ -173,14 +154,8 @@ public class SnapshotStore implements AutoCloseable {
         .withIndex(index)
         .withTimestamp(timestamp.unixTimestamp())
         .build();
-    return newSnapshot(descriptor, storage.storageLevel());
-  }
 
-  /**
-   * Creates a new snapshot buffer.
-   */
-  private Snapshot newSnapshot(SnapshotDescriptor descriptor, StorageLevel storageLevel) {
-    if (storageLevel == StorageLevel.MEMORY) {
+    if (storage.storageLevel() == StorageLevel.MEMORY) {
       return createMemorySnapshot(descriptor);
     } else {
       return createDiskSnapshot(descriptor);
@@ -201,11 +176,13 @@ public class SnapshotStore implements AutoCloseable {
    * Creates a disk snapshot.
    */
   private Snapshot createDiskSnapshot(SnapshotDescriptor descriptor) {
-    SnapshotFile file = new SnapshotFile(SnapshotFile.createSnapshotFile(
-        storage.directory(),
-        storage.prefix(),
-        descriptor.index()
-    ));
+    File snapshotFile = SnapshotFile.createSnapshotFile(
+            storage.directory(),
+            storage.prefix(),
+            descriptor.index());
+    File temporaryFile = SnapshotFile.createTemporaryFile(snapshotFile);
+
+    SnapshotFile file = new SnapshotFile(snapshotFile, temporaryFile);
     Snapshot snapshot = new FileSnapshot(file, descriptor, this);
     log.debug("Created disk snapshot: {}", snapshot);
     return snapshot;
@@ -220,6 +197,9 @@ public class SnapshotStore implements AutoCloseable {
     Map.Entry<Long, Snapshot> lastEntry = snapshots.lastEntry();
     if (lastEntry == null) {
       snapshots.put(snapshot.index(), snapshot);
+    } else if (lastEntry.getValue().index() == snapshot.index()) {
+      // in case of concurrently trying to complete the same snapshot
+      snapshot.close();
     } else if (lastEntry.getValue().index() < snapshot.index()) {
       snapshots.put(snapshot.index(), snapshot);
       Snapshot lastSnapshot = lastEntry.getValue();

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
@@ -129,7 +129,7 @@ public class RaftServiceManagerTest {
     assertEquals(2, snapshot.index());
     assertTrue(snapshotTaken.get());
 
-    snapshot = snapshot.persist().complete();
+    snapshot = snapshot.complete();
 
     assertEquals(2, raft.getSnapshotStore().getCurrentSnapshot().index());
 
@@ -161,7 +161,7 @@ public class RaftServiceManagerTest {
     assertEquals(2, snapshot.index());
     assertTrue(snapshotTaken.get());
 
-    snapshot.persist().complete();
+    snapshot.complete();
 
     assertEquals(2, raft.getSnapshotStore().getCurrentSnapshot().index());
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
@@ -24,21 +24,20 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.FileVisitResult;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 /**
- * File snapshot store test.
+ * Snapshot store test.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
@@ -88,17 +87,12 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testPersistLoadSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newTemporarySnapshot(2, new WallClockTimestamp());
+    Snapshot snapshot = store.newSnapshot(2, new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       writer.writeLong(10);
     }
 
-    snapshot = snapshot.persist();
-
-    assertTrue(snapshot.isPersisted());
-
     assertNull(store.getSnapshot(2));
-
     snapshot.complete();
     assertNotNull(store.getSnapshot(2));
 
@@ -122,7 +116,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
    * Tests writing multiple times to a snapshot designed to mimic chunked snapshots from leaders.
    */
   @Test
-  public void testStreamSnapshot() throws Exception {
+  public void testStreamSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
     Snapshot snapshot = store.newSnapshot(1, new WallClockTimestamp());
@@ -139,6 +133,39 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
         assertEquals(i, reader.readLong());
       }
     }
+  }
+
+  /**
+   * Tests case where two {@link FileSnapshot} instances are trying to write the same snapshot
+   */
+  @Test
+  public void testConcurrentSnapshotWriters() {
+    SnapshotStore store = createSnapshotStore();
+    final WallClockTimestamp timestamp = new WallClockTimestamp();
+    Snapshot first = store.newSnapshot(1, timestamp);
+    Snapshot second = store.newSnapshot(1, timestamp);
+
+    try (SnapshotWriter firstWriter = first.openWriter()) {
+      firstWriter.writeLong(1);
+    }
+
+    try (SnapshotWriter secondWriter = second.openWriter()) {
+      secondWriter.writeLong(1);
+    }
+
+    first.complete();
+    second.complete();
+
+    Snapshot completed = store.getSnapshot(first.index());
+    assertNotNull(completed);
+    long result = 0;
+    try (SnapshotReader reader = completed.openReader()) {
+      while (reader.hasRemaining()) {
+        result += reader.readLong();
+      }
+    }
+
+    assertEquals(result, 1);
   }
 
   @Before
@@ -162,5 +189,4 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     }
     testId = UUID.randomUUID().toString();
   }
-
 }


### PR DESCRIPTION
- removes the concept of "persisting" a snapshot; with in memory storage level, snapshots are not persisted, and with anything else they are written to a temporary file before being moved to a permanent location on complete
- file snapshots read from the permanent file (or fail if none yet present)
- closing a file snapshot discards its temporary file
- improves error handling on snapshot completion failure (when replicating and locally snapshotting)

Closes #1042 