### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: java
 
 sudo: false
 
+cache:
+  directories:
+  - $HOME/.m2
+
 services:
   - docker
 


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.