### PR TITLE
Revert "Atomix hardening".

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -12,8 +12,4 @@ WORKDIR /opt/atomix
 EXPOSE 5678
 EXPOSE 5679
 
-RUN groupadd -g 1000 atomix && useradd -r -s /bin/false -u 1000 -g atomix atomix && \
-chown -R 1000:1000 /opt/atomix
-USER atomix
-
 ENTRYPOINT ["./bin/atomix-agent"]


### PR DESCRIPTION
Unfortunately, this change is breaking some k8s deployments.
We will reinstate the patch once the helm chart change is completed and tested.

This reverts commit a84eb8285ea29cf98b5b83cde13f6e9ff4534718.