### PR TITLE
[AETHER-1265] Integrate Java profiler in TOST env

### DIFF
--- a/dist/Dockerfile-yourkit
+++ b/dist/Dockerfile-yourkit
@@ -1,0 +1,26 @@
+# Dockerfile
+
+FROM openjdk:8
+
+ARG VERSION
+ARG ATOMIX_YOURKIT
+RUN mkdir -p /opt/atomix
+COPY target/atomix.tar.gz /opt/atomix/atomix.tar.gz
+RUN tar -xvf /opt/atomix/atomix.tar.gz -C /opt/atomix && rm /opt/atomix/atomix.tar.gz
+
+# Install yourkit agent
+RUN curl -L -o yourkit.zip https://www.yourkit.com/download/YourKit-JavaProfiler-$ATOMIX_YOURKIT.zip && \
+    unzip -o yourkit.zip && \
+    rm yourkit.zip && \
+    mv YourKit-JavaProfiler-$(echo $ATOMIX_YOURKIT | sed 's/\(.*\)-.*/\1/')/bin/linux-x86-64/libyjpagent.so /opt/atomix/libyjpagent.so
+
+WORKDIR /opt/atomix
+
+EXPOSE 5678
+EXPOSE 5679
+EXPOSE 10001-10010
+
+# Enable the agent by default
+ENV ATOMIX_YOURKIT true
+
+ENTRYPOINT ["./bin/atomix-agent"]

--- a/dist/src/main/resources/bin/atomix-agent
+++ b/dist/src/main/resources/bin/atomix-agent
@@ -13,8 +13,14 @@ fi
 
 ATOMIX_ROOT="$(dirname "$(dirname "$0")")"
 
+# Pass gc and other useful jvm opts through the env variable
+JAVA_OPTS="${JAVA_OPTS:--XX:+UseG1GC -XX:MaxGCPauseMillis=200}"
+if [ ! -z "$ATOMIX_YOURKIT" ]; then
+  JAVA_OPTS+=" -agentpath:$ATOMIX_ROOT/libyjpagent.so=listen=all"
+fi
+export JAVA_OPTS=${JAVA_OPTS}
+
 java \
-  -XX:+UseConcMarkSweepGC \
   $JAVA_OPTS \
   -Datomix.root="$ATOMIX_ROOT" \
   -Datomix.data="$ATOMIX_ROOT/data" \


### PR DESCRIPTION
Fix an issue in the atomix-agent that does prevent passing a different gc algorithm. Adds a new dockerfile that allows to build profiler enabled images.