### PR TITLE
Add demote API to LeaderElector primitive

### DIFF
--- a/core/src/main/java/io/atomix/core/election/AsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/AsyncLeaderElector.java
@@ -86,6 +86,18 @@ public interface AsyncLeaderElector<T> extends AsyncPrimitive {
   CompletableFuture<Boolean> promote(String topic, T identifier);
 
   /**
+   * Attempts to demote a node to the bottom of the candidate list. It is not allowed
+   * to demote the current leader
+   *
+   * @param topic      leadership topic
+   * @param identifier instance identifier
+   * @return CompletableFuture that is completed with a boolean when the operation is done. Boolean is true if
+   * node is now the bottom candidate. This operation can fail (i.e. return false) if the node
+   * is not registered to run for election for the topic or if the node is the leader.
+   */
+  CompletableFuture<Boolean> demote(String topic, T identifier);
+
+  /**
    * Returns the {@link Leadership} for the specified topic.
    *
    * @param topic leadership topic

--- a/core/src/main/java/io/atomix/core/election/LeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/LeaderElector.java
@@ -64,6 +64,18 @@ public interface LeaderElector<T> extends SyncPrimitive {
   boolean promote(String topic, T identifier);
 
   /**
+   * Attempts to demote a node to the bottom of the candidate list. It is not allowed
+   * to demote the current leader
+   *
+   * @param topic      leadership topic
+   * @param identifier instance identifier
+   * @return CompletableFuture that is completed with a boolean when the operation is done. Boolean is true if
+   * node is now the bottom candidate. This operation can fail (i.e. return false) if the node
+   * is not registered to run for election for the topic or if the node is the leader.
+   */
+  boolean demote(String topic, T identifier);
+
+  /**
    * Attempts to evict a node from all leadership elections it is registered for.
    * <p>
    * If the node the current leader for a topic, this call will force the next candidate (if one exists)

--- a/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/BlockingLeaderElector.java
@@ -67,6 +67,11 @@ public class BlockingLeaderElector<T> extends Synchronous<AsyncLeaderElector<T>>
   }
 
   @Override
+  public boolean demote(String topic, T identifier) {
+    return complete(asyncElector.demote(topic, identifier));
+  }
+
+  @Override
   public void evict(T identifier) {
     complete(asyncElector.evict(identifier));
   }

--- a/core/src/main/java/io/atomix/core/election/impl/CachingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/CachingAsyncLeaderElector.java
@@ -85,6 +85,11 @@ public class CachingAsyncLeaderElector<T> extends DelegatingAsyncLeaderElector<T
   }
 
   @Override
+  public CompletableFuture<Boolean> demote(String topic, T identifier) {
+    return super.demote(topic, identifier).whenComplete((r, e) -> cache.invalidate(topic));
+  }
+
+    @Override
   public CompletableFuture<Void> evict(T nodeId) {
     return super.evict(nodeId).whenComplete((r, e) -> cache.invalidateAll());
   }

--- a/core/src/main/java/io/atomix/core/election/impl/DelegatingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/DelegatingAsyncLeaderElector.java
@@ -59,6 +59,11 @@ public class DelegatingAsyncLeaderElector<T> extends DelegatingAsyncPrimitive<As
   }
 
   @Override
+  public CompletableFuture<Boolean> demote(String topic, T identifier) {
+    return delegate().demote(topic, identifier);
+  }
+
+  @Override
   public CompletableFuture<Leadership<T>> getLeadership(String topic) {
     return delegate().getLeadership(topic);
   }

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxy.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorProxy.java
@@ -80,6 +80,11 @@ public class LeaderElectorProxy
   }
 
   @Override
+  public CompletableFuture<Boolean> demote(String topic, byte[] id) {
+    return getProxyClient().applyBy(topic, service -> service.demote(topic, id));
+  }
+
+  @Override
   public CompletableFuture<Void> evict(byte[] id) {
     return getProxyClient().acceptAll(service -> service.evict(id));
   }

--- a/core/src/main/java/io/atomix/core/election/impl/LeaderElectorService.java
+++ b/core/src/main/java/io/atomix/core/election/impl/LeaderElectorService.java
@@ -69,6 +69,19 @@ public interface LeaderElectorService {
   boolean promote(String topic, byte[] id);
 
   /**
+   * Attempts to demote a node to the bottom of candidate list. It is not allowed
+   * to demote the current leader
+   *
+   * @param topic leadership topic
+   * @param id    instance identifier of the node to promote
+   * @return {@code true} if node is now the bottom candidate. This operation can fail (i.e. return
+   * {@code false}) if the node is not registered to run for election for the topic or it is the
+   * current leader
+   */
+  @Command
+  boolean demote(String topic, byte[] id);
+
+  /**
    * Attempts to evict a node from all leadership elections it is registered for.
    * <p>
    * If the node the current leader for a topic, this call will force the next candidate (if one exists)

--- a/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
+++ b/core/src/main/java/io/atomix/core/election/impl/TranscodingAsyncLeaderElector.java
@@ -74,6 +74,11 @@ public class TranscodingAsyncLeaderElector<V1, V2> extends DelegatingAsyncPrimit
   }
 
   @Override
+  public CompletableFuture<Boolean> demote(String topic, V1 identifier) {
+    return backingElector.demote(topic, valueEncoder.apply(identifier));
+  }
+
+  @Override
   public CompletableFuture<Leadership<V1>> getLeadership(String topic) {
     return backingElector.getLeadership(topic)
         .thenApply(leadership -> leadership.map(valueDecoder));

--- a/core/src/test/java/io/atomix/core/election/impl/DefaultLeaderElectorServiceTest.java
+++ b/core/src/test/java/io/atomix/core/election/impl/DefaultLeaderElectorServiceTest.java
@@ -16,14 +16,20 @@
 package io.atomix.core.election.impl;
 
 import io.atomix.core.election.LeaderElectionType;
+import io.atomix.core.election.LeaderElector;
+import io.atomix.core.election.LeaderElectorTest;
+import io.atomix.core.election.Leadership;
 import io.atomix.primitive.PrimitiveId;
 import io.atomix.primitive.service.ServiceContext;
 import io.atomix.primitive.session.Session;
 import io.atomix.primitive.session.SessionId;
 import io.atomix.utils.time.WallClock;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,30 +37,109 @@ import static org.mockito.Mockito.when;
  * Leader elector service test.
  */
 public class DefaultLeaderElectorServiceTest {
-    @Test
-    public void testDuplicateCandidateNode() {
-        ServiceContext context = mock(ServiceContext.class);
-        when(context.serviceType()).thenReturn(LeaderElectionType.instance());
-        when(context.serviceName()).thenReturn("test");
-        when(context.serviceId()).thenReturn(PrimitiveId.from(1));
-        when(context.wallClock()).thenReturn(new WallClock());
 
-        Session session = mock(Session.class);
-        when(session.sessionId()).thenReturn(SessionId.from(1));
-        when(context.currentSession()).thenReturn(session);
+  String node1 = "4";
+  String node2 = "5";
+  String node3 = "6";
 
-        DefaultLeaderElectorService service = new DefaultLeaderElectorService();
-        service.init(context);
-        service.register(session);
+  @Test
+  public void testDuplicateCandidateNode() {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(LeaderElectionType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
 
-        byte[] id1 = "a".getBytes();
-        service.run("foo", id1);
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+    when(context.currentSession()).thenReturn(session);
 
-        byte[] id2 = "a".getBytes();
-        service.run("foo", id2);
+    DefaultLeaderElectorService service = new DefaultLeaderElectorService();
+    service.init(context);
+    service.register(session);
 
-        // To test that duplicate candidate node entry is rejected
-        assertEquals(1, service.getLeaderships().size());
-    }
+    byte[] id1 = "a".getBytes();
+    service.run("foo", id1);
+
+    byte[] id2 = "a".getBytes();
+    service.run("foo", id2);
+
+    // To test that duplicate candidate node entry is rejected
+    assertEquals(1, service.getLeaderships().size());
+  }
+
+  @Test
+  public void testDemote() {
+    ServiceContext context = mock(ServiceContext.class);
+    when(context.serviceType()).thenReturn(LeaderElectionType.instance());
+    when(context.serviceName()).thenReturn("test");
+    when(context.serviceId()).thenReturn(PrimitiveId.from(1));
+    when(context.wallClock()).thenReturn(new WallClock());
+
+    Session session = mock(Session.class);
+    when(session.sessionId()).thenReturn(SessionId.from(1));
+    when(context.currentSession()).thenReturn(session);
+
+    DefaultLeaderElectorService service = new DefaultLeaderElectorService();
+    service.init(context);
+    service.register(session);
+
+    byte[] id1 = node1.getBytes();
+    byte[] id2 = node2.getBytes();
+    byte[] id3 = node3.getBytes();
+
+    // leadership is null
+    assertFalse(service.demote("foo", id3));
+
+    service.run("foo", id1);
+
+    when(session.sessionId()).thenReturn(SessionId.from(2));
+    when(context.currentSession()).thenReturn(session);
+    service.register(session);
+    service.run("foo", id2);
+
+    // not part of the leadership
+    assertFalse(service.demote("foo", id3));
+
+    // leader cannot be demoted
+    assertEquals(service.getLeadership("foo").leader().id(), id1);
+    assertFalse(service.demote("foo", id1));
+
+    when(session.sessionId()).thenReturn(SessionId.from(3));
+    when(context.currentSession()).thenReturn(session);
+    service.register(session);
+    service.run("foo", id3);
+
+    Leadership<byte[]> leadership = service.getLeadership("foo");
+    Assert.assertEquals(id3, leadership.candidates().get(2));
+
+    // demote node2
+    assertTrue(service.demote("foo", id2));
+    leadership = service.getLeadership("foo");
+    Assert.assertEquals(id3, leadership.candidates().get(1));
+    Assert.assertEquals(id2, leadership.candidates().get(2));
+
+    // demote leader by displacing it first
+    assertTrue(service.promote("foo", id2));
+    leadership = service.getLeadership("foo");
+    Assert.assertEquals(id1, leadership.leader().id());
+    Assert.assertEquals(id2, leadership.candidates().get(0));
+    Assert.assertEquals(id1, leadership.candidates().get(1));
+    Assert.assertEquals(id3, leadership.candidates().get(2));
+
+    assertTrue(service.anoint("foo", id2));
+    leadership = service.getLeadership("foo");
+    Assert.assertEquals(id2, leadership.leader().id());
+    Assert.assertEquals(id2, leadership.candidates().get(0));
+    Assert.assertEquals(id1, leadership.candidates().get(1));
+    Assert.assertEquals(id3, leadership.candidates().get(2));
+
+    assertTrue(service.demote("foo", id1));
+    leadership = service.getLeadership("foo");
+    Assert.assertEquals(id2, leadership.leader().id());
+    Assert.assertEquals(id2, leadership.candidates().get(0));
+    Assert.assertEquals(id3, leadership.candidates().get(1));
+    Assert.assertEquals(id1, leadership.candidates().get(2));
+  }
 
 }


### PR DESCRIPTION
The new API allow to demote a non-leader node to the bottom of the candidates list. It is not allowed to displace the current leader. It can be used in conjunction with anoint() to demote the current leader