### PR TITLE
fix(protocols/raft): apply raft partition group configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 
 jdk:
-- oraclejdk8
 - openjdk8
 - openjdk10
 - openjdk11

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -37,7 +37,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
@@ -49,9 +48,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class RaftPartitionServer implements Managed<RaftPartitionServer> {
 
   private final Logger log = getLogger(getClass());
-
-  private static final long ELECTION_TIMEOUT_MILLIS = 2500;
-  private static final long HEARTBEAT_INTERVAL_MILLIS = 250;
 
   private final MemberId localMemberId;
   private final RaftPartition partition;
@@ -162,8 +158,9 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
             Serializer.using(RaftNamespaces.RAFT_PROTOCOL),
             clusterCommunicator))
         .withPrimitiveTypes(primitiveTypes)
-        .withElectionTimeout(Duration.ofMillis(ELECTION_TIMEOUT_MILLIS))
-        .withHeartbeatInterval(Duration.ofMillis(HEARTBEAT_INTERVAL_MILLIS))
+        .withElectionTimeout(config.getElectionTimeout())
+        .withHeartbeatInterval(config.getHeartbeatInterval())
+        .withSessionTimeout(config.getDefaultSessionTimeout())
         .withStorage(RaftStorage.builder()
             .withPrefix(partition.name())
             .withDirectory(partition.dataDirectory())


### PR DESCRIPTION
Apply raft configuration instead of using hardcoded values for election timeout, heartbeat interval and session timeout.