### PR TITLE
Set release version to java 8 to prevent using APIs from newer java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ script:
   - mvn verify --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 after_success:
-  - mvn test jacoco:report coveralls:report sonar:sonar --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  - mvn test jacoco:report coveralls:report sonar:sonar --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   - bin/ci-push-javadoc.sh
   - bin/ci-deploy-snapshot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ script:
   - mvn verify --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 after_success:
-  - mvn jacoco:report coveralls:report sonar:sonar --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  - mvn test jacoco:report coveralls:report sonar:sonar --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   - bin/ci-push-javadoc.sh
   - bin/ci-deploy-snapshot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ script:
   - mvn verify --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 after_success:
-  - mvn verify jacoco:report coveralls:report sonar:sonar -X --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  - mvn verify jacoco:report coveralls:report sonar:sonar --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   - bin/ci-push-javadoc.sh
   - bin/ci-deploy-snapshot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ script:
   - mvn verify --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 after_success:
-  - mvn test jacoco:report coveralls:report sonar:sonar --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  - mvn verify jacoco:report coveralls:report sonar:sonar -X --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   - bin/ci-push-javadoc.sh
   - bin/ci-deploy-snapshot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ script:
   - mvn verify --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 after_success:
-  - mvn verify jacoco:report coveralls:report sonar:sonar --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  - mvn verify coveralls:report sonar:sonar --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   - bin/ci-push-javadoc.sh
   - bin/ci-deploy-snapshot.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ script:
   - mvn verify --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 after_success:
-  - mvn verify coveralls:report sonar:sonar --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  - mvn coveralls:report sonar:sonar --batch-mode -Droot.logging.level=INFO -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   - bin/ci-push-javadoc.sh
   - bin/ci-deploy-snapshot.sh

--- a/pom.xml
+++ b/pom.xml
@@ -452,22 +452,34 @@
 
       <!-- Coverage -->
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.3.0</version>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.5</version>
         <executions>
           <execution>
-            <id>prepare-agent</id>
+            <id>default-prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
           </execution>
+          <execution>
+            <id>default-report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eluder.coveralls</groupId>
+        <artifactId>coveralls-maven-plugin</artifactId>
+        <version>4.3.0</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <propertyExpansion>basedir=${session.executionRootDirectory}</propertyExpansion>
+          <propertyExpansion>basedir=${maven.multiModuleProjectDirectory}</propertyExpansion>
           <configLocation>src/main/resources/checkstyle.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <consoleOutput>true</consoleOutput>

--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <configLocation>${project.basedir}/src/main/resources/checkstyle.xml</configLocation>
+          <configLocation>src/main/resources/checkstyle.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <consoleOutput>true</consoleOutput>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,6 @@
 
   <properties>
     <jv>${project.version}</jv>
-
-    <project.root.basedir>${project.basedir}</project.root.basedir>
     
     <!-- Java -->
     <java.version>1.8</java.version>
@@ -433,7 +431,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <propertyExpansion>basedir=${project.root.basedir}</propertyExpansion>
+          <propertyExpansion>basedir=${session.executionRootDirectory}</propertyExpansion>
           <configLocation>src/main/resources/checkstyle.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <consoleOutput>true</consoleOutput>

--- a/pom.xml
+++ b/pom.xml
@@ -459,7 +459,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.5</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,16 @@
       <activation>
         <jdk>[1.9,)</jdk>
       </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>${java.releaseVersion}</release>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>sonatype-oss-release</id>
@@ -319,7 +329,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compiler.plugin.version}</version>
         <configuration>
-          <release>${java.releaseVersion}</release>
           <source>${java.version}</source>
           <target>${java.version}</target>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
           <forkCount>0</forkCount>
           <testFailureIgnore>true</testFailureIgnore>
           <shutdown>kill</shutdown>
-          <argLine>${argLine} ${argLine.extras} ${argLine.common}</argLine>
+          <argLine>@{argLine} ${argLine.extras} ${argLine.common}</argLine>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <version>${maven.surefire.plugin.version}</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
-          <forkCount>0</forkCount>
+          <forkCount>1</forkCount>
           <testFailureIgnore>true</testFailureIgnore>
           <shutdown>kill</shutdown>
           <argLine>@{argLine} ${argLine.extras} ${argLine.common}</argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <properties>
     <jv>${project.version}</jv>
-    
+
     <!-- Java -->
     <java.version>1.8</java.version>
     <java.releaseVersion>8</java.releaseVersion>
@@ -466,12 +466,6 @@
             <id>default-report</id>
             <goals>
               <goal>report</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-check</id>
-            <goals>
-              <goal>check</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
 
     <!-- Java -->
     <java.version>1.8</java.version>
+    <java.releaseVersion>8</java.releaseVersion>
 
     <!-- Logging -->
     <slf4j.version>1.7.7</slf4j.version>
@@ -318,6 +319,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compiler.plugin.version}</version>
         <configuration>
+          <release>${java.releaseVersion}</release>
           <source>${java.version}</source>
           <target>${java.version}</target>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
     <!-- Maven plugins -->
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
-    <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+    <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
     <maven.failsafe.plugin.version>2.21.0</maven.failsafe.plugin.version>
     <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
               <packages>io.atomix.utils*</packages>
             </group>
           </groups>
-          <stylesheetfile>${basedir}/docs/style.css</stylesheetfile>
+          <stylesheetfile>${project.basedir}/docs/style.css</stylesheetfile>
           <excludePackageNames>*.impl*:io.atomix.core.config.jackson:io.atomix.core.utils:io.atomix.rest*:io.atomix.agent*:io.atomix.storage.buffer:io.atomix.storage.journal*:io.atomix.storage.statistics:io.atomix.protocols.raft.utils:io.atomix.utils.serializer.serializers:io.atomix.utils.concurrent:io.atomix.utils.logging:io.atomix.utils.misc:io.atomix.utils.memory:io.atomix.protocols.raft.roles:io.atomix.protocols.raft.protocol:io.atomix.protocols.raft.storage:io.atomix.protocols.raft.cluster:io.atomix.protocols.raft.test:io.atomix.protocols.backup.roles:io.atomix.protocols.backup.protocol:io.atomix.protocols.gossip.*
           </excludePackageNames>
         </configuration>
@@ -431,7 +431,7 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <configLocation>src/main/resources/checkstyle.xml</configLocation>
+          <configLocation>${project.basedir}/src/main/resources/checkstyle.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <consoleOutput>true</consoleOutput>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
         <version>3.0.0</version>
         <configuration>
           <propertyExpansion>basedir=${project.root.basedir}</propertyExpansion>
-          <configLocation>${project.root.basedir}/src/main/resources/checkstyle.xml</configLocation>
+          <configLocation>src/main/resources/checkstyle.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <consoleOutput>true</consoleOutput>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
   <properties>
     <jv>${project.version}</jv>
 
+    <project.root.basedir>${project.basedir}</project.root.basedir>
+    
     <!-- Java -->
     <java.version>1.8</java.version>
     <java.releaseVersion>8</java.releaseVersion>
@@ -431,7 +433,8 @@
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
-          <configLocation>src/main/resources/checkstyle.xml</configLocation>
+          <propertyExpansion>basedir=${project.root.basedir}</propertyExpansion>
+          <configLocation>${project.root.basedir}/src/main/resources/checkstyle.xml</configLocation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <consoleOutput>true</consoleOutput>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -457,13 +457,20 @@
         <version>0.8.5</version>
         <executions>
           <execution>
-            <id>default-prepare-agent</id>
+            <id>jacoco-prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
           </execution>
           <execution>
-            <id>default-report</id>
+            <id>jacoco-prepare-agent-integration</id>
+            <goals>
+              <goal>prepare-agent-integration</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-report</id>
+            <phase>verify</phase>
             <goals>
               <goal>report</goal>
             </goals>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -61,7 +61,7 @@
     <!-- See http://checkstyle.sf.net/config_header.html   -->
     <module name="RegexpHeader">
         <!-- The following line is different for maven due to how the maven checkstyle plugin works -->
-        <property name="headerFile" value="${project.basedir}/src/main/resources/atomix.header"/>
+        <property name="headerFile" value="${basedir}/src/main/resources/atomix.header"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -61,7 +61,7 @@
     <!-- See http://checkstyle.sf.net/config_header.html   -->
     <module name="RegexpHeader">
         <!-- The following line is different for maven due to how the maven checkstyle plugin works -->
-        <property name="headerFile" value="src/main/resources/atomix.header"/>
+        <property name="headerFile" value="${project.basedir}/src/main/resources/atomix.header"/>
         <property name="fileExtensions" value="java"/>
     </module>
 


### PR DESCRIPTION
This solves the issue of encountering the exception
`java.lang.NoSuchMethodError: java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer` when running on java 8, as per 
https://github.com/eclipse/jetty.project/issues/3244
https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler

fixes #1066