### PR TITLE
Fix putAll event generation

### DIFF
--- a/core/src/main/java/io/atomix/core/multimap/impl/AbstractAtomicMultimapService.java
+++ b/core/src/main/java/io/atomix/core/multimap/impl/AbstractAtomicMultimapService.java
@@ -269,7 +269,7 @@ public abstract class AbstractAtomicMultimapService extends AbstractPrimitiveSer
 
     Collection<? extends byte[]> addedValues = backingMap.computeIfAbsent(key, k -> new NonTransactionalValues()).putAll(key, values);
     if (addedValues != null) {
-      addedValues.forEach(value -> onChange(key, value, null));
+      addedValues.forEach(value -> onChange(key, null, value));
       return true;
     }
     return false;

--- a/core/src/test/java/io/atomix/core/multimap/AtomicMultimapTest.java
+++ b/core/src/test/java/io/atomix/core/multimap/AtomicMultimapTest.java
@@ -260,6 +260,20 @@ public class AtomicMultimapTest extends AbstractPrimitiveTest {
     assertEquals(AtomicMultimapEvent.Type.INSERT, event.type());
     assertEquals("bar", event.key());
     assertEquals("barbaz", event.newValue());
+
+    List<String> values = Lists.newArrayList("b", "a", "r");
+    List<String> storedValues = Lists.newArrayList();
+    assertTrue(multimap1.putAll("foo", values));
+
+    for (int i = 0; i < 3; i++) {
+      event = listener.event();
+      assertEquals(AtomicMultimapEvent.Type.INSERT, event.type());
+      assertEquals("foo", event.key());
+      assertNull(event.oldValue());
+      assertNotNull(event.newValue());
+      storedValues.add((String) event.newValue());
+    }
+    assertTrue(stringArrayCollectionIsEqual(values, storedValues));
   }
 
   @Test


### PR DESCRIPTION
Parameters order was wrong and we were generating `REMOVED` events