### PR TITLE
Avoid unnecessary retrying of duplicate commands

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.protocols.raft.session.impl;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.atomix.primitive.PrimitiveException;
 import io.atomix.primitive.PrimitiveState;
 import io.atomix.primitive.operation.PrimitiveOperation;
@@ -28,7 +30,6 @@ import io.atomix.protocols.raft.protocol.QueryRequest;
 import io.atomix.protocols.raft.protocol.QueryResponse;
 import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.utils.concurrent.ThreadContext;
-
 import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.time.Duration;
@@ -41,8 +42,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Session operation submitter.
@@ -310,7 +309,7 @@ final class RaftSessionInvoker {
      * Immediately retries the attempt.
      */
     public void retry() {
-      context.execute(() -> invoke(next()));
+      invoke(next());
     }
 
     /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/session/impl/RaftSessionInvoker.java
@@ -309,6 +309,7 @@ final class RaftSessionInvoker {
      * Immediately retries the attempt.
      */
     public void retry() {
+      context.checkThread();
       invoke(next());
     }
 
@@ -336,7 +337,7 @@ final class RaftSessionInvoker {
 
     @Override
     protected void send() {
-      leaderConnection.command(request).whenComplete(this);
+      leaderConnection.command(request).whenCompleteAsync(this, context);
     }
 
     @Override

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionInvokerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/session/impl/RaftSessionInvokerTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -93,8 +92,8 @@ public class RaftSessionInvokerTest {
     // setup  thread context
     final Logger log = LoggerFactory.getLogger(getClass());
     final int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
-    final ThreadContext context = spy(new BlockingAwareThreadPoolContextFactory(
-        "raft-partition-group-data-%d", threadPoolSize, log).createContext());
+    final ThreadContext context = new BlockingAwareThreadPoolContextFactory(
+        "raft-partition-group-data-%d", threadPoolSize, log).createContext();
 
     // collecting request futures
     final List<CompletableFuture<CommandResponse>> futures = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
### Problem

The main problem is that OperationAttempt#retry retries the commands asynchronously, which then caused a lot of traffic in the end because we were not able to detect if we already retried this operation or not. It is not necessary to send these commands async, in the RaftSessionInvoker we only have one thread. If we send it directly in resubmit we can check on the next iteration whether the operation was already retried or not.

### Example

Say we have `n` `COMMAND_FAILURES`, then we have `n` resubmit calls:

 * resubmit 1
 * resubmit 2
 * ...
 * resubmit n -1
 * resubmit n

Each resubmit will retry `1000 + n` commands, because after the thousands command the first `COMMAND_FAILURE` is send

 * resubmit 1
   * retry 1
   * retry 2
   * ...
   * retry 1000 + n -1
   * retry 1000 + n
 * ...
 * resubmit n

Each retry was scheduled on the context thread executor. When it is executed it increments the attempt and sends the operation (async again). 
Since the retry was async and we only have one thread all resubmit are executed in order. The resubmits have added `n * (1000 + n)` retry operations to the backlog, where are `(n-1) * (1000 + n)` duplicate attempts. 

With the fix I just changed the order of executing a bit. The operation is still sending async, but the attempt count is directly incremented. This means on `resubmit 1` we will increment all operation attempts by one. On the second `resubmit` we will not retry the operation since the attempt is already higher.

Hope this makes sense? :) 

closes #1046 