### PR TITLE
[ONOS-8141] Fix for duplicate candidate node id for device mastership

### DIFF
--- a/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DefaultLeaderElectorService.java
@@ -396,7 +396,7 @@ public class DefaultLeaderElectorService extends AbstractPrimitiveService<Leader
     }
 
     public boolean isDuplicate(Registration registration) {
-      return registrations.stream().anyMatch(r -> r.sessionId() == registration.sessionId());
+      return registrations.stream().anyMatch(r -> Arrays.equals(registration.id(), r.id()));
     }
 
     public Leader<byte[]> leader() {

--- a/core/src/test/java/io/atomix/core/election/impl/DefaultLeaderElectorServiceTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/DefaultLeaderElectorServiceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.core.election.impl;
+
+import io.atomix.core.election.LeaderElectionType;
+import io.atomix.primitive.PrimitiveId;
+import io.atomix.primitive.service.ServiceContext;
+import io.atomix.primitive.session.Session;
+import io.atomix.primitive.session.SessionId;
+import io.atomix.utils.time.WallClock;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Leader elector service test.
+ */
+public class DefaultLeaderElectorServiceTest {
+    @Test
+    public void testDuplicateCandidateNode() {
+        ServiceContext context = mock(ServiceContext.class);
+        when(context.serviceType()).thenReturn(LeaderElectionType.instance());
+        when(context.serviceName()).thenReturn("test");
+        when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+        when(context.wallClock()).thenReturn(new WallClock());
+
+        Session session = mock(Session.class);
+        when(session.sessionId()).thenReturn(SessionId.from(1));
+        when(context.currentSession()).thenReturn(session);
+
+        DefaultLeaderElectorService service = new DefaultLeaderElectorService();
+        service.init(context);
+        service.register(session);
+
+        byte[] id1 = "a".getBytes();
+        service.run("foo", id1);
+
+        byte[] id2 = "a".getBytes();
+        service.run("foo", id2);
+
+        // To test that duplicate candidate node entry is rejected
+        assertEquals(1, service.getLeaderships().size());
+    }
+
+}


### PR DESCRIPTION
We have seen below exception in ONOS cluster:

ERROR | onos-device-manager-background | DeviceManager                    | 190 - org.onosproject.onos-core-net - 2.3.0 | Exception thrown during integrity check
java.lang.IllegalArgumentException: Multiple entries with same key: s17mn1vmsdc03=STANDBY and s17mn1vmsdc03=STANDBY
	at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:190) ~[?:?]
	at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:109) ~[?:?]
	at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:95) ~[?:?]
	at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:357) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.buildMastershipFromLeadership(ConsistentDeviceMastershipStore.java:321) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.getMastership(ConsistentDeviceMastershipStore.java:198) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.relinquishLocalRole(ConsistentDeviceMastershipStore.java:295) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.relinquishRole(ConsistentDeviceMastershipStore.java:272) ~[?:?]
	at org.onosproject.cluster.impl.MastershipManager.relinquishMastership(MastershipManager.java:212) ~[?:?]
	at org.onosproject.net.device.impl.DeviceManager.mastershipCheck(DeviceManager.java:471) ~[?:?]
	at org.onosproject.net.device.impl.DeviceManager.lambda$activate$0(DeviceManager.java:217) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]

And after this exception some devices are not able to connect to any onos node.
We tried changing mastership of those devices using device-role command in ONOS CLI and we observed below exception:

DeviceManager                    | 190 - org.onosproject.onos-core-net - 2.3.0 | Failed to handle MastershipEvent{time=2021-06-29T18:51:42.684Z, type=MASTER_CHANGED, subject=netconf:fdfd:fd60:1600:400::5b3:830, mastershipInfo=MastershipInfo{term=255, master=Optional[s17mn1vmsdc01], roles={s17mn1vmsdc01=MASTER, s17mn1vmsdc03=STANDBY, s17mn1vmsdc02=STANDBY}}}
java.lang.IllegalArgumentException: Multiple entries with same key: s17mn1vmsdc02=STANDBY and s17mn1vmsdc02=STANDBY
	at com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:190) ~[?:?]
	at com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:109) ~[?:?]
	at com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:95) ~[?:?]
	at com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:357) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.buildMastershipFromLeadership(ConsistentDeviceMastershipStore.java:321) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.getMastership(ConsistentDeviceMastershipStore.java:198) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.relinquishLocalRole(ConsistentDeviceMastershipStore.java:295) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.relinquishRole(ConsistentDeviceMastershipStore.java:272) ~[?:?]
	at org.onosproject.cluster.impl.MastershipManager.relinquishMastership(MastershipManager.java:212) ~[?:?]
	at org.onosproject.net.device.impl.DeviceManager.handleMastershipEvent(DeviceManager.java:982) ~[?:?]
	at org.onosproject.net.device.impl.DeviceManager$InternalMastershipListener.lambda$event$0(DeviceManager.java:1002) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]

One observation so far is that we have seen some StorageException and only after that we see the above exception of integrity checks.

Storage exception on ONOS1:

2021-06-29T18:50:59,834 | ERROR | onos-netconfDeviceProviderConnection-connection-executor-5 | NetconfDeviceProvider            | 216 - org.onosproject.onos-providers-netconf-device - 2.3.0 | Unhandled Exception
org.onosproject.store.service.StorageException: org.onosproject.store.service.StorageException: An application error occurred
	at org.onosproject.store.primitives.DefaultLeaderElector.complete(DefaultLeaderElector.java:117) ~[?:?]
	at org.onosproject.store.primitives.DefaultLeaderElector.withdraw(DefaultLeaderElector.java:55) ~[?:?]
	at org.onosproject.store.cluster.impl.DistributedLeadershipStore.removeRegistration(DistributedLeadershipStore.java:230) ~[?:?]
	at org.onosproject.cluster.impl.LeadershipManager.withdraw(LeadershipManager.java:97) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.relinquishLocalRole(ConsistentDeviceMastershipStore.java:294) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.relinquishRole(ConsistentDeviceMastershipStore.java:272) ~[?:?]
	at org.onosproject.cluster.impl.MastershipManager.relinquishMastership(MastershipManager.java:212) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.initiateConnection(NetconfDeviceProvider.java:532) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.lambda$roleChanged$1(NetconfDeviceProvider.java:300) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.lambda$withDeviceLock$12(NetconfDeviceProvider.java:679) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.withDeviceLock(NetconfDeviceProvider.java:670) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.lambda$withDeviceLock$13(NetconfDeviceProvider.java:678) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.lambda$roleChanged$2(NetconfDeviceProvider.java:300) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.lambda$exceptionSafe$5(NetconfDeviceProvider.java:434) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: org.onosproject.store.service.StorageException: An application error occurred
	at org.onosproject.store.atomix.primitives.impl.AtomixFutures.lambda$adaptFuture$0(AtomixFutures.java:54) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.Futures.lambda$null$3(Futures.java:159) ~[?:?]
	at io.atomix.utils.concurrent.ThreadPoolContext.lambda$new$0(ThreadPoolContext.java:81) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	... 3 more

Couple of minutes after the above exception, we see java.lang.IllegalArgumentException: Multiple entries with same key issue and some devices are not able to connect to ONOS due to the same.

Storage exception on ONOS2:

2021-06-30T01:36:59,567 | ERROR | onos-netconfDeviceProviderConnection-connection-executor-0 | NetconfDeviceProvider            | 216 - org.onosproject.onos-providers-netconf-device - 2.3.0 | Unhandled Exception
org.onosproject.store.service.StorageException: org.onosproject.store.service.StorageException: An application error occurred
	at org.onosproject.store.primitives.DefaultLeaderElector.complete(DefaultLeaderElector.java:117) ~[?:?]
	at org.onosproject.store.primitives.DefaultLeaderElector.run(DefaultLeaderElector.java:50) ~[?:?]
	at org.onosproject.store.cluster.impl.DistributedLeadershipStore.addRegistration(DistributedLeadershipStore.java:224) ~[?:?]
	at org.onosproject.cluster.impl.LeadershipManager.runForLeadership(LeadershipManager.java:92) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.requestRole(ConsistentDeviceMastershipStore.java:157) ~[?:?]
	at org.onosproject.cluster.impl.MastershipManager.requestRoleFor(MastershipManager.java:223) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.lambda$runElectionFor$11(NetconfDeviceProvider.java:496) ~[?:?]
	at org.onosproject.provider.netconf.device.impl.NetconfDeviceProvider.lambda$exceptionSafe$5(NetconfDeviceProvider.java:434) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: org.onosproject.store.service.StorageException: An application error occurred
	at org.onosproject.store.atomix.primitives.impl.AtomixFutures.lambda$adaptFuture$0(AtomixFutures.java:54) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.Futures.lambda$null$3(Futures.java:159) ~[?:?]
	at io.atomix.utils.concurrent.ThreadPoolContext.lambda$new$0(ThreadPoolContext.java:81) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	... 3 more

Within 20 seconds of above exception, we see java.lang.IllegalArgumentException: Multiple entries with same key issue and some devices are not able to connect to ONOS due to the same.

Storage exception on ONOS3:

2021-06-29T18:08:30,329 | WARN  | onos-device-manager-background | DeviceManager                    | 190 - org.onosproject.onos-core-net - 2.3.0 | Failed to handle MastershipEvent{time=2021-06-29T17:50:22.606Z, type=MASTER_CHANGED, subject=netconf:fdfd:fd60:1900:400::533:830, mastershipInfo=MastershipInfo{term=248, master=Optional[s17mn1vmsdc02], roles={s17mn1vmsdc02=MASTER, s17mn1vmsdc01=STANDBY, s17mn1vmsdc03=NONE}}}
org.onosproject.store.service.StorageException: org.onosproject.store.service.StorageException: An application error occurred
	at org.onosproject.store.primitives.DefaultLeaderElector.complete(DefaultLeaderElector.java:117) ~[?:?]
	at org.onosproject.store.primitives.DefaultLeaderElector.run(DefaultLeaderElector.java:50) ~[?:?]
	at org.onosproject.store.cluster.impl.DistributedLeadershipStore.addRegistration(DistributedLeadershipStore.java:224) ~[?:?]
	at org.onosproject.cluster.impl.LeadershipManager.runForLeadership(LeadershipManager.java:92) ~[?:?]
	at org.onosproject.store.mastership.impl.ConsistentDeviceMastershipStore.requestRole(ConsistentDeviceMastershipStore.java:157) ~[?:?]
	at org.onosproject.cluster.impl.MastershipManager.requestRoleFor(MastershipManager.java:223) ~[?:?]
	at org.onosproject.net.device.impl.DeviceManager.reassertRole(DeviceManager.java:895) ~[?:?]
	at org.onosproject.net.device.impl.DeviceManager.handleMastershipEvent(DeviceManager.java:989) ~[?:?]
	at org.onosproject.net.device.impl.DeviceManager$InternalMastershipListener.lambda$event$0(DeviceManager.java:1002) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: org.onosproject.store.service.StorageException: An application error occurred
	at org.onosproject.store.atomix.primitives.impl.AtomixFutures.lambda$adaptFuture$0(AtomixFutures.java:54) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.AtomixFuture.lambda$wrap$0(AtomixFuture.java:48) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) ~[?:?]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) ~[?:?]
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088) ~[?:?]
	at io.atomix.utils.concurrent.Futures.lambda$null$3(Futures.java:159) ~[?:?]
	at io.atomix.utils.concurrent.ThreadPoolContext.lambda$new$0(ThreadPoolContext.java:81) ~[?:?]
	... 6 more

Couple of minutes after the above exception, we see java.lang.IllegalArgumentException: Multiple entries with same key issue and some devices are not able to connect to ONOS due to the same.
Just had a look at the code, it seems that the only way this exception is possible is due to the fact that leadership service returns duplicate candidate nodes.
AtomixLeaderElector :
    @Override
    public CompletableFuture<Leadership> run(String topic, NodeId nodeId) {
        return adaptFuture(atomixElector.run(topic, nodeId)).thenApply(leadership -> toLeadership(topic, leadership));
    }

LeaderElectorProxy in Atomix :
@Override  public CompletableFuture<Leadership<byte[]>> run(String topic, byte[] id) {    return getProxyClient().applyBy(topic, service -> service.run(topic, id));  }

We are converting node id in byte array, so I guess we should use byte array to check for duplicate registration ?

DefaultLeaderElectorService in ATomix :
@Override
  public Leadership<byte[]> run(String topic, byte[] id) {
    try {
      Leadership<byte[]> oldLeadership = leadership(topic);
      Registration registration = new Registration(id, getCurrentSession().sessionId().id());
      elections.compute(topic, (k, v) -> {
        if (v == null) {
          return new ElectionState(registration, termCounter(topic)::incrementAndGet, elections);
        } else {
          if (!v.isDuplicate(registration)) {
            return new ElectionState(v).addRegistration(
                topic, registration, termCounter(topic)::incrementAndGet);
          } else {
            return v;
          }
        }
      });
      Leadership<byte[]> newLeadership = leadership(topic);
      if (!Objects.equal(oldLeadership, newLeadership)) {
        notifyLeadershipChange(topic, oldLeadership, newLeadership);
      }
      return newLeadership;
    } catch (Exception e) {
      getLogger().error("State machine operation failed", e);
      throwIfUnchecked(e);
      throw new RuntimeException(e);
    }
  }

public boolean isDuplicate(Registration registration) {      return registrations.stream().anyMatch(r -> r.sessionId() == registration.sessionId());    }

I can see that in DefaultLeaderElectionService, we have used byte array to check for duplicate registrations. I think we need to do the same here