### PR TITLE
Improve overriden 'equals' methods

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/Member.java
+++ b/cluster/src/main/java/io/atomix/cluster/Member.java
@@ -230,6 +230,9 @@ public class Member extends Node {
 
   @Override
   public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
     if (object instanceof Member) {
       Member member = (Member) object;
       return member.id().equals(id())

--- a/core/src/main/java/io/atomix/core/election/Leader.java
+++ b/core/src/main/java/io/atomix/core/election/Leader.java
@@ -89,7 +89,7 @@ public class Leader<T> {
     if (this == other) {
       return true;
     }
-    if (other != null && other instanceof Leader) {
+    if (other instanceof Leader) {
       Leader that = (Leader) other;
       return Objects.equal(this.id, that.id)
           && this.term == that.term

--- a/core/src/main/java/io/atomix/core/map/AtomicMapEvent.java
+++ b/core/src/main/java/io/atomix/core/map/AtomicMapEvent.java
@@ -96,10 +96,12 @@ public class AtomicMapEvent<K, V> extends AbstractEvent<AtomicMapEvent.Type, K> 
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
     if (!(o instanceof AtomicMapEvent)) {
       return false;
     }
-
     AtomicMapEvent<K, V> that = (AtomicMapEvent) o;
     return Objects.equals(this.type(), that.type())
         && Objects.equals(this.key(), that.key())

--- a/core/src/main/java/io/atomix/core/map/MapEvent.java
+++ b/core/src/main/java/io/atomix/core/map/MapEvent.java
@@ -95,6 +95,9 @@ public class MapEvent<K, V> extends AbstractEvent<MapEvent.Type, K> {
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
     if (!(o instanceof MapEvent)) {
       return false;
     }

--- a/core/src/main/java/io/atomix/core/multimap/AtomicMultimapEvent.java
+++ b/core/src/main/java/io/atomix/core/multimap/AtomicMultimapEvent.java
@@ -91,6 +91,9 @@ public class AtomicMultimapEvent<K, V> extends AbstractEvent<AtomicMultimapEvent
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
     if (!(o instanceof AtomicMultimapEvent)) {
       return false;
     }

--- a/core/src/main/java/io/atomix/core/multimap/MultimapEvent.java
+++ b/core/src/main/java/io/atomix/core/multimap/MultimapEvent.java
@@ -91,6 +91,9 @@ public class MultimapEvent<K, V> extends AbstractEvent<MultimapEvent.Type, K> {
 
   @Override
   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
     if (!(o instanceof MultimapEvent)) {
       return false;
     }

--- a/primitive/src/main/java/io/atomix/primitive/partition/PartitionEvent.java
+++ b/primitive/src/main/java/io/atomix/primitive/partition/PartitionEvent.java
@@ -120,6 +120,9 @@ public class PartitionEvent extends AbstractEvent<PartitionEvent.Type, Partition
 
   @Override
   public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
     if (object instanceof PartitionEvent) {
       PartitionEvent that = (PartitionEvent) object;
       return this.partitionId().equals(that.partitionId())

--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultCommit.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultCommit.java
@@ -92,6 +92,9 @@ public class DefaultCommit<T> implements Commit<T> {
 
   @Override
   public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
     if (object instanceof Commit) {
       Commit commit = (Commit) object;
       return commit.index() == index

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/AppendRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/AppendRequest.java
@@ -121,6 +121,9 @@ public class AppendRequest extends AbstractRaftRequest {
 
   @Override
   public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
     if (object instanceof AppendRequest) {
       AppendRequest request = (AppendRequest) object;
       return request.term == term

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/ConfigureRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/ConfigureRequest.java
@@ -113,7 +113,7 @@ public class ConfigureRequest extends AbstractRaftRequest {
     if (object instanceof ConfigureRequest) {
       ConfigureRequest request = (ConfigureRequest) object;
       return request.term == term
-          && request.leader == leader
+          && request.leader.equals(leader)
           && request.index == index
           && request.timestamp == timestamp
           && request.members.equals(members);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/OpenSessionRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/OpenSessionRequest.java
@@ -127,6 +127,9 @@ public class OpenSessionRequest extends AbstractRaftRequest {
 
   @Override
   public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
     if (object instanceof OpenSessionRequest) {
       OpenSessionRequest request = (OpenSessionRequest) object;
       return request.node.equals(node)

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/PollRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/PollRequest.java
@@ -99,7 +99,7 @@ public class PollRequest extends AbstractRaftRequest {
     if (object instanceof PollRequest) {
       PollRequest request = (PollRequest) object;
       return request.term == term
-          && request.candidate == candidate
+          && request.candidate.equals(candidate)
           && request.lastLogIndex == lastLogIndex
           && request.lastLogTerm == lastLogTerm;
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
@@ -211,6 +211,9 @@ public abstract class Snapshot implements AutoCloseable {
 
   @Override
   public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
     if (object == null || getClass() != object.getClass()) {
       return false;
     }

--- a/utils/src/main/java/io/atomix/utils/Version.java
+++ b/utils/src/main/java/io/atomix/utils/Version.java
@@ -125,10 +125,12 @@ public final class Version implements Comparable<Version> {
 
   @Override
   public boolean equals(Object object) {
+    if (object == this) {
+      return true;
+    }
     if (!(object instanceof Version)) {
       return false;
     }
-
     Version that = (Version) object;
     return this.major == that.major
         && this.minor == that.minor
@@ -206,6 +208,9 @@ public final class Version implements Comparable<Version> {
 
     @Override
     public boolean equals(Object object) {
+      if (object == this) {
+        return true;
+      }
       if (!(object instanceof Build)) {
         return false;
       }

--- a/utils/src/main/java/io/atomix/utils/net/Address.java
+++ b/utils/src/main/java/io/atomix/utils/net/Address.java
@@ -230,10 +230,7 @@ public final class Address {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
+    if (!(obj instanceof Address)) {
       return false;
     }
     Address that = (Address) obj;


### PR DESCRIPTION
Remove null checks before an `instanceof` expression and add instance
checks when dealing with a lot of compared attributes. Also use
the String#equals(Object) method to check the equality of strings
instead of checking whether their instance is the same.

The JLS states that the `instanceof` expression with a `null` left-hand side operand always evaluates to false. 
https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html (15.20.2. Type Comparison Operator instanceof)