### PR TITLE
Add support for retaining tombstones in SWIM protocol

### DIFF
--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -95,6 +95,7 @@ class ChannelPool {
             if (error == null) {
               LOGGER.debug("Connected to {}", channel.remoteAddress());
               channel.closeFuture().addListener(f -> {
+                LOGGER.debug("Disconnected from {}", address);
                 synchronized (channelPool) {
                   channelPool.set(offset, null);
                 }
@@ -124,6 +125,7 @@ class ChannelPool {
                 if (e == null) {
                   LOGGER.debug("Connected to {}", channel.remoteAddress());
                   channel.closeFuture().addListener(f -> {
+                    LOGGER.debug("Disconnected from {}", address);
                     synchronized (channelPool) {
                       channelPool.set(offset, null);
                     }

--- a/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
+++ b/cluster/src/main/java/io/atomix/cluster/messaging/impl/ChannelPool.java
@@ -94,6 +94,11 @@ class ChannelPool {
           channelFuture.whenComplete((channel, error) -> {
             if (error == null) {
               LOGGER.debug("Connected to {}", channel.remoteAddress());
+              channel.closeFuture().addListener(f -> {
+                synchronized (channelPool) {
+                  channelPool.set(offset, null);
+                }
+              });
             } else {
               LOGGER.debug("Failed to connect to {}", address, error);
             }
@@ -118,6 +123,11 @@ class ChannelPool {
               currentFuture.whenComplete((c, e) -> {
                 if (e == null) {
                   LOGGER.debug("Connected to {}", channel.remoteAddress());
+                  channel.closeFuture().addListener(f -> {
+                    synchronized (channelPool) {
+                      channelPool.set(offset, null);
+                    }
+                  });
                 } else {
                   LOGGER.debug("Failed to connect to {}", channel.remoteAddress(), e);
                 }

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -202,15 +202,15 @@ public class SwimMembershipProtocol
   private boolean updateState(ImmutableMember member) {
     // If the member matches the local member, ignore the update.
     if (member.id().equals(localMember.id())) {
-        if (member.incarnationNumber() > localMember.getIncarnationNumber() || member.state() != State.ALIVE) {
-            LOGGER.debug("{} - Detected stale state. Incrementing incarnation number {} to {}",
-                localMember.id(), localMember.getIncarnationNumber(), localMember.getIncarnationNumber() + 1);
-            localMember.setIncarnationNumber(member.incarnationNumber() + 1);
-            if (config.isBroadcastDisputes()) {
-                LOGGER.trace("{} - Broadcasting member state dispute: {}", localMember.copy());
-                broadcast(localMember.copy());
-            }
+      if (member.incarnationNumber() > localMember.getIncarnationNumber() || member.state() != State.ALIVE) {
+        LOGGER.debug("{} - Detected stale state. Incrementing incarnation number {} to {}",
+            localMember.id(), localMember.getIncarnationNumber(), localMember.getIncarnationNumber() + 1);
+        localMember.setIncarnationNumber(member.incarnationNumber() + 1);
+        if (config.isBroadcastDisputes()) {
+          LOGGER.trace("{} - Broadcasting member state dispute: {}", localMember.copy());
+          broadcast(localMember.copy());
         }
+      }
       return false;
     }
 
@@ -522,7 +522,7 @@ public class SwimMembershipProtocol
   /**
    * Requests a probe of the given suspect from the given member.
    *
-   * @param member the member to perform the probe
+   * @param member  the member to perform the probe
    * @param suspect the suspect member to probe
    */
   private CompletableFuture<Boolean> requestProbe(SwimMember member, ImmutableMember suspect) {
@@ -540,7 +540,7 @@ public class SwimMembershipProtocol
   /**
    * Selects a set of random members, excluding the local member and a given member.
    *
-   * @param count count the number of random members to select
+   * @param count   count the number of random members to select
    * @param exclude the member to exclude
    * @return members a set of random members
    */
@@ -641,7 +641,7 @@ public class SwimMembershipProtocol
   /**
    * Gossips this node's pending updates with the given peer.
    *
-   * @param member the peer with which to gossip this node's updates
+   * @param member  the peer with which to gossip this node's updates
    * @param updates the updated members to gossip
    */
   private void gossip(SwimMember member, Collection<ImmutableMember> updates) {

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocol.java
@@ -38,7 +38,6 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.atomix.cluster.BootstrapService;

--- a/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolConfig.java
+++ b/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolConfig.java
@@ -33,6 +33,7 @@ public class SwimMembershipProtocolConfig extends GroupMembershipProtocolConfig 
   private static final int DEFAULT_PROBE_TIMEOUT = 2000;
   private static final int DEFAULT_SUSPECT_PROBES = 3;
   private static final int DEFAULT_FAILURE_TIMEOUT = 10000;
+  private static final boolean DEFAULT_RETAIN_TOMBSTONES = true;
 
   private boolean broadcastUpdates = DEFAULT_BROADCAST_UPDATES;
   private boolean broadcastDisputes = DEFAULT_BROADCAST_DISPUTES;
@@ -43,6 +44,7 @@ public class SwimMembershipProtocolConfig extends GroupMembershipProtocolConfig 
   private Duration probeTimeout = Duration.ofMillis(DEFAULT_PROBE_TIMEOUT);
   private int suspectProbes = DEFAULT_SUSPECT_PROBES;
   private Duration failureTimeout = Duration.ofMillis(DEFAULT_FAILURE_TIMEOUT);
+  private boolean retainTombstones = DEFAULT_RETAIN_TOMBSTONES;
 
   /**
    * Returns whether to broadcast member updates to all peers.
@@ -229,6 +231,26 @@ public class SwimMembershipProtocolConfig extends GroupMembershipProtocolConfig 
     checkNotNull(failureTimeout, "failureTimeout cannot be null");
     checkArgument(!failureTimeout.isNegative() && !failureTimeout.isZero(), "failureTimeout must be positive");
     this.failureTimeout = checkNotNull(failureTimeout);
+    return this;
+  }
+
+  /**
+   * Returns whether tombstone retention is enabled.
+   *
+   * @return whether tombstone retention is enabled
+   */
+  public boolean isRetainTombstones() {
+    return retainTombstones;
+  }
+
+  /**
+   * Sets whether to retain tombstones.
+   *
+   * @param retainTombstones whether to retain tombstones
+   * @return the membership protocol configuration
+   */
+  public SwimMembershipProtocolConfig setRetainTombstones(boolean retainTombstones) {
+    this.retainTombstones = retainTombstones;
     return this;
   }
 


### PR DESCRIPTION
This PR fixes bugs and improves the reliability of the implementation of the SWIM protocol.
* Retain tombstones to prevent member state flapping when experiencing high latency or other races
* Broadcast member state disputes when member is marked `SUSPECT` or `DEAD` to avoid false positives and propagate new incarnation numbers
* Add missing debug logs