### PR TITLE
Avoid unnecessary transfer and notify behavior when execute rebalance

### DIFF
--- a/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListService.java
+++ b/core/src/main/java/io/atomix/core/list/impl/DefaultDistributedListService.java
@@ -73,8 +73,9 @@ public class DefaultDistributedListService extends DefaultDistributedCollectionS
   public CollectionUpdateResult<Boolean> addAll(int index, Collection<? extends String> c) {
     boolean changed = false;
     for (String element : c) {
-      if (add(element).status() == CollectionUpdateResult.Status.OK) {
+      if (add(index, element).status() == CollectionUpdateResult.Status.OK) {
         changed = true;
+        index++;
       }
     }
     return ok(changed);

--- a/core/src/test/java/io/atomix/core/list/DistributedListTest.java
+++ b/core/src/test/java/io/atomix/core/list/DistributedListTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -58,6 +60,28 @@ public class DistributedListTest extends AbstractPrimitiveTest {
     assertEquals("bar", list.set(1, "baz"));
     assertEquals(2, list.size());
     assertEquals("baz", list.get(1));
+  }
+
+  @Test
+  public void testListOperations_addAll() throws Exception {
+    DistributedList<String> list = atomix().<String>listBuilder("test-list")
+            .withProtocol(protocol())
+            .build();
+
+    assertEquals(0, list.size());
+    assertTrue(list.isEmpty());
+    assertFalse(list.contains("foo"));
+    assertTrue(list.addAll(Stream.of("foo", "baz").collect(Collectors.toList())));
+    assertEquals(2, list.size());
+    assertEquals("foo", list.get(0));
+    assertEquals("baz", list.get(1));
+    assertTrue(list.addAll(1, Stream.of("bar", "wad", "liu").collect(Collectors.toList())));
+    assertEquals(5, list.size());
+    assertEquals("foo", list.get(0));
+    assertEquals("bar", list.get(1));
+    assertEquals("wad", list.get(2));
+    assertEquals("liu", list.get(3));
+    assertEquals("baz", list.get(4));
   }
 
   @Test

--- a/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
+++ b/protocols/primary-backup/src/main/java/io/atomix/protocols/backup/partition/PrimaryBackupPartition.java
@@ -16,18 +16,14 @@
 package io.atomix.protocols.backup.partition;
 
 import io.atomix.cluster.MemberId;
-import io.atomix.primitive.partition.GroupMember;
-import io.atomix.primitive.partition.MemberGroupProvider;
-import io.atomix.primitive.partition.Partition;
-import io.atomix.primitive.partition.PartitionId;
-import io.atomix.primitive.partition.PartitionManagementService;
-import io.atomix.primitive.partition.PrimaryElection;
+import io.atomix.primitive.partition.*;
 import io.atomix.protocols.backup.partition.impl.PrimaryBackupPartitionClient;
 import io.atomix.protocols.backup.partition.impl.PrimaryBackupPartitionServer;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -78,11 +74,11 @@ public class PrimaryBackupPartition implements Partition {
 
   @Override
   public Collection<MemberId> backups() {
-    return Futures.get(election.getTerm())
-        .candidates()
-        .stream()
-        .map(GroupMember::memberId)
-        .collect(Collectors.toList());
+    PrimaryTerm term = Futures.get(election.getTerm());
+    return term.candidates().stream()
+            .filter(member -> !Objects.equals(term.primary().memberId(), member.memberId()))
+            .map(GroupMember::memberId)
+            .collect(Collectors.toList());
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftNamespaces.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftNamespaces.java
@@ -58,6 +58,8 @@ import io.atomix.protocols.raft.protocol.RaftResponse;
 import io.atomix.protocols.raft.protocol.ReconfigureRequest;
 import io.atomix.protocols.raft.protocol.ReconfigureResponse;
 import io.atomix.protocols.raft.protocol.ResetRequest;
+import io.atomix.protocols.raft.protocol.TransferRequest;
+import io.atomix.protocols.raft.protocol.TransferResponse;
 import io.atomix.protocols.raft.protocol.VoteRequest;
 import io.atomix.protocols.raft.protocol.VoteResponse;
 import io.atomix.protocols.raft.storage.log.entry.CloseSessionEntry;
@@ -150,6 +152,8 @@ public final class RaftNamespaces {
       .register(RaftMember.Type.class)
       .register(Instant.class)
       .register(Configuration.class)
+      .register(TransferRequest.class)
+      .register(TransferResponse.class)
       .build("RaftProtocol");
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -261,7 +261,7 @@ final class LeaderAppender extends AbstractAppender {
       TimestampedFuture<Long> future = iterator.next();
 
       // If the future is timestamped prior to the last heartbeat to a majority of the cluster, complete the future.
-      if (future.timestamp < heartbeatTime) {
+      if (future.timestamp <= heartbeatTime) {
         future.complete(null);
         iterator.remove();
       }
@@ -277,7 +277,7 @@ final class LeaderAppender extends AbstractAppender {
     }
 
     // If heartbeat futures are still pending, attempt to send heartbeats.
-    if (!heartbeatFutures.isEmpty()) {
+    if (!heartbeatFutures.isEmpty() && member.getMember().getType() == RaftMember.Type.ACTIVE) {
       sendHeartbeats();
     }
   }

--- a/storage/src/main/java/io/atomix/storage/buffer/AbstractBuffer.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/AbstractBuffer.java
@@ -155,7 +155,7 @@ public abstract class AbstractBuffer implements Buffer {
 
   @Override
   public Buffer compact() {
-    compact(offset(position), offset, (limit != -1 ? limit : capacity) - offset(position));
+    compact(offset(position), offset, (limit != -1 ? limit : capacity) - position);
     return clear();
   }
 

--- a/storage/src/main/java/io/atomix/storage/buffer/ByteBufferBuffer.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/ByteBufferBuffer.java
@@ -42,11 +42,13 @@ public abstract class ByteBufferBuffer extends AbstractBuffer {
   protected void compact(int from, int to, int length) {
     byte[] bytes = new byte[1024];
     int position = from;
+    int destPosition = to;
     while (position < from + length) {
       int size = Math.min((from + length) - position, 1024);
       this.bytes.read(position, bytes, 0, size);
-      this.bytes.write(0, bytes, 0, size);
+      this.bytes.write(destPosition, bytes, 0, size);
       position += size;
+      destPosition += size;
     }
   }
 

--- a/storage/src/main/java/io/atomix/storage/buffer/FileBuffer.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/FileBuffer.java
@@ -109,7 +109,7 @@ public class FileBuffer extends AbstractBuffer {
 
   private final FileBytes bytes;
 
-  private FileBuffer(FileBytes bytes, int offset, int initialCapacity, int maxCapacity) {
+  protected FileBuffer(FileBytes bytes, int offset, int initialCapacity, int maxCapacity) {
     super(bytes, offset, initialCapacity, maxCapacity, null);
     this.bytes = bytes;
   }
@@ -181,11 +181,13 @@ public class FileBuffer extends AbstractBuffer {
   protected void compact(int from, int to, int length) {
     byte[] bytes = new byte[1024];
     int position = from;
+    int destPosition = to;
     while (position < from + length) {
       int size = Math.min((from + length) - position, 1024);
       this.bytes.read(position, bytes, 0, size);
-      this.bytes.write(0, bytes, 0, size);
+      this.bytes.write(destPosition, bytes, 0, size);
       position += size;
+      destPosition += size;
     }
   }
 

--- a/storage/src/main/java/io/atomix/storage/buffer/FileBytes.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/FileBytes.java
@@ -222,7 +222,7 @@ public class FileBytes extends AbstractBytes {
       randomAccessFile.setLength(0);
       randomAccessFile.setLength(size);
       for (int i = 0; i < size; i += PAGE_SIZE) {
-        randomAccessFile.write(BLANK_PAGE, 0, Math.min(size - i, PAGE_SIZE));
+        randomAccessFile.write(BLANK_PAGE, i, Math.min(size - i, PAGE_SIZE));
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -238,7 +238,7 @@ public class FileBytes extends AbstractBytes {
       randomAccessFile.setLength(length);
       seekToOffset(offset);
       for (int i = offset; i < length; i += PAGE_SIZE) {
-        randomAccessFile.write(BLANK_PAGE, 0, Math.min(length - i, PAGE_SIZE));
+        randomAccessFile.write(BLANK_PAGE, i, Math.min(length - i, PAGE_SIZE));
       }
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/storage/src/test/java/io/atomix/storage/buffer/BufferTest.java
+++ b/storage/src/test/java/io/atomix/storage/buffer/BufferTest.java
@@ -42,6 +42,8 @@ public abstract class BufferTest {
    */
   protected abstract Buffer createBuffer(int capacity, int maxCapacity);
 
+  protected abstract Buffer createBuffer(int offset, int capacity, int maxCapacity);
+
   @Test
   public void testPosition() {
     Buffer buffer = createBuffer(8);
@@ -375,6 +377,30 @@ public abstract class BufferTest {
   }
 
   @Test
+  public void testCompactWithOffsetNotZero() {
+    Buffer buffer = createBuffer(8, 2048, 2048);
+    buffer.position(4).writeInt(123)
+            .position(100).writeLong(1234)
+            .position(300).writeString("hello")
+            .position(500).writeBoolean(false)
+            .position(1020).writeInt(234)
+            .position(2040).writeLong(2345)
+            .position(4).compact();
+    assertEquals(0, buffer.position());
+    assertEquals(123, buffer.readInt());
+    buffer.position(96);
+    assertEquals(1234, buffer.readLong());
+    buffer.position(296);
+    assertEquals("hello", buffer.readString());
+    buffer.position(496);
+    assertEquals(false, buffer.readBoolean());
+    buffer.position(1016);
+    assertEquals(234, buffer.readInt());
+    buffer.position(2036);
+    assertEquals(2345, buffer.readLong());
+  }
+
+  @Test
   public void testSwappedPosition() {
     Buffer buffer = createBuffer(8).order(ByteOrder.LITTLE_ENDIAN);
     assertEquals(0, buffer.position());
@@ -656,6 +682,30 @@ public abstract class BufferTest {
     buffer.position(100).writeLong(1234).position(100).compact();
     assertEquals(0, buffer.position());
     assertEquals(1234, buffer.readLong());
+  }
+
+  @Test
+  public void testSwappedCompactWithOffsetNotZero() {
+    Buffer buffer = createBuffer(8, 2048, 2048).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.position(4).writeInt(123)
+            .position(100).writeLong(1234)
+            .position(300).writeString("hello")
+            .position(500).writeBoolean(false)
+            .position(1020).writeInt(234)
+            .position(2040).writeLong(2345)
+            .position(4).compact();
+    assertEquals(0, buffer.position());
+    assertEquals(123, buffer.readInt());
+    buffer.position(96);
+    assertEquals(1234, buffer.readLong());
+    buffer.position(296);
+    assertEquals("hello", buffer.readString());
+    buffer.position(496);
+    assertEquals(false, buffer.readBoolean());
+    buffer.position(1016);
+    assertEquals(234, buffer.readInt());
+    buffer.position(2036);
+    assertEquals(2345, buffer.readLong());
   }
 
   @Test

--- a/storage/src/test/java/io/atomix/storage/buffer/DirectBufferTest.java
+++ b/storage/src/test/java/io/atomix/storage/buffer/DirectBufferTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.storage.buffer;
 
+import io.atomix.utils.memory.Memory;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -37,6 +38,11 @@ public class DirectBufferTest extends BufferTest {
   @Override
   protected Buffer createBuffer(int capacity, int maxCapacity) {
     return DirectBuffer.allocate(capacity, maxCapacity);
+  }
+
+  @Override
+  protected Buffer createBuffer(int offset, int capacity, int maxCapacity) {
+    return new DirectBuffer(DirectBytes.allocate((int) Memory.Util.toPow2(capacity)), offset, capacity, maxCapacity);
   }
 
   @Test

--- a/storage/src/test/java/io/atomix/storage/buffer/FileBufferTest.java
+++ b/storage/src/test/java/io/atomix/storage/buffer/FileBufferTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.storage.buffer;
 
+import io.atomix.utils.memory.Memory;
 import org.junit.AfterClass;
 import org.junit.Test;
 
@@ -44,6 +45,11 @@ public class FileBufferTest extends BufferTest {
   @Override
   protected Buffer createBuffer(int capacity, int maxCapacity) {
     return FileBuffer.allocate(FileTesting.createFile(), capacity, maxCapacity);
+  }
+
+  @Override
+  protected Buffer createBuffer(int offset, int capacity, int maxCapacity) {
+    return new FileBuffer(new FileBytes(FileTesting.createFile(), FileBytes.DEFAULT_MODE, (int) Math.min(Memory.Util.toPow2(capacity), maxCapacity)), offset, capacity, maxCapacity);
   }
 
   @Test

--- a/storage/src/test/java/io/atomix/storage/buffer/HeapBufferTest.java
+++ b/storage/src/test/java/io/atomix/storage/buffer/HeapBufferTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.storage.buffer;
 
+import io.atomix.utils.memory.Memory;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -36,6 +37,11 @@ public class HeapBufferTest extends BufferTest {
   @Override
   protected Buffer createBuffer(int capacity, int maxCapacity) {
     return HeapBuffer.allocate(capacity, maxCapacity);
+  }
+
+  @Override
+  protected Buffer createBuffer(int offset, int capacity, int maxCapacity) {
+    return new HeapBuffer(HeapBytes.allocate((int)Memory.Util.toPow2(capacity)), offset, capacity, maxCapacity);
   }
 
   @Test

--- a/storage/src/test/java/io/atomix/storage/buffer/MappedBufferTest.java
+++ b/storage/src/test/java/io/atomix/storage/buffer/MappedBufferTest.java
@@ -15,10 +15,12 @@
  */
 package io.atomix.storage.buffer;
 
+import io.atomix.utils.memory.Memory;
 import org.junit.AfterClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
@@ -44,6 +46,11 @@ public class MappedBufferTest extends BufferTest {
   @Override
   protected Buffer createBuffer(int capacity, int maxCapacity) {
     return MappedBuffer.allocate(FileTesting.createFile(), capacity, maxCapacity);
+  }
+
+  @Override
+  protected Buffer createBuffer(int offset, int capacity, int maxCapacity) {
+    return new MappedBuffer(MappedBytes.allocate(FileTesting.createFile(), FileChannel.MapMode.READ_WRITE, capacity), 0, capacity, maxCapacity);
   }
 
   /**


### PR DESCRIPTION
Find and transfer leadership to the candidate with the fewest primaries directly, avoid unnecessary transfer and notify behavior

