### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ jdk:
 - openjdk11
 
 matrix:
+  fast_finish: true
   allow_failures:
   - jdk: openjdk10
   - jdk: openjdk11


### PR DESCRIPTION

According to the official document [Fast Finishing](https://docs.travis-ci.com/user/build-matrix/#fast-finishing), if some rows in the build matrix are allowed to fail, we can add fast_finish: true to the .travis.yml to get faster feedbacks.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
